### PR TITLE
Add diagnostics to discovery announcer

### DIFF
--- a/discovery/src/main/java/io/airlift/discovery/client/DiscoveryModule.java
+++ b/discovery/src/main/java/io/airlift/discovery/client/DiscoveryModule.java
@@ -61,6 +61,7 @@ public class DiscoveryModule
 
         // bind announcer
         binder.bind(Announcer.class).in(Scopes.SINGLETON);
+        newExporter(binder).export(Announcer.class).withGeneratedName();
 
         // Must create a multibinder for service announcements or construction will fail if no
         // service announcements are bound, which is legal for processes that don't have public services

--- a/discovery/src/main/java/io/airlift/discovery/client/HttpDiscoveryAnnouncementClient.java
+++ b/discovery/src/main/java/io/airlift/discovery/client/HttpDiscoveryAnnouncementClient.java
@@ -105,7 +105,7 @@ public class HttpDiscoveryAnnouncementClient implements DiscoveryAnnouncementCli
         });
     }
 
-    private boolean isSuccess(int statusCode)
+    private static boolean isSuccess(int statusCode)
     {
         return statusCode / 100 == 2;
     }
@@ -132,10 +132,10 @@ public class HttpDiscoveryAnnouncementClient implements DiscoveryAnnouncementCli
                 .setUri(URI.create(uri + "/v1/announcement/" + nodeInfo.getNodeId()))
                 .setHeader("User-Agent", nodeInfo.getNodeId())
                 .build();
-        return httpClient.executeAsync(request, new DiscoveryResponseHandler<Void>("Unannouncement", uri));
+        return httpClient.executeAsync(request, new DiscoveryResponseHandler<>("Unannouncement", uri));
     }
 
-    private Duration extractMaxAge(Response response)
+    private static Duration extractMaxAge(Response response)
     {
         String header = response.getHeader(HttpHeaders.CACHE_CONTROL);
         if (header != null) {


### PR DESCRIPTION
Sometimes there are gaps in the discovery announcment, so add logging to
determine where gaps are happening.