### PR TITLE
Fix unit test compilation error with the eclipse compiler using Java 7.

### DIFF
--- a/units/src/test/java/io/airlift/units/TestDurationValidator.java
+++ b/units/src/test/java/io/airlift/units/TestDurationValidator.java
@@ -26,6 +26,7 @@ import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
 import javax.validation.ValidationException;
 import javax.validation.Validator;
+import javax.validation.metadata.ConstraintDescriptor;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -105,6 +106,7 @@ public class TestDurationValidator
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testFailsMaxDurationConstraint()
     {
         ConstrainedDuration object = new ConstrainedDuration(new Duration(11, TimeUnit.SECONDS));
@@ -112,11 +114,12 @@ public class TestDurationValidator
         assertEquals(violations.size(), 2);
 
         for (ConstraintViolation<ConstrainedDuration> violation : violations) {
-            Assertions.assertInstanceOf(violation.getConstraintDescriptor().getAnnotation(), MaxDuration.class);
+            Assertions.assertInstanceOf(((ConstraintDescriptor<MaxDuration>) violation.getConstraintDescriptor()).getAnnotation(), MaxDuration.class);
         }
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testFailsMinDurationConstraint()
     {
         ConstrainedDuration object = new ConstrainedDuration(new Duration(1, TimeUnit.SECONDS));
@@ -124,7 +127,7 @@ public class TestDurationValidator
         assertEquals(violations.size(), 2);
 
         for (ConstraintViolation<ConstrainedDuration> violation : violations) {
-            Assertions.assertInstanceOf(violation.getConstraintDescriptor().getAnnotation(), MinDuration.class);
+            Assertions.assertInstanceOf(((ConstraintDescriptor<MinDuration>) violation.getConstraintDescriptor()).getAnnotation(), MinDuration.class);
         }
     }
 


### PR DESCRIPTION
The eclipse compiler refuses to compile

```
Assertions.assertInstanceOf(violation.getConstraintDescriptor().getAnnotation(), MinDuration.class);
```

with

```
Bound mismatch: The generic method assertInstanceOf(T, Class<U>) of type Assertions is not applicable for the arguments (capture#2-of ?, Class<MinDuration>). The inferred type MinDuration is not a valid substitute for the bounded parameter <U extends T>.
```

The additional cast fixes this compile problem. The problem does not exist when Eclipse is set to Java 8 compilance.
