### PR TITLE
Replace GzipFilter with GzipHandler

### DIFF
--- a/http-server/pom.xml
+++ b/http-server/pom.xml
@@ -129,11 +129,6 @@
 
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-servlets</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-security</artifactId>
         </dependency>
 


### PR DESCRIPTION
GzipFilter is deprecated in recent versions of Jetty and is now a no-op.