### PR TITLE
Allow dynamic response generator for timeouts

### DIFF
--- a/http-server/src/main/java/io/airlift/http/server/AsyncResponseHandler.java
+++ b/http-server/src/main/java/io/airlift/http/server/AsyncResponseHandler.java
@@ -14,6 +14,8 @@
 package io.airlift.http.server;
 
 import com.google.common.annotations.Beta;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -22,7 +24,6 @@ import io.airlift.units.Duration;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.TimeoutHandler;
 import javax.ws.rs.core.Response;
-
 import java.lang.ref.WeakReference;
 import java.util.concurrent.Executor;
 
@@ -62,22 +63,17 @@ public class AsyncResponseHandler
 
     public AsyncResponseHandler withTimeout(Duration timeout, final Response timeoutResponse)
     {
-        return withTimeout(timeout, new ResponseGenerator() {
-            @Override
-            public Response getResponse() {
-                return timeoutResponse;
-            }
-        });
+        return withTimeout(timeout, Suppliers.ofInstance(timeoutResponse));
     }
 
-    public AsyncResponseHandler withTimeout(Duration timeout, final ResponseGenerator timeoutResponse)
+    public AsyncResponseHandler withTimeout(Duration timeout, final Supplier<Response> timeoutResponse)
     {
         asyncResponse.setTimeoutHandler(new TimeoutHandler()
         {
             @Override
             public void handleTimeout(AsyncResponse asyncResponse)
             {
-                asyncResponse.resume(timeoutResponse.getResponse());
+                asyncResponse.resume(timeoutResponse.get());
                 cancelFuture();
             }
         });


### PR DESCRIPTION
There are cases where we are supposed to respond back with custom
information in the response in the event of timeouts. On the other
hand we  don't want to construct the response object unless it's
actually required. This change allows us to defer response creation
until we know it is required.
