### PR TITLE
Remove AsyncHttpClient references from the http-client README

### DIFF
--- a/http-client/README.md
+++ b/http-client/README.md
@@ -1,4 +1,4 @@
-You can create an `HttpClient` or `AsyncHttpClient` using the `HttpClientBinder` and have it injected into your code using Guice. First, create an annotation for your client:
+You can create an `HttpClient` using the `HttpClientBinder` and have it injected into your code using Guice. First, create an annotation for your client:
 
     @Retention(RUNTIME)
     @Target({FIELD, PARAMETER, METHOD})
@@ -18,7 +18,7 @@ Finally, use the annotation to have the `HttpClient` injected into your code:
         ...
     }
 
-The reason to use different client bindings for each service is to allow them to be configured individually.  In the example above, the string `"foo"` passed to `bindHttpClient` specifies the prefix for the configuration. This means that you can configure the connect timeout via the config property named `foo.http-client.connect-timeout`. The config classes are `HttpClientConfig` and `AsyncHttpClientConfig`. The `AsyncHttpClient` uses both config classes. See the config classes for the full list of configurable properties.
+The reason to use different client bindings for each service is to allow them to be configured individually.  In the example above, the string `"foo"` passed to `bindHttpClient` specifies the prefix for the configuration. This means that you can configure the connect timeout via the config property named `foo.http-client.connect-timeout`. The config class is `HttpClientConfig`. See the config class for the full list of configurable properties.
 
 The client supports modifying requests via a user specified set of filters. These filters are added using the binder:
 
@@ -38,8 +38,4 @@ Using aliases is similar to using filters:
         .withAlias(BarClient.class)
         .withAlias(QuxClient.class);
 
-Allow of the examples above are for `HttpClient`. Binding an `AsyncHttpClient` is almost identical:
-
-    httpClientBinder(binder).bindAsyncHttpClient("foo", FooClient.class)
-
-You can use the same annotation for binding both an `HttpClient` and `AsyncHttpClient`. Note that the filters and aliases are unique to the binding, allowing you to have a different set for each one.
+Note that the filters and aliases are unique to the binding, allowing you to have a different set for each one.


### PR DESCRIPTION
Remove AsyncHttpClient references from the http-client README
