### PR TITLE
do not throw exception in SpnegoAuthentication

### DIFF
--- a/http-client/src/main/java/io/airlift/http/client/spnego/SpnegoAuthentication.java
+++ b/http-client/src/main/java/io/airlift/http/client/spnego/SpnegoAuthentication.java
@@ -125,14 +125,14 @@ public class SpnegoAuthentication
                         request.header(headerInfo.getHeader(), format("%s %s", NEGOTIATE, Base64.getEncoder().encodeToString(token)));
                     }
                     else {
-                        throw new RuntimeException(format("No token generated from GSS context for %s", request.getURI()));
+                        LOG.warn(format("No token generated from GSS context for %s", request.getURI()));
                     }
                 }
                 catch (GSSException e) {
-                    throw new RuntimeException(format("Failed to establish GSSContext for request %s", request.getURI()), e);
+                    LOG.warn(e, format("Failed to establish GSSContext for request %s", request.getURI()));
                 }
                 catch (LoginException e) {
-                    throw new RuntimeException(format("Failed to establish LoginContext for request %s", request.getURI()), e);
+                    LOG.warn(e, format("Failed to establish LoginContext for request %s", request.getURI()));
                 }
                 finally {
                     try {


### PR DESCRIPTION
When authentication is enabled and the client cannot get correct kerberos credentiails(for instance, incorrect KDC settings, invalid personal credentials, etc), the exception thrown from SpnegoAuthentication's apply() method will propagate to Jetty's ResponseListener.notifyComplete() method and get caught there. This will cause the client's HttpRequest wait in an idle loop until timeout(60 seconds by default). This fix is to remove those exceptions and let the response against 401 authentication challenge go, which will make the client fail fast and loudly with detailed exception messages like below:

java.lang.RuntimeException: Error starting query at https://xxx:7778/v1/statement returned an invalid response: JsonResponse{statusCode=401, statusMessage=Unauthorized, headers={Content-Length=[0], Date=[Mon, 30 Nov 2015 19:42:07 GMT], WWW-Authenticate=[Negotiate realm="presto"]}, hasValue=false, value=null} [Error: ]
	at com.facebook.presto.client.StatementClient.requestFailedException(StatementClient.java:281)
	at com.facebook.presto.client.StatementClient.<init>(StatementClient.java:103)
	at com.facebook.presto.cli.QueryRunner.startInternalQuery(QueryRunner.java:82)
	at com.facebook.presto.cli.QueryRunner.startQuery(QueryRunner.java:77)
	at com.facebook.presto.cli.Console.process(Console.java:282)
	at com.facebook.presto.cli.Console.runConsole(Console.java:224)
	at com.facebook.presto.cli.Console.run(Console.java:130)
	at com.facebook.presto.cli.Presto.main(Presto.java:32)