### PR TITLE
Fix thread safety issue in Distribution copy constructor

### DIFF
--- a/stats/src/main/java/io/airlift/stats/Distribution.java
+++ b/stats/src/main/java/io/airlift/stats/Distribution.java
@@ -39,7 +39,9 @@ public class Distribution
 
     public Distribution(Distribution distribution)
     {
-        digest = new QuantileDigest(distribution.digest);
+        synchronized (distribution) {
+            digest = new QuantileDigest(distribution.digest);
+        }
         total = new DecayCounter(distribution.total.getAlpha());
         total.merge(distribution.total);
     }


### PR DESCRIPTION
"digest" is guarded by "this", so the constructor needs to
synchronize on the other instance before accessing its digest
object.