### PR TITLE
Update jetty version to 9.3.13.v20161014

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
         <dep.airlift.version>0.140-SNAPSHOT</dep.airlift.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
-        <dep.jetty.version>9.3.13.M0</dep.jetty.version>
+        <dep.jetty.version>9.3.13.v20161014</dep.jetty.version>
         <dep.jersey.version>2.22.2</dep.jersey.version>
     </properties>
 


### PR DESCRIPTION
This version contains the `requestCopy` method fix:
https://github.com/eclipse/jetty.project/pull/937

The bug in `requestCopy` method was causing failures for Kerberos authentication
in Presto CLI when the user name and the schema name was the same.