### PR TITLE
Fix inconsistent TestMoreFutures.testTimeout*() tests

### DIFF
--- a/concurrent/src/test/java/io/airlift/concurrent/TestMoreFutures.java
+++ b/concurrent/src/test/java/io/airlift/concurrent/TestMoreFutures.java
@@ -453,6 +453,7 @@ public class TestMoreFutures
         assertFalse(timeoutFuture.isCancelled());
 
         // root exception is cancelled on a timeout
+        assertFailure(() -> rootFuture.get(10, SECONDS), e -> assertInstanceOf(e, CancellationException.class));
         assertTrue(rootFuture.isDone());
         assertTrue(rootFuture.isCancelled());
     }
@@ -472,6 +473,7 @@ public class TestMoreFutures
         assertTrue(timeoutFuture.isCancelled());
 
         // root exception is cancelled on a timeout
+        assertFailure(() -> rootFuture.get(10, SECONDS), e -> assertInstanceOf(e, CancellationException.class));
         assertTrue(rootFuture.isDone());
         assertTrue(rootFuture.isCancelled());
     }


### PR DESCRIPTION
Fix inconsistent TestMoreFutures.testTimeout*() tests