### PR TITLE
Implement HttpClientDefaultsBinder

### DIFF
--- a/configuration/src/main/java/io/airlift/configuration/ConfigBinder.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigBinder.java
@@ -110,6 +110,15 @@ public class ConfigBinder
         createConfigDefaultsBinder(key).addBinding().toInstance(new ConfigDefaultsHolder<>(key, configDefaults));
     }
 
+    /**
+     * Binds default values for all the instances of given config class for the current binder
+     */
+    public <T> void bindConfigGeneralDefaults(Class<T> configClass, ConfigDefaults<T> configDefaults)
+    {
+        Key<T> key = Key.get(configClass, GeneralDefaults.class);
+        createConfigDefaultsBinder(key).addBinding().toInstance(new ConfigDefaultsHolder<>(key, configDefaults));
+    }
+
     private <T> Multibinder<ConfigDefaultsHolder<T>> createConfigDefaultsBinder(Key<T> key)
     {
         @SuppressWarnings("SerializableInnerClassWithNonSerializableOuterClass")

--- a/configuration/src/main/java/io/airlift/configuration/ConfigurationFactory.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigurationFactory.java
@@ -148,11 +148,23 @@ public class ConfigurationFactory
 
     private <T> ConfigDefaults<T> getConfigDefaults(Key<T> key)
     {
-        List<ConfigDefaults<T>> defaults = registeredDefaultConfigs.get(key).stream()
+        Key generalDefaultsKey = Key.get(key.getTypeLiteral(), GeneralDefaults.class);
+        List<ConfigDefaults<T>> generalDefaults = registeredDefaultConfigs.get(generalDefaultsKey).stream()
                 .map(holder -> (ConfigDefaultsHolder<T>) holder)
                 .sorted()
                 .map(ConfigDefaultsHolder::getConfigDefaults)
                 .collect(toList());
+
+        List<ConfigDefaults<T>> keyDefaults = registeredDefaultConfigs.get(key).stream()
+                .map(holder -> (ConfigDefaultsHolder<T>) holder)
+                .sorted()
+                .map(ConfigDefaultsHolder::getConfigDefaults)
+                .collect(toList());
+
+        List<ConfigDefaults<T>> defaults = ImmutableList.<ConfigDefaults<T>>builder()
+                .addAll(generalDefaults)
+                .addAll(keyDefaults)
+                .build();
 
         return ConfigDefaults.configDefaults(defaults);
     }

--- a/configuration/src/main/java/io/airlift/configuration/GeneralDefaults.java
+++ b/configuration/src/main/java/io/airlift/configuration/GeneralDefaults.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.configuration;
+
+import javax.inject.Qualifier;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({FIELD, PARAMETER, METHOD})
+@Retention(RUNTIME)
+@Qualifier
+@interface GeneralDefaults
+{
+}

--- a/configuration/src/test/java/io/airlift/configuration/TestConfig.java
+++ b/configuration/src/test/java/io/airlift/configuration/TestConfig.java
@@ -197,6 +197,35 @@ public class TestConfig
         }
     }
 
+    @Test
+    public void testConfigGeneralDefaults()
+            throws Exception
+    {
+        int generalDefaultValue = 1;
+        int defaultValue = 2;
+        int customValue = 3;
+
+        Module module = binder -> {
+            configBinder(binder).bindConfigGeneralDefaults(Config1.class, (config -> {
+                config.setByteOption((byte) generalDefaultValue);
+                config.setIntegerOption(generalDefaultValue);
+                config.setLongOption(generalDefaultValue);
+            }));
+            configBinder(binder).bindConfigDefaults(Config1.class, MyAnnotation.class, (config -> {
+                config.setIntegerOption(defaultValue);
+                config.setLongOption(defaultValue);
+            }));
+            configBinder(binder).bindConfig(Config1.class, MyAnnotation.class);
+        };
+
+        Injector injector = createInjector(ImmutableMap.of("longOption", "" + customValue), module);
+
+        Config1 config = injector.getInstance(Key.get(Config1.class, MyAnnotation.class));
+        assertEquals(config.getByteOption(), generalDefaultValue);
+        assertEquals(config.getIntegerOption(), defaultValue);
+        assertEquals(config.getLongOption(), customValue);
+    }
+
     private static Injector createInjector(Map<String, String> properties, Module module)
     {
         ConfigurationFactory configurationFactory = new ConfigurationFactory(properties);

--- a/http-client/src/main/java/io/airlift/http/client/DefaultsQualifier.java
+++ b/http-client/src/main/java/io/airlift/http/client/DefaultsQualifier.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.http.client;
+
+import javax.inject.Qualifier;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({FIELD, PARAMETER, METHOD})
+@Retention(RUNTIME)
+@Qualifier
+@interface DefaultsQualifier
+{
+}

--- a/http-client/src/main/java/io/airlift/http/client/HttpClientDefaultsBinder.java
+++ b/http-client/src/main/java/io/airlift/http/client/HttpClientDefaultsBinder.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.http.client;
+
+import com.google.inject.Binder;
+import com.google.inject.binder.LinkedBindingBuilder;
+import com.google.inject.multibindings.Multibinder;
+import io.airlift.configuration.ConfigDefaults;
+
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
+import static io.airlift.configuration.ConfigBinder.configBinder;
+import static java.util.Objects.requireNonNull;
+
+public class HttpClientDefaultsBinder
+{
+    private final Binder binder;
+    private final Multibinder<HttpRequestFilter> multibinder;
+
+    public static HttpClientDefaultsBinder httpClientDefaultsBinder(Binder binder)
+    {
+        return new HttpClientDefaultsBinder(binder);
+    }
+
+    private HttpClientDefaultsBinder(Binder binder)
+    {
+        this.binder = requireNonNull(binder, "binder is null");
+        this.multibinder = newSetBinder(binder, HttpRequestFilter.class, DefaultsQualifier.class);
+    }
+
+    public HttpClientDefaultsBinder bindConfig(ConfigDefaults<HttpClientConfig> config)
+    {
+        configBinder(binder).bindConfigGeneralDefaults(HttpClientConfig.class, config);
+        return this;
+    }
+
+    public LinkedBindingBuilder<HttpRequestFilter> addFilterBinding()
+    {
+        return multibinder.addBinding();
+    }
+}

--- a/http-client/src/main/java/io/airlift/http/client/HttpClientModule.java
+++ b/http-client/src/main/java/io/airlift/http/client/HttpClientModule.java
@@ -18,6 +18,7 @@ package io.airlift.http.client;
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.Key;
@@ -87,6 +88,9 @@ public class HttpClientModule
         // bind the client
         binder.bind(HttpClient.class).annotatedWith(annotation).toProvider(new HttpClientProvider(name, annotation)).in(Scopes.SINGLETON);
 
+        // kick off the binding for the default filters
+        newSetBinder(binder, HttpRequestFilter.class, DefaultsQualifier.class);
+
         // kick off the binding for the filter set
         newSetBinder(binder, HttpRequestFilter.class, filterQualifier(annotation));
 
@@ -125,7 +129,10 @@ public class HttpClientModule
             KerberosConfig kerberosConfig = injector.getInstance(KerberosConfig.class);
 
             HttpClientConfig config = injector.getInstance(Key.get(HttpClientConfig.class, annotation));
-            Set<HttpRequestFilter> filters = injector.getInstance(filterKey(annotation));
+            Set<HttpRequestFilter> filters = ImmutableSet.<HttpRequestFilter>builder()
+                    .addAll(injector.getInstance(Key.get(new TypeLiteral<Set<HttpRequestFilter>>() {}, DefaultsQualifier.class)))
+                    .addAll(injector.getInstance(filterKey(annotation)))
+                    .build();
 
             JettyIoPoolManager ioPoolProvider;
             if (injector.getExistingBinding(Key.get(JettyIoPoolManager.class, annotation)) != null) {


### PR DESCRIPTION
This binder helps to provide default configuration values and filters
that must be applied to all the HttpClients within the same Guice context.

This is introduced to cover the following use case:

In Presto multiple Http clients are being used by multiple modules. However
configuration parameters, such as SSL certificate, or some security filter must
be common for all of them. So, instead of setting these values to every single client,
what could be tricky and fragile, the HttpClientDefaultsBinder is introduced.
