### PR TITLE
JMX Agent uses NodeInfo

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+* 0.71
+
+- JMXAgent now uses NodeInfo to find IP address to bind to.
+
 * 0.70
 
 - Upgrade to Jackson 2.1.3

--- a/jmx/src/main/java/io/airlift/jmx/JmxAgent.java
+++ b/jmx/src/main/java/io/airlift/jmx/JmxAgent.java
@@ -15,8 +15,11 @@
  */
 package io.airlift.jmx;
 
+import com.google.common.net.InetAddresses;
+
 import com.google.inject.Inject;
 import io.airlift.log.Logger;
+import io.airlift.node.NodeInfo;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
@@ -24,8 +27,8 @@ import javax.management.MBeanServer;
 import javax.management.remote.JMXConnectorServer;
 import javax.management.remote.JMXConnectorServerFactory;
 import javax.management.remote.JMXServiceURL;
+
 import java.io.IOException;
-import java.net.InetAddress;
 import java.net.MalformedURLException;
 import java.rmi.registry.LocateRegistry;
 import java.util.Collections;
@@ -41,11 +44,11 @@ public class JmxAgent
     private final JMXServiceURL url;
 
     @Inject
-    public JmxAgent(MBeanServer server, JmxConfig config)
+    public JmxAgent(MBeanServer server, JmxConfig config, NodeInfo nodeInfo)
             throws IOException
     {
         if (config.getHostname() == null) {
-            host = InetAddress.getLocalHost().getHostAddress();
+            host = InetAddresses.toUriString(nodeInfo.getInternalIp());
         }
         else {
             host = config.getHostname();

--- a/jmx/src/test/java/io/airlift/jmx/TestJMXAgent.java
+++ b/jmx/src/test/java/io/airlift/jmx/TestJMXAgent.java
@@ -15,15 +15,18 @@
  */
 package io.airlift.jmx;
 
+import io.airlift.node.NodeInfo;
 import org.testng.annotations.Test;
 
 import javax.management.MBeanServer;
 import javax.management.MBeanServerConnection;
 import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXConnectorFactory;
+
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.net.Inet4Address;
+import java.net.InetAddress;
 
 import static org.testng.Assert.assertTrue;
 
@@ -34,7 +37,7 @@ public class TestJMXAgent
             throws IOException
     {
         MBeanServer server = ManagementFactory.getPlatformMBeanServer();
-        JmxAgent agent = new JmxAgent(server, new JmxConfig());
+        JmxAgent agent = new JmxAgent(server, new JmxConfig(), new NodeInfo("test"));
         agent.start();
 
         JMXConnector connector = JMXConnectorFactory.connect(agent.getURL());
@@ -48,10 +51,10 @@ public class TestJMXAgent
     public void testSpecificHost()
             throws IOException
     {
-        final String host = Inet4Address.getLocalHost().getCanonicalHostName();
+        final String host = new NodeInfo("test").getInternalIp().getCanonicalHostName();
 
         MBeanServer server = ManagementFactory.getPlatformMBeanServer();
-        JmxAgent agent = new JmxAgent(server, new JmxConfig().setHostname(host));
+        JmxAgent agent = new JmxAgent(server, new JmxConfig().setHostname(host), new NodeInfo("test"));
         agent.start();
 
         JMXConnector connector = JMXConnectorFactory.connect(agent.getURL());
@@ -65,7 +68,7 @@ public class TestJMXAgent
     public void testSpecificHostAndPort()
             throws IOException
     {
-        final String host = Inet4Address.getLocalHost().getCanonicalHostName();
+        final String host = new NodeInfo("test").getInternalIp().getCanonicalHostName();
         final int port = NetUtils.findUnusedPort();
 
         MBeanServer server = ManagementFactory.getPlatformMBeanServer();
@@ -73,7 +76,7 @@ public class TestJMXAgent
                 .setRmiRegistryPort(port)
                 .setHostname(host);
 
-        JmxAgent agent = new JmxAgent(server, config);
+        JmxAgent agent = new JmxAgent(server, config, new NodeInfo("test"));
         agent.start();
 
         JMXConnector connector = JMXConnectorFactory.connect(agent.getURL());

--- a/jmx/src/test/java/io/airlift/jmx/TestJmxModule.java
+++ b/jmx/src/test/java/io/airlift/jmx/TestJmxModule.java
@@ -16,11 +16,13 @@
 package io.airlift.jmx;
 
 import com.beust.jcommander.internal.Maps;
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Stage;
 import io.airlift.configuration.ConfigurationFactory;
 import io.airlift.configuration.ConfigurationModule;
+import io.airlift.node.NodeModule;
 import org.testng.annotations.Test;
 import org.weakref.jmx.guice.MBeanModule;
 
@@ -31,18 +33,21 @@ public class TestJmxModule
     @Test
     public void testCanConstruct()
     {
-        Map<String, String> properties = Maps.newHashMap();
+        Map<String, String> properties = ImmutableMap.of("node.environment", "test");
         ConfigurationFactory configFactory = new ConfigurationFactory(properties);
-        Injector injector = Guice.createInjector(new JmxModule(), new ConfigurationModule(configFactory));
+        Injector injector = Guice.createInjector(new JmxModule(),
+                new NodeModule(),
+                new ConfigurationModule(configFactory));
         injector.getInstance(JmxAgent.class);
     }
 
     @Test
     public void testCanExportBeans()
     {
-        Map<String, String> properties = Maps.newHashMap();
+        Map<String, String> properties = ImmutableMap.of("node.environment", "test");
         ConfigurationFactory configFactory = new ConfigurationFactory(properties);
         Injector injector = Guice.createInjector(Stage.PRODUCTION, new JmxModule(),
+                                                 new NodeModule(),
                                                  new MBeanModule(),
                                                  new ConfigurationModule(configFactory));
         injector.getInstance(JmxAgent.class);


### PR DESCRIPTION
Make JMX Agent use NodeInfo so that the IP address detected will be
similar to the main server (prefer IPv4 over IPv6).
