### PR TITLE
Add useCanonicalHostname property to KerberosConfig

### DIFF
--- a/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
@@ -1362,7 +1362,8 @@ public class JettyHttpClient
                     kerberosConfig.getConfig(),
                     kerberosConfig.getCredentialCache(),
                     config.getKerberosPrincipal(),
-                    config.getKerberosRemoteServiceName());
+                    config.getKerberosRemoteServiceName(),
+                    kerberosConfig.isUseCanonicalHostname());
 
             authenticationStore = new SpnegoAuthenticationStore(spnego);
         }

--- a/http-client/src/main/java/io/airlift/http/client/spnego/KerberosConfig.java
+++ b/http-client/src/main/java/io/airlift/http/client/spnego/KerberosConfig.java
@@ -10,6 +10,7 @@ public class KerberosConfig
     private File credentialCache;
     private File keytab;
     private File config;
+    private boolean useCanonicalHostname = true;
 
     public File getCredentialCache()
     {
@@ -47,6 +48,19 @@ public class KerberosConfig
     public KerberosConfig setConfig(File config)
     {
         this.config = config;
+        return this;
+    }
+
+    public boolean isUseCanonicalHostname()
+    {
+        return useCanonicalHostname;
+    }
+
+    @Config("http.authentication.krb5.use-canonical-hostname")
+    @ConfigDescription("Canonicalize service hostname using the DNS reverse lookup")
+    public KerberosConfig setUseCanonicalHostname(boolean useCanonicalHostname)
+    {
+        this.useCanonicalHostname = useCanonicalHostname;
         return this;
     }
 }

--- a/http-client/src/test/java/io/airlift/http/client/spnego/TestSecurityConfig.java
+++ b/http-client/src/test/java/io/airlift/http/client/spnego/TestSecurityConfig.java
@@ -28,7 +28,8 @@ public class TestSecurityConfig
         ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(KerberosConfig.class)
                 .setConfig(null)
                 .setKeytab(null)
-                .setCredentialCache(null));
+                .setCredentialCache(null)
+                .setUseCanonicalHostname(true));
     }
 
     @Test
@@ -38,12 +39,14 @@ public class TestSecurityConfig
                 .put("http.authentication.krb5.config", "/etc/krb5.conf")
                 .put("http.authentication.krb5.keytab", "/etc/krb5.keytab")
                 .put("http.authentication.krb5.credential-cache", "/etc/krb5.ccache")
+                .put("http.authentication.krb5.use-canonical-hostname", "false")
                 .build();
 
         KerberosConfig expected = new KerberosConfig()
                 .setConfig(new File("/etc/krb5.conf"))
                 .setKeytab(new File("/etc/krb5.keytab"))
-                .setCredentialCache(new File("/etc/krb5.ccache"));
+                .setCredentialCache(new File("/etc/krb5.ccache"))
+                .setUseCanonicalHostname(false);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
This flag adds possibility to disable reverse dns resolve on the
environments where modifying reverse dns records isn't possible.
With this flag set to false service pricipal is simply being built
with the hostname specified by user in the service URL.
With this flag set to true reverse dns lookup is being made to
canonicalize service hostname.