### PR TITLE
Change io.airlift:stats to only depend on io.airlift:log in test scope

### DIFF
--- a/stats/pom.xml
+++ b/stats/pom.xml
@@ -22,6 +22,7 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>log</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
swift pulls in io.airlift:stats, which pulls in io.airlift:log, which pulls in stuff to do log4j over slf4j, which is harmful to projects that have configured slf4j to log over log4j...

the io.airlift:stats -> io.airlift:log dependency was only needed for test scope, so this fixes the problem.
