### PR TITLE
Workaround IntelliJ mishandling of system-scoped dependencies

### DIFF
--- a/jmx/pom.xml
+++ b/jmx/pom.xml
@@ -16,15 +16,6 @@
     </properties>
 
     <dependencies>
-        <!-- TODO: remove after upgrade to Java 9 -->
-        <dependency>
-            <groupId>com.sun</groupId>
-            <artifactId>tools</artifactId>
-            <version>1.8</version>
-            <scope>system</scope>
-            <systemPath>${java.home}/../lib/tools.jar</systemPath>
-        </dependency>
-
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>log</artifactId>
@@ -68,5 +59,29 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <!-- TODO: remove after upgrade to Java 9 -->
+            <!-- IntelliJ incorrectly loads "system" dependencies in "compile" scope. This is problematic
+                 for running programs from IntelliJ using Java 9, because it places tools.jar in the classpath.
+                 This hack allows us to only include tools.jar during compilation from the command line. -->
+            <id>lib/tools.jar</id>
+            <activation>
+                <property>
+                    <name>!idea.maven.embedder.version</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.sun</groupId>
+                    <artifactId>tools</artifactId>
+                    <version>1.8</version>
+                    <scope>system</scope>
+                    <systemPath>${java.home}/../lib/tools.jar</systemPath>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>
 


### PR DESCRIPTION
IntelliJ loads system dependencies in compile scope, which tools.jar
to be added to the classpath and causes problems when running with Java 9