### PR TITLE
Add support for clean import into Eclipse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,10 @@ test-output/
 .idea
 .*.swp
 .*.swo
+target/        
+# Eclipse                                                                                                                                 
+.project                                                                                                                                        
+.classpath                                                                                                                                      
+.settings/
+.pmdruleset.xml
+.pmd

--- a/pom.xml
+++ b/pom.xml
@@ -296,6 +296,31 @@
                         <releaseProfiles>oss-release,airlift-release</releaseProfiles>
                     </configuration>
                 </plugin>
+                <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+                <plugin>
+                  <groupId>org.eclipse.m2e</groupId>
+                  <artifactId>lifecycle-mapping</artifactId>
+                  <version>1.0.0</version>
+                  <configuration>
+                    <lifecycleMappingMetadata>
+                      <pluginExecutions>
+                        <pluginExecution>
+                          <pluginExecutionFilter>
+                            <groupId>org.jacoco</groupId>
+                            <artifactId>jacoco-maven-plugin</artifactId>
+                            <versionRange>[0.6.2.201302030002,)</versionRange>
+                            <goals>
+                              <goal>prepare-agent</goal>
+                            </goals>
+                          </pluginExecutionFilter>
+                          <action>
+                            <ignore></ignore>
+                          </action>
+                        </pluginExecution>
+                      </pluginExecutions>
+                    </lifecycleMappingMetadata>
+                  </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
- changes to the root POM for jacoco that allows a clean import into Eclipse using m2e
- add eclipse files to .gitignore
