### PR TITLE
Add support for configurable event logging

### DIFF
--- a/event/pom.xml
+++ b/event/pom.xml
@@ -41,6 +41,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
         </dependency>
@@ -78,6 +83,11 @@
         <dependency>
             <groupId>com.google.inject.extensions</groupId>
             <artifactId>guice-multibindings</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
         </dependency>
 
         <!-- for testing -->

--- a/event/src/main/java/io/airlift/event/client/EventConfig.java
+++ b/event/src/main/java/io/airlift/event/client/EventConfig.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.event.client;
+
+import io.airlift.configuration.Config;
+import io.airlift.units.DataSize;
+
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+
+public class EventConfig
+{
+    private String logPath = "var/log/events.log";
+    // for now support only a single event type for logging
+    private String eventTypeToLog;
+    private boolean logEnabled;
+    private String logLayoutClass;
+    private int logHistory = 15;
+    private DataSize logMaxFileSize = new DataSize(128, MEGABYTE);
+
+    public String getLogPath()
+    {
+        return logPath;
+    }
+
+    @Config("event-log.path")
+    public EventConfig setLogPath(String logPath)
+    {
+        this.logPath = logPath;
+        return this;
+    }
+
+    public String getEventTypeToLog()
+    {
+        return eventTypeToLog;
+    }
+
+    @Config("event-log.type")
+    public EventConfig setEventTypeToLog(String eventTypeToLog)
+    {
+        this.eventTypeToLog = eventTypeToLog;
+        return this;
+    }
+
+    public boolean isLogEnabled()
+    {
+        return logEnabled;
+    }
+
+    @Config("event-log.enabled")
+    public EventConfig setLogEnabled(boolean logEnabled)
+    {
+        this.logEnabled = logEnabled;
+        return this;
+    }
+
+    public String getLogLayoutClass()
+    {
+        return logLayoutClass;
+    }
+
+    @Config("event-log.layout")
+    public EventConfig setLogLayoutClass(String logLayoutClass)
+    {
+        this.logLayoutClass = logLayoutClass;
+        return this;
+    }
+
+    public int getLogHistory()
+    {
+        return logHistory;
+    }
+
+    @Config("event-log.max-history")
+    public EventConfig setLogHistory(int logHistory)
+    {
+        this.logHistory = logHistory;
+        return this;
+    }
+
+    public DataSize getLogMaxFileSize()
+    {
+        return logMaxFileSize;
+    }
+
+    @Config("event-log.max-size")
+    public EventConfig setLogMaxFileSize(DataSize logMaxFileSize)
+    {
+        this.logMaxFileSize = logMaxFileSize;
+        return this;
+    }
+}

--- a/event/src/main/java/io/airlift/event/client/EventLoggingModule.java
+++ b/event/src/main/java/io/airlift/event/client/EventLoggingModule.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.event.client;
+
+import com.google.inject.Binder;
+import com.google.inject.Key;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
+import static io.airlift.configuration.ConfigBinder.configBinder;
+
+public class EventLoggingModule implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        // for backwards compatibility
+        binder.install(new EventModule());
+
+        configBinder(binder).bindConfig(EventConfig.class);
+        newSetBinder(binder, EventClient.class).addBinding().to(Key.get(LoggingEventClient.class)).in(Scopes.SINGLETON);
+    }
+}

--- a/event/src/main/java/io/airlift/event/client/LoggingEventClient.java
+++ b/event/src/main/java/io/airlift/event/client/LoggingEventClient.java
@@ -1,0 +1,91 @@
+package io.airlift.event.client;
+
+import ch.qos.logback.core.ContextBase;
+import ch.qos.logback.core.Layout;
+import ch.qos.logback.core.rolling.RollingFileAppender;
+import ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP;
+import ch.qos.logback.core.rolling.TimeBasedRollingPolicy;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Throwables;
+
+import javax.inject.Inject;
+import java.io.IOException;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class LoggingEventClient
+        extends AbstractEventClient
+{
+    private final boolean isLogEnabled;
+    private String eventType = null;
+    private RollingFileAppender fileAppender = null;
+
+    @Inject
+    public LoggingEventClient(EventConfig eventConfig)
+    {
+        isLogEnabled = eventConfig.isLogEnabled();
+
+        if (!isLogEnabled) {
+            return;
+        }
+
+        checkNotNull(eventConfig.getEventTypeToLog(), "event type to log is null");
+        checkNotNull(eventConfig.getLogLayoutClass(), "event log layout class is null");
+
+        this.eventType = eventConfig.getEventTypeToLog();
+        String logPath = eventConfig.getLogPath();
+        Layout logLayout = null;
+        try {
+            Class<?> layoutClass = Class.forName(eventConfig.getLogLayoutClass());
+            checkArgument(Layout.class.isAssignableFrom(layoutClass), "event log layout class must be a subclass of Layout");
+            logLayout = (Layout<?>) layoutClass.newInstance();
+        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+            Throwables.propagate(e);
+        }
+
+        ContextBase context = new ContextBase();
+        fileAppender = new RollingFileAppender<>();
+        SizeAndTimeBasedFNATP triggeringPolicy = new SizeAndTimeBasedFNATP<>();
+        TimeBasedRollingPolicy rollingPolicy = new TimeBasedRollingPolicy<>();
+
+        rollingPolicy.setContext(context);
+        rollingPolicy.setFileNamePattern(logPath + "-%d{yyyy-MM-dd}.%i.log.gz");
+        rollingPolicy.setMaxHistory(eventConfig.getLogHistory());
+        rollingPolicy.setTimeBasedFileNamingAndTriggeringPolicy(triggeringPolicy);
+        rollingPolicy.setParent(fileAppender);
+        rollingPolicy.start();
+
+        triggeringPolicy.setContext(context);
+        triggeringPolicy.setTimeBasedRollingPolicy(rollingPolicy);
+        triggeringPolicy.setMaxFileSize(String.valueOf(eventConfig.getLogMaxFileSize()));
+        triggeringPolicy.start();
+
+        fileAppender.setContext(context);
+        fileAppender.setFile(logPath);
+        fileAppender.setAppend(true);
+        fileAppender.setLayout(logLayout);
+        fileAppender.setRollingPolicy(rollingPolicy);
+        fileAppender.start();
+    }
+
+    @Override
+    protected <T> void postEvent(T event)
+            throws IOException
+    {
+        if (!isLogEnabled) {
+            return;
+        }
+
+        EventType eventTypeAnnotation = event.getClass().getAnnotation(EventType.class);
+        if (eventTypeAnnotation != null && eventTypeAnnotation.value().equals(eventType)) {
+            fileAppender.doAppend(event);
+        }
+    }
+
+    @VisibleForTesting
+    void setFileAppender(RollingFileAppender appender)
+    {
+        this.fileAppender = appender;
+    }
+}

--- a/event/src/test/java/io/airlift/event/client/TestLoggingEventClient.java
+++ b/event/src/test/java/io/airlift/event/client/TestLoggingEventClient.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.event.client;
+
+import ch.qos.logback.core.LayoutBase;
+import ch.qos.logback.core.rolling.RollingFileAppender;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestLoggingEventClient
+{
+    private File temp;
+
+    @BeforeClass
+    public void setup() throws IOException
+    {
+        temp = File.createTempFile("event-logging-tests", ".log");
+    }
+
+    @AfterClass
+    public void tearDown()
+    {
+        temp.delete();
+    }
+
+    @Test
+    public void testInitWithDefaults() throws IOException {
+        EventConfig config = new EventConfig();
+        MockRollingFileAppender appender = new MockRollingFileAppender();
+        LoggingEventClient client = createLoggingEventClient(config, appender);
+        client.postEvent("test event");
+        assertEquals(appender.getLogs().size(), 0, "client shouldn't log any events");
+    }
+
+    @Test
+    public void testEventLogging() throws IOException
+    {
+        EventConfig config = new EventConfig();
+        config.setLogEnabled(true);
+        config.setLogLayoutClass(MockLayout.class.getName());
+        config.setLogPath(temp.getAbsolutePath());
+        config.setEventTypeToLog("MockEvent");
+        MockRollingFileAppender appender = new MockRollingFileAppender();
+        LoggingEventClient client = createLoggingEventClient(config, appender);
+        client.postEvent(new MockEvent());
+        assertEquals(appender.getLogs().size(), 1, "client should log a single event");
+        assertEquals(appender.getLogs().get(0).getClass(), MockEvent.class, "client should log a single event");
+    }
+
+    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "java.lang.ClassNotFoundException: nonexistent_class.*")
+    public void testNonexistentLogLayoutClass()
+    {
+        EventConfig config = new EventConfig();
+        config.setLogEnabled(true);
+        config.setLogPath(temp.getAbsolutePath());
+        config.setEventTypeToLog("MockEvent");
+        config.setLogLayoutClass("nonexistent_class");
+        MockRollingFileAppender appender = new MockRollingFileAppender();
+        createLoggingEventClient(config, appender);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class, expectedExceptionsMessageRegExp = "event type to log is null")
+    public void testNullEventType()
+    {
+        EventConfig config = new EventConfig();
+        config.setLogEnabled(true);
+        config.setLogPath(temp.getAbsolutePath());
+        config.setEventTypeToLog(null);
+        config.setLogLayoutClass(MockLayout.class.getName());
+        MockRollingFileAppender appender = new MockRollingFileAppender();
+        createLoggingEventClient(config, appender);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class, expectedExceptionsMessageRegExp = "event log layout class is null")
+    public void testNullLogLayout()
+    {
+        EventConfig config = new EventConfig();
+        config.setLogEnabled(true);
+        config.setLogPath(temp.getAbsolutePath());
+        config.setEventTypeToLog("MockEvent");
+        config.setLogLayoutClass(null);
+        MockRollingFileAppender appender = new MockRollingFileAppender();
+        createLoggingEventClient(config, appender);
+    }
+
+    private LoggingEventClient createLoggingEventClient(EventConfig config, MockRollingFileAppender appender)
+    {
+        LoggingEventClient client = new LoggingEventClient(config);
+        client.setFileAppender(appender);
+        return client;
+    }
+}
+
+@EventType("MockEvent")
+class MockEvent
+{
+}
+
+class MockRollingFileAppender extends RollingFileAppender
+{
+    private final List<Object> logs;
+
+    public MockRollingFileAppender()
+    {
+        logs = new ArrayList<>();
+    }
+
+    @Override
+    public void doAppend(Object eventObject) {
+        logs.add(eventObject);
+    }
+
+    public List<Object> getLogs()
+    {
+        return logs;
+    }
+}
+
+class MockLayout extends LayoutBase
+{
+    @Override
+    public String doLayout(Object event) {
+        return event.toString();
+    }
+}


### PR DESCRIPTION
This PR adds support for configurable event logging, e.g., to log query completion events to a particular log file with a custom log format. Related issues are facebook/presto#2917 and facebook/presto#4642

Once this is merged we can add this new `EventLoggingModule` to `PrestoServer`.

@martint @electrum can you please take a look?
@billonahill can you also take a look to see whether this addresses your use case?

##### Sample configuration:
```
event-log.enabled=true
event-log.path=/mnt/presto-server-0.142-SNAPSHOT/query-completion-events.log
event-log.type=QueryCompletion
event-log.layout=presto.test.QueryCompletionLogLayout
```

##### Open issues:
- Do we want to provide a default log layout? If so where (in Presto or in Airlift)?