### PR TITLE
Allow external tools to suspend Discovery Announcer through JMX to detach corrupted or shutting down service providers

### DIFF
--- a/discovery/src/main/java/io/airlift/discovery/client/Announcer.java
+++ b/discovery/src/main/java/io/airlift/discovery/client/Announcer.java
@@ -39,6 +39,8 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.RejectedExecutionException;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
@@ -51,9 +53,9 @@ public class Announcer
     private final ConcurrentMap<UUID, ServiceAnnouncement> announcements = new MapMaker().makeMap();
 
     private final DiscoveryAnnouncementClient announcementClient;
-    private final ScheduledExecutorService executor;
-    private final AtomicBoolean started = new AtomicBoolean(false);
-    private final AtomicBoolean suspended = new AtomicBoolean(false);
+
+    private volatile boolean destroyed = false;
+    private volatile ScheduledExecutorService executor = null;
 
     private final ExponentialBackOff errorBackOff = new ExponentialBackOff(
             new Duration(1, MILLISECONDS),
@@ -72,40 +74,28 @@ public class Announcer
         for (ServiceAnnouncement serviceAnnouncement : serviceAnnouncements) {
             addServiceAnnouncement(serviceAnnouncement);
         }
-        executor = new ScheduledThreadPoolExecutor(5, daemonThreadsNamed("Announcer-%s"));
     }
 
     public void start()
     {
-        Preconditions.checkState(!executor.isShutdown(), "Announcer has been destroyed");
-        if (started.compareAndSet(false, true)) {
-            // announce immediately, if discovery is running
-            try {
-                announce().get(30, TimeUnit.SECONDS);
+        ListenableFuture<Duration> future = resume();
+        try {
+            if (future != null) {
+                future.get(30, TimeUnit.SECONDS);
             }
-            catch (Exception ignored) {
-            }
+        }
+        catch (Exception ignored) {
         }
     }
 
     @PreDestroy
     public void destroy()
     {
-        executor.shutdownNow();
         try {
-            executor.awaitTermination(30, TimeUnit.SECONDS);
-        }
-        catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
-
-        // unannounce
-        if (suspended.get()) {
-            return;
-        }
-
-        try {
-            getFutureResult(announcementClient.unannounce(), DiscoveryException.class);
+            ListenableFuture<Void> future = suspend(false);
+            if (future != null) {
+                getFutureResult(future, DiscoveryException.class);
+            }
         }
         catch (DiscoveryException e) {
             if (e.getCause() instanceof ConnectException) {
@@ -117,24 +107,56 @@ public class Announcer
         }
     }
 
-    @Managed
-    public boolean getSuspendAnnouncing()
+    private synchronized ListenableFuture<Duration> resume()
     {
-        return suspended.get();
+        Preconditions.checkState(!destroyed, "Announcer has been destroyed");
+
+        if (executor == null) {
+            executor = new ScheduledThreadPoolExecutor(5, daemonThreadsNamed("Announcer-%s"));
+
+            // announce immediately, if discovery is running
+            return announce(executor);
+
+        } else {
+            return null;
+        }
+    }
+
+    private synchronized ListenableFuture<Void> suspend(boolean allowResuming)
+    {
+        if (!allowResuming) {
+            destroyed = true;
+        }
+
+        if (executor != null) {
+            executor.shutdownNow();
+            ScheduledExecutorService shutdownInProgress = executor;
+            executor = null;
+
+            try {
+                shutdownInProgress.awaitTermination(30, TimeUnit.SECONDS);
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+
+            return announcementClient.unannounce();
+
+        } else {
+            return null;
+        }
     }
 
     @Managed
-    public void setSuspendAnnouncing(boolean suspend)
+    public boolean suspendAnnoucing()
     {
-        if (suspend) {
-            if (!suspended.getAndSet(true)) {
-                announcementClient.unannounce();
-            }
-        } else {
-            if (suspended.getAndSet(false)) {
-                announcementClient.announce(getServiceAnnouncements());
-            }
-        }
+        return suspend(true) != null;
+    }
+
+    @Managed
+    public boolean resumeAnnoucing()
+    {
+        return resume() != null;
     }
 
     public void addServiceAnnouncement(ServiceAnnouncement serviceAnnouncement)
@@ -153,7 +175,7 @@ public class Announcer
         return ImmutableSet.copyOf(announcements.values());
     }
 
-    private ListenableFuture<Duration> announce()
+    private ListenableFuture<Duration> announce(final ScheduledExecutorService executor)
     {
         ListenableFuture<Duration> future = announcementClient.announce(getServiceAnnouncements());
 
@@ -166,21 +188,21 @@ public class Announcer
 
                 // wait 80% of the suggested delay
                 duration = new Duration(duration.toMillis() * 0.8, MILLISECONDS);
-                scheduleNextAnnouncement(duration);
+                scheduleNextAnnouncement(executor, duration);
             }
 
             @Override
             public void onFailure(Throwable t)
             {
                 Duration duration = errorBackOff.failed(t);
-                scheduleNextAnnouncement(duration);
+                scheduleNextAnnouncement(executor, duration);
             }
         }, executor);
 
         return future;
     }
 
-    private void scheduleNextAnnouncement(Duration delay)
+    private void scheduleNextAnnouncement(final ScheduledExecutorService executor, Duration delay)
     {
         // already stopped?  avoids rejection exception
         if (executor.isShutdown()) {
@@ -191,9 +213,7 @@ public class Announcer
             @Override
             public void run()
             {
-                if (!suspended.get()) {
-                    announce();
-                }
+                announce(executor);
             }
         }, delay.toMillis(), MILLISECONDS);
     }

--- a/discovery/src/main/java/io/airlift/discovery/client/DiscoveryModule.java
+++ b/discovery/src/main/java/io/airlift/discovery/client/DiscoveryModule.java
@@ -80,6 +80,7 @@ public class DiscoveryModule
         binder.bind(ServiceSelectorManager.class).in(Scopes.SINGLETON);
 
         newExporter(binder).export(ServiceInventory.class).withGeneratedName();
+        newExporter(binder).export(Announcer.class).withGeneratedName();
     }
 
     @SuppressWarnings("deprecation")

--- a/discovery/src/test/java/io/airlift/discovery/client/TestAnnouncer.java
+++ b/discovery/src/test/java/io/airlift/discovery/client/TestAnnouncer.java
@@ -33,6 +33,7 @@ import java.util.concurrent.TimeUnit;
 import static io.airlift.discovery.client.ServiceTypes.serviceType;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 public class TestAnnouncer
@@ -153,12 +154,12 @@ public class TestAnnouncer
         Thread.sleep(100);
         assertAnnounced(serviceAnnouncement);
 
-        announcer.setSuspendAnnouncing(true);
+        assertTrue(announcer.suspendAnnoucing());
 
         Thread.sleep(100);
         assertAnnounced();
 
-        announcer.setSuspendAnnouncing(false);
+        assertTrue(announcer.resumeAnnoucing());
 
         Thread.sleep(100);
         assertAnnounced(serviceAnnouncement);

--- a/discovery/src/test/java/io/airlift/discovery/client/TestAnnouncer.java
+++ b/discovery/src/test/java/io/airlift/discovery/client/TestAnnouncer.java
@@ -144,6 +144,26 @@ public class TestAnnouncer
         assertAnnounced();
     }
 
+    @Test
+    public void testSuspendAndResume()
+        throws Exception
+    {
+        announcer.start();
+
+        Thread.sleep(100);
+        assertAnnounced(serviceAnnouncement);
+
+        announcer.setSuspendAnnouncing(true);
+
+        Thread.sleep(100);
+        assertAnnounced();
+
+        announcer.setSuspendAnnouncing(false);
+
+        Thread.sleep(100);
+        assertAnnounced(serviceAnnouncement);
+    }
+
     private void assertAnnounced(ServiceAnnouncement... serviceAnnouncements)
     {
         ServiceDescriptors serviceDescriptors = discoveryClient.getServices(serviceType.value(), "pool").checkedGet();


### PR DESCRIPTION
We're using Presto and airlift.discovery. If we restart a presto-worker (discovery service provider) process, tasks running on the provider fail. To prevent this problem, we need to re-create the entire cluster.
This patch allows us to detach a service provider (presto-worker) so that service users (presto-coordinator) don't send new tasks to the provider any more. Once all existent tasks complete, we can restart the service provider safely.

Automation tool of the graceful shutdown process works as following (pseudo code):

```
jmx = JMX::MBean.create_connection host: "localhost", port: 3000
jmx.find_by_name("io.airlift.discovery.client:name=Announcer").setSuspendAnnouncing(true)
taskManager = jmx.find_by_name("com.facebook.presto.execution:name=TaskManager")
while taskManager.TaskManagementExecutor.QueuedTaskCount > 0 do
    sleep 1
end
Process.kill :TERM, pid
```

Although this change itself is incomplete for graceful restart, I think having suspending functionality at Announcer is a first step.
