### PR TITLE
Remove Maven settings file on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,6 @@ cache:
     - $HOME/.m2/repository/mysql
 
 sudo: false
+
+before_install:
+  - rm -f ~/.m2/settings.xml


### PR DESCRIPTION
This file contains many obsolete repositories and is not needed.