### PR TITLE
hardcode airlift versions in pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,8 @@
         <air.check.fail-basic>true</air.check.fail-basic>
         <air.check.skip-pmd>true</air.check.skip-pmd>
 
-        <dep.airlift.version>${project.version}</dep.airlift.version>
-        <dep.packaging.version>${project.version}</dep.packaging.version>
+        <dep.airlift.version>0.72-SNAPSHOT</dep.airlift.version>
+        <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
     </properties>
 
     <organization>

--- a/rack-server-base/pom.xml
+++ b/rack-server-base/pom.xml
@@ -13,10 +13,6 @@
         <version>0.72-SNAPSHOT</version>
     </parent>
 
-    <properties>
-        <dep.airlift.version>${project.parent.version}</dep.airlift.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>io.airlift</groupId>


### PR DESCRIPTION
They can be hardcoded just fine, the release plugin will pick these up and replace them correctly.
