### PR TITLE
Add support for binding default values for any configuration class

### DIFF
--- a/configuration/pom.xml
+++ b/configuration/pom.xml
@@ -37,6 +37,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.inject.extensions</groupId>
+            <artifactId>guice-multibindings</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>cglib</groupId>
             <artifactId>cglib-nodep</artifactId>
         </dependency>

--- a/configuration/src/main/java/io/airlift/configuration/ConfigBinder.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigBinder.java
@@ -10,6 +10,7 @@ import com.google.inject.multibindings.Multibinder;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static java.util.Objects.requireNonNull;
 
 public class ConfigBinder
@@ -75,7 +76,7 @@ public class ConfigBinder
     private <T> void bindConfig(Key<T> key, Class<T> configClass, String prefix)
     {
         binder.bind(key).toProvider(new ConfigurationProvider<>(key, configClass, prefix));
-        getConfigDefaultsBinder(key);
+        createConfigDefaultsBinder(key);
     }
 
     public <T> void bindConfigDefaults(Class<T> configClass, ConfigDefaults<T> configDefaults)
@@ -106,10 +107,10 @@ public class ConfigBinder
 
     private <T> void bindConfigDefaults(Key<T> key, ConfigDefaults<T> configDefaults)
     {
-        getConfigDefaultsBinder(key).addBinding().toInstance(new ConfigDefaultsHolder<>(key, configDefaults));
+        createConfigDefaultsBinder(key).addBinding().toInstance(new ConfigDefaultsHolder<>(key, configDefaults));
     }
 
-    private <T> Multibinder<ConfigDefaultsHolder<T>> getConfigDefaultsBinder(Key<T> key)
+    private <T> Multibinder<ConfigDefaultsHolder<T>> createConfigDefaultsBinder(Key<T> key)
     {
         @SuppressWarnings("SerializableInnerClassWithNonSerializableOuterClass")
         Type type = new TypeToken<ConfigDefaultsHolder<T>>() {}
@@ -119,11 +120,11 @@ public class ConfigBinder
         TypeLiteral<ConfigDefaultsHolder<T>> typeLiteral = (TypeLiteral<ConfigDefaultsHolder<T>>) TypeLiteral.get(type);
 
         if (key.getAnnotation() == null) {
-            return Multibinder.newSetBinder(binder, typeLiteral);
+            return newSetBinder(binder, typeLiteral);
         }
         if (key.hasAttributes()) {
-            return Multibinder.newSetBinder(binder, typeLiteral, key.getAnnotation());
+            return newSetBinder(binder, typeLiteral, key.getAnnotation());
         }
-        return Multibinder.newSetBinder(binder, typeLiteral, key.getAnnotationType());
+        return newSetBinder(binder, typeLiteral, key.getAnnotationType());
     }
 }

--- a/configuration/src/main/java/io/airlift/configuration/ConfigBinder.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigBinder.java
@@ -1,0 +1,129 @@
+package io.airlift.configuration;
+
+import com.google.common.reflect.TypeParameter;
+import com.google.common.reflect.TypeToken;
+import com.google.inject.Binder;
+import com.google.inject.Key;
+import com.google.inject.TypeLiteral;
+import com.google.inject.multibindings.Multibinder;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import static java.util.Objects.requireNonNull;
+
+public class ConfigBinder
+{
+    public static ConfigBinder configBinder(Binder binder)
+    {
+        return new ConfigBinder(binder);
+    }
+
+    private final Binder binder;
+
+    private ConfigBinder(Binder binder)
+    {
+        this.binder = requireNonNull(binder, "binder is null");
+    }
+
+    public <T> void bindConfig(Class<T> configClass)
+    {
+        requireNonNull(configClass, "configClass is null");
+
+        bindConfig(Key.get(configClass), configClass, null);
+    }
+
+    public <T> void bindConfig(Class<T> configClass, Annotation annotation)
+    {
+        requireNonNull(configClass, "configClass is null");
+        requireNonNull(annotation, "annotation is null");
+
+        bindConfig(Key.get(configClass, annotation), configClass, null);
+    }
+
+    public <T> void bindConfig(Class<T> configClass, Class<? extends Annotation> annotation)
+    {
+        requireNonNull(configClass, "configClass is null");
+        requireNonNull(annotation, "annotation is null");
+
+        bindConfig(Key.get(configClass, annotation), configClass, null);
+    }
+
+    public <T> void bindConfig(Class<T> configClass, String prefix)
+    {
+        requireNonNull(configClass, "configClass is null");
+
+        bindConfig(Key.get(configClass), configClass, prefix);
+    }
+
+    public <T> void bindConfig(Class<T> configClass, Annotation annotation, String prefix)
+    {
+        requireNonNull(configClass, "configClass is null");
+        requireNonNull(annotation, "annotation is null");
+
+        bindConfig(Key.get(configClass, annotation), configClass, prefix);
+    }
+
+    public <T> void bindConfig(Class<T> configClass, Class<? extends Annotation> annotation, String prefix)
+    {
+        requireNonNull(configClass, "configClass is null");
+        requireNonNull(annotation, "annotation is null");
+
+        bindConfig(Key.get(configClass, annotation), configClass, prefix);
+    }
+
+    private <T> void bindConfig(Key<T> key, Class<T> configClass, String prefix)
+    {
+        binder.bind(key).toProvider(new ConfigurationProvider<>(key, configClass, prefix));
+        getConfigDefaultsBinder(key);
+    }
+
+    public <T> void bindConfigDefaults(Class<T> configClass, ConfigDefaults<T> configDefaults)
+    {
+        requireNonNull(configClass, "configClass is null");
+        requireNonNull(configDefaults, "configDefaults is null");
+
+        bindConfigDefaults(Key.get(configClass), configDefaults);
+    }
+
+    public <T> void bindConfigDefaults(Class<T> configClass, Annotation annotation, ConfigDefaults<T> configDefaults)
+    {
+        requireNonNull(configClass, "configClass is null");
+        requireNonNull(annotation, "annotation is null");
+        requireNonNull(configDefaults, "configDefaults is null");
+
+        bindConfigDefaults(Key.get(configClass, annotation), configDefaults);
+    }
+
+    public <T> void bindConfigDefaults(Class<T> configClass, Class<? extends Annotation> annotation, ConfigDefaults<T> configDefaults)
+    {
+        requireNonNull(configClass, "configClass is null");
+        requireNonNull(annotation, "annotation is null");
+        requireNonNull(configDefaults, "configDefaults is null");
+
+        bindConfigDefaults(Key.get(configClass, annotation), configDefaults);
+    }
+
+    private <T> void bindConfigDefaults(Key<T> key, ConfigDefaults<T> configDefaults)
+    {
+        getConfigDefaultsBinder(key).addBinding().toInstance(new ConfigDefaultsHolder<>(key, configDefaults));
+    }
+
+    private <T> Multibinder<ConfigDefaultsHolder<T>> getConfigDefaultsBinder(Key<T> key)
+    {
+        @SuppressWarnings("SerializableInnerClassWithNonSerializableOuterClass")
+        Type type = new TypeToken<ConfigDefaultsHolder<T>>() {}
+                .where(new TypeParameter<T>() {}, (TypeToken<T>) TypeToken.of(key.getTypeLiteral().getType()))
+                .getType();
+
+        TypeLiteral<ConfigDefaultsHolder<T>> typeLiteral = (TypeLiteral<ConfigDefaultsHolder<T>>) TypeLiteral.get(type);
+
+        if (key.getAnnotation() == null) {
+            return Multibinder.newSetBinder(binder, typeLiteral);
+        }
+        if (key.hasAttributes()) {
+            return Multibinder.newSetBinder(binder, typeLiteral, key.getAnnotation());
+        }
+        return Multibinder.newSetBinder(binder, typeLiteral, key.getAnnotationType());
+    }
+}

--- a/configuration/src/main/java/io/airlift/configuration/ConfigDefaults.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigDefaults.java
@@ -1,0 +1,26 @@
+package io.airlift.configuration;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+public interface ConfigDefaults<T>
+{
+    static <T> ConfigDefaults<T> noDefaults()
+    {
+        return config -> {
+        };
+    }
+
+    static <T> ConfigDefaults<T> configDefaults(List<? extends ConfigDefaults<T>> configDefaults)
+    {
+        List<ConfigDefaults<T>> finalConfigDefaults = ImmutableList.copyOf(configDefaults);
+        return config -> {
+            for (ConfigDefaults<T> configDefault : finalConfigDefaults) {
+                configDefault.setDefaults(config);
+            }
+        };
+    }
+
+    void setDefaults(T config);
+}

--- a/configuration/src/main/java/io/airlift/configuration/ConfigDefaultsHolder.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigDefaultsHolder.java
@@ -1,10 +1,12 @@
 package io.airlift.configuration;
 
-import com.google.common.base.MoreObjects;
 import com.google.inject.Key;
 
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
 
 class ConfigDefaultsHolder<T>
         implements Comparable<ConfigDefaultsHolder<T>>
@@ -13,12 +15,12 @@ class ConfigDefaultsHolder<T>
 
     private final Key<T> configKey;
     private final ConfigDefaults<T> configDefaults;
-    private final long priority = NEXT_PRIORITY.incrementAndGet();
+    private final long priority = NEXT_PRIORITY.getAndIncrement();
 
     ConfigDefaultsHolder(Key<T> configKey, ConfigDefaults<T> configDefaults)
     {
-        this.configKey = configKey;
-        this.configDefaults = configDefaults;
+        this.configKey = requireNonNull(configKey, "configKey is null");
+        this.configDefaults = requireNonNull(configDefaults, "configDefaults is null");
     }
 
     public Key<T> getConfigKey()
@@ -60,7 +62,7 @@ class ConfigDefaultsHolder<T>
     @Override
     public String toString()
     {
-        return MoreObjects.toStringHelper(this)
+        return toStringHelper(this)
                 .add("configKey", configKey)
                 .add("configDefaults", configDefaults)
                 .add("priority", priority)

--- a/configuration/src/main/java/io/airlift/configuration/ConfigDefaultsHolder.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigDefaultsHolder.java
@@ -1,0 +1,69 @@
+package io.airlift.configuration;
+
+import com.google.common.base.MoreObjects;
+import com.google.inject.Key;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
+
+class ConfigDefaultsHolder<T>
+        implements Comparable<ConfigDefaultsHolder<T>>
+{
+    private static final AtomicLong NEXT_PRIORITY = new AtomicLong();
+
+    private final Key<T> configKey;
+    private final ConfigDefaults<T> configDefaults;
+    private final long priority = NEXT_PRIORITY.incrementAndGet();
+
+    ConfigDefaultsHolder(Key<T> configKey, ConfigDefaults<T> configDefaults)
+    {
+        this.configKey = configKey;
+        this.configDefaults = configDefaults;
+    }
+
+    public Key<T> getConfigKey()
+    {
+        return configKey;
+    }
+
+    public ConfigDefaults<T> getConfigDefaults()
+    {
+        return configDefaults;
+    }
+
+    @Override
+    public int compareTo(ConfigDefaultsHolder<T> o)
+    {
+        return Long.compare(priority, o.priority);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(configDefaults, priority);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        ConfigDefaultsHolder<?> other = (ConfigDefaultsHolder<?>) obj;
+        return Objects.equals(this.configDefaults, other.configDefaults)
+                && Objects.equals(this.priority, other.priority);
+    }
+
+    @Override
+    public String toString()
+    {
+        return MoreObjects.toStringHelper(this)
+                .add("configKey", configKey)
+                .add("configDefaults", configDefaults)
+                .add("priority", priority)
+                .toString();
+    }
+}

--- a/configuration/src/main/java/io/airlift/configuration/ConfigurationAwareModule.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigurationAwareModule.java
@@ -19,7 +19,8 @@ import com.google.common.annotations.Beta;
 import com.google.inject.Module;
 
 @Beta
-public interface ConfigurationAwareModule extends Module
+public interface ConfigurationAwareModule
+        extends Module
 {
     void setConfigurationFactory(ConfigurationFactory configurationFactory);
 }

--- a/configuration/src/main/java/io/airlift/configuration/ConfigurationAwareProvider.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigurationAwareProvider.java
@@ -4,14 +4,15 @@ import com.google.inject.Provider;
 
 /**
  * A provider with access to the airlift {@link ConfigurationFactory}.
- *
+ * <p>
  * Implementing this interface ensures that the provider gets access to the
  * {@link ConfigurationFactory} and {@link WarningsMonitor} before the first
  * call to {@link Provider#get()}.
  *
  * @param <T> Element type that is returned by this provider.
  */
-public interface ConfigurationAwareProvider<T> extends Provider<T>
+public interface ConfigurationAwareProvider<T>
+        extends Provider<T>
 {
     /**
      * Called by the airlift framework before the first call to get.

--- a/configuration/src/main/java/io/airlift/configuration/ConfigurationFactory.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigurationFactory.java
@@ -79,7 +79,7 @@ public class ConfigurationFactory
         this(properties, Problems.NULL_MONITOR);
     }
 
-    ConfigurationFactory(Map<String, String> properties, final Problems.Monitor monitor)
+    ConfigurationFactory(Map<String, String> properties, Problems.Monitor monitor)
     {
         this.monitor = monitor;
         this.properties = ImmutableMap.copyOf(properties);
@@ -121,7 +121,7 @@ public class ConfigurationFactory
 
     public <T> T build(Class<T> configClass)
     {
-        return build(configClass, null).instance;
+        return build(configClass, null).getInstance();
     }
 
     /**
@@ -139,11 +139,11 @@ public class ConfigurationFactory
         }
 
         ConfigurationHolder<T> holder = build(configurationProvider.getConfigClass(), configurationProvider.getPrefix());
-        instance = holder.instance;
+        instance = holder.getInstance();
 
         // inform caller about warnings
         if (warningsMonitor != null) {
-            for (Message message : holder.problems.getWarnings()) {
+            for (Message message : holder.getProblems().getWarnings()) {
                 warningsMonitor.onWarning(message.toString());
             }
         }
@@ -415,16 +415,27 @@ public class ConfigurationFactory
             this.instance = instance;
             this.problems = problems;
         }
+
+        public T getInstance()
+        {
+            return instance;
+        }
+
+        public Problems getProblems()
+        {
+            return problems;
+        }
     }
 
-    private List<ConfigurationProvider<?>> getAllProviders(Module... modules)
+    private static List<ConfigurationProvider<?>> getAllProviders(Module... modules)
     {
-        final List<ConfigurationProvider<?>> providers = Lists.newArrayList();
+        List<ConfigurationProvider<?>> providers = Lists.newArrayList();
 
         ElementsIterator elementsIterator = new ElementsIterator(modules);
-        for (final Element element : elementsIterator) {
+        for (Element element : elementsIterator) {
             element.acceptVisitor(new DefaultElementVisitor<Void>()
             {
+                @Override
                 public <T> Void visit(Binding<T> binding)
                 {
                     // look for ConfigurationProviders...

--- a/configuration/src/main/java/io/airlift/configuration/ConfigurationInspector.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigurationInspector.java
@@ -67,7 +67,8 @@ public class ConfigurationInspector
         }
     }
 
-    public static class ConfigRecord<T> implements Comparable<ConfigRecord<?>>
+    public static class ConfigRecord<T>
+            implements Comparable<ConfigRecord<?>>
     {
         private final Key<T> key;
         private final Class<T> configClass;
@@ -76,7 +77,7 @@ public class ConfigurationInspector
 
         public static <T> ConfigRecord<T> createConfigRecord(ConfigurationProvider<T> configurationProvider)
         {
-            return new ConfigRecord<T>(configurationProvider);
+            return new ConfigRecord<>(configurationProvider);
         }
 
         private ConfigRecord(ConfigurationProvider<T> configurationProvider)
@@ -170,7 +171,8 @@ public class ConfigurationInspector
         }
     }
 
-    public static class ConfigAttribute implements Comparable<ConfigAttribute>
+    public static class ConfigAttribute
+            implements Comparable<ConfigAttribute>
     {
         private final String attributeName;
         private final String propertyName;

--- a/configuration/src/main/java/io/airlift/configuration/ConfigurationInspector.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigurationInspector.java
@@ -39,16 +39,6 @@ public class ConfigurationInspector
         return builder.build();
     }
 
-    private static <T> T newDefaultInstance(ConfigurationMetadata<T> configurationMetadata)
-    {
-        try {
-            return configurationMetadata.getConstructor().newInstance();
-        }
-        catch (Throwable ignored) {
-            return null;
-        }
-    }
-
     private static String getValue(Method getter, Object instance, String defaultValue)
     {
         if (getter == null || instance == null) {
@@ -90,6 +80,8 @@ public class ConfigurationInspector
 
             ConfigurationMetadata<T> metadata = configurationProvider.getConfigurationMetadata();
 
+            T defaults = configurationProvider.getDefaultConfig();
+
             T instance = null;
             try {
                 instance = configurationProvider.get();
@@ -98,7 +90,6 @@ public class ConfigurationInspector
                 // provider could blow up for any reason, which is fine for this code
                 // this is catch throwable because we may get an AssertionError
             }
-            T defaults = newDefaultInstance(metadata);
 
             String prefix = configurationProvider.getPrefix();
             prefix = prefix == null ? "" : (prefix + ".");

--- a/configuration/src/main/java/io/airlift/configuration/ConfigurationLoader.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigurationLoader.java
@@ -15,8 +15,6 @@
  */
 package io.airlift.configuration;
 
-import static com.google.common.collect.Maps.fromProperties;
-
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Maps;
 
@@ -26,6 +24,8 @@ import java.io.IOException;
 import java.io.Reader;
 import java.util.Map;
 import java.util.Properties;
+
+import static com.google.common.collect.Maps.fromProperties;
 
 public class ConfigurationLoader
 {
@@ -53,12 +53,9 @@ public class ConfigurationLoader
     public Map<String, String> loadPropertiesFrom(String path)
             throws IOException
     {
-        Reader reader = new FileReader(new File(path));
         Properties properties = new Properties();
-        try {
+        try (Reader reader = new FileReader(new File(path))) {
             properties.load(reader);
-        } finally {
-            reader.close();
         }
 
         return fromProperties(properties);

--- a/configuration/src/main/java/io/airlift/configuration/ConfigurationMetadata.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigurationMetadata.java
@@ -36,12 +36,14 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 
 public class ConfigurationMetadata<T>
 {
-    public static <T> ConfigurationMetadata<T> getValidConfigurationMetadata(Class<T> configClass) throws ConfigurationException
+    public static <T> ConfigurationMetadata<T> getValidConfigurationMetadata(Class<T> configClass)
+            throws ConfigurationException
     {
         return getValidConfigurationMetadata(configClass, Problems.NULL_MONITOR);
     }
 
-    static <T> ConfigurationMetadata<T> getValidConfigurationMetadata(Class<T> configClass, Problems.Monitor monitor) throws ConfigurationException
+    static <T> ConfigurationMetadata<T> getValidConfigurationMetadata(Class<T> configClass, Problems.Monitor monitor)
+            throws ConfigurationException
     {
         ConfigurationMetadata<T> metadata = getConfigurationMetadata(configClass, monitor);
         metadata.getProblems().throwIfHasErrors();
@@ -55,7 +57,7 @@ public class ConfigurationMetadata<T>
 
     static <T> ConfigurationMetadata<T> getConfigurationMetadata(Class<T> configClass, Problems.Monitor monitor)
     {
-        return new ConfigurationMetadata<T>(configClass, monitor);
+        return new ConfigurationMetadata<>(configClass, monitor);
     }
 
     private final Class<T> configClass;
@@ -82,7 +84,7 @@ public class ConfigurationMetadata<T>
 
         this.defunctConfig = Sets.newHashSet();
         if (configClass.isAnnotationPresent(DefunctConfig.class)) {
-            final DefunctConfig defunctConfig = configClass.getAnnotation(DefunctConfig.class);
+            DefunctConfig defunctConfig = configClass.getAnnotation(DefunctConfig.class);
             if (defunctConfig.value().length < 1) {
                 problems.addError("@DefunctConfig annotation on class [%s] is empty", configClass.getName());
             }
@@ -103,7 +105,8 @@ public class ConfigurationMetadata<T>
             if (!Modifier.isPublic(constructor.getModifiers())) {
                 problems.addError("Constructor [%s] is not public", constructor.toGenericString());
             }
-        } catch (Exception e) {
+        }
+        catch (Exception e) {
             problems.addError("Configuration class [%s] does not have a public no-arg constructor", configClass.getName());
         }
         this.constructor = constructor;
@@ -173,7 +176,9 @@ public class ConfigurationMetadata<T>
             }
 
             if (!legacyConfig.replacedBy().isEmpty()) {
-                problems.addError("@Config method [%s] has annotation claiming to be replaced by another property ('%s')", configMethod.toGenericString(), legacyConfig.replacedBy());
+                problems.addError("@Config method [%s] has annotation claiming to be replaced by another property ('%s')",
+                        configMethod.toGenericString(),
+                        legacyConfig.replacedBy());
                 isValid = false;
             }
 
@@ -181,7 +186,8 @@ public class ConfigurationMetadata<T>
                 if (arrayEntry == null || arrayEntry.isEmpty()) {
                     problems.addError("@LegacyConfig method [%s] annotation contains null or empty value", configMethod.toGenericString());
                     isValid = false;
-                } else if (arrayEntry.equals(config.value())) {
+                }
+                else if (arrayEntry.equals(config.value())) {
                     problems.addError("@Config property name '%s' appears in @LegacyConfig annotation for method [%s]", config.value(), configMethod.toGenericString());
                     isValid = false;
                 }
@@ -279,7 +285,7 @@ public class ConfigurationMetadata<T>
         }
 
         if (defunctConfig.contains(propertyName)) {
-             problems.addError("@Config property '%s' on method [%s] is defunct on class [%s]", propertyName, configMethod, configClass);
+            problems.addError("@Config property '%s' on method [%s] is defunct on class [%s]", propertyName, configMethod, configClass);
         }
 
         // Add the injection point for the current setter/property
@@ -300,12 +306,18 @@ public class ConfigurationMetadata<T>
     @Override
     public boolean equals(Object o)
     {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         ConfigurationMetadata<?> that = (ConfigurationMetadata<?>) o;
 
-        if (!configClass.equals(that.configClass)) return false;
+        if (!configClass.equals(that.configClass)) {
+            return false;
+        }
 
         return true;
     }
@@ -377,13 +389,21 @@ public class ConfigurationMetadata<T>
         @Override
         public boolean equals(Object o)
         {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
 
             InjectionPointMetaData that = (InjectionPointMetaData) o;
 
-            if (!configClass.equals(that.configClass)) return false;
-            if (!property.equals(that.property)) return false;
+            if (!configClass.equals(that.configClass)) {
+                return false;
+            }
+            if (!property.equals(that.property)) {
+                return false;
+            }
 
             return true;
         }
@@ -408,7 +428,7 @@ public class ConfigurationMetadata<T>
         private final Set<InjectionPointMetaData> legacyInjectionPoints;
 
         public AttributeMetadata(Class<?> configClass, String name, String description, Method getter,
-                                 InjectionPointMetaData injectionPoint, Set<InjectionPointMetaData> legacyInjectionPoints)
+                InjectionPointMetaData injectionPoint, Set<InjectionPointMetaData> legacyInjectionPoints)
         {
             Preconditions.checkNotNull(configClass);
             Preconditions.checkNotNull(name);
@@ -458,13 +478,21 @@ public class ConfigurationMetadata<T>
         @Override
         public boolean equals(Object o)
         {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
 
             AttributeMetadata that = (AttributeMetadata) o;
 
-            if (!configClass.equals(that.configClass)) return false;
-            if (!name.equals(that.name)) return false;
+            if (!configClass.equals(that.configClass)) {
+                return false;
+            }
+            if (!name.equals(that.name)) {
+                return false;
+            }
 
             return true;
         }
@@ -491,9 +519,9 @@ public class ConfigurationMetadata<T>
         private final Class<?> configClass;
         private final String name;
 
-        private String description = null;
-        private Method getter = null;
-        private InjectionPointMetaData injectionPoint = null;
+        private String description;
+        private Method getter;
+        private InjectionPointMetaData injectionPoint;
         private final Set<InjectionPointMetaData> legacyInjectionPoints = Sets.newHashSet();
 
         public AttributeMetaDataBuilder(Class<?> configClass, String name)
@@ -564,11 +592,11 @@ public class ConfigurationMetadata<T>
      *
      * @param configClass the class to analyze
      * @return a map that associates a concrete method to the actual method tagged
-     *         (which may belong to a different class in class hierarchy)
+     * (which may belong to a different class in class hierarchy)
      */
     private static Collection<Method> findAnnotatedMethods(Class<?> configClass, Class<? extends java.lang.annotation.Annotation> annotation)
     {
-        List<Method> result = new ArrayList<Method>();
+        List<Method> result = new ArrayList<>();
 
         // gather all publicly available methods
         // this returns everything, even if it's declared in a parent
@@ -595,7 +623,8 @@ public class ConfigurationMetadata<T>
             if (method != null && method.isAnnotationPresent(annotation)) {
                 return method;
             }
-        } catch (NoSuchMethodException e) {
+        }
+        catch (NoSuchMethodException e) {
             // ignore
         }
 
@@ -630,29 +659,32 @@ public class ConfigurationMetadata<T>
                         if (validateSetter(method)) {
                             for (String property : method.getAnnotation(LegacyConfig.class).value()) {
                                 if (defunctConfig.contains(property)) {
-                                     problems.addError("@LegacyConfig property '%s' on method [%s] is defunct on class [%s]", property, method, configClass);
+                                    problems.addError("@LegacyConfig property '%s' on method [%s] is defunct on class [%s]", property, method, configClass);
                                 }
 
                                 if (!property.equals(propertyName)) {
                                     setters.add(InjectionPointMetaData.newLegacy(configClass, property, method));
-                                } else {
+                                }
+                                else {
                                     problems.addError("@LegacyConfig property '%s' on method [%s] is replaced by @Config property of same name on method [%s]",
                                             property, method.toGenericString(), setterName);
                                 }
                             }
                         }
-                    } else if (method.isAnnotationPresent(LegacyConfig.class)
+                    }
+                    else if (method.isAnnotationPresent(LegacyConfig.class)
                             && method.getAnnotation(LegacyConfig.class).replacedBy().equals(propertyName)) {
                         // Found @LegacyConfig setter linked by replacedBy() property
                         if (validateSetter(method)) {
                             for (String property : method.getAnnotation(LegacyConfig.class).value()) {
                                 if (defunctConfig.contains(property)) {
-                                     problems.addError("@LegacyConfig property '%s' on method [%s] is defunct on class [%s]", property, method, configClass);
+                                    problems.addError("@LegacyConfig property '%s' on method [%s] is defunct on class [%s]", property, method, configClass);
                                 }
 
                                 if (!property.equals(propertyName)) {
                                     setters.add(InjectionPointMetaData.newLegacy(configClass, property, method));
-                                } else {
+                                }
+                                else {
                                     problems.addError("@LegacyConfig property '%s' on method [%s] is replaced by @Config property of same name on method [%s]",
                                             property, method.toGenericString(), setterName);
                                 }
@@ -671,14 +703,15 @@ public class ConfigurationMetadata<T>
         String getterName = "get" + attributeName;
         String isName = "is" + attributeName;
 
-        List<Method> getters = new ArrayList<Method>();
-        List<Method> unusableGetters = new ArrayList<Method>();
+        List<Method> getters = new ArrayList<>();
+        List<Method> unusableGetters = new ArrayList<>();
         for (Class<?> clazz = configClass; (clazz != null) && !clazz.equals(Object.class); clazz = clazz.getSuperclass()) {
             for (Method method : clazz.getDeclaredMethods()) {
                 if (method.getName().equals(getterName) || method.getName().equals(isName)) {
                     if (isUsableMethod(method) && !method.getReturnType().equals(Void.TYPE) && method.getParameterTypes().length == 0) {
                         getters.add(method);
-                    } else {
+                    }
+                    else {
                         unusableGetters.add(method);
                     }
                 }
@@ -688,7 +721,7 @@ public class ConfigurationMetadata<T>
         // too small
         if (getters.isEmpty()) {
             String unusable = "";
-            if (unusableGetters.size() > 0) {
+            if (!unusableGetters.isEmpty()) {
                 StringBuilder builder = new StringBuilder(" The following methods are unusable: ");
                 for (Method method : unusableGetters) {
                     builder.append('[').append(method.toGenericString()).append(']');
@@ -710,7 +743,7 @@ public class ConfigurationMetadata<T>
         return getters.get(0);
     }
 
-    private boolean isUsableMethod(Method method)
+    private static boolean isUsableMethod(Method method)
     {
         return !method.isSynthetic() && !method.isBridge() && !Modifier.isStatic(method.getModifiers()) && Modifier.isPublic(method.getModifiers());
     }

--- a/configuration/src/main/java/io/airlift/configuration/ConfigurationModule.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigurationModule.java
@@ -16,10 +16,11 @@
 package io.airlift.configuration;
 
 import com.google.inject.Binder;
-import com.google.inject.Key;
 import com.google.inject.Module;
 
 import java.lang.annotation.Annotation;
+
+import static io.airlift.configuration.ConfigBinder.configBinder;
 
 public class ConfigurationModule
         implements Module
@@ -115,19 +116,15 @@ public class ConfigurationModule
 
         public <T> void to(Class<T> configClass)
         {
-            Key<T> key;
             if (annotationType != null) {
-                key = Key.get(configClass, annotationType);
+                configBinder(binder).bindConfig(configClass, annotationType, prefix);
             }
             else if (annotation != null) {
-                key = Key.get(configClass, annotation);
+                configBinder(binder).bindConfig(configClass, annotation, prefix);
             }
             else {
-                key = Key.get(configClass);
+                configBinder(binder).bindConfig(configClass, prefix);
             }
-
-            ConfigurationProvider<T> configurationProvider = new ConfigurationProvider<>(key, configClass, prefix);
-            binder.bind(key).toProvider(configurationProvider);
         }
     }
 }

--- a/configuration/src/main/java/io/airlift/configuration/ConfigurationModule.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigurationModule.java
@@ -49,7 +49,8 @@ public class ConfigurationModule
                 if (element.getClassName().equals(ConfigurationModule.class.getName())) {
                     foundThisClass = true;
                 }
-            } else {
+            }
+            else {
                 if (!element.getClassName().equals(ConfigurationModule.class.getName())) {
                     return element;
                 }
@@ -64,7 +65,8 @@ public class ConfigurationModule
         return new AnnotatedBindingBuilder(binder.withSource(getCaller()));
     }
 
-    public static class AnnotatedBindingBuilder extends PrefixBindingBuilder
+    public static class AnnotatedBindingBuilder
+            extends PrefixBindingBuilder
     {
         public AnnotatedBindingBuilder(Binder binder)
         {
@@ -82,7 +84,8 @@ public class ConfigurationModule
         }
     }
 
-    public static class PrefixBindingBuilder extends ConfigBindingBuilder
+    public static class PrefixBindingBuilder
+            extends ConfigBindingBuilder
     {
         public PrefixBindingBuilder(Binder binder, Class<? extends Annotation> annotationType, Annotation annotation)
         {
@@ -110,17 +113,20 @@ public class ConfigurationModule
             this.prefix = prefix;
         }
 
-        public <T> void to(Class<T> configClass) {
+        public <T> void to(Class<T> configClass)
+        {
             Key<T> key;
             if (annotationType != null) {
                 key = Key.get(configClass, annotationType);
-            } else if(annotation != null) {
+            }
+            else if (annotation != null) {
                 key = Key.get(configClass, annotation);
-            } else {
+            }
+            else {
                 key = Key.get(configClass);
             }
 
-            ConfigurationProvider<T> configurationProvider = new ConfigurationProvider<T>(key, configClass, prefix);
+            ConfigurationProvider<T> configurationProvider = new ConfigurationProvider<>(key, configClass, prefix);
             binder.bind(key).toProvider(configurationProvider);
         }
     }

--- a/configuration/src/main/java/io/airlift/configuration/ConfigurationModule.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigurationModule.java
@@ -61,6 +61,10 @@ public class ConfigurationModule
         return null;
     }
 
+    /**
+     * @deprecated As of Airlift 0.109, replaced by {@link ConfigBinder#configBinder(Binder)}.
+     */
+    @Deprecated
     public static AnnotatedBindingBuilder bindConfig(Binder binder)
     {
         return new AnnotatedBindingBuilder(binder.withSource(getCaller()));

--- a/configuration/src/main/java/io/airlift/configuration/ConfigurationProvider.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigurationProvider.java
@@ -19,7 +19,8 @@ import com.google.common.base.Preconditions;
 import com.google.inject.Inject;
 import com.google.inject.Key;
 
-public class ConfigurationProvider<T> implements ConfigurationAwareProvider<T>
+public class ConfigurationProvider<T>
+        implements ConfigurationAwareProvider<T>
 {
     private final Key<T> key;
     private final Class<T> configClass;
@@ -37,12 +38,14 @@ public class ConfigurationProvider<T> implements ConfigurationAwareProvider<T>
         this.prefix = prefix;
     }
 
+    @Override
     @Inject
     public void setConfigurationFactory(ConfigurationFactory configurationFactory)
     {
         this.configurationFactory = configurationFactory;
     }
 
+    @Override
     @Inject(optional = true)
     public void setWarningsMonitor(WarningsMonitor warningsMonitor)
     {
@@ -64,7 +67,8 @@ public class ConfigurationProvider<T> implements ConfigurationAwareProvider<T>
         return prefix;
     }
 
-    public ConfigurationMetadata<T> getConfigurationMetadata() {
+    public ConfigurationMetadata<T> getConfigurationMetadata()
+    {
         return ConfigurationMetadata.getConfigurationMetadata(configClass);
     }
 

--- a/configuration/src/main/java/io/airlift/configuration/ConfigurationProvider.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigurationProvider.java
@@ -72,6 +72,11 @@ public class ConfigurationProvider<T>
         return ConfigurationMetadata.getConfigurationMetadata(configClass);
     }
 
+    public T getDefaultConfig()
+    {
+        return configurationFactory.getDefaultConfig(key);
+    }
+
     @Override
     public T get()
     {

--- a/configuration/src/main/java/io/airlift/configuration/ConfigurationValidator.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigurationValidator.java
@@ -51,9 +51,10 @@ public class ConfigurationValidator
         final List<Message> messages = Lists.newArrayList();
 
         ElementsIterator elementsIterator = new ElementsIterator(modules);
-        for (final Element element : elementsIterator) {
+        for (Element element : elementsIterator) {
             element.acceptVisitor(new DefaultElementVisitor<Void>()
             {
+                @Override
                 public <T> Void visit(Binding<T> binding)
                 {
                     // look for ConfigurationProviders...
@@ -68,7 +69,8 @@ public class ConfigurationValidator
                             try {
                                 // call the getter which will cause object creation
                                 configurationProvider.get();
-                            } catch (ConfigurationException e) {
+                            }
+                            catch (ConfigurationException e) {
                                 // if we got errors, add them to the errors list
                                 for (Message message : e.getErrorMessages()) {
                                     messages.add(new Message(singletonList(binding.getSource()), message.getMessage(), message.getCause()));

--- a/configuration/src/main/java/io/airlift/configuration/ConfigurationValidator.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigurationValidator.java
@@ -23,6 +23,7 @@ import com.google.inject.Module;
 import com.google.inject.Provider;
 import com.google.inject.spi.DefaultElementVisitor;
 import com.google.inject.spi.Element;
+import com.google.inject.spi.InstanceBinding;
 import com.google.inject.spi.Message;
 import com.google.inject.spi.ProviderInstanceBinding;
 
@@ -51,6 +52,24 @@ public class ConfigurationValidator
         final List<Message> messages = Lists.newArrayList();
 
         ElementsIterator elementsIterator = new ElementsIterator(modules);
+        for (Element element : elementsIterator) {
+            element.acceptVisitor(new DefaultElementVisitor<Void>()
+            {
+                @Override
+                public <T> Void visit(Binding<T> binding)
+                {
+                    // look for default configs
+                    if (binding instanceof InstanceBinding) {
+                        InstanceBinding<T> instanceBinding = (InstanceBinding<T>) binding;
+                        if (instanceBinding.getInstance() instanceof ConfigDefaultsHolder) {
+                            configurationFactory.registerConfigDefaults((ConfigDefaultsHolder<?>) instanceBinding.getInstance());
+                        }
+                    }
+                    return null;
+                }
+            });
+        }
+
         for (Element element : elementsIterator) {
             element.acceptVisitor(new DefaultElementVisitor<Void>()
             {

--- a/configuration/src/main/java/io/airlift/configuration/InvalidConfigurationException.java
+++ b/configuration/src/main/java/io/airlift/configuration/InvalidConfigurationException.java
@@ -15,7 +15,8 @@
  */
 package io.airlift.configuration;
 
-public class InvalidConfigurationException extends Exception
+public class InvalidConfigurationException
+        extends Exception
 {
     public InvalidConfigurationException(String message, Object... args)
     {

--- a/configuration/src/main/java/io/airlift/configuration/Problems.java
+++ b/configuration/src/main/java/io/airlift/configuration/Problems.java
@@ -40,7 +40,8 @@ class Problems
 
     public static final Problems.Monitor NULL_MONITOR = new NullMonitor();
 
-    private static final class NullMonitor implements Problems.Monitor
+    private static final class NullMonitor
+            implements Problems.Monitor
     {
         @Override
         public void onError(Message unused)
@@ -63,7 +64,8 @@ class Problems
         this.monitor = monitor;
     }
 
-    public void throwIfHasErrors() throws ConfigurationException
+    public void throwIfHasErrors()
+            throws ConfigurationException
     {
         if (!errors.isEmpty()) {
             throw getException();

--- a/configuration/src/main/java/io/airlift/configuration/ValidationErrorModule.java
+++ b/configuration/src/main/java/io/airlift/configuration/ValidationErrorModule.java
@@ -22,7 +22,8 @@ import com.google.inject.spi.Message;
 
 import java.util.List;
 
-public class ValidationErrorModule implements Module
+public class ValidationErrorModule
+        implements Module
 {
     private final List<Message> messages;
 
@@ -34,8 +35,6 @@ public class ValidationErrorModule implements Module
     @Override
     public void configure(Binder binder)
     {
-        for (Message message : messages) {
-            binder.addError(message);
-        }
+        messages.forEach(binder::addError);
     }
 }

--- a/configuration/src/main/java/io/airlift/configuration/testing/ConfigAssertions.java
+++ b/configuration/src/main/java/io/airlift/configuration/testing/ConfigAssertions.java
@@ -57,27 +57,27 @@ public final class ConfigAssertions
 
         // verify all supplied attributes are supported
         if (!metadata.getAttributes().keySet().containsAll(expectedAttributeValues.keySet())) {
-            TreeSet<String> unsupportedAttributes = new TreeSet<String>(expectedAttributeValues.keySet());
+            TreeSet<String> unsupportedAttributes = new TreeSet<>(expectedAttributeValues.keySet());
             unsupportedAttributes.removeAll(metadata.getAttributes().keySet());
             Assert.fail("Unsupported attributes: " + unsupportedAttributes);
         }
 
         // verify all supplied attributes are supported not deprecated
-        Set<String> nonDeprecatedAttributes = new TreeSet<String>();
+        Set<String> nonDeprecatedAttributes = new TreeSet<>();
         for (AttributeMetadata attribute : metadata.getAttributes().values()) {
             if (attribute.getInjectionPoint().getProperty() != null) {
                 nonDeprecatedAttributes.add(attribute.getName());
             }
         }
         if (!nonDeprecatedAttributes.containsAll(expectedAttributeValues.keySet())) {
-            TreeSet<String> unsupportedAttributes = new TreeSet<String>(expectedAttributeValues.keySet());
+            TreeSet<String> unsupportedAttributes = new TreeSet<>(expectedAttributeValues.keySet());
             unsupportedAttributes.removeAll(nonDeprecatedAttributes);
             Assert.fail("Deprecated attributes: " + unsupportedAttributes);
         }
 
         // verify all attributes are tested
         if (!expectedAttributeValues.keySet().containsAll(nonDeprecatedAttributes)) {
-            TreeSet<String> untestedAttributes = new TreeSet<String>(nonDeprecatedAttributes);
+            TreeSet<String> untestedAttributes = new TreeSet<>(nonDeprecatedAttributes);
             untestedAttributes.removeAll(expectedAttributeValues.keySet());
             Assert.fail("Untested attributes: " + untestedAttributes);
         }
@@ -110,14 +110,14 @@ public final class ConfigAssertions
         assertPropertiesSupported(metadata, properties.keySet(), false);
 
         // verify that every (non-deprecated) property is tested
-        Set<String> nonDeprecatedProperties = new TreeSet<String>();
+        Set<String> nonDeprecatedProperties = new TreeSet<>();
         for (AttributeMetadata attribute : metadata.getAttributes().values()) {
             if (attribute.getInjectionPoint().getProperty() != null) {
                 nonDeprecatedProperties.add(attribute.getInjectionPoint().getProperty());
             }
         }
         if (!properties.keySet().equals(nonDeprecatedProperties)) {
-            TreeSet<String> untestedProperties = new TreeSet<String>(nonDeprecatedProperties);
+            TreeSet<String> untestedProperties = new TreeSet<>(nonDeprecatedProperties);
             untestedProperties.removeAll(properties.keySet());
             Assert.fail("Untested properties " + untestedProperties);
         }
@@ -149,18 +149,18 @@ public final class ConfigAssertions
         }
 
         // verify that all deprecated properties are tested
-        Set<String> knownDeprecatedProperties = new TreeSet<String>();
+        Set<String> knownDeprecatedProperties = new TreeSet<>();
         for (AttributeMetadata attribute : metadata.getAttributes().values()) {
             for (ConfigurationMetadata.InjectionPointMetaData deprecated : attribute.getLegacyInjectionPoints()) {
                 knownDeprecatedProperties.add(deprecated.getProperty());
             }
         }
-        Set<String> suppliedDeprecatedProperties = new TreeSet<String>();
+        Set<String> suppliedDeprecatedProperties = new TreeSet<>();
         for (Map<String, String> evenOlderProperties : oldPropertiesList) {
             suppliedDeprecatedProperties.addAll(evenOlderProperties.keySet());
         }
         if (!suppliedDeprecatedProperties.containsAll(knownDeprecatedProperties)) {
-            TreeSet<String> untestedDeprecatedProperties = new TreeSet<String>(knownDeprecatedProperties);
+            TreeSet<String> untestedDeprecatedProperties = new TreeSet<>(knownDeprecatedProperties);
             untestedDeprecatedProperties.removeAll(suppliedDeprecatedProperties);
             Assert.fail("Untested deprecated properties: " + untestedDeprecatedProperties);
         }
@@ -175,8 +175,8 @@ public final class ConfigAssertions
 
     private static void assertPropertiesSupported(ConfigurationMetadata<?> metadata, Set<String> propertyNames, boolean allowDeprecatedProperties)
     {
-        Set<String> supportedProperties = new TreeSet<String>();
-        Set<String> nonDeprecatedProperties = new TreeSet<String>();
+        Set<String> supportedProperties = new TreeSet<>();
+        Set<String> nonDeprecatedProperties = new TreeSet<>();
         for (AttributeMetadata attribute : metadata.getAttributes().values()) {
             if (attribute.getInjectionPoint().getProperty() != null) {
                 nonDeprecatedProperties.add(attribute.getInjectionPoint().getProperty());
@@ -187,14 +187,14 @@ public final class ConfigAssertions
             }
         }
         if (!supportedProperties.containsAll(propertyNames)) {
-            TreeSet<String> unsupportedProperties = new TreeSet<String>(propertyNames);
+            TreeSet<String> unsupportedProperties = new TreeSet<>(propertyNames);
             unsupportedProperties.removeAll(supportedProperties);
             Assert.fail("Unsupported properties: " + unsupportedProperties);
         }
 
         // check for usage of deprecated properties
         if (!allowDeprecatedProperties && !nonDeprecatedProperties.containsAll(propertyNames)) {
-            TreeSet<String> deprecatedProperties = new TreeSet<String>(propertyNames);
+            TreeSet<String> deprecatedProperties = new TreeSet<>(propertyNames);
             deprecatedProperties.removeAll(nonDeprecatedProperties);
             Assert.fail("Deprecated properties: " + deprecatedProperties);
         }
@@ -237,9 +237,9 @@ public final class ConfigAssertions
         ConfigurationMetadata<?> metadata = ConfigurationMetadata.getValidConfigurationMetadata(configClass);
 
         // collect information about the attributes that have been set
-        Map<String, Object> attributeValues = new TreeMap<String, Object>();
-        Set<String> setDeprecatedAttributes = new TreeSet<String>();
-        Set<Method> validSetterMethods = new HashSet<Method>();
+        Map<String, Object> attributeValues = new TreeMap<>();
+        Set<String> setDeprecatedAttributes = new TreeSet<>();
+        Set<Method> validSetterMethods = new HashSet<>();
         for (AttributeMetadata attribute : metadata.getAttributes().values()) {
             if (attribute.getInjectionPoint().getProperty() != null) {
                 validSetterMethods.add(attribute.getInjectionPoint().getSetter());
@@ -249,7 +249,8 @@ public final class ConfigAssertions
                 if (attribute.getInjectionPoint().getProperty() != null) {
                     Object value = invoke(config, attribute.getGetter());
                     attributeValues.put(attribute.getName(), value);
-                } else {
+                }
+                else {
                     setDeprecatedAttributes.add(attribute.getName());
                 }
             }
@@ -262,7 +263,7 @@ public final class ConfigAssertions
 
         // verify no other methods have been set
         if (!validSetterMethods.containsAll(invokedMethods)) {
-            Set<Method> invalidInvocations = new HashSet<Method>(invokedMethods);
+            Set<Method> invalidInvocations = new HashSet<>(invokedMethods);
             invalidInvocations.removeAll(validSetterMethods);
             Assert.fail("Invoked non-attribute setter methods: " + invalidInvocations);
 
@@ -273,7 +274,7 @@ public final class ConfigAssertions
     public static <T> T recordDefaults(Class<T> type)
     {
         final T instance = newDefaultInstance(type);
-        T proxy = (T) Enhancer.create(type, new Class[]{$$RecordingConfigProxy.class}, new MethodInterceptor()
+        T proxy = (T) Enhancer.create(type, new Class<?>[] {$$RecordingConfigProxy.class}, new MethodInterceptor()
         {
             private final ConcurrentMap<Method, Object> invokedMethods = new MapMaker().makeMap();
 
@@ -282,7 +283,7 @@ public final class ConfigAssertions
                     throws Throwable
             {
                 if (GET_RECORDING_CONFIG_METHOD.equals(method)) {
-                    return new $$RecordedConfigData<T>(instance, ImmutableSet.copyOf(invokedMethods.keySet()));
+                    return new $$RecordedConfigData<>(instance, ImmutableSet.copyOf(invokedMethods.keySet()));
                 }
 
                 invokedMethods.put(method, Boolean.TRUE);
@@ -330,7 +331,7 @@ public final class ConfigAssertions
         }
     }
 
-    public static interface $$RecordingConfigProxy<T>
+    public interface $$RecordingConfigProxy<T>
     {
         $$RecordedConfigData<T> $$getRecordedConfig();
     }
@@ -346,7 +347,8 @@ public final class ConfigAssertions
     {
         try {
             return configClass.newInstance();
-        } catch (Exception e) {
+        }
+        catch (Exception e) {
             AssertionError error = new AssertionError(String.format("Exception creating default instance of %s", configClass.getName()));
             error.initCause(e);
             throw error;
@@ -357,7 +359,8 @@ public final class ConfigAssertions
     {
         try {
             return getter.invoke(actual);
-        } catch (Exception e) {
+        }
+        catch (Exception e) {
             AssertionError error = new AssertionError(String.format("Exception invoking %s", getter.toGenericString()));
             error.initCause(e);
             throw error;

--- a/configuration/src/test/java/io/airlift/configuration/TestConfig.java
+++ b/configuration/src/test/java/io/airlift/configuration/TestConfig.java
@@ -17,7 +17,6 @@ package io.airlift.configuration;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMap.Builder;
-import com.google.inject.Binder;
 import com.google.inject.CreationException;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -34,9 +33,9 @@ import java.util.Map.Entry;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
- public class TestConfig
+public class TestConfig
 {
-    private ImmutableMap<String,String> properties;
+    private ImmutableMap<String, String> properties;
 
     @Test
     public void testConfig()
@@ -52,7 +51,7 @@ import static org.testng.Assert.fail;
         verifyConfig(injector.getInstance(Config1.class));
     }
 
-    private void verifyConfig(Config1 config)
+    private static void verifyConfig(Config1 config)
     {
         assertEquals("a string", config.getStringOption());
         assertEquals(true, config.getBooleanOption());
@@ -86,22 +85,16 @@ import static org.testng.Assert.fail;
         }
     }
 
-    private Injector createInjector(Map<String, String> properties, Module module)
+    private static Injector createInjector(Map<String, String> properties, Module module)
     {
         ConfigurationFactory configurationFactory = new ConfigurationFactory(properties);
         List<Message> messages = new ConfigurationValidator(configurationFactory, null).validate(module);
         return Guice.createInjector(new ConfigurationModule(configurationFactory), module, new ValidationErrorModule(messages));
     }
 
-    private <T> Module createModule(final Class<T> configClass, final String prefix)
+    private static <T> Module createModule(Class<T> configClass, String prefix)
     {
-        Module module = new Module() {
-            @Override
-            public void configure(Binder binder)
-            {
-                ConfigurationModule.bindConfig(binder).prefixedWith(prefix).to(configClass);
-            }
-        };
+        Module module = binder -> ConfigurationModule.bindConfig(binder).prefixedWith(prefix).to(configClass);
         return module;
     }
 
@@ -110,27 +103,27 @@ import static org.testng.Assert.fail;
             throws Exception
     {
         properties = ImmutableMap.<String, String>builder()
-            .put("stringOption", "a string")
-            .put("booleanOption", "true")
-            .put("boxedBooleanOption", "true")
-            .put("byteOption", Byte.toString(Byte.MAX_VALUE))
-            .put("boxedByteOption", Byte.toString(Byte.MAX_VALUE))
-            .put("shortOption", Short.toString(Short.MAX_VALUE))
-            .put("boxedShortOption", Short.toString(Short.MAX_VALUE))
-            .put("integerOption", Integer.toString(Integer.MAX_VALUE))
-            .put("boxedIntegerOption", Integer.toString(Integer.MAX_VALUE))
-            .put("longOption", Long.toString(Long.MAX_VALUE))
-            .put("boxedLongOption", Long.toString(Long.MAX_VALUE))
-            .put("floatOption", Float.toString(Float.MAX_VALUE))
-            .put("boxedFloatOption", Float.toString(Float.MAX_VALUE))
-            .put("doubleOption", Double.toString(Double.MAX_VALUE))
-            .put("boxedDoubleOption", Double.toString(Double.MAX_VALUE))
-            .put("myEnumOption", MyEnum.FOO.toString())
-            .put("valueClassOption", "a value class")
-            .build();
+                .put("stringOption", "a string")
+                .put("booleanOption", "true")
+                .put("boxedBooleanOption", "true")
+                .put("byteOption", Byte.toString(Byte.MAX_VALUE))
+                .put("boxedByteOption", Byte.toString(Byte.MAX_VALUE))
+                .put("shortOption", Short.toString(Short.MAX_VALUE))
+                .put("boxedShortOption", Short.toString(Short.MAX_VALUE))
+                .put("integerOption", Integer.toString(Integer.MAX_VALUE))
+                .put("boxedIntegerOption", Integer.toString(Integer.MAX_VALUE))
+                .put("longOption", Long.toString(Long.MAX_VALUE))
+                .put("boxedLongOption", Long.toString(Long.MAX_VALUE))
+                .put("floatOption", Float.toString(Float.MAX_VALUE))
+                .put("boxedFloatOption", Float.toString(Float.MAX_VALUE))
+                .put("doubleOption", Double.toString(Double.MAX_VALUE))
+                .put("boxedDoubleOption", Double.toString(Double.MAX_VALUE))
+                .put("myEnumOption", MyEnum.FOO.toString())
+                .put("valueClassOption", "a value class")
+                .build();
     }
 
-    private Map<String, String> prefix(String prefix, Map<String, String> properties)
+    private static Map<String, String> prefix(String prefix, Map<String, String> properties)
     {
         Builder<String, String> builder = ImmutableMap.builder();
         for (Entry<String, String> entry : properties.entrySet()) {

--- a/http-client/src/main/java/io/airlift/http/client/HttpClientBinder.java
+++ b/http-client/src/main/java/io/airlift/http/client/HttpClientBinder.java
@@ -19,6 +19,7 @@ import com.google.common.annotations.Beta;
 import com.google.inject.Binder;
 import com.google.inject.binder.LinkedBindingBuilder;
 import com.google.inject.multibindings.Multibinder;
+import io.airlift.configuration.ConfigDefaults;
 
 import java.lang.annotation.Annotation;
 import java.util.Collection;
@@ -77,6 +78,12 @@ public class HttpClientBinder
             for (Class<? extends Annotation> annotation : aliases) {
                 module.addAlias(annotation);
             }
+            return this;
+        }
+
+        public HttpClientBindingBuilder withConfigDefaults(ConfigDefaults<HttpClientConfig> configDefaults)
+        {
+            module.withConfigDefaults(configDefaults);
             return this;
         }
 

--- a/http-client/src/main/java/io/airlift/http/client/HttpClientModule.java
+++ b/http-client/src/main/java/io/airlift/http/client/HttpClientModule.java
@@ -24,6 +24,8 @@ import com.google.inject.Key;
 import com.google.inject.Provider;
 import com.google.inject.Scopes;
 import com.google.inject.TypeLiteral;
+import io.airlift.configuration.ConfigBinder;
+import io.airlift.configuration.ConfigDefaults;
 import io.airlift.http.client.jetty.JettyHttpClient;
 import io.airlift.http.client.jetty.JettyIoPool;
 import io.airlift.http.client.jetty.JettyIoPoolConfig;
@@ -48,6 +50,8 @@ public class HttpClientModule
 {
     private static final Logger log = Logger.get(HttpClientModule.class);
 
+    private ConfigDefaults<HttpClientConfig> configDefaults;
+
     protected HttpClientModule(String name, Class<? extends Annotation> annotation)
     {
         super(name, annotation);
@@ -57,6 +61,11 @@ public class HttpClientModule
     public Annotation getFilterQualifier()
     {
         return filterQualifier(annotation);
+    }
+
+    void withConfigDefaults(ConfigDefaults<HttpClientConfig> configDefaults)
+    {
+        this.configDefaults = configDefaults;
     }
 
     void withPrivateIoThreadPool()
@@ -70,6 +79,9 @@ public class HttpClientModule
     {
         // bind the configuration
         bindConfig(binder).annotatedWith(annotation).prefixedWith(name).to(HttpClientConfig.class);
+        if (configDefaults != null) {
+            ConfigBinder.configBinder(binder).bindConfigDefaults(HttpClientConfig.class, configDefaults);
+        }
 
         // Shared thread pool
         bindConfig(binder).to(JettyIoPoolConfig.class);


### PR DESCRIPTION
This change adds a configurable preprocessor between construction of the configuration class and setting of the configuration properties.  The preprocessor has full access to the configuration instance.  For example, the following sets the default `StoreConfig.ttl`:

```java
        ConfigBinder.configBinder(binder).bindConfigDefaults(StoreConfig.class, c -> {
            c.setTtl(new Duration(15, TimeUnit.MINUTES));
        });
```

Additionally, multiple `ConfigDefaults` can be bound, and each is applied in the order in which it was bound.  This allows for wrapper libraries to override global defaults, and for usages of the wrapper libraries to override the wrapper defaults.