### PR TITLE
Use custom ID generation for trace tokens

### DIFF
--- a/trace-token/src/main/java/io/airlift/tracetoken/TraceTokenManager.java
+++ b/trace-token/src/main/java/io/airlift/tracetoken/TraceTokenManager.java
@@ -15,10 +15,17 @@
  */
 package io.airlift.tracetoken;
 
-import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static java.lang.String.format;
+import static java.util.Locale.ENGLISH;
+import static java.util.UUID.randomUUID;
 
 public class TraceTokenManager
 {
+    private final String prefix = randomUUID().toString().toLowerCase(ENGLISH).replace("-", "");
+    private final AtomicLong sequence = new AtomicLong();
+
     private final ThreadLocal<String> token = new ThreadLocal<String>();
 
     public void registerRequestToken(String token)
@@ -33,7 +40,7 @@ public class TraceTokenManager
 
     public String createAndRegisterNewRequestToken()
     {
-        String newToken = UUID.randomUUID().toString();
+        String newToken = prefix + format("%010x", sequence.getAndIncrement());
         this.token.set(newToken);
 
         return newToken;

--- a/trace-token/src/test/java/io/airlift/tracetoken/TestTraceTokenManager.java
+++ b/trace-token/src/test/java/io/airlift/tracetoken/TestTraceTokenManager.java
@@ -18,6 +18,7 @@ package io.airlift.tracetoken;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNull;
 
 public class TestTraceTokenManager
@@ -36,6 +37,11 @@ public class TestTraceTokenManager
 
         String token = manager.createAndRegisterNewRequestToken();
         assertEquals(manager.getCurrentRequestToken(), token);
+        assertEquals(manager.getCurrentRequestToken(), token);
+
+        String token2 = manager.createAndRegisterNewRequestToken();
+        assertEquals(manager.getCurrentRequestToken(), token2);
+        assertNotEquals(token2, token);
     }
 
     @Test


### PR DESCRIPTION
Generating random UUIDs can be a performance bottleneck due to
the default implementation of SecureRandom.