### PR TITLE
Convert back to ListenableFuture

### DIFF
--- a/concurrent/src/main/java/io/airlift/concurrent/MoreFutures.java
+++ b/concurrent/src/main/java/io/airlift/concurrent/MoreFutures.java
@@ -1,6 +1,5 @@
 package io.airlift.concurrent;
 
-import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -27,7 +26,8 @@ import java.util.stream.Collectors;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Throwables.propagateIfInstanceOf;
+import static com.google.common.base.Throwables.propagateIfPossible;
+import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static com.google.common.collect.Iterables.isEmpty;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static java.util.Objects.requireNonNull;
@@ -163,8 +163,8 @@ public final class MoreFutures
         }
         catch (ExecutionException e) {
             Throwable cause = e.getCause() == null ? e : e.getCause();
-            propagateIfInstanceOf(cause, exceptionType);
-            throw Throwables.propagate(cause);
+            propagateIfPossible(cause, exceptionType);
+            throw new RuntimeException(cause);
         }
     }
 
@@ -222,8 +222,8 @@ public final class MoreFutures
         }
         catch (ExecutionException e) {
             Throwable cause = e.getCause() == null ? e : e.getCause();
-            propagateIfInstanceOf(cause, exceptionType);
-            throw Throwables.propagate(cause);
+            propagateIfPossible(cause, exceptionType);
+            throw new RuntimeException(cause);
         }
         catch (TimeoutException expected) {
             // expected
@@ -494,7 +494,7 @@ public final class MoreFutures
             }
             catch (Throwable t) {
                 settableFuture.internalCompleteExceptionally(t);
-                propagateIfInstanceOf(t, RuntimeException.class);
+                throwIfInstanceOf(t, RuntimeException.class);
             }
 
             // cancel the original future, if it still exists

--- a/concurrent/src/test/java/io/airlift/concurrent/TestMoreFutures.java
+++ b/concurrent/src/test/java/io/airlift/concurrent/TestMoreFutures.java
@@ -1,6 +1,7 @@
 package io.airlift.concurrent;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.airlift.units.Duration;
 import org.testng.annotations.AfterClass;
@@ -17,6 +18,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
 
+import static com.google.common.util.concurrent.Futures.immediateFailedFuture;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static io.airlift.concurrent.MoreFutures.addTimeout;
 import static io.airlift.concurrent.MoreFutures.allAsList;
 import static io.airlift.concurrent.MoreFutures.failedFuture;
@@ -26,6 +29,7 @@ import static io.airlift.concurrent.MoreFutures.toListenableFuture;
 import static io.airlift.concurrent.MoreFutures.tryGetFutureValue;
 import static io.airlift.concurrent.MoreFutures.unmodifiableFuture;
 import static io.airlift.concurrent.MoreFutures.unwrapCompletionException;
+import static io.airlift.concurrent.MoreFutures.whenAnyComplete;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.testing.Assertions.assertInstanceOf;
 import static java.util.concurrent.CompletableFuture.completedFuture;
@@ -390,6 +394,20 @@ public class TestMoreFutures
     }
 
     @Test
+    public void testWhenAnyComplete()
+            throws Exception
+    {
+        assertGetUncheckedListenable(future -> getFutureValue(whenAnyComplete(ImmutableList.of(SettableFuture.create(), future, SettableFuture.create()))));
+
+        assertFailure(() -> whenAnyComplete(null), e -> assertInstanceOf(e, NullPointerException.class));
+        assertFailure(() -> whenAnyComplete(ImmutableList.of()), e -> assertInstanceOf(e, IllegalArgumentException.class));
+
+        assertEquals(
+                tryGetFutureValue(whenAnyComplete(ImmutableList.of(SettableFuture.create(), SettableFuture.create())), 10, MILLISECONDS),
+                Optional.empty());
+    }
+
+    @Test
     public void testAnyOf()
             throws Exception
     {
@@ -398,7 +416,8 @@ public class TestMoreFutures
         assertFailure(() -> MoreFutures.firstCompletedFuture(null), e -> assertInstanceOf(e, NullPointerException.class));
         assertFailure(() -> MoreFutures.firstCompletedFuture(ImmutableList.of()), e -> assertInstanceOf(e, IllegalArgumentException.class));
 
-        assertEquals(tryGetFutureValue(MoreFutures.firstCompletedFuture(ImmutableList.of(new CompletableFuture<>(), new CompletableFuture<>())), 10, MILLISECONDS),
+        assertEquals(
+                tryGetFutureValue(MoreFutures.firstCompletedFuture(ImmutableList.of(new CompletableFuture<>(), new CompletableFuture<>())), 10, MILLISECONDS),
                 Optional.empty());
     }
 
@@ -570,6 +589,37 @@ public class TestMoreFutures
         assertTrue(rootFuture.isCancelled());
     }
 
+    private static void assertGetUncheckedListenable(UncheckedGetterListenable getter)
+            throws Exception
+    {
+        assertEquals(getter.get(immediateFuture("foo")), "foo");
+
+        assertFailure(() -> getter.get(immediateFailedFuture(new IllegalArgumentException("foo"))), (e) -> {
+            assertInstanceOf(e, IllegalArgumentException.class);
+            assertEquals(e.getMessage(), "foo");
+        });
+
+        assertFailure(() -> getter.get(immediateFailedFuture(new SQLException("foo"))), (e) -> {
+            assertInstanceOf(e, RuntimeException.class);
+            assertInstanceOf(e.getCause(), SQLException.class);
+            assertEquals(e.getCause().getMessage(), "foo");
+        });
+
+        Thread.currentThread().interrupt();
+        assertFailure(() -> getter.get(SettableFuture.create()), (e) -> {
+            assertInstanceOf(e, RuntimeException.class);
+            assertInstanceOf(e.getCause(), InterruptedException.class);
+            assertTrue(Thread.interrupted());
+        });
+        assertFalse(Thread.currentThread().isInterrupted());
+
+        SettableFuture<Object> canceledFuture = SettableFuture.create();
+        canceledFuture.cancel(true);
+        assertFailure(() -> getter.get(canceledFuture), e -> assertInstanceOf(e, CancellationException.class));
+
+        assertEquals(getter.get(immediateFuture(null)), null);
+    }
+
     private void assertGetUnchecked(UncheckedGetter getter)
             throws Exception
     {
@@ -620,6 +670,12 @@ public class TestMoreFutures
             return;
         }
         fail("expected exception to be thrown");
+    }
+
+    private interface UncheckedGetterListenable
+    {
+        Object get(ListenableFuture<Object> future)
+                throws Exception;
     }
 
     private interface UncheckedGetter

--- a/concurrent/src/test/java/io/airlift/concurrent/TestMoreFutures.java
+++ b/concurrent/src/test/java/io/airlift/concurrent/TestMoreFutures.java
@@ -520,7 +520,7 @@ public class TestMoreFutures
         CompletableFuture<String> rootFuture = new CompletableFuture<>();
         CompletableFuture<String> timeoutFuture = addTimeout(rootFuture, () -> "timeout", new Duration(0, MILLISECONDS), executorService);
 
-        assertEquals(tryGetFutureValue(timeoutFuture, 10, SECONDS).get(), "timeout");
+        assertEquals(tryGetFutureValue(timeoutFuture, 10, SECONDS).orElse("failed"), "timeout");
         assertTrue(timeoutFuture.isDone());
         assertFalse(timeoutFuture.isCancelled());
 
@@ -570,7 +570,7 @@ public class TestMoreFutures
         assertTrue(rootFuture.isCancelled());
     }
 
-    public void assertGetUnchecked(UncheckedGetter getter)
+    private void assertGetUnchecked(UncheckedGetter getter)
             throws Exception
     {
         assertGetUncheckedInternal(getter);
@@ -579,7 +579,7 @@ public class TestMoreFutures
         assertGetUncheckedInternal(future -> getter.get(addTimeout(future, () -> { throw new RuntimeException("timeout"); }, new Duration(10, SECONDS), executorService)));
     }
 
-    public static void assertGetUncheckedInternal(UncheckedGetter getter)
+    private static void assertGetUncheckedInternal(UncheckedGetter getter)
             throws Exception
     {
         assertEquals(getter.get(completedFuture("foo")), "foo");


### PR DESCRIPTION
The CompletableFuture interface is difficult to use correctly, and it is
easy to introduce subtle bugs that result in lost notifications. For example
CompletableFuture does not propagate cancel from wrapped futures to the
core future. Additionally, it is easy to accidentally schedule tasks on a system
wide fork join pool.

ListenableFuture on the other hand is easy to understand and reasonable, and
the transformations in Guava handle cancelation properly.