### PR TITLE
Do not interrupt thread on async timeout

### DIFF
--- a/http-server/src/main/java/io/airlift/http/server/AsyncResponseHandler.java
+++ b/http-server/src/main/java/io/airlift/http/server/AsyncResponseHandler.java
@@ -81,7 +81,9 @@ public class AsyncResponseHandler
         ListenableFuture<?> futureResponse = futureResponseReference.get();
         if (futureResponse != null) {
             try {
-                futureResponse.cancel(true);
+                // Do not interrupt the future if it is running. Jersey uses
+                // the calling thread to write the response to the wire.
+                futureResponse.cancel(false);
             }
             catch (Exception ignored) {
             }


### PR DESCRIPTION
Jersey uses the thread that resumes the async response to write the
response to the wire. Interrupting that thread while the response
is being written causes a 500 error.
