### PR TITLE
Fix insertion into sparse HLL

### DIFF
--- a/stats/src/main/java/io/airlift/stats/cardinality/SparseHll.java
+++ b/stats/src/main/java/io/airlift/stats/cardinality/SparseHll.java
@@ -85,7 +85,8 @@ final class SparseHll
     {
         // TODO: investigate whether accumulate, sort and merge results in better performance due to avoiding the shift+insert in every call
 
-        int position = searchBucket(Utils.computeIndex(hash, EXTENDED_PREFIX_BITS));
+        int bucket = Utils.computeIndex(hash, EXTENDED_PREFIX_BITS);
+        int position = searchBucket(bucket);
 
         // add entry if missing
         if (position < 0) {
@@ -105,10 +106,10 @@ final class SparseHll
         }
         else {
             int currentEntry = entries[position];
-            int newValue = Utils.computeValue(hash, EXTENDED_PREFIX_BITS);
+            int newValue = Utils.numberOfLeadingZeros(hash, EXTENDED_PREFIX_BITS);
 
-            if (decodeBucketValue(currentEntry) > newValue) {
-                entries[position] = encode(position, newValue);
+            if (decodeBucketValue(currentEntry) < newValue) {
+                entries[position] = encode(bucket, newValue);
             }
         }
     }


### PR DESCRIPTION
The logic for inserting into an existing bucket was very broken:
- The comparison was inverted (< vs >)
- The "position" was being encoded in the entry instead of the
  actual bucket number.

This bug is not very likely to occur in practice because of the
low chances of collisions in the sparse representations. The
algorithm switches to the dense representation way before the
collision rate increases.