### PR TITLE
Fix inconsistent TestMoreFutures.testTimeout

### DIFF
--- a/concurrent/src/test/java/io/airlift/concurrent/TestMoreFutures.java
+++ b/concurrent/src/test/java/io/airlift/concurrent/TestMoreFutures.java
@@ -433,6 +433,7 @@ public class TestMoreFutures
         assertFalse(timeoutFuture.isCancelled());
 
         // root exception is cancelled on a timeout
+        assertFailure(() -> rootFuture.get(10, SECONDS), e -> assertInstanceOf(e, CancellationException.class));
         assertTrue(rootFuture.isDone());
         assertTrue(rootFuture.isCancelled());
     }


### PR DESCRIPTION
There is a race between canceling the inner and outer future

Fixes #447