### PR TITLE
Http client improvements

### DIFF
--- a/http-client/src/main/java/io/airlift/http/client/Response.java
+++ b/http-client/src/main/java/io/airlift/http/client/Response.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ListMultimap;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
 import java.util.List;
 
 @Beta
@@ -43,6 +44,9 @@ public interface Response
     ListMultimap<HeaderName, String> getHeaders();
 
     long getBytesRead();
+
+    ByteBuffer getBytes()
+            throws IOException;
 
     InputStream getInputStream()
             throws IOException;

--- a/http-client/src/main/java/io/airlift/http/client/testing/TestingResponse.java
+++ b/http-client/src/main/java/io/airlift/http/client/testing/TestingResponse.java
@@ -13,10 +13,12 @@ import io.airlift.http.client.Response;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
 import java.util.Map;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.io.ByteStreams.toByteArray;
 
 public class TestingResponse
         implements Response
@@ -59,6 +61,13 @@ public class TestingResponse
     public long getBytesRead()
     {
         return countingInputStream.getCount();
+    }
+
+    @Override
+    public ByteBuffer getBytes()
+            throws IOException
+    {
+        return ByteBuffer.wrap(toByteArray(countingInputStream));
     }
 
     @Override

--- a/http-client/src/test/java/io/airlift/http/client/AbstractHttpClientTest.java
+++ b/http-client/src/test/java/io/airlift/http/client/AbstractHttpClientTest.java
@@ -42,6 +42,7 @@ import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
+import java.nio.ByteBuffer;
 import java.nio.channels.UnresolvedAddressException;
 import java.util.ArrayList;
 import java.util.List;
@@ -52,6 +53,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.zip.Deflater;
 
+import static com.google.common.base.Charsets.UTF_8;
 import static com.google.common.base.Throwables.propagate;
 import static com.google.common.base.Throwables.propagateIfInstanceOf;
 import static com.google.common.base.Throwables.propagateIfPossible;
@@ -617,6 +619,38 @@ public abstract class AbstractHttpClientTest
         else {
             assertEquals(statusMessage, "message");
         }
+    }
+
+    @Test
+    public void testResponseGetBytes()
+            throws Exception
+    {
+        servlet.setResponseBody("body");
+
+        Request request = prepareGet()
+                .setUri(baseURI)
+                .build();
+
+        String body = executeRequest(request, new ResponseHandler<String, Exception>()
+        {
+            @Override
+            public String handleException(Request request, Exception exception)
+                    throws Exception
+            {
+                throw exception;
+            }
+
+            @Override
+            public String handle(Request request, Response response)
+                    throws Exception
+            {
+                ByteBuffer byteBuffer = response.getBytes();
+                byte[] bytes = new byte[byteBuffer.remaining()];
+                byteBuffer.get(bytes);
+                return new String(bytes, UTF_8);
+            }
+        });
+        assertEquals(body, "body");
     }
 
     @Test(expectedExceptions = UnexpectedResponseException.class)


### PR DESCRIPTION
During the developing of our internal presto connector we have discovered the lack of possibility to get the already buffered data from the `Response` without extra copying. 
Also we noticed that `checkSufficientThreads` was missing for HttpClient when it is present for HttpServer.
