### PR TITLE
Add support for monitoring jetty thread pools

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+* 0.151
+
+- Add support for monitoring the Jetty client shared thread pool.
+
 * 0.150
 
 - Remove @Inject from Logger.

--- a/http-client/src/main/java/io/airlift/http/client/jetty/QueuedThreadPoolMBean.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/QueuedThreadPoolMBean.java
@@ -1,0 +1,82 @@
+package io.airlift.http.client.jetty;
+
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.weakref.jmx.Managed;
+
+import static java.util.Objects.requireNonNull;
+
+public class QueuedThreadPoolMBean
+{
+    private final QueuedThreadPool threadPool;
+
+    public QueuedThreadPoolMBean(QueuedThreadPool threadPool)
+    {
+        this.threadPool = requireNonNull(threadPool, "threadPool is null");
+    }
+
+    @Managed(description = "maximum time a thread may be idle in ms")
+    public int getIdleTimeout()
+    {
+        return threadPool.getIdleTimeout();
+    }
+
+    @Managed(description = "maximum number of threads in the pool")
+    public int getMaxThreads()
+    {
+        return threadPool.getMaxThreads();
+    }
+
+    @Managed(description = "minimum number of threads in the pool")
+    public int getMinThreads()
+    {
+        return threadPool.getMinThreads();
+    }
+
+    @Managed(description = "name of the thread pool")
+    public String getName()
+    {
+        return threadPool.getName();
+    }
+
+    @Managed(description = "priority of the threads in the pool")
+    public int getPriority()
+    {
+        return threadPool.getThreadsPriority();
+    }
+
+    @Managed(description = "size of the job queue")
+    public int getQueueSize()
+    {
+        return threadPool.getQueueSize();
+    }
+
+    @Managed(description = "threshold at which the pool is low on threads")
+    public int getLowThreadsThreshold()
+    {
+        return threadPool.getLowThreadsThreshold();
+    }
+
+    @Managed(description = "number of threads in the pool")
+    public int getThreads()
+    {
+        return threadPool.getThreads();
+    }
+
+    @Managed(description = "number of idle threads in the pool")
+    public int getIdleThreads()
+    {
+        return threadPool.getIdleThreads();
+    }
+
+    @Managed(description = "number of busy threads in the pool")
+    public int getBusyThreads()
+    {
+        return threadPool.getBusyThreads();
+    }
+
+    @Managed(description = "whether thread pool is low on threads")
+    public boolean isLowOnThreads()
+    {
+        return threadPool.isLowOnThreads();
+    }
+}

--- a/http-client/src/main/java/io/airlift/http/client/jetty/QueuedThreadPoolMBeanProvider.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/QueuedThreadPoolMBeanProvider.java
@@ -1,0 +1,27 @@
+package io.airlift.http.client.jetty;
+
+import io.airlift.http.client.HttpClientModule.JettyIoPoolManager;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import static java.util.Objects.requireNonNull;
+
+public class QueuedThreadPoolMBeanProvider
+        implements Provider<QueuedThreadPoolMBean>
+{
+    private final JettyIoPoolManager jettyIoPoolManager;
+
+    @Inject
+    public QueuedThreadPoolMBeanProvider(JettyIoPoolManager jettyIoPoolManager)
+    {
+        this.jettyIoPoolManager = requireNonNull(jettyIoPoolManager, "jettyIoPoolManager is null");
+    }
+
+    @Override
+    public QueuedThreadPoolMBean get()
+    {
+        return new QueuedThreadPoolMBean((QueuedThreadPool) jettyIoPoolManager.get().getExecutor());
+    }
+}


### PR DESCRIPTION
Currently we can only monitor the `http-worker` thread pool. This PR adds support for monitoring the other jetty pools too. Unfortunately, I couldn't use the existing `ThreadPoolExecutorMBean` as it requires a thread pool of type `ThreadPoolExecutor` while Jetty has thread pools of type `QueuedThreadPool`.

![screen shot 2017-04-07 at 12 04 06 pm](https://cloud.githubusercontent.com/assets/1223839/24815562/5b7a844e-1b8a-11e7-91a9-270aa6ddfc9c.png)

