### PR TITLE
Support initializer before LifeCycleManager.start

### DIFF
--- a/bootstrap/src/main/java/io/airlift/bootstrap/Bootstrap.java
+++ b/bootstrap/src/main/java/io/airlift/bootstrap/Bootstrap.java
@@ -41,12 +41,14 @@ import io.airlift.log.Logging;
 import io.airlift.log.LoggingConfiguration;
 
 import java.io.PrintWriter;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.function.Consumer;
 
 import static com.google.common.collect.Maps.fromProperties;
 import static io.airlift.configuration.Configuration.processConfiguration;
@@ -69,6 +71,7 @@ public class Bootstrap
 
     private Map<String, String> requiredConfigurationProperties;
     private Map<String, String> optionalConfigurationProperties;
+    private List<Consumer<Injector>> initializersBeforeStart;
     private boolean initializeLogging = true;
     private boolean quiet;
     private boolean strictConfig;
@@ -130,6 +133,16 @@ public class Bootstrap
     public Bootstrap doNotInitializeLogging()
     {
         this.initializeLogging = false;
+        return this;
+    }
+
+    @Beta
+    public Bootstrap addInitializerBeforeStart(Consumer<Injector> initializer)
+    {
+        if (this.initializersBeforeStart == null) {
+            this.initializersBeforeStart = new ArrayList<>();
+        }
+        this.initializersBeforeStart.add(initializer);
         return this;
     }
 
@@ -240,6 +253,13 @@ public class Bootstrap
 
         // create the injector
         Injector injector = Guice.createInjector(Stage.PRODUCTION, moduleList.build());
+
+        // initialize before start
+        if (initializersBeforeStart != null) {
+            for (Consumer<Injector> initializer : initializersBeforeStart) {
+                initializer.accept(injector);
+            }
+        }
 
         // Create the life-cycle manager
         LifeCycleManager lifeCycleManager = injector.getInstance(LifeCycleManager.class);

--- a/bootstrap/src/test/java/io/airlift/bootstrap/TestBootstrap.java
+++ b/bootstrap/src/test/java/io/airlift/bootstrap/TestBootstrap.java
@@ -17,12 +17,14 @@ package io.airlift.bootstrap;
 
 import com.google.inject.Binder;
 import com.google.inject.ConfigurationException;
+import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.google.inject.ProvisionException;
 import io.airlift.testing.Assertions;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
 
@@ -65,6 +67,29 @@ public class TestBootstrap
         }
     }
 
+    @Test
+    public void testInitializerBeforeStart()
+            throws Exception
+    {
+        Bootstrap bootstrap = new Bootstrap(new Module()
+        {
+            @Override
+            public void configure(Binder binder)
+            {
+                binder.bind(InstanceC.class);
+                binder.bind(InstanceD.class);
+            }
+        });
+
+        Injector injector = bootstrap.addInitializerBeforeStart(
+                inj -> inj.getInstance(InstanceC.class).init()
+        ).initialize();
+        InstanceC instanceC = injector.getInstance(InstanceC.class);
+        InstanceD instanceD = injector.getInstance(InstanceD.class);
+
+        Assertions.assertLessThan(instanceC.creationTime, instanceD.creationTime);
+    }
+
     public static class Instance {}
 
     public static class InstanceA
@@ -77,5 +102,32 @@ public class TestBootstrap
     {
         @Inject
         public InstanceB(InstanceA a) { }
+    }
+
+    public static class InstanceC
+    {
+        public long creationTime;
+
+        @Inject
+        public InstanceC() { }
+
+        public void init()
+        {
+            creationTime = System.nanoTime();
+        }
+    }
+
+    public static class InstanceD
+    {
+        public long creationTime;
+
+        @Inject
+        public InstanceD() { }
+
+        @PostConstruct
+        public void init()
+        {
+            creationTime = System.nanoTime();
+        }
     }
 }


### PR DESCRIPTION
There would be a situation that some initializers' operation must be finished before `@PostConstruct`( `LifeCycleManager.start`) methods are called. For example, some plugins must be loaded before other instances start services.
