### PR TITLE
Synchronize access to bval validators

### DIFF
--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -27,6 +27,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>annotations</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>log</artifactId>
         </dependency>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -21,6 +21,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>annotations</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
         </dependency>

--- a/testing/src/main/java/io/airlift/testing/ValidationAssertions.java
+++ b/testing/src/main/java/io/airlift/testing/ValidationAssertions.java
@@ -18,6 +18,7 @@ package io.airlift.testing;
 import com.google.common.annotations.Beta;
 import org.apache.bval.jsr.ApacheValidationProvider;
 
+import javax.annotation.concurrent.GuardedBy;
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
 import javax.validation.Validator;
@@ -32,7 +33,15 @@ import static org.testng.Assert.fail;
 @Beta
 public class ValidationAssertions
 {
+    @GuardedBy("VALIDATOR")
     private static final Validator VALIDATOR = Validation.byProvider(ApacheValidationProvider.class).configure().buildValidatorFactory().getValidator();
+
+    private static <T> Set<ConstraintViolation<T>> validate(T object)
+    {
+        synchronized (VALIDATOR) {
+            return VALIDATOR.validate(object);
+        }
+    }
 
     public static void assertValidates(Object object)
     {
@@ -41,13 +50,13 @@ public class ValidationAssertions
 
     public static void assertValidates(Object object, String message)
     {
-        assertTrue(VALIDATOR.validate(object).isEmpty(),
+        assertTrue(validate(object).isEmpty(),
                    format("%sexpected:<%s> to pass validation", toMessageString(message), object));
     }
 
     public static <T> void assertFailsValidation(T object, String field, String expectedErrorMessage, Class<? extends Annotation> annotation, String message)
     {
-        Set<ConstraintViolation<T>> violations = VALIDATOR.validate(object);
+        Set<ConstraintViolation<T>> violations = validate(object);
 
         for (ConstraintViolation<T> violation : violations) {
             if (annotation.isInstance(violation.getConstraintDescriptor().getAnnotation()) &&


### PR DESCRIPTION
bval validation is not thread safe (e.g.
`org.apache.bval.jsr.ConstraintValidation#validator` is lazily, unsafely
initialized).

Fixes prestodb/presto#7512