### PR TITLE
Save error response body in FullJsonResponseHandler

### DIFF
--- a/http-client/src/main/java/io/airlift/http/client/FullJsonResponseHandler.java
+++ b/http-client/src/main/java/io/airlift/http/client/FullJsonResponseHandler.java
@@ -56,16 +56,21 @@ public class FullJsonResponseHandler<T>
     @Override
     public JsonResponse<T> handle(Request request, Response response)
     {
+        byte[] bytes = readResponseBytes(response);
         String contentType = response.getHeader(CONTENT_TYPE);
         if ((contentType == null) || !MediaType.parse(contentType).is(MEDIA_TYPE_JSON)) {
-            return new JsonResponse<>(response.getStatusCode(), response.getStatusMessage(), response.getHeaders());
+            return new JsonResponse<>(response.getStatusCode(), response.getStatusMessage(), response.getHeaders(), bytes);
         }
+        return new JsonResponse<>(response.getStatusCode(), response.getStatusMessage(), response.getHeaders(), jsonCodec, bytes);
+    }
+
+    private static byte[] readResponseBytes(Response response)
+    {
         try {
-            byte[] bytes = ByteStreams.toByteArray(response.getInputStream());
-            return new JsonResponse<>(response.getStatusCode(), response.getStatusMessage(), response.getHeaders(), jsonCodec, bytes);
+            return ByteStreams.toByteArray(response.getInputStream());
         }
         catch (IOException e) {
-            throw new RuntimeException("Error reading JSON response from server", e);
+            throw new RuntimeException("Error reading response from server", e);
         }
     }
 
@@ -76,10 +81,11 @@ public class FullJsonResponseHandler<T>
         private final ListMultimap<String, String> headers;
         private final boolean hasValue;
         private final byte[] jsonBytes;
+        private final byte[] nonJsonBytes;
         private final T value;
         private final IllegalArgumentException exception;
 
-        public JsonResponse(int statusCode, String statusMessage, ListMultimap<String, String> headers)
+        public JsonResponse(int statusCode, String statusMessage, ListMultimap<String, String> headers, byte[] nonJsonBytes)
         {
             this.statusCode = statusCode;
             this.statusMessage = statusMessage;
@@ -87,6 +93,7 @@ public class FullJsonResponseHandler<T>
 
             this.hasValue = false;
             this.jsonBytes = null;
+            this.nonJsonBytes = nonJsonBytes;
             this.value = null;
             this.exception = null;
         }
@@ -99,6 +106,7 @@ public class FullJsonResponseHandler<T>
             this.headers = ImmutableListMultimap.copyOf(headers);
 
             this.jsonBytes = jsonBytes;
+            this.nonJsonBytes = null;
 
             T value = null;
             IllegalArgumentException exception = null;
@@ -163,6 +171,11 @@ public class FullJsonResponseHandler<T>
         public IllegalArgumentException getException()
         {
             return exception;
+        }
+
+        public byte[] getNonJsonBytes()
+        {
+            return (nonJsonBytes == null) ? null : nonJsonBytes.clone();
         }
 
         @Override

--- a/http-client/src/test/java/io/airlift/http/client/TestFullJsonResponseHandler.java
+++ b/http-client/src/test/java/io/airlift/http/client/TestFullJsonResponseHandler.java
@@ -51,6 +51,7 @@ public class TestFullJsonResponseHandler
 
         assertNotSame(response.getJson(), response.getJson());
         assertNotSame(response.getJsonBytes(), response.getJsonBytes());
+        assertNull(response.getNonJsonBytes());
     }
 
     @Test
@@ -64,6 +65,8 @@ public class TestFullJsonResponseHandler
                 "Unable to create " + User.class + " from JSON response:\n" + json);
         assertTrue(response.getException().getCause() instanceof IllegalArgumentException);
         assertEquals(response.getException().getCause().getMessage(), "Invalid [simple type, class io.airlift.http.client.TestFullJsonResponseHandler$User] json bytes");
+        assertEquals(response.getJsonBytes(), json.getBytes(UTF_8));
+        assertNull(response.getNonJsonBytes());
     }
 
     @Test
@@ -79,6 +82,8 @@ public class TestFullJsonResponseHandler
         catch (IllegalStateException e) {
             assertEquals(e.getMessage(), "Response does not contain a JSON value");
             assertEquals(e.getCause(), response.getException());
+            assertEquals(response.getJsonBytes(), json.getBytes(UTF_8));
+            assertNull(response.getNonJsonBytes());
         }
     }
 
@@ -91,6 +96,7 @@ public class TestFullJsonResponseHandler
         assertNull(response.getException());
         assertNull(response.getJson());
         assertNull(response.getJsonBytes());
+        assertEquals(response.getNonJsonBytes(), "hello".getBytes(UTF_8));
     }
 
     @Test
@@ -103,6 +109,7 @@ public class TestFullJsonResponseHandler
         assertNull(response.getException());
         assertNull(response.getJson());
         assertNull(response.getJsonBytes());
+        assertEquals(response.getNonJsonBytes(), "hello".getBytes(UTF_8));
         assertTrue(response.getHeaders().isEmpty());
     }
 
@@ -115,6 +122,7 @@ public class TestFullJsonResponseHandler
         assertTrue(response.hasValue());
         assertEquals(response.getJson(), json);
         assertEquals(response.getJsonBytes(), json.getBytes(UTF_8));
+        assertNull(response.getNonJsonBytes());
         assertNull(response.getValue().getName());
         assertEquals(response.getValue().getAge(), 0);
     }


### PR DESCRIPTION
If the server returns a non-JSON media type (which is common when an
server error occurs), the bytes of the response are available via the
new getNonJsonBytes() method. This allows seeing the error response
from the server which contain valuable information.
