### PR TITLE
Ignore only announce error only

### DIFF
--- a/discovery/src/main/java/io/airlift/discovery/client/Announcer.java
+++ b/discovery/src/main/java/io/airlift/discovery/client/Announcer.java
@@ -78,8 +78,9 @@ public class Announcer
         Preconditions.checkState(!executor.isShutdown(), "Announcer has been destroyed");
         if (started.compareAndSet(false, true)) {
             // announce immediately, if discovery is running
+            ListenableFuture<Duration> announce = announce();
             try {
-                announce().get(30, TimeUnit.SECONDS);
+                announce.get(30, TimeUnit.SECONDS);
             }
             catch (Exception ignored) {
             }


### PR DESCRIPTION
Ignore only announce error only

Untill now any thrown exception within announce creation and its
execution in Announcer#start were ignored.

Exception during announce execution are typically logged in
ExponentialBackOff. While exceptions during announce creation are just
swallowed. This may lead to serious problem as no error is reported and
discovery mechanism is disabled.
