### PR TITLE
Make nanosSince() convert to most succinct unit

### DIFF
--- a/units/src/main/java/io/airlift/units/Duration.java
+++ b/units/src/main/java/io/airlift/units/Duration.java
@@ -43,7 +43,7 @@ public final class Duration implements Comparable<Duration>
 
         long value = end - start;
         double millis = value * millisPerTimeUnit(NANOSECONDS);
-        return new Duration(millis, MILLISECONDS);
+        return new Duration(millis, MILLISECONDS).convertToMostSuccinctTimeUnit();
     }
 
     private final double value;


### PR DESCRIPTION
This method is often used for timing purposes in log messages, and is already in milliseconds (despite the name), so converting to the most succinct unit will eliminate a lot of boilerplate in callers.
