### PR TITLE
Add missing javax.activation dependency

### DIFF
--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -52,6 +52,12 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-common</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -312,6 +312,12 @@
 
             <!-- jersey -->
             <dependency>
+                <groupId>javax.activation</groupId>
+                <artifactId>activation</artifactId>
+                <version>1.1.1</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.glassfish.jersey.core</groupId>
                 <artifactId>jersey-common</artifactId>
                 <version>${dep.jersey.version}</version>


### PR DESCRIPTION
This is needed for Java 9, which doesn't expose
those annotations by default