### PR TITLE
Remove dependencies on internal JVM classes for JMX agent

### DIFF
--- a/jmx/pom.xml
+++ b/jmx/pom.xml
@@ -51,6 +51,11 @@
             <artifactId>guice</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>annotations</artifactId>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>org.testng</groupId>

--- a/jmx/src/test/java/io/airlift/jmx/TestJmxAgent.java
+++ b/jmx/src/test/java/io/airlift/jmx/TestJmxAgent.java
@@ -1,6 +1,5 @@
 package io.airlift.jmx;
 
-import com.google.common.net.HostAndPort;
 import org.testng.annotations.Test;
 
 import javax.management.MBeanServerConnection;
@@ -8,34 +7,73 @@ import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXConnectorFactory;
 import javax.management.remote.JMXServiceURL;
 
-import static java.lang.String.format;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+
 import static org.testng.Assert.assertTrue;
 
 public class TestJmxAgent
 {
     @Test
-    public void testSanity()
+    public void testRandomPorts()
             throws Exception
     {
-        HostAndPort address = JmxAgent.getRunningAgentAddress(null, null);
+        verify(new JmxConfig());
+    }
 
-        JmxAgent agent = new JmxAgent(new JmxConfig());
-        if (address == null) {
-            // if agent wasn't running, it must have been started by the instantiation of JmxAgent
-            address = JmxAgent.getRunningAgentAddress(null, null);
-            assertNotNull(address);
+    @Test
+    public void testRegistryPort()
+            throws Exception
+    {
+        JmxConfig config = new JmxConfig().setRmiRegistryPort(NetUtils.findUnusedPort());
+
+        verify(config);
+    }
+
+    @Test
+    public void testRmiServerPort()
+            throws Exception
+    {
+        JmxConfig config = new JmxConfig().setRmiServerPort(NetUtils.findUnusedPort());
+
+        verify(config);
+    }
+
+    @Test
+    public void testBothPorts()
+            throws Exception
+    {
+        JmxConfig config = new JmxConfig()
+                .setRmiServerPort(NetUtils.findUnusedPort())
+                .setRmiRegistryPort(NetUtils.findUnusedPort());
+
+        verify(config);
+    }
+
+    @Test
+    public void testRestart()
+            throws Exception
+    {
+        JmxConfig config = new JmxConfig()
+                .setRmiServerPort(NetUtils.findUnusedPort())
+                .setRmiRegistryPort(NetUtils.findUnusedPort());
+
+        verify(config);
+        verify(config);
+    }
+
+    private void verify(JmxConfig config)
+            throws IOException
+    {
+        try (JmxAgent agent = new JmxAgent(config, ManagementFactory.getPlatformMBeanServer())) {
+            agent.start();
+            JMXServiceURL url = agent.getUrl();
+
+            JMXConnector connector = JMXConnectorFactory.connect(url);
+            connector.connect();
+
+            MBeanServerConnection connection = connector.getMBeanServerConnection();
+            assertTrue(connection.getMBeanCount() > 0);
         }
-
-        JMXServiceURL url = agent.getUrl();
-
-        assertEquals(url.toString(), format("service:jmx:rmi:///jndi/rmi://%s:%s/jmxrmi", address.getHostText(), address.getPort()));
-
-        JMXConnector connector = JMXConnectorFactory.connect(url);
-        connector.connect();
-
-        MBeanServerConnection connection = connector.getMBeanServerConnection();
-        assertTrue(connection.getMBeanCount() > 0);
     }
 }


### PR DESCRIPTION
This sacrifices discoverability via jstatd, but makes the code
compatible with Java 9.