### PR TITLE
Parameterize the JMX agent for Java 8 vs 9

### DIFF
--- a/jmx/src/main/java/io/airlift/jmx/JavaVersion.java
+++ b/jmx/src/main/java/io/airlift/jmx/JavaVersion.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.jmx;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.StandardSystemProperty;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.lang.String.format;
+
+// TODO: remove this when we upgrade to Java 9 (replace with java.lang.Runtime.getVersion())
+class JavaVersion
+{
+    // As described in JEP-223
+    private static final String VERSION_NUMBER = "(?<MAJOR>[1-9][0-9]*)(\\.(?<MINOR>(0|[1-9][0-9]*))(\\.(?:(0|[1-9][0-9]*)))?)?";
+    private static final String PRE = "(?:-(?:[a-zA-Z0-9]+))?";
+    private static final String BUILD = "(?:(?:\\+)(?:0|[1-9][0-9]*)?)?";
+    private static final String OPT = "(?:-(?:[-a-zA-Z0-9.]+))?";
+    private static final Pattern PATTERN = Pattern.compile(VERSION_NUMBER + PRE + BUILD + OPT);
+
+    // For Java 8 and below
+    private static final Pattern LEGACY_PATTERN = Pattern.compile("1\\.(?<MAJOR>[0-9]+)(\\.(?<MINOR>(0|[1-9][0-9]*)))?(_(?<UPDATE>[1-9][0-9]*))?");
+
+    private final int major;
+    private final int minor;
+    private final OptionalInt update;
+
+    public static JavaVersion current()
+    {
+        return parse(StandardSystemProperty.JAVA_VERSION.value());
+    }
+
+    public static JavaVersion parse(String version)
+    {
+        Matcher matcher = LEGACY_PATTERN.matcher(version);
+        if (matcher.matches()) {
+            int major = Integer.parseInt(matcher.group("MAJOR"));
+            int minor = Optional.ofNullable(matcher.group("MINOR"))
+                    .map(Integer::parseInt)
+                    .orElse(0);
+
+            String update = matcher.group("UPDATE");
+            if (update == null) {
+                return new JavaVersion(major, minor);
+            }
+
+            return new JavaVersion(major, minor, OptionalInt.of(Integer.parseInt(update)));
+        }
+
+        matcher = PATTERN.matcher(version);
+        if (matcher.matches()) {
+            int major = Integer.parseInt(matcher.group("MAJOR"));
+            int minor = Optional.ofNullable(matcher.group("MINOR"))
+                    .map(Integer::parseInt)
+                    .orElse(0);
+
+            return new JavaVersion(major, minor);
+        }
+
+        throw new IllegalArgumentException(format("Cannot parse version %s", version));
+    }
+
+    public JavaVersion(int major, int minor, OptionalInt update)
+    {
+        this.major = major;
+        this.minor = minor;
+        this.update = update;
+    }
+
+    public JavaVersion(int major, int minor)
+    {
+        this(major, minor, OptionalInt.empty());
+    }
+
+    public int getMajor()
+    {
+        return major;
+    }
+
+    public int getMinor()
+    {
+        return minor;
+    }
+
+    public OptionalInt getUpdate()
+    {
+        return update;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        JavaVersion that = (JavaVersion) o;
+        return major == that.major &&
+                minor == that.minor &&
+                Objects.equals(update, that.update);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(major, minor, update);
+    }
+
+    @Override
+    public String toString()
+    {
+        return MoreObjects.toStringHelper(this)
+                .add("major", major)
+                .add("minor", minor)
+                .add("update", update)
+                .toString();
+    }
+}

--- a/jmx/src/main/java/io/airlift/jmx/JmxAgent.java
+++ b/jmx/src/main/java/io/airlift/jmx/JmxAgent.java
@@ -1,6 +1,4 @@
 /*
- * Copyright 2010 Proofpoint, Inc.
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -15,99 +13,9 @@
  */
 package io.airlift.jmx;
 
-import com.google.common.base.Throwables;
-import com.google.common.net.HostAndPort;
-import com.google.inject.Inject;
-import com.sun.tools.attach.AttachNotSupportedException;
-import com.sun.tools.attach.VirtualMachine;
-import io.airlift.log.Logger;
-
 import javax.management.remote.JMXServiceURL;
 
-import java.io.IOException;
-import java.lang.management.ManagementFactory;
-import java.net.MalformedURLException;
-import java.util.Properties;
-
-public class JmxAgent
+interface JmxAgent
 {
-    private static final Logger log = Logger.get(JmxAgent.class);
-
-    private final JMXServiceURL url;
-
-    @Inject
-    public JmxAgent(JmxConfig config)
-            throws IOException
-    {
-        int registryPort;
-        if (config.getRmiRegistryPort() == null) {
-            registryPort = NetUtils.findUnusedPort();
-        }
-        else {
-            registryPort = config.getRmiRegistryPort();
-        }
-
-        int serverPort = 0;
-        if (config.getRmiServerPort() != null) {
-            serverPort = config.getRmiServerPort();
-        }
-
-        try {
-            VirtualMachine virtualMachine = VirtualMachine.attach(Long.toString(getProcessId()));
-            try {
-                virtualMachine.startLocalManagementAgent();
-
-                Properties properties = new Properties();
-                properties.setProperty("com.sun.management.jmxremote.port", Integer.toString(registryPort));
-                properties.setProperty("com.sun.management.jmxremote.rmi.port", Integer.toString(serverPort));
-                properties.setProperty("com.sun.management.jmxremote.authenticate", "false");
-                properties.setProperty("com.sun.management.jmxremote.ssl", "false");
-                virtualMachine.startManagementAgent(properties);
-            }
-            finally {
-                virtualMachine.detach();
-            }
-        }
-        catch (AttachNotSupportedException e) {
-            throw Throwables.propagate(e);
-        }
-
-        HostAndPort address;
-        try {
-            // This is how the jdk jmx agent constructs its url
-            JMXServiceURL url = new JMXServiceURL("rmi", null, registryPort);
-            address = HostAndPort.fromParts(url.getHost(), url.getPort());
-        }
-        catch (MalformedURLException e) {
-            // should not happen...
-            throw new AssertionError(e);
-        }
-
-        log.info("JMX agent started and listening on %s", address);
-
-        this.url = new JMXServiceURL(String.format("service:jmx:rmi:///jndi/rmi://%s:%s/jmxrmi", address.getHostText(), address.getPort()));
-    }
-
-    public JMXServiceURL getUrl()
-    {
-        return url;
-    }
-
-    private static long getProcessId()
-    {
-        // TODO: replace with ProcessHandle.current().getPid() in Java 9
-        String name = ManagementFactory.getRuntimeMXBean().getName();
-        int index = name.indexOf('@');
-
-        if (index < 1) {
-            throw new AssertionError("Cannot get process PID");
-        }
-
-        try {
-            return Long.parseLong(name.substring(0, index));
-        }
-        catch (NumberFormatException e) {
-            throw new AssertionError("Cannot get process PID");
-        }
-    }
+    JMXServiceURL getUrl();
 }

--- a/jmx/src/main/java/io/airlift/jmx/JmxAgent8.java
+++ b/jmx/src/main/java/io/airlift/jmx/JmxAgent8.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.jmx;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Throwables;
+import com.google.common.net.HostAndPort;
+import com.google.inject.Inject;
+import io.airlift.log.Logger;
+import sun.management.Agent;
+import sun.management.jmxremote.ConnectorBootstrap;
+import sun.rmi.server.UnicastRef;
+
+import javax.management.remote.JMXConnectorServer;
+import javax.management.remote.JMXServiceURL;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.net.MalformedURLException;
+import java.rmi.server.RemoteObject;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static java.lang.String.format;
+
+class JmxAgent8
+    implements JmxAgent
+{
+    private static final Logger log = Logger.get(JmxAgent.class);
+
+    private final JMXServiceURL url;
+
+    @Inject
+    public JmxAgent8(JmxConfig config)
+            throws IOException
+    {
+        // first, see if the jmx agent is already started (e.g., via command line properties passed to the jvm)
+        HostAndPort address = getRunningAgentAddress(config.getRmiRegistryPort(), config.getRmiServerPort());
+        if (address != null) {
+            log.info("JMX agent already running and listening on %s", address);
+        }
+        else {
+            // otherwise, start it manually
+            int registryPort;
+            if (config.getRmiRegistryPort() == null) {
+                registryPort = NetUtils.findUnusedPort();
+            }
+            else {
+                registryPort = config.getRmiRegistryPort();
+            }
+
+            int serverPort = 0;
+            if (config.getRmiServerPort() != null) {
+                serverPort = config.getRmiServerPort();
+            }
+
+            // This is somewhat of a hack, but the jmx agent in Oracle/OpenJDK doesn't
+            // have a programmatic API for starting it and controlling its parameters
+            System.setProperty("com.sun.management.jmxremote", "true");
+            System.setProperty("com.sun.management.jmxremote.port", Integer.toString(registryPort));
+            System.setProperty("com.sun.management.jmxremote.rmi.port", Integer.toString(serverPort));
+            System.setProperty("com.sun.management.jmxremote.authenticate", "false");
+            System.setProperty("com.sun.management.jmxremote.ssl", "false");
+
+            try {
+                Agent.startAgent();
+            }
+            catch (Exception e) {
+                throw Throwables.propagate(e);
+            }
+
+            try {
+                // This is how the jdk jmx agent constructs its url
+                JMXServiceURL url = new JMXServiceURL("rmi", null, registryPort);
+                address = HostAndPort.fromParts(url.getHost(), url.getPort());
+            }
+            catch (MalformedURLException e) {
+                // should not happen...
+                throw new AssertionError(e);
+            }
+
+            log.info("JMX agent started and listening on %s", address);
+        }
+
+        this.url = new JMXServiceURL(String.format("service:jmx:rmi:///jndi/rmi://%s:%s/jmxrmi", address.getHostText(), address.getPort()));
+    }
+
+    public JMXServiceURL getUrl()
+    {
+        return url;
+    }
+
+    @VisibleForTesting
+    static HostAndPort getRunningAgentAddress(Integer registryPort, Integer serverPort)
+    {
+        JMXConnectorServer jmxServer;
+        RemoteObject registry;
+        int actualRegistryPort;
+        try {
+            jmxServer = getField(Agent.class, JMXConnectorServer.class, "jmxServer");
+            registry = getField(ConnectorBootstrap.class, RemoteObject.class, "registry");
+
+            if (jmxServer == null || registry == null) {
+                log.warn("Cannot determine if JMX agent is already running (not an Oracle JVM?). Will try to start it manually.");
+                return null;
+            }
+
+            actualRegistryPort = ((UnicastRef) registry.getRef()).getLiveRef().getPort();
+        }
+        catch (Exception e) {
+            log.warn(e, "Cannot determine if JMX agent is already running. Will try to start it manually.");
+            return null;
+        }
+
+        checkState(actualRegistryPort > 0, "Expected actual RMI registry port to be > 0, actual: %s", actualRegistryPort);
+
+        // if registry port and server port were configured and the agent is already running, make sure
+        // the configuration agrees to avoid surprises
+        if (registryPort != null && registryPort != 0) {
+            checkArgument(actualRegistryPort == registryPort,
+                    "JMX agent is already running, but actual RMI registry port (%s) doesn't match configured port (%s)",
+                    actualRegistryPort,
+                    registryPort);
+        }
+
+        if (serverPort != null && serverPort != 0) {
+            int actualServerPort = jmxServer.getAddress().getPort();
+            checkArgument(actualServerPort == serverPort,
+                    "JMX agent is already running, but actual RMI server port (%s) doesn't match configured port (%s)",
+                    actualServerPort,
+                    serverPort);
+        }
+
+        return HostAndPort.fromParts(jmxServer.getAddress().getHost(), actualRegistryPort);
+    }
+
+    private static <T> T getField(Class<?> clazz, Class<T> returnType, String name)
+            throws Exception
+    {
+        Field field = clazz.getDeclaredField(name);
+        field.setAccessible(true);
+        try {
+            return returnType.cast(field.get(clazz));
+        }
+        catch (ClassCastException e) {
+            throw new IllegalArgumentException(format("Field %s in class %s is not of type %s, actual: %s", name, clazz.getName(), returnType.getName(), field.getType().getName()), e);
+        }
+    }
+}

--- a/jmx/src/main/java/io/airlift/jmx/JmxAgent9.java
+++ b/jmx/src/main/java/io/airlift/jmx/JmxAgent9.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.jmx;
+
+import com.google.common.base.Throwables;
+import com.google.common.net.HostAndPort;
+import com.google.inject.Inject;
+import com.sun.tools.attach.AttachNotSupportedException;
+import com.sun.tools.attach.VirtualMachine;
+import io.airlift.log.Logger;
+
+import javax.management.remote.JMXServiceURL;
+
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.net.MalformedURLException;
+import java.util.Properties;
+
+class JmxAgent9
+    implements JmxAgent
+{
+    private static final Logger log = Logger.get(JmxAgent.class);
+
+    private final JMXServiceURL url;
+
+    @Inject
+    public JmxAgent9(JmxConfig config)
+            throws IOException
+    {
+        int registryPort;
+        if (config.getRmiRegistryPort() == null) {
+            registryPort = NetUtils.findUnusedPort();
+        }
+        else {
+            registryPort = config.getRmiRegistryPort();
+        }
+
+        int serverPort = 0;
+        if (config.getRmiServerPort() != null) {
+            serverPort = config.getRmiServerPort();
+        }
+
+        try {
+            VirtualMachine virtualMachine = VirtualMachine.attach(Long.toString(getProcessId()));
+            try {
+                virtualMachine.startLocalManagementAgent();
+
+                Properties properties = new Properties();
+                properties.setProperty("com.sun.management.jmxremote.port", Integer.toString(registryPort));
+                properties.setProperty("com.sun.management.jmxremote.rmi.port", Integer.toString(serverPort));
+                properties.setProperty("com.sun.management.jmxremote.authenticate", "false");
+                properties.setProperty("com.sun.management.jmxremote.ssl", "false");
+                virtualMachine.startManagementAgent(properties);
+            }
+            finally {
+                virtualMachine.detach();
+            }
+        }
+        catch (AttachNotSupportedException e) {
+            throw Throwables.propagate(e);
+        }
+
+        HostAndPort address;
+        try {
+            // This is how the jdk jmx agent constructs its url
+            JMXServiceURL url = new JMXServiceURL("rmi", null, registryPort);
+            address = HostAndPort.fromParts(url.getHost(), url.getPort());
+        }
+        catch (MalformedURLException e) {
+            // should not happen...
+            throw new AssertionError(e);
+        }
+
+        log.info("JMX agent started and listening on %s", address);
+
+        this.url = new JMXServiceURL(String.format("service:jmx:rmi:///jndi/rmi://%s:%s/jmxrmi", address.getHostText(), address.getPort()));
+    }
+
+    public JMXServiceURL getUrl()
+    {
+        return url;
+    }
+
+    private static long getProcessId()
+    {
+        // TODO: replace with ProcessHandle.current().getPid() in Java 9
+        String name = ManagementFactory.getRuntimeMXBean().getName();
+        int index = name.indexOf('@');
+
+        if (index < 1) {
+            throw new AssertionError("Cannot get process PID");
+        }
+
+        try {
+            return Long.parseLong(name.substring(0, index));
+        }
+        catch (NumberFormatException e) {
+            throw new AssertionError("Cannot get process PID");
+        }
+    }
+
+    public static void main(String[] args)
+            throws IOException
+    {
+        new JmxAgent9(new JmxConfig());
+        new JmxAgent9(new JmxConfig());
+    }
+}

--- a/jmx/src/main/java/io/airlift/jmx/JmxModule.java
+++ b/jmx/src/main/java/io/airlift/jmx/JmxModule.java
@@ -40,13 +40,21 @@ public class JmxModule
         binder.disableCircularProxies();
 
         binder.bind(MBeanServer.class).toInstance(ManagementFactory.getPlatformMBeanServer());
-        binder.bind(JmxAgent.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(JmxConfig.class);
 
         newExporter(binder).export(StackTraceMBean.class).withGeneratedName();
         binder.bind(StackTraceMBean.class).in(Scopes.SINGLETON);
 
         discoveryBinder(binder).bindServiceAnnouncement(JmxAnnouncementProvider.class);
+
+        if (JavaVersion.current().getMajor() < 9) {
+            binder.bind(JmxAgent8.class).in(Scopes.SINGLETON);
+            binder.bind(JmxAgent.class).to(JmxAgent8.class);
+        }
+        else {
+            binder.bind(JmxAgent9.class).in(Scopes.SINGLETON);
+            binder.bind(JmxAgent.class).to(JmxAgent9.class);
+        }
     }
 
     static class JmxAnnouncementProvider

--- a/jmx/src/test/java/io/airlift/jmx/TestJmxAgent.java
+++ b/jmx/src/test/java/io/airlift/jmx/TestJmxAgent.java
@@ -1,27 +1,36 @@
 package io.airlift.jmx;
 
+import com.google.common.net.HostAndPort;
 import org.testng.annotations.Test;
 
-import javax.management.MBeanServerConnection;
 import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXConnectorFactory;
 import javax.management.remote.JMXServiceURL;
 
-import static org.testng.Assert.assertTrue;
+import static java.lang.String.format;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 
 public class TestJmxAgent
 {
     @Test
-    public void testSanity()
+    public void testJava8Agent()
             throws Exception
     {
-        JmxAgent agent = new JmxAgent(new JmxConfig());
+        HostAndPort address = JmxAgent8.getRunningAgentAddress(null, null);
+
+        JmxAgent agent = new JmxAgent8(new JmxConfig());
+        if (address == null) {
+            // if agent wasn't running, it must have been started by the instantiation of JmxAgent
+            address = JmxAgent8.getRunningAgentAddress(null, null);
+            assertNotNull(address);
+        }
+
         JMXServiceURL url = agent.getUrl();
+
+        assertEquals(url.toString(), format("service:jmx:rmi:///jndi/rmi://%s:%s/jmxrmi", address.getHostText(), address.getPort()));
 
         JMXConnector connector = JMXConnectorFactory.connect(url);
         connector.connect();
-
-        MBeanServerConnection connection = connector.getMBeanServerConnection();
-        assertTrue(connection.getMBeanCount() > 0);
     }
 }


### PR DESCRIPTION
Using the VirtualMachine API requires access to tools.jar in Java 8.
This creates a number of tooling issues, including how to reliably
get the location of that file when running with JDK 8.

To sidestep those issues this change resurrects the old behavior
and introduces a dynamic switch to pick the appropriate implementation
given the version of Java being used.