### PR TITLE
Upgrade to Jetty 9.3.13.M0

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+* 0.139
+
+- Upgrade to Jetty 9.3.13.M0
+
 * 0.138
 
 - Add toJsonWithLengthLimit to JsonCodec

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
         <dep.airlift.version>0.139-SNAPSHOT</dep.airlift.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
-        <dep.jetty.version>9.3.9.M1</dep.jetty.version>
+        <dep.jetty.version>9.3.13.M0</dep.jetty.version>
         <dep.jersey.version>2.22.2</dep.jersey.version>
     </properties>
 


### PR DESCRIPTION
This fixes a race when using async responses which can result in a 500
error being returned