### PR TITLE
Bind server sockets to loopback address in unit tests

### DIFF
--- a/http-client/src/test/java/io/airlift/http/client/AbstractHttpClientTest.java
+++ b/http-client/src/test/java/io/airlift/http/client/AbstractHttpClientTest.java
@@ -824,7 +824,7 @@ public abstract class AbstractHttpClientTest
             this.host = host;
             this.writeBuffer = writeBuffer;
             this.readBytes = readBytes;
-            this.serverSocket = new ServerSocket(0);
+            this.serverSocket = new ServerSocket(0, 50, InetAddress.getByName(host));
             this.closeConnectionImmediately = closeConnectionImmediately;
         }
 
@@ -1032,7 +1032,7 @@ public abstract class AbstractHttpClientTest
         private BackloggedServer()
                 throws IOException
         {
-            this.serverSocket = new ServerSocket(0, 1);
+            this.serverSocket = new ServerSocket(0, 1, InetAddress.getByName("127.0.0.1"));
             localSocketAddress = serverSocket.getLocalSocketAddress();
 
             // some systems like Linux have a large minimum backlog

--- a/http-client/src/test/java/io/airlift/http/client/TestingSocksProxy.java
+++ b/http-client/src/test/java/io/airlift/http/client/TestingSocksProxy.java
@@ -69,7 +69,7 @@ public class TestingSocksProxy
         checkState(serverSocket == null, "%s already started", getClass().getName());
 
         try {
-            serverSocket = new ServerSocket(bindPort);
+            serverSocket = new ServerSocket(bindPort, 50, InetAddress.getByName("127.0.0.1"));
             hostAndPort = HostAndPort.fromParts(serverSocket.getInetAddress().getHostAddress(), serverSocket.getLocalPort());
             executorService = listeningDecorator(newCachedThreadPool(threadsNamed("socks-proxy-" + serverSocket.getLocalPort() + "-%s")));
 


### PR DESCRIPTION
Otherwise sockets can bind to arbitrary interfaces and tests may fail.