### PR TITLE
Add global http client filter binding

### DIFF
--- a/http-client/src/main/java/io/airlift/http/client/GlobalFilter.java
+++ b/http-client/src/main/java/io/airlift/http/client/GlobalFilter.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.http.client;
+
+import javax.inject.Qualifier;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({FIELD, PARAMETER, METHOD})
+@Retention(RUNTIME)
+@Qualifier
+@interface GlobalFilter
+{
+}

--- a/http-client/src/main/java/io/airlift/http/client/HttpClientBinder.java
+++ b/http-client/src/main/java/io/airlift/http/client/HttpClientBinder.java
@@ -17,6 +17,7 @@ package io.airlift.http.client;
 
 import com.google.common.annotations.Beta;
 import com.google.inject.Binder;
+import com.google.inject.Scopes;
 import com.google.inject.binder.LinkedBindingBuilder;
 import com.google.inject.multibindings.Multibinder;
 import io.airlift.configuration.ConfigDefaults;
@@ -31,10 +32,12 @@ import static com.google.inject.multibindings.Multibinder.newSetBinder;
 public class HttpClientBinder
 {
     private final Binder binder;
+    private final Multibinder<HttpRequestFilter> globalFilterBinder;
 
     private HttpClientBinder(Binder binder)
     {
         this.binder = checkNotNull(binder, "binder is null").skipSources(getClass());
+        this.globalFilterBinder = newSetBinder(binder, HttpRequestFilter.class, GlobalFilter.class);
     }
 
     public static HttpClientBinder httpClientBinder(Binder binder)
@@ -47,6 +50,23 @@ public class HttpClientBinder
         checkNotNull(name, "name is null");
         checkNotNull(annotation, "annotation is null");
         return createBindingBuilder(new HttpClientModule(name, annotation));
+    }
+
+    public LinkedBindingBuilder<HttpRequestFilter> addGlobalFilterBinding()
+    {
+        return globalFilterBinder.addBinding();
+    }
+
+    public HttpClientBinder bindGlobalFilter(Class<? extends HttpRequestFilter> filterClass)
+    {
+        globalFilterBinder.addBinding().to(filterClass).in(Scopes.SINGLETON);
+        return this;
+    }
+
+    public HttpClientBinder bindGlobalFilter(HttpRequestFilter filter)
+    {
+        globalFilterBinder.addBinding().toInstance(filter);
+        return this;
     }
 
     private HttpClientBindingBuilder createBindingBuilder(HttpClientModule module)


### PR DESCRIPTION
Global filter will be applied for all the request of all the http
clients within the Guice context.