### PR TITLE
Revert Jetty to 9.3.9.M1

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+* 0.136
+
+- Revert Jetty to 9.3.9.M1
+
 * 0.135
 
 - Add ThreadLocalCache

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+Airlift 0.136
+
+Minor maintenance release. See CHANGES.
+
 Airlift 0.135
 
 * Units

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
         <dep.airlift.version>0.136-SNAPSHOT</dep.airlift.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
-        <dep.jetty.version>9.3.11.v20160721</dep.jetty.version>
+        <dep.jetty.version>9.3.9.M1</dep.jetty.version>
         <dep.jersey.version>2.22.2</dep.jersey.version>
     </properties>
 


### PR DESCRIPTION
We saw sporadic issues in production with 9.3.11 where
client would send randomly corrupted requests.