### PR TITLE
Check if fieldValue is null instead of fieldName in MBeanRepresentation

### DIFF
--- a/jmx-http/src/main/java/io/airlift/jmx/MBeanRepresentation.java
+++ b/jmx-http/src/main/java/io/airlift/jmx/MBeanRepresentation.java
@@ -323,7 +323,7 @@ public class MBeanRepresentation
         ImmutableMap.Builder<String, Object> builder = ImmutableMap.builder();
         for (String fieldName : descriptor.getFieldNames()) {
             Object fieldValue = descriptor.getFieldValue(fieldName);
-            if (fieldName != null) {
+            if (fieldValue != null) {
                 builder.put(fieldName, fieldValue);
             }
         }


### PR DESCRIPTION
Hi, I found this one with JDK8, there is a MBean called com.sun.management:type=DiagnosticCommand which has some null descriptor values, which is ok, but the check in the method wasn't (I think this was a typo).
