### PR TITLE
Do not include dependencies from zip files in lib dir

### DIFF
--- a/packaging/src/main/resources/assemblies/distribution.xml
+++ b/packaging/src/main/resources/assemblies/distribution.xml
@@ -43,9 +43,13 @@
             <useProjectArtifact>true</useProjectArtifact>
             <outputDirectory>/lib</outputDirectory>
             <outputFileNameMapping>${artifact.artifactId}-${artifact.baseVersion}${dashClassifier?}.${artifact.extension}</outputFileNameMapping>
+            <useTransitiveFiltering>true</useTransitiveFiltering>
             <includes>
                 <include>*:jar:*</include>
             </includes>
+            <excludes>
+                <exclude>*:zip:*</exclude>
+            </excludes>
         </dependencySet>
 
         <dependencySet>


### PR DESCRIPTION
Zip files are not code and should not be included in the lib dir of an assembly.  Also, transitive dependencies from zip files should not be considered.
