### PR TITLE
Add a config loader for the classpath.

### DIFF
--- a/configuration/src/main/java/io/airlift/configuration/ConfigurationLoader.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigurationLoader.java
@@ -15,7 +15,8 @@
  */
 package io.airlift.configuration;
 
-import com.google.common.collect.ImmutableMap;
+import static com.google.common.collect.Maps.fromProperties;
+
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Maps;
 
@@ -60,21 +61,11 @@ public class ConfigurationLoader
             reader.close();
         }
 
-        return toMap(properties);
+        return fromProperties(properties);
     }
 
     public Map<String, String> getSystemProperties()
     {
-        return toMap(System.getProperties());
-    }
-
-    private static ImmutableMap<String, String> toMap(Properties properties)
-    {
-        ImmutableMap.Builder<String, String> result = ImmutableMap.builder();
-        for (Map.Entry<Object, Object> entry : properties.entrySet()) {
-            result.put(entry.getKey().toString(), entry.getValue().toString());
-        }
-
-        return result.build();
+        return fromProperties(System.getProperties());
     }
 }

--- a/testing/src/main/java/io/airlift/testing/ConfigurationUtils.java
+++ b/testing/src/main/java/io/airlift/testing/ConfigurationUtils.java
@@ -1,0 +1,25 @@
+package io.airlift.testing;
+
+import static com.google.common.collect.Maps.fromProperties;
+import static com.google.common.io.Resources.getResource;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Properties;
+
+public final class ConfigurationUtils
+{
+    private ConfigurationUtils()
+    {
+    }
+
+    /**
+     * Load a properties file from the class path and return as a Map suitable for a configuration factory.
+     */
+    public static Map<String, String> loadPropertiesFromClasspath(String path) throws IOException
+    {
+        Properties properties = new Properties();
+        properties.load(getResource(ConfigurationUtils.class, path).openStream());
+        return fromProperties(properties);
+    }
+}


### PR DESCRIPTION
Allows loading a properties object from the classpath and expose the
result as a Map suitable for a Configuration factory.

Also remove the private toMap() method from ConfigurationLoader (replaced with Guava code).
