### PR TITLE
Add convenience method durationSince to Duration

### DIFF
--- a/units/src/main/java/io/airlift/units/Duration.java
+++ b/units/src/main/java/io/airlift/units/Duration.java
@@ -46,6 +46,11 @@ public final class Duration implements Comparable<Duration>
         return new Duration(millis, MILLISECONDS);
     }
 
+    public static Duration durationSince(long start)
+    {
+        return nanosSince(start).convertToMostSuccinctTimeUnit();
+    }
+
     private final double value;
     private final TimeUnit unit;
 


### PR DESCRIPTION
This method is useful for logging:

``` java
    long start = System.nanoTime();
    ...
    log.info("Did something in %s", durationSince(start));
```
