### PR TITLE
Interrupt the BodyGenerator thread when writes fail

### DIFF
--- a/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
@@ -42,6 +42,7 @@ import org.weakref.jmx.Managed;
 import javax.annotation.concurrent.GuardedBy;
 
 import java.io.ByteArrayInputStream;
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InterruptedIOException;
@@ -578,6 +579,7 @@ public class JettyHttpClient
 
         private final BodyGenerator bodyGenerator;
         private final Executor executor;
+        private final AtomicReference<Thread> bodyGeneratorThread = new AtomicReference<>();
 
         public BodyGeneratorContentProvider(BodyGenerator bodyGenerator, Executor executor)
         {
@@ -602,41 +604,26 @@ public class JettyHttpClient
                 @Override
                 public void run()
                 {
-                    BodyGeneratorOutputStream out = new BodyGeneratorOutputStream(chunks);
                     try {
-                        bodyGenerator.write(out);
-                        out.close();
+                        bodyGeneratorThread.set(Thread.currentThread());
+                        BodyGeneratorOutputStream out = new BodyGeneratorOutputStream(chunks);
+                        try {
+                            bodyGenerator.write(out);
+                            out.close();
+                        }
+                        catch (Exception e) {
+                            exception.set(e);
+                            chunks.clear();
+                            chunks.add(EXCEPTION);
+                        }
                     }
-                    catch (Exception e) {
-                        exception.set(e);
-                        chunks.add(EXCEPTION);
+                    finally {
+                        bodyGeneratorThread.set(null);
                     }
                 }
             });
 
-            return new AbstractIterator<ByteBuffer>()
-            {
-                @Override
-                protected ByteBuffer computeNext()
-                {
-                    ByteBuffer chunk;
-                    try {
-                        chunk = chunks.take();
-                    }
-                    catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
-                        throw new RuntimeException("Interrupted", e);
-                    }
-
-                    if (chunk == EXCEPTION) {
-                        throw Throwables.propagate(exception.get());
-                    }
-                    if (chunk == DONE) {
-                        return endOfData();
-                    }
-                    return chunk;
-                }
-            };
+            return new ChunksIterator(chunks, exception);
         }
 
         private final class BodyGeneratorOutputStream
@@ -685,6 +672,51 @@ public class JettyHttpClient
                 }
                 catch (InterruptedException e) {
                     throw new InterruptedIOException();
+                }
+            }
+        }
+
+        private class ChunksIterator extends AbstractIterator<ByteBuffer>
+                implements Closeable
+        {
+            private final BlockingQueue<ByteBuffer> chunks;
+            private final AtomicReference<Exception> exception;
+
+            ChunksIterator(BlockingQueue<ByteBuffer> chunks, AtomicReference<Exception> exception)
+            {
+                this.chunks = chunks;
+                this.exception = exception;
+            }
+
+            @Override
+            protected ByteBuffer computeNext()
+            {
+                ByteBuffer chunk;
+                try {
+                    chunk = chunks.take();
+                }
+                catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException("Interrupted", e);
+                }
+
+                if (chunk == EXCEPTION) {
+                    bodyGeneratorThread.set(null);
+                    throw Throwables.propagate(exception.get());
+                }
+                if (chunk == DONE) {
+                    bodyGeneratorThread.set(null);
+                    return endOfData();
+                }
+                return chunk;
+            }
+
+            @Override
+            public void close()
+            {
+                Thread thread = bodyGeneratorThread.get();
+                if (thread != null) {
+                    thread.interrupt();
                 }
             }
         }


### PR DESCRIPTION
We've been having outages where HttpClient stops making forward progress.

First, we see a bunch of EOFExceptions like:

```
java.io.EOFException: HttpConnectionOverHTTP@709941a1(l:/10.94.102.205:57021 <-> r:pulse-2107208448.us-east-1.elb.amazonaws.com/54.85.56.180:8080)
        at org.eclipse.jetty.client.http.HttpReceiverOverHTTP.earlyEOF(HttpReceiverOverHTTP.java:267) ~[jetty-client-9.2.6.v20141205.jar:9.2.6.v20141205]
        at org.eclipse.jetty.http.HttpParser.parseNext(HttpParser.java:1312) ~[jetty-http-9.2.6.v20141205.jar:9.2.6.v20141205]
        at org.eclipse.jetty.client.http.HttpReceiverOverHTTP.shutdown(HttpReceiverOverHTTP.java:170) ~[jetty-client-9.2.6.v20141205.jar:9.2.6.v20141205]
        at org.eclipse.jetty.client.http.HttpReceiverOverHTTP.readAndParse(HttpReceiverOverHTTP.java:117) ~[jetty-client-9.2.6.v20141205.jar:9.2.6.v20141205]
        at org.eclipse.jetty.client.http.HttpReceiverOverHTTP.process(HttpReceiverOverHTTP.java:70) ~[jetty-client-9.2.6.v20141205.jar:9.2.6.v20141205]
        at org.eclipse.jetty.client.http.HttpReceiverOverHTTP.receive(HttpReceiverOverHTTP.java:65) ~[jetty-client-9.2.6.v20141205.jar:9.2.6.v20141205]
        at org.eclipse.jetty.client.http.HttpChannelOverHTTP.receive(HttpChannelOverHTTP.java:75) ~[jetty-client-9.2.6.v20141205.jar:9.2.6.v20141205]
        at org.eclipse.jetty.client.http.HttpConnectionOverHTTP.onFillable(HttpConnectionOverHTTP.java:100) ~[jetty-client-9.2.6.v20141205.jar:9.2.6.v20141205]
        at org.eclipse.jetty.io.AbstractConnection$2.run(AbstractConnection.java:540) ~[jetty-io-9.2.6.v20141205.jar:9.2.6.v20141205]
        at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:626) ~[jetty-util-9.2.6.v20141205.jar:9.2.6.v20141205]
        at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:546) ~[jetty-util-9.2.6.v20141205.jar:9.2.6.v20141205]
        at java.lang.Thread.run(Thread.java:722) [na:1.7.0_17]
```

I have no idea what the underlying exception is, as Jetty only logs that at debug level.

Eventually the server hangs. There are ~150 threads blocked in either `JettyHttpClient$BodyGeneratorContentProvider$BodyGeneratorOutputStream.write` or `JettyHttpClient$BodyGeneratorContentProvider$BodyGeneratorOutputStream.close`, but nowhere near that number of open sockets.
