### PR TITLE
correct the way airlift selects the IPv6 address to use

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+* 0.108
+
+- Exclude link local addresses in NodeInfo
+
 * 0.107
 
 - Remove dependency on SLF4J from log manager

--- a/node/src/main/java/io/airlift/node/NodeInfo.java
+++ b/node/src/main/java/io/airlift/node/NodeInfo.java
@@ -340,6 +340,7 @@ public class NodeInfo
     private static boolean isGoodAddress(InetAddress address)
     {
         return !address.isAnyLocalAddress() &&
+                !address.isLinkLocalAddress() &&
                 !address.isLoopbackAddress() &&
                 !address.isMulticastAddress();
     }


### PR DESCRIPTION
Be cool if the InetAddress.getLocalHost() returns an IPv6 address and filter out link-local IPv6 addresses from the "good" addresses.