### PR TITLE
Statically configure logging for Jetty HTTP client

### DIFF
--- a/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
@@ -96,6 +96,10 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 public class JettyHttpClient
         implements io.airlift.http.client.HttpClient
 {
+    static {
+        JettyLogging.setup();
+    }
+
     private static final AtomicLong nameCounter = new AtomicLong();
     private static final String PRESTO_STATS_KEY = "presto_stats";
     private static final long SWEEP_PERIOD_MILLIS = 5000;

--- a/http-client/src/main/java/io/airlift/http/client/jetty/JettyIoPool.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/JettyIoPool.java
@@ -17,6 +17,10 @@ import static java.lang.Thread.currentThread;
 public final class JettyIoPool
         implements Closeable
 {
+    static {
+        JettyLogging.setup();
+    }
+
     private final String name;
     private final QueuedThreadPool executor;
     private final ByteBufferPool byteBufferPool;

--- a/http-client/src/main/java/io/airlift/http/client/jetty/JettyLogging.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/JettyLogging.java
@@ -1,0 +1,75 @@
+package io.airlift.http.client.jetty;
+
+import org.eclipse.jetty.util.log.JavaUtilLog;
+import org.eclipse.jetty.util.log.Log;
+import org.eclipse.jetty.util.log.Logger;
+
+final class JettyLogging
+{
+    private JettyLogging() {}
+
+    public static void setup()
+    {
+        Log.setLog(new NoOpLogger());
+        Log.initialized();
+        Log.setLog(new JavaUtilLog());
+    }
+
+    private static class NoOpLogger
+            implements Logger
+    {
+        @Override
+        public String getName()
+        {
+            return "";
+        }
+
+        @Override
+        public void warn(String msg, Object... args) {}
+
+        @Override
+        public void warn(Throwable thrown) {}
+
+        @Override
+        public void warn(String msg, Throwable thrown) {}
+
+        @Override
+        public void info(String msg, Object... args) {}
+
+        @Override
+        public void info(Throwable thrown) {}
+
+        @Override
+        public void info(String msg, Throwable thrown) {}
+
+        @Override
+        public boolean isDebugEnabled()
+        {
+            return false;
+        }
+
+        @Override
+        public void setDebugEnabled(boolean enabled) {}
+
+        @Override
+        public void debug(String msg, Object... args) {}
+
+        @Override
+        public void debug(String msg, long value) {}
+
+        @Override
+        public void debug(Throwable thrown) {}
+
+        @Override
+        public void debug(String msg, Throwable thrown) {}
+
+        @Override
+        public Logger getLogger(String name)
+        {
+            return this;
+        }
+
+        @Override
+        public void ignore(Throwable ignored) {}
+    }
+}

--- a/http-client/src/main/resources/jetty-logging.properties
+++ b/http-client/src/main/resources/jetty-logging.properties
@@ -1,1 +1,0 @@
-org.eclipse.jetty.util.log.class=org.eclipse.jetty.util.log.JavaUtilLog


### PR DESCRIPTION
This removes the need for the logging properties file.
It also suppresses the "Logging initialized message.