### PR TITLE
Add lifecycle bindings for providers.

### DIFF
--- a/bootstrap/src/main/java/io/airlift/bootstrap/LifecycledBindingBuilder.java
+++ b/bootstrap/src/main/java/io/airlift/bootstrap/LifecycledBindingBuilder.java
@@ -1,0 +1,64 @@
+package io.airlift.bootstrap;
+
+import com.google.inject.Binder;
+import com.google.inject.Key;
+import com.google.inject.TypeLiteral;
+import com.google.inject.binder.ScopedBindingBuilder;
+
+import javax.inject.Provider;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Creates Provider bindings where objects created by the provider are automatically added to the lifecycle.
+ *
+ *
+ * In a guice module, use
+ * <pre>
+ *   LifecycledBindingBuilder.lifecycleBinding(binder, Foo.class).toProvider(FooProvider.class).in(Scopes.SINGLETON);
+ * </pre>
+ *
+ * All <tt>Foo</tt> objects created by the FooProvider will automatically added to the Lifecycle and their {@link PostConstruct}
+ * and {@link PreDestroy} methods are called.
+ */
+public final class LifecycledBindingBuilder<T>
+{
+    private final Binder binder;
+    private final Key<T> key;
+
+    public static <Type> LifecycledBindingBuilder<Type> lifecycleBinding(Binder binder, Class<Type> clazz)
+    {
+        return new LifecycledBindingBuilder<Type>(binder, Key.get(checkNotNull(clazz, "clazz is null")));
+    }
+
+    public static <Type> LifecycledBindingBuilder<Type> lifecycleBinding(Binder binder, Key<Type> key)
+    {
+        return new LifecycledBindingBuilder<Type>(binder, key);
+    }
+
+    private LifecycledBindingBuilder(Binder binder, Key<T> key)
+    {
+        this.binder = checkNotNull(binder, "binder is null");
+        this.key = checkNotNull(key, "key is null");
+    }
+
+    public ScopedBindingBuilder toProvider(Provider<? extends T> delegate)
+    {
+        return binder.bind(key).toProvider(new LifecyclingProvider<T>(delegate));
+    }
+
+    public ScopedBindingBuilder toProvider(Class<? extends Provider<? extends T>> providerType)
+    {
+        return binder.bind(key).toProvider(new LifecyclingProvider<T>(Key.get(providerType)));
+    }
+
+    public ScopedBindingBuilder toProvider(TypeLiteral<? extends Provider<? extends T>> providerType)
+    {
+        return binder.bind(key).toProvider(new LifecyclingProvider<T>(Key.get(providerType)));
+    }
+
+    public ScopedBindingBuilder toProvider(Key<? extends Provider<? extends T>> providerKey)
+    {
+        return binder.bind(key).toProvider(new LifecyclingProvider<T>(providerKey));
+    }
+}

--- a/bootstrap/src/main/java/io/airlift/bootstrap/LifecyclingProvider.java
+++ b/bootstrap/src/main/java/io/airlift/bootstrap/LifecyclingProvider.java
@@ -1,0 +1,88 @@
+package io.airlift.bootstrap;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.ProvisionException;
+import com.google.inject.spi.Dependency;
+import com.google.inject.spi.InjectionPoint;
+import com.google.inject.spi.ProviderWithDependencies;
+
+import javax.inject.Provider;
+
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+/**
+ * Wraps an existing provider and adds all objects from that provider to the lifecycle.
+ */
+class LifecyclingProvider<T>
+    implements ProviderWithDependencies<T>
+{
+    private final Key<? extends Provider<? extends T>> key;
+    private final Set<Dependency<?>> dependencies;
+
+    private Provider<? extends T> delegate;
+    private LifeCycleManager lifeCycleManager;
+
+    LifecyclingProvider(Provider<? extends T> delegate)
+    {
+        this.delegate = checkNotNull(delegate, "delegate is null");
+        this.key = null;
+
+        Set<InjectionPoint> injectionPoints = InjectionPoint.forInstanceMethodsAndFields(delegate.getClass());
+        ImmutableSet.Builder<Dependency<?>> builder = ImmutableSet.builder();
+        for (InjectionPoint ip : injectionPoints) {
+            builder.addAll(ip.getDependencies());
+        }
+        this.dependencies = builder.build();
+
+    }
+
+    LifecyclingProvider(Key<? extends Provider<? extends T>> key)
+    {
+        this.key = checkNotNull(key, "key is null");
+
+        this.delegate = null;
+        this.dependencies = ImmutableSet.of();
+    }
+
+    @Inject
+    void setInjector(Injector injector)
+    {
+        checkNotNull(injector, "injector is null");
+        this.lifeCycleManager = injector.getInstance(LifeCycleManager.class);
+
+        if (key != null) {
+            this.delegate = injector.getInstance(key);
+        }
+        else {
+            injector.injectMembers(delegate);
+        }
+    }
+
+    @Override
+    public T get()
+    {
+        checkState(delegate != null, "delegate is null");
+
+        T value = delegate.get();
+
+        try {
+            lifeCycleManager.addInstance(value);
+        }
+        catch (Exception e) {
+            throw new ProvisionException("While adding to lifecycle manager", e);
+        }
+        return value;
+    }
+
+    @Override
+    public Set<Dependency<?>> getDependencies()
+    {
+        return dependencies;
+    }
+}

--- a/bootstrap/src/test/java/io/airlift/bootstrap/AbstractLifeCycleChecker.java
+++ b/bootstrap/src/test/java/io/airlift/bootstrap/AbstractLifeCycleChecker.java
@@ -1,0 +1,69 @@
+package io.airlift.bootstrap;
+
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.google.common.base.Preconditions.checkState;
+
+public abstract class AbstractLifeCycleChecker
+{
+    private final AtomicInteger count = new AtomicInteger(0);
+    private final AtomicInteger preDestroyCalled = new AtomicInteger();
+    private final AtomicInteger postConstructCalled = new AtomicInteger();
+    private final AtomicInteger injectCalled = new AtomicInteger();
+
+    private final AtomicBoolean started = new AtomicBoolean();
+    private final AtomicBoolean stopped = new AtomicBoolean();
+
+
+    @PostConstruct
+    public final void checkStart()
+    {
+        if (started.compareAndSet(false, true)) {
+            checkState(postConstructCalled.get() == 0, "already injected!");
+            postConstructCalled.set(count.incrementAndGet());
+        }
+    }
+
+    @PreDestroy
+    public final void checkStop()
+    {
+        if (stopped.compareAndSet(false, true)) {
+            checkState(preDestroyCalled.get() == 0, "already injected!");
+            preDestroyCalled.set(count.incrementAndGet());
+        }
+    }
+
+    @Inject
+    final void checkInject(Injector injector)
+    {
+        checkState(injectCalled.get() == 0, "already injected!");
+        injectCalled.set(count.incrementAndGet());
+    }
+
+    public int getPreDestroyCalled()
+    {
+        return preDestroyCalled.get();
+    }
+
+    public int getPostConstructCalled()
+    {
+        return postConstructCalled.get();
+    }
+
+    public int getInjectCalled()
+    {
+        return injectCalled.get();
+    }
+
+    public int getCount()
+    {
+        return count.get();
+    }
+}

--- a/bootstrap/src/test/java/io/airlift/bootstrap/TestLifecycledBindingBuilder.java
+++ b/bootstrap/src/test/java/io/airlift/bootstrap/TestLifecycledBindingBuilder.java
@@ -1,0 +1,261 @@
+package io.airlift.bootstrap;
+
+import com.google.inject.Binder;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import com.google.inject.Provider;
+import com.google.inject.Scopes;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotSame;
+import static org.testng.Assert.assertSame;
+
+public class TestLifecycledBindingBuilder
+{
+    @Inject
+    private LifeCycleManager manager;
+
+    @Test
+    public void testWrapNonInjectingProvider()
+        throws Exception
+    {
+        final NonInjectingFooProvider provider = new NonInjectingFooProvider();
+
+        Injector inj = new Bootstrap(new Module()
+        {
+            @Override
+            public void configure(Binder binder)
+            {
+                LifecycledBindingBuilder.lifecycleBinding(binder, Foo.class).toProvider(provider);
+            }
+        })
+            .doNotInitializeLogging()
+            .strictConfig()
+            .initialize();
+
+        inj.injectMembers(this);
+
+        assertEquals(provider.getInjectCalled(), 1);
+        assertEquals(provider.getPostConstructCalled(), 2);
+        assertEquals(provider.getCount(), 2);
+
+        assertEquals(provider.getPreDestroyCalled(), 0);
+
+        Foo foo1 = inj.getInstance(Foo.class);
+        assertEquals(foo1.getPostConstructCalled(), 1);
+        assertEquals(foo1.getCount(), 1);
+
+        // Calling the injector is job of the provider,
+        // not the lifecycle.
+        assertEquals(foo1.getInjectCalled(), 0);
+        assertEquals(foo1.getPreDestroyCalled(), 0);
+
+        Foo foo2 = inj.getInstance(Foo.class);
+
+        assertNotSame(foo2, foo1);
+
+        assertEquals(foo2.getPostConstructCalled(), 1);
+        assertEquals(foo2.getCount(), 1);
+
+        assertEquals(foo2.getInjectCalled(), 0);
+        assertEquals(foo2.getPreDestroyCalled(), 0);
+
+        manager.stop();
+
+        assertEquals(provider.getPreDestroyCalled(), 3);
+        assertEquals(provider.getCount(), 3);
+
+        assertEquals(foo1.getPreDestroyCalled(), 2);
+        assertEquals(foo1.getCount(), 2);
+
+        assertEquals(foo2.getPreDestroyCalled(), 2);
+        assertEquals(foo2.getCount(), 2);
+    }
+
+    @Test
+    public void testWrapNonInjectingProviderSingleton()
+        throws Exception
+    {
+        Injector inj = new Bootstrap(new Module() {
+            @Override
+            public void configure(Binder binder)
+            {
+                LifecycledBindingBuilder.lifecycleBinding(binder, Foo.class).toProvider(NonInjectingFooProvider.class).in(Scopes.SINGLETON);
+                binder.bind(NonInjectingFooProvider.class).in(Scopes.SINGLETON);
+            }
+        })
+            .doNotInitializeLogging()
+            .strictConfig()
+            .initialize();
+
+        inj.injectMembers(this);
+
+        NonInjectingFooProvider provider = inj.getInstance(NonInjectingFooProvider.class);
+
+        assertEquals(provider.getInjectCalled(), 1);
+        assertEquals(provider.getPostConstructCalled(), 2);
+        assertEquals(provider.getCount(), 2);
+
+        assertEquals(provider.getPreDestroyCalled(), 0);
+
+        Foo foo1 = inj.getInstance(Foo.class);
+        assertEquals(foo1.getPostConstructCalled(), 1);
+        assertEquals(foo1.getCount(), 1);
+
+        // Calling the injector is job of the provider,
+        // not the lifecycle.
+        assertEquals(foo1.getInjectCalled(), 0);
+        assertEquals(foo1.getPreDestroyCalled(), 0);
+
+        Foo foo2 = inj.getInstance(Foo.class);
+
+        assertSame(foo2, foo1);
+
+        manager.stop();
+
+        assertEquals(provider.getPreDestroyCalled(), 3);
+        assertEquals(provider.getCount(), 3);
+
+        assertEquals(foo1.getPreDestroyCalled(), 2);
+        assertEquals(foo1.getCount(), 2);
+    }
+
+    @Test
+    public void testWrapInjectingProvider()
+        throws Exception
+    {
+        final InjectingFooProvider provider = new InjectingFooProvider();
+
+        Injector inj = new Bootstrap(new Module() {
+            @Override
+            public void configure(Binder binder)
+            {
+                LifecycledBindingBuilder.lifecycleBinding(binder, Foo.class).toProvider(provider);
+            }
+        })
+            .doNotInitializeLogging()
+            .strictConfig()
+            .initialize();
+
+        inj.injectMembers(this);
+
+        assertEquals(provider.getInjectCalled(), 1);
+        assertEquals(provider.getPostConstructCalled(), 2);
+        assertEquals(provider.getCount(), 2);
+
+        assertEquals(provider.getPreDestroyCalled(), 0);
+
+        Foo foo1 = inj.getInstance(Foo.class);
+        assertEquals(foo1.getInjectCalled(), 1);
+        assertEquals(foo1.getPostConstructCalled(), 2);
+        assertEquals(foo1.getCount(), 2);
+
+        assertEquals(foo1.getPreDestroyCalled(), 0);
+
+        Foo foo2 = inj.getInstance(Foo.class);
+
+        assertNotSame(foo2, foo1);
+
+        assertEquals(foo2.getInjectCalled(), 1);
+        assertEquals(foo2.getPostConstructCalled(), 2);
+        assertEquals(foo2.getCount(), 2);
+
+        assertEquals(foo2.getPreDestroyCalled(), 0);
+
+        manager.stop();
+
+        assertEquals(provider.getPreDestroyCalled(), 3);
+        assertEquals(provider.getCount(), 3);
+
+        assertEquals(foo1.getPreDestroyCalled(), 3);
+        assertEquals(foo1.getCount(), 3);
+
+        assertEquals(foo2.getPreDestroyCalled(), 3);
+        assertEquals(foo2.getCount(), 3);
+    }
+
+    @Test
+    public void testWrapInjectingProviderSingleton()
+        throws Exception
+    {
+        Injector inj = new Bootstrap(new Module() {
+            @Override
+            public void configure(Binder binder)
+            {
+                LifecycledBindingBuilder.lifecycleBinding(binder, Foo.class).toProvider(InjectingFooProvider.class).in(Scopes.SINGLETON);
+                binder.bind(InjectingFooProvider.class).in(Scopes.SINGLETON);
+            }
+        })
+            .doNotInitializeLogging()
+            .strictConfig()
+            .initialize();
+
+        inj.injectMembers(this);
+
+        InjectingFooProvider provider = inj.getInstance(InjectingFooProvider.class);
+
+        assertEquals(provider.getInjectCalled(), 1);
+        assertEquals(provider.getPostConstructCalled(), 2);
+        assertEquals(provider.getCount(), 2);
+
+        assertEquals(provider.getPreDestroyCalled(), 0);
+
+        Foo foo1 = inj.getInstance(Foo.class);
+        assertEquals(foo1.getInjectCalled(), 1);
+        assertEquals(foo1.getPostConstructCalled(), 2);
+        assertEquals(foo1.getCount(), 2);
+
+        assertEquals(foo1.getPreDestroyCalled(), 0);
+
+        Foo foo2 = inj.getInstance(Foo.class);
+
+        assertSame(foo2, foo1);
+
+        manager.stop();
+
+        assertEquals(provider.getPreDestroyCalled(), 3);
+        assertEquals(provider.getCount(), 3);
+
+        assertEquals(foo1.getPreDestroyCalled(), 3);
+        assertEquals(foo1.getCount(), 3);
+    }
+
+    private static class NonInjectingFooProvider
+        extends AbstractLifeCycleChecker
+        implements Provider<Foo>
+    {
+        public Foo get()
+        {
+            return new Foo();
+        }
+    }
+
+    private static class InjectingFooProvider
+        extends AbstractLifeCycleChecker
+        implements Provider<Foo>
+    {
+        private Injector injector;
+
+        @Inject
+        void setInject(Injector injector)
+        {
+            this.injector = injector;
+        }
+
+        public Foo get()
+        {
+            Foo foo = new Foo();
+            Assert.assertNotNull(injector);
+            injector.injectMembers(foo);
+            return foo;
+        }
+    }
+
+    private static class Foo extends AbstractLifeCycleChecker
+    {
+    }
+}

--- a/http-client/pom.xml
+++ b/http-client/pom.xml
@@ -22,6 +22,11 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>bootstrap</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>concurrent</artifactId>
         </dependency>
 

--- a/http-client/src/test/java/io/airlift/http/client/ForTest.java
+++ b/http-client/src/test/java/io/airlift/http/client/ForTest.java
@@ -1,0 +1,17 @@
+package io.airlift.http.client;
+
+import javax.inject.Qualifier;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@Qualifier
+public @interface ForTest
+{}

--- a/http-client/src/test/java/io/airlift/http/client/TestHttpClientModule.java
+++ b/http-client/src/test/java/io/airlift/http/client/TestHttpClientModule.java
@@ -1,0 +1,138 @@
+package io.airlift.http.client;
+
+import com.google.inject.Binder;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+
+import io.airlift.bootstrap.Bootstrap;
+import io.airlift.bootstrap.LifeCycleManager;
+import io.airlift.http.client.AbstractHttpClientTest.ResponseStatusCodeHandler;
+
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.HandlerCollection;
+import org.eclipse.jetty.server.nio.SelectChannelConnector;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.URI;
+
+import static io.airlift.http.client.Request.Builder.prepareGet;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+public class TestHttpClientModule
+{
+    @Inject
+    @ForTest
+    private HttpClient httpClient;
+
+    @Inject
+    private LifeCycleManager manager;
+
+    protected EchoServlet servlet;
+    protected Server server;
+    protected URI baseURI;
+    private String scheme = "http";
+    private String host = "127.0.0.1";
+
+    @BeforeMethod
+    public void setUp()
+        throws Exception
+    {
+        servlet = new EchoServlet();
+
+        int port;
+        try (ServerSocket socket = new ServerSocket()) {
+            socket.bind(new InetSocketAddress(0));
+            port = socket.getLocalPort();
+        }
+        baseURI = new URI(scheme, null, host, port, null, null, null);
+
+        Server server = new Server();
+        server.setSendServerVersion(false);
+
+        SelectChannelConnector httpConnector = new SelectChannelConnector();
+
+        httpConnector.setName(scheme);
+        httpConnector.setPort(port);
+        server.addConnector(httpConnector);
+
+        ServletHolder servletHolder = new ServletHolder(servlet);
+        ServletContextHandler context = new ServletContextHandler(ServletContextHandler.NO_SESSIONS);
+        context.addServlet(servletHolder, "/*");
+        HandlerCollection handlers = new HandlerCollection();
+        handlers.addHandler(context);
+        server.setHandler(handlers);
+
+        this.server = server;
+        server.start();
+    }
+
+    @AfterMethod
+    public void tearDown()
+        throws Exception
+    {
+        assertNotNull(server);
+        assertNotNull(manager);
+
+        server.stop();
+        manager.stop();
+    }
+
+    @Test
+    public void TestSyncHttpClient()
+        throws Exception
+    {
+        doTest(new Module()
+        {
+            @Override
+            public void configure(Binder binder)
+            {
+                HttpClientBinder.httpClientBinder(binder).bindHttpClient("test", ForTest.class);
+            }
+        });
+    }
+
+    @Test
+    public void TestAsyncHttpClient()
+        throws Exception
+    {
+        doTest(new Module()
+        {
+            @Override
+            public void configure(Binder binder)
+            {
+                HttpClientBinder.httpClientBinder(binder).bindAsyncHttpClient("test", ForTest.class);
+            }
+        });
+    }
+
+    private void doTest(Module module)
+        throws Exception
+    {
+        Injector injector = new Bootstrap(module)
+            .doNotInitializeLogging()
+            .strictConfig()
+            .initialize();
+
+        injector.injectMembers(this);
+
+        URI uri = baseURI.resolve("/road/to/nowhere?query");
+        Request request = prepareGet()
+            .setUri(uri)
+            .addHeader("foo", "bar")
+            .addHeader("dupe", "first")
+            .addHeader("dupe", "second")
+            .build();
+
+        int statusCode = httpClient.execute(request, new ResponseStatusCodeHandler());
+        assertEquals(statusCode, 200);
+    }
+}


### PR DESCRIPTION
This allows objects returned from arbitrary providers to participate in the lifecycle
and have their @PostConstruct and @PreDestroy methods called.

Also fixes a couple of issues in the LifeCycleManager where @PostConstruct and @PreDestroy
methods were called multiple times.
