### PR TITLE
Convert values of type Descriptor to Map

### DIFF
--- a/jmx-http/src/main/java/io/airlift/jmx/MBeanRepresentation.java
+++ b/jmx-http/src/main/java/io/airlift/jmx/MBeanRepresentation.java
@@ -324,6 +324,9 @@ public class MBeanRepresentation
         for (String fieldName : descriptor.getFieldNames()) {
             Object fieldValue = descriptor.getFieldValue(fieldName);
             if (fieldValue != null) {
+                if (fieldValue instanceof Descriptor) {
+                    fieldValue = toMap((Descriptor) fieldValue);
+                }
                 builder.put(fieldName, fieldValue);
             }
         }


### PR DESCRIPTION
The current code breaks with java 8 due to an mbean that has a nested descriptor in one
of its operation descriptors.
