### PR TITLE
Reduce HttpClient MaxRequestsQueuedPerDestination default

### DIFF
--- a/event/src/test/java/io/airlift/event/client/TestHttpEventClient.java
+++ b/event/src/test/java/io/airlift/event/client/TestHttpEventClient.java
@@ -129,7 +129,9 @@ public class TestHttpEventClient
     public void setup()
             throws Exception
     {
-        httpClient = new JettyHttpClient(new HttpClientConfig().setConnectTimeout(new Duration(10, SECONDS)));
+        httpClient = new JettyHttpClient(new HttpClientConfig()
+                .setConnectTimeout(new Duration(10, SECONDS))
+                .setMaxRequestsQueuedPerDestination(100));
 
         servlet = new DummyServlet();
         server = createServer(servlet);

--- a/http-client/src/main/java/io/airlift/http/client/HttpClientConfig.java
+++ b/http-client/src/main/java/io/airlift/http/client/HttpClientConfig.java
@@ -18,6 +18,7 @@ package io.airlift.http.client;
 import com.google.common.annotations.Beta;
 import com.google.common.net.HostAndPort;
 import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
 import io.airlift.units.DataSize;
 import io.airlift.units.DataSize.Unit;
 import io.airlift.units.Duration;
@@ -39,7 +40,7 @@ public class HttpClientConfig
     private Duration keepAliveInterval = null;
     private int maxConnections = 200;
     private int maxConnectionsPerServer = 20;
-    private int maxRequestsQueuedPerDestination = 1024;
+    private int maxRequestsQueuedPerDestination = 20;
     private DataSize maxContentLength = new DataSize(16, Unit.MEGABYTE);
     private HostAndPort socksProxy;
     private String keyStorePath = System.getProperty(JAVAX_NET_SSL_KEY_STORE);
@@ -86,12 +87,15 @@ public class HttpClientConfig
     }
 
     @Min(1)
+    @Deprecated
     public int getMaxConnections()
     {
         return maxConnections;
     }
 
     @Config("http-client.max-connections")
+    @ConfigDescription("unused")
+    @Deprecated
     public HttpClientConfig setMaxConnections(int maxConnections)
     {
         this.maxConnections = maxConnections;

--- a/http-client/src/test/java/io/airlift/http/client/TestHttpClientConfig.java
+++ b/http-client/src/test/java/io/airlift/http/client/TestHttpClientConfig.java
@@ -23,6 +23,7 @@ import io.airlift.units.DataSize.Unit;
 import io.airlift.units.Duration;
 import org.testng.annotations.Test;
 
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import java.util.Map;
@@ -43,7 +44,7 @@ public class TestHttpClientConfig
                 .setKeepAliveInterval(null)
                 .setMaxConnections(200)
                 .setMaxConnectionsPerServer(20)
-                .setMaxRequestsQueuedPerDestination(1024)
+                .setMaxRequestsQueuedPerDestination(20)
                 .setMaxContentLength(new DataSize(16, Unit.MEGABYTE))
                 .setSocksProxy(null)
                 .setKeyStorePath(System.getProperty(JAVAX_NET_SSL_KEY_STORE))
@@ -86,5 +87,9 @@ public class TestHttpClientConfig
     {
         assertFailsValidation(new HttpClientConfig().setConnectTimeout(null), "connectTimeout", "may not be null", NotNull.class);
         assertFailsValidation(new HttpClientConfig().setReadTimeout(null), "readTimeout", "may not be null", NotNull.class);
+        assertFailsValidation(new HttpClientConfig().setMaxConnections(0), "maxConnections", "must be greater than or equal to 1", Min.class);
+        assertFailsValidation(new HttpClientConfig().setMaxConnectionsPerServer(0), "maxConnectionsPerServer", "must be greater than or equal to 1", Min.class);
+        assertFailsValidation(new HttpClientConfig().setMaxRequestsQueuedPerDestination(0), "maxRequestsQueuedPerDestination", "must be greater than or equal to 1", Min.class);
+        assertFailsValidation(new HttpClientConfig().setMaxContentLength(null), "maxContentLength", "may not be null", NotNull.class);
     }
 }


### PR DESCRIPTION
Reduce HttpClient MaxRequestsQueuedPerDestination default

When a destination is hung, better for requests to fail over to another instance than queue for an hour or so.
