### PR TITLE
Fix inappropriate throwing of exceptions.

### DIFF
--- a/discovery/src/main/java/io/airlift/discovery/client/HttpDiscoveryAnnouncementClient.java
+++ b/discovery/src/main/java/io/airlift/discovery/client/HttpDiscoveryAnnouncementClient.java
@@ -171,7 +171,7 @@ public class HttpDiscoveryAnnouncementClient implements DiscoveryAnnouncementCli
                 return new DiscoveryException(name + " was canceled");
             }
             if (exception instanceof DiscoveryException) {
-                throw (DiscoveryException) exception;
+                return (DiscoveryException) exception;
             }
 
             return new DiscoveryException(name + " failed", exception);

--- a/discovery/src/main/java/io/airlift/discovery/client/HttpDiscoveryLookupClient.java
+++ b/discovery/src/main/java/io/airlift/discovery/client/HttpDiscoveryLookupClient.java
@@ -200,7 +200,7 @@ public class HttpDiscoveryLookupClient implements DiscoveryLookupClient
                 return new DiscoveryException(name + " was canceled");
             }
             if (exception instanceof DiscoveryException) {
-                throw (DiscoveryException) exception;
+                return (DiscoveryException) exception;
             }
 
             return new DiscoveryException(name + " failed", exception);

--- a/http-client/src/main/java/io/airlift/http/client/FullJsonResponseHandler.java
+++ b/http-client/src/main/java/io/airlift/http/client/FullJsonResponseHandler.java
@@ -54,7 +54,10 @@ public class FullJsonResponseHandler<T> implements ResponseHandler<JsonResponse<
         if (exception instanceof ConnectException) {
             return new RuntimeException("Server refused connection: " + request.getUri().toASCIIString());
         }
-        return Throwables.propagate(exception);
+        if (exception instanceof RuntimeException) {
+            return (RuntimeException) exception;
+        }
+        return new RuntimeException(exception);
     }
 
     @Override

--- a/http-client/src/main/java/io/airlift/http/client/JsonResponseHandler.java
+++ b/http-client/src/main/java/io/airlift/http/client/JsonResponseHandler.java
@@ -62,7 +62,10 @@ public class JsonResponseHandler<T> implements ResponseHandler<T, RuntimeExcepti
         if (exception instanceof ConnectException) {
             return new RuntimeException("Server refused connection: " + request.getUri().toASCIIString(), exception);
         }
-        return Throwables.propagate(exception);
+        if (exception instanceof RuntimeException) {
+            return (RuntimeException) exception;
+        }
+        return new RuntimeException(exception);
     }
 
     @Override

--- a/http-client/src/main/java/io/airlift/http/client/StatusResponseHandler.java
+++ b/http-client/src/main/java/io/airlift/http/client/StatusResponseHandler.java
@@ -42,7 +42,10 @@ public class StatusResponseHandler implements ResponseHandler<StatusResponse, Ru
         if (exception instanceof ConnectException) {
             return new RuntimeException("Server refused connection: " + request.getUri().toASCIIString(), exception);
         }
-        return Throwables.propagate(exception);
+        if (exception instanceof RuntimeException) {
+            return (RuntimeException) exception;
+        }
+        return new RuntimeException(exception);
     }
 
     @Override

--- a/http-client/src/main/java/io/airlift/http/client/StringResponseHandler.java
+++ b/http-client/src/main/java/io/airlift/http/client/StringResponseHandler.java
@@ -47,7 +47,10 @@ public class StringResponseHandler implements ResponseHandler<StringResponse, Ru
         if (exception instanceof ConnectException) {
             return new RuntimeException("Server refused connection: " + request.getUri().toASCIIString(), exception);
         }
-        return Throwables.propagate(exception);
+        if (exception instanceof RuntimeException) {
+            return (RuntimeException) exception;
+        }
+        return new RuntimeException(exception);
     }
 
     @Override


### PR DESCRIPTION
NettyAsyncHttpClient expects ResponseHandler.handleException() to return the mapped exception, not throw it.
