### PR TITLE
Pick up oss-profile for invoker plugin.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -361,8 +361,34 @@
                     <artifactId>maven-invoker-plugin</artifactId>
                     <version>1.5</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-release-plugin</artifactId>
+                    <configuration>
+                        <releaseProfiles>oss-release,airlift-release</releaseProfiles>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>
+    <profiles>
+        <profile>
+            <id>airlift-release</id>
+            <build>
+                <plugins>
+                    <!-- When deploying artifacts through the invoker plugin, pass the oss-release -->
+                    <!-- profile through -->
+                    <plugin>
+                        <artifactId>maven-invoker-plugin</artifactId>
+                        <configuration>
+                            <profiles combine.children="append">
+                                <profile>oss-release</profile>
+                            </profiles>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>
 

--- a/sample-server-archetype-builder/pom.xml
+++ b/sample-server-archetype-builder/pom.xml
@@ -97,10 +97,6 @@
 
                                 <replace file="${project.build.directory}/archetype/src/main/resources/archetype-resources/pom.xml">
                                     <replacefilter>
-                                        <replacetoken><![CDATA[<relativePath>../rest-server-base/pom.xml</relativePath>]]></replacetoken>
-                                        <replacevalue />
-                                    </replacefilter>
-                                    <replacefilter>
                                         <replacetoken><![CDATA[<air.main.basedir>${project.parent.basedir}</air.main.basedir>]]></replacetoken>
                                         <replacevalue />
                                     </replacefilter>
@@ -124,6 +120,16 @@
                                     <replacefilter>
                                         <replacetoken><![CDATA[<build>]]></replacetoken>
                                         <replacevalue><![CDATA[
+  <parent>
+      <groupId>io.airlift</groupId>
+      <artifactId>airbase</artifactId>
+      <version>5</version>
+  </parent>
+
+  <properties>
+    <air.check.skip-all>true</air.check.skip-all>
+  </properties>
+
   <description>Sample server archetype</description>
   <url>http://github.com/airlift/airlift</url>
 

--- a/skeleton-server-archetype-builder/pom.xml
+++ b/skeleton-server-archetype-builder/pom.xml
@@ -119,6 +119,16 @@
                                     <replacefilter>
                                         <replacetoken><![CDATA[<build>]]></replacetoken>
                                         <replacevalue><![CDATA[
+  <parent>
+      <groupId>io.airlift</groupId>
+      <artifactId>airbase</artifactId>
+      <version>5</version>
+  </parent>
+
+  <properties>
+    <air.check.skip-all>true</air.check.skip-all>
+  </properties>
+
   <description>Skeleton server archetype</description>
   <url>http://github.com/airlift/airlift</url>
 


### PR DESCRIPTION
make the invoker plugin pick up the oss-release profile correctly. Change the
archetype code to actually have the profile (from airbase) and therefore sign
the generated artifacts correctly for upload to OSS.
