### PR TITLE
Run tests in single-threaded mode

### DIFF
--- a/units/src/test/java/io/airlift/units/TestDataSize.java
+++ b/units/src/test/java/io/airlift/units/TestDataSize.java
@@ -101,13 +101,15 @@ public class TestDataSize
     @Test(dataProvider = "printedValues")
     public void testNonEnglishLocale(String expectedString, double value, DataSize.Unit unit)
     {
-        Locale previous = Locale.getDefault();
-        Locale.setDefault(Locale.GERMAN);
-        try {
-            assertEquals(new DataSize(value, unit).toString(), expectedString);
-        }
-        finally {
-            Locale.setDefault(previous);
+        synchronized (Locale.class) {
+            Locale previous = Locale.getDefault();
+            Locale.setDefault(Locale.GERMAN);
+            try {
+                assertEquals(new DataSize(value, unit).toString(), expectedString);
+            }
+            finally {
+                Locale.setDefault(previous);
+            }
         }
     }
 

--- a/units/src/test/java/io/airlift/units/TestDuration.java
+++ b/units/src/test/java/io/airlift/units/TestDuration.java
@@ -130,13 +130,15 @@ public class TestDuration
     public void testNonEnglishLocale(String expectedString, double value, TimeUnit unit)
             throws Exception
     {
-        Locale previous = Locale.getDefault();
-        Locale.setDefault(Locale.GERMAN);
-        try {
-            assertEquals(new Duration(value, unit).toString(), expectedString);
-        }
-        finally {
-            Locale.setDefault(previous);
+        synchronized (Locale.class) {
+            Locale previous = Locale.getDefault();
+            Locale.setDefault(Locale.GERMAN);
+            try {
+                assertEquals(new Duration(value, unit).toString(), expectedString);
+            }
+            finally {
+                Locale.setDefault(previous);
+            }
         }
     }
 


### PR DESCRIPTION
The testNonEnglishLocale tests modifies the VM-wide locale setting,
so the invocations need to execute serially to avoid race conditions.