### PR TITLE
Allow node internal address to be a hostname

### DIFF
--- a/http-server/src/main/java/io/airlift/http/server/HttpServerInfo.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServerInfo.java
@@ -16,7 +16,6 @@
 package io.airlift.http.server;
 
 import com.google.common.base.Throwables;
-import com.google.common.net.InetAddresses;
 import com.google.inject.Inject;
 import io.airlift.node.NodeInfo;
 
@@ -37,7 +36,7 @@ public class HttpServerInfo
     public HttpServerInfo(HttpServerConfig config, NodeInfo nodeInfo)
     {
         if (config.isHttpEnabled()) {
-            httpUri = buildUri("http", InetAddresses.toUriString(nodeInfo.getInternalIp()), config.getHttpPort());
+            httpUri = buildUri("http", nodeInfo.getInternalAddress(), config.getHttpPort());
             httpExternalUri = buildUri("http", nodeInfo.getExternalAddress(), httpUri.getPort());
         }
         else {
@@ -46,7 +45,7 @@ public class HttpServerInfo
         }
 
         if (config.isHttpsEnabled()) {
-            httpsUri = buildUri("https", InetAddresses.toUriString(nodeInfo.getInternalIp()), config.getHttpsPort());
+            httpsUri = buildUri("https", nodeInfo.getInternalAddress(), config.getHttpsPort());
             httpsExternalUri = buildUri("https", nodeInfo.getExternalAddress(), httpsUri.getPort());
         }
         else {
@@ -56,10 +55,10 @@ public class HttpServerInfo
 
         if (config.isAdminEnabled()) {
             if (config.isHttpsEnabled()) {
-                adminUri = buildUri("https", InetAddresses.toUriString(nodeInfo.getInternalIp()), config.getAdminPort());
+                adminUri = buildUri("https", nodeInfo.getInternalAddress(), config.getAdminPort());
                 adminExternalUri = buildUri("https", nodeInfo.getExternalAddress(), adminUri.getPort());
             } else {
-                adminUri = buildUri("http", InetAddresses.toUriString(nodeInfo.getInternalIp()), config.getAdminPort());
+                adminUri = buildUri("http", nodeInfo.getInternalAddress(), config.getAdminPort());
                 adminExternalUri = buildUri("http", nodeInfo.getExternalAddress(), adminUri.getPort());
             }
         }

--- a/http-server/src/test/java/io/airlift/http/server/HttpServerInfoTest.java
+++ b/http-server/src/test/java/io/airlift/http/server/HttpServerInfoTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.http.server;
+
+import io.airlift.node.NodeConfig;
+import io.airlift.node.NodeInfo;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+
+import static org.testng.Assert.assertEquals;
+
+public class HttpServerInfoTest
+{
+    @Test
+    public void testIPv6Url()
+            throws Exception
+    {
+        NodeConfig nodeConfig = new NodeConfig();
+        nodeConfig.setEnvironment("test");
+        nodeConfig.setNodeInternalAddress("::1");
+        nodeConfig.setNodeExternalAddress("2001:db8:85a3::8a2e:370:7334");
+
+        NodeInfo nodeInfo = new NodeInfo(nodeConfig);
+
+        HttpServerConfig serverConfig = new HttpServerConfig();
+        serverConfig.setHttpEnabled(true);
+        serverConfig.setHttpPort(80);
+        serverConfig.setHttpsEnabled(true);
+        serverConfig.setHttpsPort(443);
+        serverConfig.setAdminEnabled(true);
+        serverConfig.setAdminPort(444);
+
+        HttpServerInfo httpServerInfo = new HttpServerInfo(serverConfig, nodeInfo);
+
+        assertEquals(httpServerInfo.getHttpUri(), new URI("http://[::1]:80"));
+        assertEquals(httpServerInfo.getHttpExternalUri(), new URI("http://[2001:db8:85a3::8a2e:370:7334]:80"));
+
+        assertEquals(httpServerInfo.getHttpsUri(), new URI("https://[::1]:443"));
+        assertEquals(httpServerInfo.getHttpsExternalUri(), new URI("https://[2001:db8:85a3::8a2e:370:7334]:443"));
+
+        assertEquals(httpServerInfo.getAdminUri(), new URI("https://[::1]:444"));
+        assertEquals(httpServerInfo.getAdminExternalUri(), new URI("https://[2001:db8:85a3::8a2e:370:7334]:444"));
+    }
+}

--- a/http-server/src/test/java/io/airlift/http/server/TestHttpServerModule.java
+++ b/http-server/src/test/java/io/airlift/http/server/TestHttpServerModule.java
@@ -23,7 +23,6 @@ import com.google.common.collect.ListMultimap;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Files;
 import com.google.common.net.HttpHeaders;
-import com.google.common.net.InetAddresses;
 import com.google.common.net.MediaType;
 import com.google.inject.Binder;
 import com.google.inject.Guice;
@@ -171,7 +170,7 @@ public class TestHttpServerModule
             assertNotNull(httpServerInfo);
             assertNotNull(httpServerInfo.getHttpUri());
             assertEquals(httpServerInfo.getHttpUri().getScheme(), "http");
-            assertEquals(InetAddresses.forUriString(httpServerInfo.getHttpUri().getHost()), nodeInfo.getInternalIp());
+            assertEquals(httpServerInfo.getHttpUri().getHost(), nodeInfo.getInternalAddress());
             assertNull(httpServerInfo.getHttpsUri());
         }
         catch (Exception e) {

--- a/node/src/main/java/io/airlift/node/NodeConfig.java
+++ b/node/src/main/java/io/airlift/node/NodeConfig.java
@@ -18,6 +18,7 @@ package io.airlift.node;
 import com.google.common.net.InetAddresses;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.DefunctConfig;
+import io.airlift.configuration.LegacyConfig;
 
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
@@ -35,11 +36,12 @@ public class NodeConfig
     private String pool = "general";
     private String nodeId;
     private String location;
-    private InetAddress nodeInternalIp;
+    private String nodeInternalAddress;
     private String nodeExternalAddress;
     private InetAddress nodeBindIp;
     private String binarySpec;
     private String configSpec;
+    private AddressSource internalAddressSource = AddressSource.IP;
 
     @NotNull
     @Pattern(regexp = ENV_REGEXP, message = "is malformed")
@@ -94,23 +96,16 @@ public class NodeConfig
         return this;
     }
 
-    public InetAddress getNodeInternalIp()
+    public String getNodeInternalAddress()
     {
-        return nodeInternalIp;
+        return nodeInternalAddress;
     }
 
-    public NodeConfig setNodeInternalIp(InetAddress nodeInternalIp)
+    @Config("node.internal-address")
+    @LegacyConfig("node.ip")
+    public NodeConfig setNodeInternalAddress(String nodeInternalAddress)
     {
-        this.nodeInternalIp = nodeInternalIp;
-        return this;
-    }
-
-    @Config("node.ip")
-    public NodeConfig setNodeInternalIp(String nodeInternalIp)
-    {
-        if (nodeInternalIp != null) {
-            this.nodeInternalIp = InetAddresses.forString(nodeInternalIp);
-        }
+        this.nodeInternalAddress = nodeInternalAddress;
         return this;
     }
 
@@ -168,5 +163,22 @@ public class NodeConfig
     {
         this.configSpec = configSpec;
         return this;
+    }
+
+    public AddressSource getInternalAddressSource()
+    {
+        return internalAddressSource;
+    }
+
+    @Config("node.internal-address-source")
+    public NodeConfig setInternalAddressSource(AddressSource internalAddressSource)
+    {
+        this.internalAddressSource = internalAddressSource;
+        return this;
+    }
+
+    public enum AddressSource
+    {
+        HOSTNAME, FQDN, IP
     }
 }

--- a/node/src/main/java/io/airlift/node/testing/TestingNodeModule.java
+++ b/node/src/main/java/io/airlift/node/testing/TestingNodeModule.java
@@ -15,6 +15,7 @@
  */
 package io.airlift.node.testing;
 
+import com.google.common.net.InetAddresses;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
@@ -74,7 +75,7 @@ public class TestingNodeModule
         binder.bind(NodeInfo.class).in(Scopes.SINGLETON);
         NodeConfig nodeConfig = new NodeConfig()
                 .setEnvironment(environment)
-                .setNodeInternalIp(getV4Localhost())
+                .setNodeInternalAddress(InetAddresses.toAddrString(getV4Localhost()))
                 .setNodeBindIp(getV4Localhost());
 
         if (pool.isPresent()) {

--- a/node/src/test/java/io/airlift/node/TestNodeConfig.java
+++ b/node/src/test/java/io/airlift/node/TestNodeConfig.java
@@ -26,6 +26,8 @@ import javax.validation.constraints.Pattern;
 import java.util.Map;
 import java.util.UUID;
 
+import static io.airlift.node.NodeConfig.AddressSource.HOSTNAME;
+import static io.airlift.node.NodeConfig.AddressSource.IP;
 import static io.airlift.testing.ValidationAssertions.assertFailsValidation;
 import static io.airlift.testing.ValidationAssertions.assertValidates;
 
@@ -38,12 +40,13 @@ public class TestNodeConfig
                 .setEnvironment(null)
                 .setPool("general")
                 .setNodeId(null)
-                .setNodeInternalIp((String) null)
+                .setNodeInternalAddress(null)
                 .setNodeBindIp((String) null)
                 .setNodeExternalAddress(null)
                 .setLocation(null)
                 .setBinarySpec(null)
-                .setConfigSpec(null));
+                .setConfigSpec(null)
+                .setInternalAddressSource(IP));
     }
 
     @Test
@@ -53,24 +56,26 @@ public class TestNodeConfig
                 .put("node.environment", "environment")
                 .put("node.pool", "pool")
                 .put("node.id", "nodeId")
-                .put("node.ip", "10.9.8.7")
+                .put("node.internal-address", "internal")
                 .put("node.bind-ip", "10.11.12.13")
                 .put("node.external-address", "external")
                 .put("node.location", "location")
                 .put("node.binary-spec", "binary")
                 .put("node.config-spec", "config")
+                .put("node.internal-address-source", "HOSTNAME")
                 .build();
 
         NodeConfig expected = new NodeConfig()
                 .setEnvironment("environment")
                 .setPool("pool")
                 .setNodeId("nodeId")
-                .setNodeInternalIp(InetAddresses.forString("10.9.8.7"))
+                .setNodeInternalAddress("internal")
                 .setNodeBindIp(InetAddresses.forString("10.11.12.13"))
                 .setNodeExternalAddress("external")
                 .setLocation("location")
                 .setBinarySpec("binary")
-                .setConfigSpec("config");
+                .setConfigSpec("config")
+                .setInternalAddressSource(HOSTNAME);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/node/src/test/java/io/airlift/node/TestNodeModule.java
+++ b/node/src/test/java/io/airlift/node/TestNodeModule.java
@@ -25,10 +25,14 @@ import io.airlift.testing.Assertions;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
 public class TestNodeModule
 {
     @Test
     public void testDefaultConfig()
+            throws UnknownHostException
     {
         long testStartTime = System.currentTimeMillis();
 
@@ -46,8 +50,8 @@ public class TestNodeModule
 
         Assertions.assertNotEquals(nodeInfo.getNodeId(), nodeInfo.getInstanceId());
 
-        Assert.assertNotNull(nodeInfo.getInternalIp());
-        Assert.assertFalse(nodeInfo.getInternalIp().isAnyLocalAddress());
+        Assert.assertNotNull(nodeInfo.getInternalAddress());
+        Assert.assertFalse(InetAddress.getByName(nodeInfo.getInternalAddress()).isAnyLocalAddress());
         Assert.assertNotNull(nodeInfo.getBindIp());
         Assert.assertTrue(nodeInfo.getBindIp().isAnyLocalAddress());
         Assertions.assertGreaterThanOrEqual(nodeInfo.getStartTime(), testStartTime);
@@ -67,12 +71,12 @@ public class TestNodeModule
         String location = "location";
         String binarySpec = "binary";
         String configSpec = "config";
-        String publicIp = "10.0.0.22";
+        String publicAddress = "public";
         ConfigurationFactory configFactory = new ConfigurationFactory(ImmutableMap.<String, String>builder()
                 .put("node.environment", environment)
                 .put("node.pool", pool)
                 .put("node.id", nodeId)
-                .put("node.ip", publicIp)
+                .put("node.internal-address", publicAddress)
                 .put("node.location", location)
                 .put("node.binary-spec", binarySpec)
                 .put("node.config-spec", configSpec)
@@ -92,7 +96,7 @@ public class TestNodeModule
 
         Assertions.assertNotEquals(nodeInfo.getNodeId(), nodeInfo.getInstanceId());
 
-        Assert.assertEquals(nodeInfo.getInternalIp(), InetAddresses.forString(publicIp));
+        Assert.assertEquals(nodeInfo.getInternalAddress(), publicAddress);
         Assert.assertEquals(nodeInfo.getBindIp(), InetAddresses.forString("0.0.0.0"));
         Assertions.assertGreaterThanOrEqual(nodeInfo.getStartTime(), testStartTime);
 

--- a/node/src/test/java/io/airlift/node/testing/TestTestingNodeModule.java
+++ b/node/src/test/java/io/airlift/node/testing/TestTestingNodeModule.java
@@ -5,6 +5,8 @@ import com.google.inject.Injector;
 import io.airlift.node.NodeInfo;
 import org.testng.annotations.Test;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.Optional;
 
 import static io.airlift.testing.Assertions.assertGreaterThanOrEqual;
@@ -18,6 +20,7 @@ public class TestTestingNodeModule
 {
     @Test
     public void testTestingNode()
+            throws UnknownHostException
     {
         long testStartTime = System.currentTimeMillis();
 
@@ -35,8 +38,8 @@ public class TestTestingNodeModule
 
         assertNotEquals(nodeInfo.getNodeId(), nodeInfo.getInstanceId());
 
-        assertEquals(nodeInfo.getInternalIp().toString(), "localhost/127.0.0.1");
-        assertEquals(nodeInfo.getBindIp(), nodeInfo.getInternalIp());
+        assertEquals(nodeInfo.getInternalAddress(), "127.0.0.1");
+        assertEquals(nodeInfo.getBindIp(), InetAddress.getByName(nodeInfo.getInternalAddress()));
         assertEquals(nodeInfo.getExternalAddress(), "127.0.0.1");
 
         assertGreaterThanOrEqual(nodeInfo.getStartTime(), testStartTime);


### PR DESCRIPTION
For SSL communication it is more convenient to generate certificates
for the top level host name. To do so, nodes must introduce themselves
with the hostname, instead of the IP. This change allows to either set
the internal node hostname explicitly, or to make the auto-resolve
algorithm to return node hostname instead of IP.