### PR TITLE
Buffer HTTP data with chunks

### DIFF
--- a/http-client/src/main/java/io/airlift/http/client/GatheringByteArrayInputStream.java
+++ b/http-client/src/main/java/io/airlift/http/client/GatheringByteArrayInputStream.java
@@ -1,0 +1,116 @@
+package io.airlift.http.client;
+
+import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.io.InputStream;
+import java.util.Iterator;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkPositionIndexes;
+import static com.google.common.base.Preconditions.checkState;
+import static java.lang.Math.min;
+import static java.lang.System.arraycopy;
+import static java.util.Objects.requireNonNull;
+
+@ThreadSafe
+public class GatheringByteArrayInputStream
+        extends InputStream
+{
+    @GuardedBy("this")
+    private final Iterator<byte[]> buffers;
+    @GuardedBy("this")
+    private final byte[] singleByte = new byte[1];
+    @GuardedBy("this")
+    private byte[] currentBuffer = new byte[0];
+    @GuardedBy("this")
+    private int currentBufferPosition;
+    @GuardedBy("this")
+    private long remainingBytes;
+
+    public GatheringByteArrayInputStream(List<byte[]> buffers, long totalBytes)
+    {
+        checkArgument(totalBytes >= 0, "totalBytes should equal to or greater than 0");
+
+        this.buffers = requireNonNull(buffers, "buffers is null").iterator();
+        this.remainingBytes = totalBytes;
+    }
+
+    @Override
+    public synchronized int read(byte[] buffer)
+    {
+        return read(buffer, 0, buffer.length);
+    }
+
+    @Override
+    public synchronized int read()
+    {
+        int bytes = read(singleByte);
+        if (bytes == -1) {
+            return -1;
+        }
+        return singleByte[0] & 0xFF;
+    }
+
+    @Override
+    public synchronized long skip(long n)
+    {
+        if (n < 0) {
+            return 0;
+        }
+
+        long totalSkippedBytes = min(n, remainingBytes);
+
+        n = totalSkippedBytes;
+        while (n > 0) {
+            if (currentBufferPosition >= currentBuffer.length) {
+                advanceCurrentBuffer();
+            }
+            int skippedBytes = (int) min(n, currentBuffer.length - currentBufferPosition);
+            n -= skippedBytes;
+            currentBufferPosition += skippedBytes;
+        }
+        remainingBytes -= totalSkippedBytes;
+        return totalSkippedBytes;
+    }
+
+    @Override
+    public synchronized int read(byte[] buffer, int offset, int length)
+    {
+        requireNonNull(buffer, "buffer is null");
+        checkPositionIndexes(offset, offset + length, buffer.length);
+
+        if (remainingBytes == 0) {
+            return -1;
+        }
+
+        int totalReadBytes = (int) min(length, remainingBytes);
+
+        length = totalReadBytes;
+        while (length > 0) {
+            if (currentBufferPosition >= currentBuffer.length) {
+                advanceCurrentBuffer();
+            }
+            int readBytes = min(length, currentBuffer.length - currentBufferPosition);
+            arraycopy(currentBuffer, currentBufferPosition, buffer, offset, readBytes);
+            offset += readBytes;
+            length -= readBytes;
+            currentBufferPosition += readBytes;
+        }
+        remainingBytes -= totalReadBytes;
+        return totalReadBytes;
+    }
+
+    @Override
+    public void close() {}
+
+    private synchronized void advanceCurrentBuffer()
+    {
+        checkState(currentBufferPosition >= currentBuffer.length, "there is still un-read space in currentBuffer");
+        checkState(buffers.hasNext(), "buffers should have more data when remainingBytes is greater than 0");
+
+        currentBuffer = buffers.next();
+        currentBufferPosition = 0;
+    }
+}

--- a/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
@@ -1,6 +1,5 @@
 package io.airlift.http.client.jetty;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableList;
@@ -12,6 +11,7 @@ import com.google.common.primitives.Ints;
 import com.google.common.util.concurrent.AbstractFuture;
 import io.airlift.http.client.BodyGenerator;
 import io.airlift.http.client.FileBodyGenerator;
+import io.airlift.http.client.GatheringByteArrayInputStream;
 import io.airlift.http.client.HeaderName;
 import io.airlift.http.client.HttpClientConfig;
 import io.airlift.http.client.HttpRequestFilter;
@@ -25,6 +25,7 @@ import io.airlift.http.client.spnego.SpnegoAuthentication;
 import io.airlift.http.client.spnego.SpnegoAuthenticationStore;
 import io.airlift.log.Logger;
 import io.airlift.stats.Distribution;
+import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import org.eclipse.jetty.client.DuplexConnectionPool;
 import org.eclipse.jetty.client.HttpClient;
@@ -59,7 +60,6 @@ import org.weakref.jmx.Nested;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InterruptedIOException;
@@ -67,6 +67,7 @@ import java.io.OutputStream;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -87,7 +88,12 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.units.DataSize.Unit.KILOBYTE;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -1045,21 +1051,28 @@ public class JettyHttpClient
         }
     }
 
+    @ThreadSafe
     private static class BufferingResponseListener
             extends Listener.Adapter
     {
+        private static final long BUFFER_MAX_BYTES = new DataSize(1, MEGABYTE).toBytes();
+        private static final long BUFFER_MIN_BYTES = new DataSize(1, KILOBYTE).toBytes();
         private final JettyResponseFuture<?, ?> future;
         private final int maxLength;
 
         @GuardedBy("this")
-        private byte[] buffer = new byte[0];
+        private byte[] currentBuffer = new byte[0];
         @GuardedBy("this")
-        private int size;
+        private int currentBufferPosition;
+        @GuardedBy("this")
+        private List<byte[]> buffers = new ArrayList<>();
+        @GuardedBy("this")
+        private long size;
 
         public BufferingResponseListener(JettyResponseFuture<?, ?> future, int maxLength)
         {
             this.future = checkNotNull(future, "future is null");
-            Preconditions.checkArgument(maxLength > 0, "maxLength must be greater than zero");
+            checkArgument(maxLength > 0, "maxLength must be greater than zero");
             this.maxLength = maxLength;
         }
 
@@ -1070,30 +1083,27 @@ public class JettyHttpClient
             if (length > maxLength) {
                 response.abort(new ResponseTooLargeException());
             }
-            if (length > buffer.length) {
-                buffer = Arrays.copyOf(buffer, Ints.saturatedCast(length));
-            }
         }
 
         @Override
         public synchronized void onContent(Response response, ByteBuffer content)
         {
             int length = content.remaining();
-            int requiredCapacity = size + length;
-            if (requiredCapacity > buffer.length) {
-                if (requiredCapacity > maxLength) {
-                    response.abort(new ResponseTooLargeException());
-                    return;
-                }
-
-                // newCapacity = min(log2ceiling(requiredCapacity), maxLength);
-                int newCapacity = min(Integer.highestOneBit(requiredCapacity) << 1, maxLength);
-
-                buffer = Arrays.copyOf(buffer, newCapacity);
+            size += length;
+            if (size > maxLength) {
+                response.abort(new ResponseTooLargeException());
+                return;
             }
 
-            content.get(buffer, size, length);
-            size += length;
+            while (length > 0) {
+                if (currentBufferPosition >= currentBuffer.length) {
+                    allocateCurrentBuffer();
+                }
+                int readLength = min(length, currentBuffer.length - currentBufferPosition);
+                content.get(currentBuffer, currentBufferPosition, readLength);
+                length -= readLength;
+                currentBufferPosition += readLength;
+            }
         }
 
         @Override
@@ -1104,8 +1114,21 @@ public class JettyHttpClient
                 future.failed(throwable);
             }
             else {
-                future.completed(result.getResponse(), new ByteArrayInputStream(buffer, 0, size));
+                currentBuffer = new byte[0];
+                currentBufferPosition = 0;
+                future.completed(result.getResponse(), new GatheringByteArrayInputStream(buffers, size));
+                buffers = new ArrayList<>();
+                size = 0;
             }
+        }
+
+        private synchronized void allocateCurrentBuffer()
+        {
+            checkState(currentBufferPosition >= currentBuffer.length, "there is still remaining space in currentBuffer");
+
+            currentBuffer = new byte[(int) min(BUFFER_MAX_BYTES, max(2 * currentBuffer.length, BUFFER_MIN_BYTES))];
+            buffers.add(currentBuffer);
+            currentBufferPosition = 0;
         }
     }
 

--- a/http-client/src/test/java/io/airlift/http/client/TestGatheringByteArrayInputStream.java
+++ b/http-client/src/test/java/io/airlift/http/client/TestGatheringByteArrayInputStream.java
@@ -1,0 +1,158 @@
+package io.airlift.http.client;
+
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+
+import static java.lang.Math.min;
+import static java.lang.System.arraycopy;
+import static org.testng.Assert.assertEquals;
+
+public class TestGatheringByteArrayInputStream
+{
+    @Test
+    public void testNormal()
+    {
+        byte[] lastStringArray = "client".getBytes();
+        byte[] lastArray = Arrays.copyOf(lastStringArray, lastStringArray.length + 32);
+        arraycopy(lastStringArray, 0, lastArray, 0, lastStringArray.length);
+
+        List<byte[]> buffers = ImmutableList.of(
+                "hello ".getBytes(),
+                "this ".getBytes(),
+                "is ".getBytes(),
+                "http ".getBytes(),
+                lastArray);
+        byte[] expectedAll = "hello this is http client".getBytes();
+        byte[] expectedPartial = "hello this".getBytes();
+
+        try (GatheringByteArrayInputStream in = new GatheringByteArrayInputStream(buffers, expectedAll.length)) {
+            byte[] buffer = new byte[expectedAll.length + 32];
+
+            // read the first part
+            assertEquals(in.read(buffer, 0, expectedPartial.length), expectedPartial.length);
+
+            // verify the first part
+            assertByteArrayEquals(buffer, 0, expectedPartial, 0, expectedPartial.length);
+
+            // read the remaining part
+            assertEquals(in.read(buffer, expectedPartial.length, buffer.length - expectedPartial.length), expectedAll.length - expectedPartial.length);
+
+            // verify the whole string
+            assertByteArrayEquals(buffer, 0, expectedAll, 0, expectedAll.length);
+
+            // make sure there is no more data
+            assertEquals(-1, in.read(buffer, 0, expectedAll.length));
+        }
+    }
+
+    @Test
+    public void testSingleByteRead()
+    {
+        byte[] expected = "This is a test for single byte read".getBytes();
+        List<byte[]> buffers = ImmutableList.of(
+                "This ".getBytes(),
+                "is ".getBytes(),
+                "a test ".getBytes(),
+                "for".getBytes(),
+                " single byte read".getBytes());
+        byte[] resultBuffer = new byte[expected.length];
+
+        try (GatheringByteArrayInputStream in = new GatheringByteArrayInputStream(buffers, expected.length)) {
+            for (int i = 0; i < expected.length; i++) {
+                resultBuffer[i] = (byte) in.read();
+            }
+            assertByteArrayEquals(resultBuffer, 0, expected, 0, expected.length);
+            assertEquals(in.read(), -1);
+        }
+    }
+
+    @Test
+    public void testNegativeSingleByteRead()
+    {
+        byte[] expected = new byte[1];
+        expected[0] = -100;
+        try (GatheringByteArrayInputStream in = new GatheringByteArrayInputStream(ImmutableList.of(expected), expected.length)) {
+            assertEquals(in.read(), expected[0] & 0x000000ff);
+            assertEquals(in.read(), -1);
+        }
+    }
+
+    @Test
+    public void testSkip()
+    {
+        byte[] allDataBytes = "Hello, this is http client package, and I am just a test for GatheringByteArrayInputStream".getBytes();
+        int length = allDataBytes.length;
+        try (GatheringByteArrayInputStream in = new GatheringByteArrayInputStream(
+                ImmutableList.of(
+                        Arrays.copyOfRange(allDataBytes, 0, length / 3),
+                        Arrays.copyOfRange(allDataBytes, length / 3, length / 3 + length / 2),
+                        Arrays.copyOfRange(allDataBytes, length / 3 + length / 2, length)),
+                length)) {
+            int skipped = length / 2;
+            int firstPartLength = length / 4;
+            int restPartLength = length - firstPartLength - skipped;
+            byte[] actual = new byte[length - skipped + 10];
+
+            // read the first part
+            assertEquals(in.read(actual, 0, firstPartLength), firstPartLength);
+            assertByteArrayEquals(actual, 0, allDataBytes, 0, firstPartLength);
+
+            // skip some bytes
+            assertEquals(in.skip(skipped), skipped);
+
+            // read the rest part
+            assertEquals(in.read(actual, firstPartLength, restPartLength + 10), restPartLength);
+            assertByteArrayEquals(actual, firstPartLength, allDataBytes, firstPartLength + skipped, restPartLength);
+
+            assertEquals(in.skip(10), 0);
+            assertEquals(in.read(), -1);
+        }
+    }
+
+    @Test
+    public void testLargeData()
+    {
+        int length = 123456789;
+        Random random = new Random(0);
+        byte[] expected = new byte[length];
+
+        // randomly generate the bytes
+        random.nextBytes(expected);
+        List<byte[]> buffers = new ArrayList<>();
+        int copyBytes = 0;
+        while (copyBytes < length) {
+            int currentLength = min(length - copyBytes, random.nextInt(1 << 20) + 64);
+            buffers.add(Arrays.copyOfRange(expected, copyBytes, copyBytes + currentLength));
+            copyBytes += currentLength;
+        }
+        try (GatheringByteArrayInputStream in = new GatheringByteArrayInputStream(buffers, length)) {
+            byte[] actual = new byte[length];
+            copyBytes = 0;
+            while (copyBytes < length) {
+                int currentLength = min(length - copyBytes, random.nextInt(1 << 20) + 64);
+                assertEquals(in.read(actual, copyBytes, currentLength), currentLength);
+                assertByteArrayEquals(actual, copyBytes, expected, copyBytes, currentLength);
+                copyBytes += currentLength;
+            }
+            assertEquals(in.skip(100), 0);
+            assertEquals(in.read(), -1);
+        }
+    }
+
+    private static void assertByteArrayEquals(
+            byte[] actual,
+            int actualStart,
+            byte[] expected,
+            int expectedStart,
+            int length)
+    {
+        for (int i = 0; i < length; i++) {
+            assertEquals(actual[i + actualStart], expected[i + expectedStart]);
+        }
+    }
+}


### PR DESCRIPTION
- Avoid large byte array by buffering data with chunks
- Use ScatteringByteArrayInputStream to wrap buffered data

Fixes https://github.com/prestodb/presto/issues/5350