### PR TITLE
Move io.airlift.log.Level back to public

### DIFF
--- a/log-manager/src/main/java/io/airlift/log/Level.java
+++ b/log-manager/src/main/java/io/airlift/log/Level.java
@@ -15,7 +15,7 @@ public enum Level
         this.julLevel = julLevel;
     }
 
-    public java.util.logging.Level toJulLevel()
+    java.util.logging.Level toJulLevel()
     {
         return julLevel;
     }

--- a/log-manager/src/main/java/io/airlift/log/Level.java
+++ b/log-manager/src/main/java/io/airlift/log/Level.java
@@ -1,6 +1,6 @@
 package io.airlift.log;
 
-enum Level
+public enum Level
 {
     OFF(java.util.logging.Level.OFF),
     DEBUG(java.util.logging.Level.FINE),


### PR DESCRIPTION
Level is used by multiple Presto projects and should be public. Changes to Presto will be submitted subsequently (need to move to airlift 0.107-SNAPSHOT).