### PR TITLE
Fix bootstrap test

### DIFF
--- a/bootstrap/src/test/java/io/airlift/bootstrap/TestLifeCycleManager.java
+++ b/bootstrap/src/test/java/io/airlift/bootstrap/TestLifeCycleManager.java
@@ -44,7 +44,7 @@ public class TestLifeCycleManager
         stateLog.clear();
     }
 
-    public static void note(String str)
+    static void note(String str)
     {
         // I'm assuming that tests are run serially
         stateLog.add(str);


### PR DESCRIPTION
TestNG assumes every method is a test method if the class is annotated
with @Test. Unfortunately, annotating the class is the only way to
specifiy single-threaded behavior.