### PR TITLE
Fix config to include and exclude HTTPS cipher suites

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+* 0.121
+
+- Fix configuration property to include and exclude HTTPS cipher suites
+
 * 0.120
 
 - Add configuration property to include and exclude HTTPS cipher suites

--- a/http-server/pom.xml
+++ b/http-server/pom.xml
@@ -188,6 +188,12 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-client</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>
 

--- a/http-server/src/main/java/io/airlift/http/server/HttpServer.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServer.java
@@ -171,13 +171,9 @@ public class HttpServer
             SslContextFactory sslContextFactory = new SslContextFactory(config.getKeystorePath());
             sslContextFactory.setKeyStorePassword(config.getKeystorePassword());
             List<String> includedCipherSuites = config.getHttpsIncludedCipherSuites();
-            if (includedCipherSuites.isEmpty()) {
-                sslContextFactory.setIncludeCipherSuites(includedCipherSuites.toArray(new String[includedCipherSuites.size()]));
-            }
+            sslContextFactory.setIncludeCipherSuites(includedCipherSuites.toArray(new String[includedCipherSuites.size()]));
             List<String> excludedCipherSuites = config.getHttpsExcludedCipherSuites();
-            if (excludedCipherSuites.isEmpty()) {
-                sslContextFactory.setExcludeCipherSuites(excludedCipherSuites.toArray(new String[excludedCipherSuites.size()]));
-            }
+            sslContextFactory.setExcludeCipherSuites(excludedCipherSuites.toArray(new String[excludedCipherSuites.size()]));
             SslConnectionFactory sslConnectionFactory = new SslConnectionFactory(sslContextFactory, "http/1.1");
 
             Integer acceptors = config.getHttpsAcceptorThreads();

--- a/http-server/src/test/java/io/airlift/http/server/TestHttpServerCipher.java
+++ b/http-server/src/test/java/io/airlift/http/server/TestHttpServerCipher.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.http.server;
+
+import com.google.common.collect.ImmutableSet;
+import io.airlift.event.client.NullEventClient;
+import io.airlift.node.NodeInfo;
+import io.airlift.tracetoken.TraceTokenManager;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import javax.servlet.Filter;
+import javax.servlet.http.HttpServlet;
+
+import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.concurrent.ExecutionException;
+
+import static com.google.common.io.Resources.getResource;
+
+public class TestHttpServerCipher
+{
+    private static final String KEY_STORE_PATH = constructKeyStorePath();
+    private static final String KEY_STORE_PASSWORD = "airlift";
+    public static final String CIPHER_1 = "TLS_RSA_WITH_AES_128_CBC_SHA";
+    public static final String CIPHER_2 = "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA";
+    public static final String CIPHER_3 = "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256";
+
+    private static String constructKeyStorePath()
+    {
+        try {
+            return new File(getResource("test.keystore").toURI()).getAbsolutePath();
+        }
+        catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void testIncludeCipherEmpty()
+            throws Exception
+    {
+        HttpServerConfig config = new HttpServerConfig()
+                .setHttpsEnabled(true)
+                .setHttpsPort(0)
+                .setKeystorePath(KEY_STORE_PATH)
+                .setKeystorePassword(KEY_STORE_PASSWORD)
+                .setHttpsIncludedCipherSuites(" ,   ");
+        NodeInfo nodeInfo = new NodeInfo("test");
+        HttpServerInfo httpServerInfo = new HttpServerInfo(config, nodeInfo);
+        HttpServer server = createServer(nodeInfo, httpServerInfo, config);
+        try {
+            server.start();
+            URI httpsUri = httpServerInfo.getHttpsUri();
+
+            HttpClient httpClient = createClientIncludeCiphers(CIPHER_1);
+            httpClient.GET(httpsUri);
+
+            httpClient = createClientIncludeCiphers(CIPHER_2);
+            httpClient.GET(httpsUri);
+
+            httpClient = createClientIncludeCiphers(CIPHER_3);
+            httpClient.GET(httpsUri);
+        }
+        finally {
+            server.stop();
+        }
+    }
+
+    @Test
+    public void testIncludedCipher()
+            throws Exception
+    {
+        HttpServerConfig config = new HttpServerConfig()
+                .setHttpsEnabled(true)
+                .setHttpsPort(0)
+                .setKeystorePath(KEY_STORE_PATH)
+                .setKeystorePassword(KEY_STORE_PASSWORD)
+                .setHttpsIncludedCipherSuites(CIPHER_1 + "," + CIPHER_2);
+        NodeInfo nodeInfo = new NodeInfo("test");
+        HttpServerInfo httpServerInfo = new HttpServerInfo(config, nodeInfo);
+        HttpServer server = createServer(nodeInfo, httpServerInfo, config);
+        try {
+            server.start();
+            URI httpsUri = httpServerInfo.getHttpsUri();
+
+            // should succeed because only one of the two allowed certificate is excluded
+            HttpClient httpClient = createClientIncludeCiphers(CIPHER_1);
+            httpClient.GET(httpsUri);
+
+            // should succeed because only one of the two allowed certificate is excluded
+            httpClient = createClientIncludeCiphers(CIPHER_2);
+            httpClient.GET(httpsUri);
+
+            httpClient = createClientIncludeCiphers(CIPHER_3);
+            try {
+                httpClient.GET(httpsUri);
+                Assert.fail("SSL handshake should fail because client included only ciphers the server didn't include");
+            }
+            catch (ExecutionException e) {
+                // expected
+            }
+        }
+        finally {
+            server.stop();
+        }
+    }
+
+    @Test
+    public void testExcludedCipher()
+            throws Exception
+    {
+        HttpServerConfig config = new HttpServerConfig()
+                .setHttpsEnabled(true)
+                .setHttpsPort(0)
+                .setKeystorePath(KEY_STORE_PATH)
+                .setKeystorePassword(KEY_STORE_PASSWORD)
+                .setHttpsExcludedCipherSuites(CIPHER_1 + "," + CIPHER_2);
+        NodeInfo nodeInfo = new NodeInfo("test");
+        HttpServerInfo httpServerInfo = new HttpServerInfo(config, nodeInfo);
+        HttpServer server = createServer(nodeInfo, httpServerInfo, config);
+
+        try {
+            server.start();
+            URI httpsUri = httpServerInfo.getHttpsUri();
+
+            // should succeed because all ciphers accepted
+            HttpClient httpClient = createClientIncludeCiphers();
+            httpClient.GET(httpsUri);
+
+            httpClient = createClientIncludeCiphers(CIPHER_1, CIPHER_2);
+            try {
+                httpClient.GET(httpsUri);
+                Assert.fail("SSL handshake should fail because client included only ciphers the server excluded");
+            }
+            catch (ExecutionException e) {
+                // expected
+            }
+        }
+        finally {
+            server.stop();
+        }
+    }
+
+    private HttpClient createClientIncludeCiphers(String... includedCipherSuites)
+            throws Exception
+    {
+        SslContextFactory sslContextFactory = new SslContextFactory();
+        sslContextFactory.setIncludeCipherSuites(includedCipherSuites);
+        sslContextFactory.setKeyStorePath(KEY_STORE_PATH);
+        sslContextFactory.setKeyStorePassword(KEY_STORE_PASSWORD);
+        HttpClient httpClient = new HttpClient(sslContextFactory);
+        httpClient.start();
+        return httpClient;
+    }
+
+    private HttpServer createServer(NodeInfo nodeInfo, HttpServerInfo httpServerInfo, HttpServerConfig config)
+    {
+        return createServer(new DummyServlet(), nodeInfo, httpServerInfo, config);
+    }
+
+    private HttpServer createServer(HttpServlet servlet, NodeInfo nodeInfo, HttpServerInfo httpServerInfo, HttpServerConfig config)
+    {
+        HashLoginServiceProvider loginServiceProvider = new HashLoginServiceProvider(config);
+        HttpServerProvider serverProvider = new HttpServerProvider(
+                httpServerInfo,
+                nodeInfo,
+                config,
+                servlet,
+                ImmutableSet.<Filter>of(new DummyFilter()),
+                ImmutableSet.<HttpServerBinder.HttpResourceBinding>of(),
+                ImmutableSet.<Filter>of(),
+                new RequestStats(),
+                new NullEventClient());
+        serverProvider.setTheAdminServlet(new DummyServlet());
+        serverProvider.setLoginService(loginServiceProvider.get());
+        serverProvider.setTokenManager(new TraceTokenManager());
+        return serverProvider.get();
+    }
+}


### PR DESCRIPTION
A typo in the implementation made the config ineffective.