### PR TITLE
Remove explicit version for io.airlift:slice

### DIFF
--- a/stats/pom.xml
+++ b/stats/pom.xml
@@ -44,7 +44,6 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>slice</artifactId>
-            <version>0.5</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Airbase 20 now has a dependency definition for slice
