### PR TITLE
Fix HTTP server test on IPv6-only machines

### DIFF
--- a/http-server/src/test/java/io/airlift/http/server/TestHttpServerModule.java
+++ b/http-server/src/test/java/io/airlift/http/server/TestHttpServerModule.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ListMultimap;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Files;
 import com.google.common.net.HttpHeaders;
+import com.google.common.net.InetAddresses;
 import com.google.common.net.MediaType;
 import com.google.inject.Binder;
 import com.google.inject.Guice;
@@ -169,7 +170,7 @@ public class TestHttpServerModule
             assertNotNull(httpServerInfo);
             assertNotNull(httpServerInfo.getHttpUri());
             assertEquals(httpServerInfo.getHttpUri().getScheme(), "http");
-            assertEquals(httpServerInfo.getHttpUri().getHost(), nodeInfo.getInternalIp().getHostAddress());
+            assertEquals(InetAddresses.forUriString(httpServerInfo.getHttpUri().getHost()), nodeInfo.getInternalIp());
             assertNull(httpServerInfo.getHttpsUri());
         }
         catch (Exception e) {


### PR DESCRIPTION
InetAddress.getHostAddress() returns a scope ID for IPv6 addresses.