### PR TITLE
upgrade to java 7

### DIFF
--- a/dbpool/src/main/java/io/airlift/dbpool/ManagedDataSource.java
+++ b/dbpool/src/main/java/io/airlift/dbpool/ManagedDataSource.java
@@ -26,9 +26,11 @@ import javax.sql.PooledConnection;
 import java.io.PrintWriter;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Logger;
 
 import static io.airlift.units.Duration.nanosSince;
 import static java.lang.Math.ceil;
@@ -184,6 +186,13 @@ public abstract class ManagedDataSource implements DataSource
     public void setLogWriter(PrintWriter out)
             throws SQLException
     {
+    }
+
+    @Override
+    public Logger getParentLogger()
+            throws SQLFeatureNotSupportedException
+    {
+        throw new SQLFeatureNotSupportedException("java.util.logging not supported");
     }
 
     @Override

--- a/dbpool/src/test/java/io/airlift/dbpool/MockConnectionPoolDataSource.java
+++ b/dbpool/src/test/java/io/airlift/dbpool/MockConnectionPoolDataSource.java
@@ -31,6 +31,7 @@ import java.sql.NClob;
 import java.sql.PreparedStatement;
 import java.sql.SQLClientInfoException;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.sql.SQLWarning;
 import java.sql.SQLXML;
 import java.sql.Savepoint;
@@ -40,6 +41,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executor;
+import java.util.logging.Logger;
 
 public class MockConnectionPoolDataSource implements ConnectionPoolDataSource
 {
@@ -86,6 +89,13 @@ public class MockConnectionPoolDataSource implements ConnectionPoolDataSource
             throws SQLException
     {
         logWriter = out;
+    }
+
+    @Override
+    public Logger getParentLogger()
+            throws SQLFeatureNotSupportedException
+    {
+        throw new SQLFeatureNotSupportedException("java.util.logging not supported");
     }
 
     @Override
@@ -205,6 +215,40 @@ public class MockConnectionPoolDataSource implements ConnectionPoolDataSource
             mockPooledConnection.errorOccurred();
         }
 
+        @Override
+        public void setSchema(String schema)
+                throws SQLException
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getSchema()
+                throws SQLException
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int getNetworkTimeout()
+                throws SQLException
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setNetworkTimeout(Executor executor, int milliseconds)
+                throws SQLException
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void abort(Executor executor)
+                throws SQLException
+        {
+            throw new UnsupportedOperationException();
+        }
 
         @Override
         public Statement createStatement()

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
                                     <version>3.0.0</version>
                                 </requireMavenVersion>
                                 <requireJavaVersion>
-                                    <version>1.6</version>
+                                    <version>1.7</version>
                                 </requireJavaVersion>
                                 <bannedDependencies>
                                     <excludes>
@@ -288,8 +288,8 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>2.3.2</version>
                     <configuration>
-                        <source>1.6</source>
-                        <target>1.6</target>
+                        <source>1.7</source>
+                        <target>1.7</target>
                     </configuration>
                 </plugin>
 

--- a/rest-server-base/pom.xml
+++ b/rest-server-base/pom.xml
@@ -144,7 +144,7 @@
                                             <version>3.0.0</version>
                                         </requireMavenVersion>
                                         <requireJavaVersion>
-                                            <version>1.6</version>
+                                            <version>1.7</version>
                                         </requireJavaVersion>
                                         <requirePluginVersions />
                                         <bannedDependencies>
@@ -191,8 +191,8 @@
                         <artifactId>maven-compiler-plugin</artifactId>
                         <version>2.3.2</version>
                         <configuration>
-                            <source>1.6</source>
-                            <target>1.6</target>
+                            <source>1.7</source>
+                            <target>1.7</target>
                         </configuration>
                     </plugin>
 


### PR DESCRIPTION
This change makes java 7 _mandatory_. Should we go ahead with it so that we can start taking advantage of java 7 language and library features?
