### PR TITLE
Don't try to start the JMX agent if it's already running

### DIFF
--- a/jmx/src/main/java/io/airlift/jmx/JmxAgent.java
+++ b/jmx/src/main/java/io/airlift/jmx/JmxAgent.java
@@ -16,75 +16,132 @@
 package io.airlift.jmx;
 
 import com.google.common.base.Throwables;
+import com.google.common.net.HostAndPort;
 import com.google.inject.Inject;
 import io.airlift.log.Logger;
 import sun.management.Agent;
+import sun.management.jmxremote.ConnectorBootstrap;
+import sun.rmi.server.UnicastRef;
 
-import javax.annotation.PostConstruct;
+import javax.management.remote.JMXConnectorServer;
 import javax.management.remote.JMXServiceURL;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.net.MalformedURLException;
+import java.rmi.server.RemoteObject;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static java.lang.String.format;
 
 public class JmxAgent
 {
-    private final int registryPort;
-    private final int serverPort;
-
     private static final Logger log = Logger.get(JmxAgent.class);
-    private final JMXServiceURL url;
+
+    private final HostAndPort address;
 
     @Inject
     public JmxAgent(JmxConfig config)
             throws IOException
     {
-        if (config.getRmiRegistryPort() == null) {
-            registryPort = NetUtils.findUnusedPort();
+        // first, see if the jmx agent is already started (e.g., via command line properties passed to the jvm)
+        HostAndPort address = getRunningAgentAddress(config.getRmiRegistryPort(), config.getRmiServerPort());
+        if (address != null) {
+            log.info("JMX agent already running and listening on %s", address);
         }
         else {
-            registryPort = config.getRmiRegistryPort();
+            // otherwise, start it manually
+            int registryPort;
+            if (config.getRmiRegistryPort() == null) {
+                registryPort = NetUtils.findUnusedPort();
+            }
+            else {
+                registryPort = config.getRmiRegistryPort();
+            }
+
+            int serverPort = 0;
+            if (config.getRmiServerPort() != null) {
+                serverPort = config.getRmiServerPort();
+            }
+
+            // This is somewhat of a hack, but the jmx agent in Oracle/OpenJDK doesn't
+            // have a programmatic API for starting it and controlling its parameters
+            System.setProperty("com.sun.management.jmxremote", "true");
+            System.setProperty("com.sun.management.jmxremote.port", Integer.toString(registryPort));
+            System.setProperty("com.sun.management.jmxremote.rmi.port", Integer.toString(serverPort));
+            System.setProperty("com.sun.management.jmxremote.authenticate", "false");
+            System.setProperty("com.sun.management.jmxremote.ssl", "false");
+
+            try {
+                Agent.startAgent();
+            }
+            catch (Exception e) {
+                throw Throwables.propagate(e);
+            }
+
+            try {
+                // This is how the jdk jmx agent constructs its url
+                JMXServiceURL url = new JMXServiceURL("rmi", null, registryPort);
+                address = HostAndPort.fromParts(url.getHost(), url.getPort());
+            }
+            catch (MalformedURLException e) {
+                // should not happen...
+                throw new AssertionError(e);
+            }
+
+            log.info("JMX agent started and listening on %s", address);
         }
 
-        if (config.getRmiServerPort() == null) {
-            serverPort = NetUtils.findUnusedPort();
-        }
-        else {
-            serverPort = config.getRmiServerPort();
-        }
-
-        try {
-            // This is how the jdk jmx agent constructs its url
-            url = new JMXServiceURL("rmi", null, registryPort);
-        }
-        catch (MalformedURLException e) {
-            // should not happen...
-            throw new AssertionError(e);
-        }
+        this.address = address;
     }
 
-    public JMXServiceURL getURL()
+    private static HostAndPort getRunningAgentAddress(Integer registryPort, Integer serverPort)
     {
-        return url;
-    }
-
-    @PostConstruct
-    public void start()
-            throws IOException
-    {
-        // This is somewhat of a hack, but the jmx agent in Oracle/OpenJDK doesn't
-        // have a programmatic API for starting it and controlling its parameters
-        System.setProperty("com.sun.management.jmxremote", "true");
-        System.setProperty("com.sun.management.jmxremote.port", Integer.toString(registryPort));
-        System.setProperty("com.sun.management.jmxremote.rmi.port", Integer.toString(serverPort));
-        System.setProperty("com.sun.management.jmxremote.authenticate", "false");
-        System.setProperty("com.sun.management.jmxremote.ssl", "false");
-
         try {
-            Agent.startAgent();
+            JMXConnectorServer jmxServer = getField(Agent.class, JMXConnectorServer.class, "jmxServer");
+            RemoteObject registry = getField(ConnectorBootstrap.class, RemoteObject.class, "registry");
+
+            if (jmxServer != null && registry != null) {
+                int actualRegistryPort = ((UnicastRef) registry.getRef()).getLiveRef().getPort();
+
+                checkState(actualRegistryPort > 0, "Expected actual RMI registry port to be > 0, actual: %s", actualRegistryPort);
+
+                // if registry port and server port were configured and the agent is already running, make sure
+                // the configuration agrees to avoid surprises
+                if (registryPort != null && registryPort != 0) {
+                    checkArgument(actualRegistryPort == registryPort, "JMX agent is already running, but actual RMI registry port (%s) doesn't match configured port (%s)", actualRegistryPort, registryPort);
+                }
+
+                if (serverPort != null && serverPort != 0) {
+                    int actualServerPort = jmxServer.getAddress().getPort();
+                    checkArgument(actualServerPort == serverPort, "JMX agent is already running, but actual RMI server port (%s) doesn't match configured port (%s)", actualServerPort, serverPort);
+                }
+
+                return HostAndPort.fromParts(jmxServer.getAddress().getHost(), actualRegistryPort);
+            }
         }
         catch (Exception e) {
-            throw Throwables.propagate(e);
+            log.warn(e, "Cannot determine if JMX agent is already running. Will try to start it manually.");
         }
 
-        log.info("JMX Agent listening on %s:%s", url.getHost(), url.getPort());
+        return null;
+    }
+
+    public HostAndPort getAddress()
+    {
+        return address;
+    }
+
+    private static <T> T getField(Class<?> clazz, Class<T> returnType, String name)
+            throws Exception
+    {
+        Field field = clazz.getDeclaredField(name);
+        field.setAccessible(true);
+        try {
+            return returnType.cast(field.get(clazz));
+        }
+        catch (ClassCastException e) {
+            throw new IllegalArgumentException(format("Field %s in class %s is not of type %s, actual: %s", name, clazz.getName(), returnType.getName(), field.getType().getName()), e);
+        }
     }
 }

--- a/jmx/src/main/java/io/airlift/jmx/JmxModule.java
+++ b/jmx/src/main/java/io/airlift/jmx/JmxModule.java
@@ -65,7 +65,7 @@ public class JmxModule
         public ServiceAnnouncement get()
         {
             return serviceAnnouncement("jmx")
-                    .addProperty("jmx", jmxAgent.getURL().toString())
+                    .addProperty("jmx", jmxAgent.getAddress().toString())
                     .build();
         }
     }


### PR DESCRIPTION
This is to allow starting the VM with com.sun.management.jmxremote.\* options to initialize the JMX agent on startup and work around the issue described in http://mail.openjdk.java.net/pipermail/serviceability-dev/2013-August/011455.html
