### PR TITLE
Don't send HTTP entity if no body generator

### DIFF
--- a/http-client/src/main/java/io/airlift/http/client/ApacheHttpClient.java
+++ b/http-client/src/main/java/io/airlift/http/client/ApacheHttpClient.java
@@ -177,72 +177,74 @@ public class ApacheHttpClient implements io.airlift.http.client.HttpClient
                 addHeader(entry.getKey(), entry.getValue());
             }
 
-            setEntity(new HttpEntity()
-            {
-                @Override
-                public boolean isRepeatable()
+            if (request.getBodyGenerator() != null) {
+                setEntity(new HttpEntity()
                 {
-                    return true;
-                }
+                    @Override
+                    public boolean isRepeatable()
+                    {
+                        return true;
+                    }
 
-                @Override
-                public boolean isChunked()
-                {
-                    return true;
-                }
+                    @Override
+                    public boolean isChunked()
+                    {
+                        return true;
+                    }
 
-                @Override
-                public long getContentLength()
-                {
-                    return -1;
-                }
+                    @Override
+                    public long getContentLength()
+                    {
+                        return -1;
+                    }
 
-                @Override
-                public Header getContentType()
-                {
-                    return null;
-                }
+                    @Override
+                    public Header getContentType()
+                    {
+                        return null;
+                    }
 
-                @Override
-                public Header getContentEncoding()
-                {
-                    return null;
-                }
+                    @Override
+                    public Header getContentEncoding()
+                    {
+                        return null;
+                    }
 
-                @Override
-                public InputStream getContent()
-                        throws IOException, IllegalStateException
-                {
-                    throw new UnsupportedOperationException();
-                }
+                    @Override
+                    public InputStream getContent()
+                            throws IOException, IllegalStateException
+                    {
+                        throw new UnsupportedOperationException();
+                    }
 
-                @Override
-                public void writeTo(OutputStream out)
-                        throws IOException
-                {
-                    if (request.getBodyGenerator() != null) {
-                        try {
-                            countingOutputStream = new CountingOutputStream(out);
-                            request.getBodyGenerator().write(countingOutputStream);
-                        }
-                        catch (Exception e) {
-                            Throwables.propagateIfPossible(e, IOException.class);
-                            throw new IOException(e);
+                    @Override
+                    public void writeTo(OutputStream out)
+                            throws IOException
+                    {
+                        if (request.getBodyGenerator() != null) {
+                            try {
+                                countingOutputStream = new CountingOutputStream(out);
+                                request.getBodyGenerator().write(countingOutputStream);
+                            }
+                            catch (Exception e) {
+                                Throwables.propagateIfPossible(e, IOException.class);
+                                throw new IOException(e);
+                            }
                         }
                     }
-                }
 
-                @Override
-                public boolean isStreaming()
-                {
-                    return true;
-                }
+                    @Override
+                    public boolean isStreaming()
+                    {
+                        return true;
+                    }
 
-                @Override
-                public void consumeContent()
-                {
-                }
-            });
+                    @Override
+                    public void consumeContent()
+                    {
+                    }
+                });
+            }
         }
 
         @Override

--- a/http-client/src/test/java/io/airlift/http/client/TestRequest.java
+++ b/http-client/src/test/java/io/airlift/http/client/TestRequest.java
@@ -31,17 +31,29 @@ public class TestRequest
 
         EquivalenceTester.<Request>equivalenceTester()
                 .addEquivalentGroup(
+                        new Request(createUri1(), "GET", createHeaders1(), null),
+                        new Request(createUri1(), "GET", createHeaders1(), null))
+                .addEquivalentGroup(
                         new Request(createUri1(), "GET", createHeaders1(), bodyGenerator),
                         new Request(createUri1(), "GET", createHeaders1(), bodyGenerator))
                 .addEquivalentGroup(
+                        new Request(createUri1(), "GET", createHeaders2(), bodyGenerator))
+                .addEquivalentGroup(
                         new Request(createUri2(), "GET", createHeaders1(), bodyGenerator))
+                .addEquivalentGroup(
+                        new Request(createUri1(), "PUT", createHeaders1(), null),
+                        new Request(createUri1(), "PUT", createHeaders1(), null))
+                .addEquivalentGroup(
+                        new Request(createUri2(), "PUT", createHeaders1(), null))
+                .addEquivalentGroup(
+                        new Request(createUri1(), "PUT", createHeaders2(), null))
                 .addEquivalentGroup(
                         new Request(createUri1(), "PUT", createHeaders1(), bodyGenerator),
                         new Request(createUri1(), "PUT", createHeaders1(), bodyGenerator))
                 .addEquivalentGroup(
-                        new Request(createUri1(), "GET", createHeaders2(), bodyGenerator))
-                .addEquivalentGroup(
                         new Request(createUri1(), "GET", createHeaders1(), createBodyGenerator()))
+                .addEquivalentGroup(
+                        new Request(createUri1(), "PUT", createHeaders1(), createBodyGenerator()))
                 .check();
     }
 


### PR DESCRIPTION
Some HTTP servers refuse requests that have unexpected entities. See proofpoint/platform#121

Sending as two commits, with the second backing out an undesired extra change, as this is how they were applied to proofpoint/platform. I can squash these if requested.
