### PR TITLE
Clean up LoginContext based on ref counting

### DIFF
--- a/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
@@ -1360,6 +1360,8 @@ public class JettyHttpClient
                 throws Exception
         {
             authenticationStore.clearAuthenticationResults();
+            spnego.shutdown();
+
             super.doStop();
         }
     }


### PR DESCRIPTION
Code cleanup with simple ref-counting based LoginContext logout logic for the original cached credential fix. cc: @martint / @zhenyuy-fb 
