### PR TITLE
always set useKeytab=true

### DIFF
--- a/http-client/src/main/java/io/airlift/http/client/spnego/SpnegoAuthentication.java
+++ b/http-client/src/main/java/io/airlift/http/client/spnego/SpnegoAuthentication.java
@@ -80,12 +80,12 @@ public class SpnegoAuthentication
                     ImmutableMap.Builder<String, String> optionsBuilder = ImmutableMap.builder();
                     optionsBuilder.put("refreshKrb5Config", "true");
                     optionsBuilder.put("doNotPrompt", "true");
+                    optionsBuilder.put("useKeyTab", "true");
                     if (LOG.isDebugEnabled()) {
                         optionsBuilder.put("debug", "true");
                     }
 
                     if (keytab != null) {
-                        optionsBuilder.put("useKeytab", "true");
                         optionsBuilder.put("keytab", keytab.getAbsolutePath());
                     }
 


### PR DESCRIPTION
this will enable the client to still use the keytab even its location is derived from kerberos configuration file rather than command line option.