### PR TITLE
Always remove gzip handler from Jetty client

### DIFF
--- a/http-client/src/test/java/io/airlift/http/client/AbstractHttpClientTest.java
+++ b/http-client/src/test/java/io/airlift/http/client/AbstractHttpClientTest.java
@@ -608,6 +608,19 @@ public abstract class AbstractHttpClientTest
         executeRequest(request, new UnexpectedResponseStatusCodeHandler(200));
     }
 
+    @Test
+    public void testCompressionIsDisabled()
+            throws Exception
+    {
+        Request request = prepareGet()
+                .setUri(baseURI)
+                .build();
+
+        String body = executeRequest(request, new ResponseToStringHandler());
+        Assert.assertEquals(body, "");
+        Assert.assertFalse(servlet.requestHeaders.containsKey("Accept-Encoding"));
+    }
+
     private ExecutorService executor;
 
     @BeforeClass


### PR DESCRIPTION
There was a rarely used second constructor that did not disable it.
This change unifies the constructors and adds an integration test.
