### PR TITLE
Add ConfigurationAwareProvider interface.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,8 @@
 - Add additional Logger methods for literal messages
 - Update RequestStats to use DistributionStat instead of MeterStat
 - Deprecate TimedStat and introduce TimeStat
+- Add ConfigurationAwareProvider interface to implement custom
+  configuration providers
 
 * 0.78
 

--- a/configuration/src/main/java/io/airlift/configuration/ConfigurationAwareProvider.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigurationAwareProvider.java
@@ -1,0 +1,30 @@
+package io.airlift.configuration;
+
+import com.google.inject.Provider;
+
+/**
+ * A provider with access to the airlift {@link ConfigurationFactory}.
+ *
+ * Implementing this interface ensures that the provider gets access to the
+ * {@link ConfigurationFactory} and {@link WarningsMonitor} before the first
+ * call to {@link Provider#get()}.
+ *
+ * @param <T> Element type that is returned by this provider.
+ */
+public interface ConfigurationAwareProvider<T> extends Provider<T>
+{
+    /**
+     * Called by the airlift framework before the first call to get.
+     *
+     * @param configurationFactory The airlift configuration factory.
+     */
+    void setConfigurationFactory(ConfigurationFactory configurationFactory);
+
+    /**
+     * May be called by the airlift framework before the first call to get.
+     * This is an optional call.
+     *
+     * @param warningsMonitor An airlift {@link WarningsMonitor}.
+     */
+    void setWarningsMonitor(WarningsMonitor warningsMonitor);
+}

--- a/configuration/src/main/java/io/airlift/configuration/ConfigurationProvider.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigurationProvider.java
@@ -18,9 +18,8 @@ package io.airlift.configuration;
 import com.google.common.base.Preconditions;
 import com.google.inject.Inject;
 import com.google.inject.Key;
-import com.google.inject.Provider;
 
-public class ConfigurationProvider<T> implements Provider<T>
+public class ConfigurationProvider<T> implements ConfigurationAwareProvider<T>
 {
     private final Key<T> key;
     private final Class<T> configClass;

--- a/configuration/src/main/java/io/airlift/configuration/ConfigurationValidator.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigurationValidator.java
@@ -60,8 +60,8 @@ public class ConfigurationValidator
                     if (binding instanceof ProviderInstanceBinding) {
                         ProviderInstanceBinding<?> providerInstanceBinding = (ProviderInstanceBinding<?>) binding;
                         Provider<?> provider = providerInstanceBinding.getProviderInstance();
-                        if (provider instanceof ConfigurationProvider) {
-                            ConfigurationProvider<?> configurationProvider = (ConfigurationProvider<?>) provider;
+                        if (provider instanceof ConfigurationAwareProvider) {
+                            ConfigurationAwareProvider<?> configurationProvider = (ConfigurationAwareProvider<?>) provider;
                             // give the provider the configuration factory
                             configurationProvider.setConfigurationFactory(configurationFactory);
                             configurationProvider.setWarningsMonitor(warningsMonitor);


### PR DESCRIPTION
Providers implementing this interface get access to the
ConfigurationFactory during bootstrap phase, can consume properties
from the factory and build custom configured objects.
