### PR TITLE
Improve response handling in FullJsonResponseHandler

### DIFF
--- a/http-client/src/test/java/io/airlift/http/client/TestFullJsonResponseHandler.java
+++ b/http-client/src/test/java/io/airlift/http/client/TestFullJsonResponseHandler.java
@@ -51,7 +51,11 @@ public class TestFullJsonResponseHandler
 
         assertNotSame(response.getJson(), response.getJson());
         assertNotSame(response.getJsonBytes(), response.getJsonBytes());
-        assertNull(response.getNonJsonBytes());
+        assertNotSame(response.getResponseBytes(), response.getResponseBytes());
+        assertNotSame(response.getResponseBody(), response.getResponseBody());
+
+        assertEquals(response.getResponseBytes(), response.getJsonBytes());
+        assertEquals(response.getResponseBody(), response.getJson());
     }
 
     @Test
@@ -65,8 +69,12 @@ public class TestFullJsonResponseHandler
                 "Unable to create " + User.class + " from JSON response:\n" + json);
         assertTrue(response.getException().getCause() instanceof IllegalArgumentException);
         assertEquals(response.getException().getCause().getMessage(), "Invalid [simple type, class io.airlift.http.client.TestFullJsonResponseHandler$User] json bytes");
+
         assertEquals(response.getJsonBytes(), json.getBytes(UTF_8));
-        assertNull(response.getNonJsonBytes());
+        assertEquals(response.getJson(), json);
+
+        assertEquals(response.getResponseBytes(), response.getJsonBytes());
+        assertEquals(response.getResponseBody(), response.getJson());
     }
 
     @Test
@@ -82,8 +90,12 @@ public class TestFullJsonResponseHandler
         catch (IllegalStateException e) {
             assertEquals(e.getMessage(), "Response does not contain a JSON value");
             assertEquals(e.getCause(), response.getException());
+
             assertEquals(response.getJsonBytes(), json.getBytes(UTF_8));
-            assertNull(response.getNonJsonBytes());
+            assertEquals(response.getJson(), json);
+
+            assertEquals(response.getResponseBytes(), response.getJsonBytes());
+            assertEquals(response.getResponseBody(), response.getJson());
         }
     }
 
@@ -96,7 +108,9 @@ public class TestFullJsonResponseHandler
         assertNull(response.getException());
         assertNull(response.getJson());
         assertNull(response.getJsonBytes());
-        assertEquals(response.getNonJsonBytes(), "hello".getBytes(UTF_8));
+
+        assertEquals(response.getResponseBytes(), "hello".getBytes(UTF_8));
+        assertEquals(response.getResponseBody(), "hello");
     }
 
     @Test
@@ -109,7 +123,10 @@ public class TestFullJsonResponseHandler
         assertNull(response.getException());
         assertNull(response.getJson());
         assertNull(response.getJsonBytes());
-        assertEquals(response.getNonJsonBytes(), "hello".getBytes(UTF_8));
+
+        assertEquals(response.getResponseBytes(), "hello".getBytes(UTF_8));
+        assertEquals(response.getResponseBody(), "hello");
+
         assertTrue(response.getHeaders().isEmpty());
     }
 
@@ -122,9 +139,11 @@ public class TestFullJsonResponseHandler
         assertTrue(response.hasValue());
         assertEquals(response.getJson(), json);
         assertEquals(response.getJsonBytes(), json.getBytes(UTF_8));
-        assertNull(response.getNonJsonBytes());
         assertNull(response.getValue().getName());
         assertEquals(response.getValue().getAge(), 0);
+
+        assertEquals(response.getResponseBytes(), response.getJsonBytes());
+        assertEquals(response.getResponseBody(), response.getJson());
     }
 
     public static class User


### PR DESCRIPTION
The class has two new methods, getResponseBytes() and getResponseBody()
for returning the content of the response body. These are useful for
handling error responses from the server. The latter returns the body
as a String using the character set of the response's content type.

The methods getJsonBytes() and getJson() now always return the same as the
newly added methods and are deprecated.
