### PR TITLE
Update copyright holder to Airlift.IO

### DIFF
--- a/src/license/LICENSE-HEADER.txt
+++ b/src/license/LICENSE-HEADER.txt
@@ -1,5 +1,3 @@
-Copyright (C) ${inceptionYear} Airlift.IO
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at


### PR DESCRIPTION
Not sure "Airlift.IO" makes sense to go here...but I think it makes even less sense to leave it as Proofpoint.
