### PR TITLE
Fix config record comparison

### DIFF
--- a/configuration/src/main/java/io/airlift/configuration/ConfigurationInspector.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigurationInspector.java
@@ -19,7 +19,9 @@ import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Ordering;
 import com.google.inject.Key;
+
 import io.airlift.configuration.ConfigurationMetadata.AttributeMetadata;
 
 import java.lang.reflect.Method;
@@ -163,6 +165,7 @@ public class ConfigurationInspector
             return ComparisonChain.start()
                     .compare(String.valueOf(this.key.getTypeLiteral().getType()), String.valueOf(that.key.getTypeLiteral().getType()))
                     .compare(String.valueOf(this.key.getAnnotationType()), String.valueOf(that.key.getAnnotationType()))
+                    .compare(this.key, that.key, Ordering.arbitrary())
                     .result();
         }
     }


### PR DESCRIPTION
Make sure that two config records, that have been created from Config
objects with keys, that compare equal in annotation type and type
literal do not compare equal. Otherwise, the configuration keys consumed
by those ConfigRecords are not displayed.
