### PR TITLE
Change JsonMapper to throw typed exception when parse or validation fails

### DIFF
--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -89,6 +89,11 @@
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
 

--- a/jaxrs/src/main/java/io/airlift/jaxrs/BeanValidationException.java
+++ b/jaxrs/src/main/java/io/airlift/jaxrs/BeanValidationException.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2012 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.jaxrs;
+
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableSet;
+
+import javax.validation.ConstraintViolation;
+
+import java.util.Set;
+
+import static com.google.common.collect.Iterables.transform;
+
+/**
+ * Thrown when bean validation has errors.
+ */
+public class BeanValidationException
+        extends ParsingException
+{
+    private final Set<ConstraintViolation<Object>> violations;
+
+    public BeanValidationException(Set<ConstraintViolation<Object>> violations)
+    {
+        super(Joiner.on(", ").join(transform(violations, constraintMessageBuilder())));
+        this.violations = ImmutableSet.copyOf(violations);
+    }
+
+    public Set<ConstraintViolation<Object>> getViolations()
+    {
+        return violations;
+    }
+
+    public static <T> Function<ConstraintViolation<T>, String> constraintMessageBuilder()
+    {
+        return new Function<ConstraintViolation<T>, String>()
+        {
+            @Override
+            public String apply(ConstraintViolation<T> violation)
+            {
+                return violation.getPropertyPath().toString() + " " + violation.getMessage();
+            }
+        };
+    }
+}

--- a/jaxrs/src/main/java/io/airlift/jaxrs/JaxrsModule.java
+++ b/jaxrs/src/main/java/io/airlift/jaxrs/JaxrsModule.java
@@ -20,19 +20,21 @@ import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
-import io.airlift.http.server.TheServlet;
 import com.sun.jersey.core.util.FeaturesAndProperties;
 import com.sun.jersey.guice.spi.container.servlet.GuiceContainer;
 import com.sun.jersey.spi.MessageBodyWorkers;
 import com.sun.jersey.spi.container.ExceptionMapperContext;
 import com.sun.jersey.spi.container.WebApplication;
+import io.airlift.http.server.TheServlet;
 
 import javax.servlet.Servlet;
 import javax.ws.rs.ext.Providers;
+
 import java.util.HashMap;
 import java.util.Map;
 
-public class JaxrsModule implements Module
+public class JaxrsModule
+        implements Module
 {
     @Override
     public void configure(Binder binder)
@@ -43,6 +45,7 @@ public class JaxrsModule implements Module
         binder.bind(GuiceContainer.class).in(Scopes.SINGLETON);
         binder.bind(Servlet.class).annotatedWith(TheServlet.class).to(Key.get(GuiceContainer.class));
         binder.bind(JsonMapper.class).in(Scopes.SINGLETON);
+        binder.bind(ParsingExceptionMapper.class).in(Scopes.SINGLETON);
     }
 
     @Provides

--- a/jaxrs/src/main/java/io/airlift/jaxrs/JsonMapperParsingException.java
+++ b/jaxrs/src/main/java/io/airlift/jaxrs/JsonMapperParsingException.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2012 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.jaxrs;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Wraps JsonProcessingExceptions to provide more information about parsing errors.
+ */
+public class JsonMapperParsingException
+        extends ParsingException
+{
+    private Class<?> type;
+
+    public JsonMapperParsingException(Class<?> type, Throwable cause)
+    {
+        super("Invalid json for Java type " + checkNotNull(type, "type is null").getName(), cause);
+        this.type = type;
+    }
+
+    /**
+     * Returns the type of object that failed Json parsing.
+     */
+    public Class<?> getType()
+    {
+        return type;
+    }
+}

--- a/jaxrs/src/main/java/io/airlift/jaxrs/ParsingException.java
+++ b/jaxrs/src/main/java/io/airlift/jaxrs/ParsingException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2012 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.jaxrs;
+
+import java.io.IOException;
+
+/**
+ * Exceptions that extend this class will be caught by the ParsingExceptionMapper and returned with a
+ * 400 response status code.
+ */
+public class ParsingException
+        extends IOException
+{
+    public ParsingException(String message)
+    {
+        super(message);
+    }
+
+    public ParsingException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+}

--- a/jaxrs/src/main/java/io/airlift/jaxrs/ParsingExceptionMapper.java
+++ b/jaxrs/src/main/java/io/airlift/jaxrs/ParsingExceptionMapper.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2012 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.jaxrs;
+
+import com.google.common.base.Throwables;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * Maps ParsingExceptions to a 400 response code.
+ */
+@Provider
+public class ParsingExceptionMapper
+        implements ExceptionMapper<ParsingException>
+{
+    public Response toResponse(ParsingException e)
+    {
+        return Response.status(Response.Status.BAD_REQUEST)
+                .entity(Throwables.getStackTraceAsString(e))
+                .build();
+    }
+}


### PR DESCRIPTION
Modified JsonMapper's readFrom() method to throw JsonMapperParsingException and BeanValidationException rather than throwing WebApplicationException. This allows ExceptionMappers to be created to manipulate the response if needed. ExceptionMappers don't work with WebApplicationException. Also, fixed deprecated calls to TypeFactory.type. Also added test for the throwing of the BeanValidationException.
