### PR TITLE
Set ThreadContextClassLoader to null when loading bval

### DIFF
--- a/configuration/src/main/java/io/airlift/configuration/ConfigurationFactory.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigurationFactory.java
@@ -64,7 +64,19 @@ import static java.util.stream.Collectors.toList;
 
 public class ConfigurationFactory
 {
-    private static final Validator VALIDATOR = Validation.byProvider(ApacheValidationProvider.class).configure().buildValidatorFactory().getValidator();
+    private static final Validator VALIDATOR;
+
+    static {
+        // this prevents bval from using the thread context classloader
+        ClassLoader currentClassLoader = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(null);
+            VALIDATOR = Validation.byProvider(ApacheValidationProvider.class).configure().buildValidatorFactory().getValidator();
+        }
+        finally {
+            Thread.currentThread().setContextClassLoader(currentClassLoader);
+        }
+    }
 
     private final Map<String, String> properties;
     private final Problems.Monitor monitor;


### PR DESCRIPTION
This forces bval to use getClass().getClassLoader() instead of the
ThreadContextClassLoader (which is initialized to the system class
loader).