### PR TITLE
Make HyperLogLog.addHash public

### DIFF
--- a/stats/src/main/java/io/airlift/stats/cardinality/HyperLogLog.java
+++ b/stats/src/main/java/io/airlift/stats/cardinality/HyperLogLog.java
@@ -60,7 +60,12 @@ public class HyperLogLog
         addHash(Murmur3.hash64(value));
     }
 
-    private void addHash(long hash)
+    /**
+     * Adds a value that has already been hashed, to the set of values tracked by this HyperLogLog instance.
+     * @param hash The hash should be the 64 least significant bits of the murmur3_128 hash of the value.
+     * For example: io.airlift.slice.Murmur3.hash64(value).
+     */
+    public void addHash(long hash)
     {
         instance.insertHash(hash);
 


### PR DESCRIPTION
I need to add already hashed values to an existing HyperLogLog value in my proposed change to SetDigest (https://github.com/facebook/presto-facebook/pulls/hermanventer). Making addHash public would be just perfect for this scenario and it seems like a generally useful thing to do.
