### PR TITLE
Disable logging for secret config properties

### DIFF
--- a/configuration/src/main/java/io/airlift/configuration/Config.java
+++ b/configuration/src/main/java/io/airlift/configuration/Config.java
@@ -30,4 +30,5 @@ import java.lang.annotation.Target;
 public @interface Config
 {
     String value();
+    boolean redact() default false;
 }

--- a/configuration/src/main/java/io/airlift/configuration/ConfigurationInspector.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigurationInspector.java
@@ -105,7 +105,7 @@ public class ConfigurationInspector
                     description = "";
                 }
 
-                builder.add(new ConfigAttribute(attribute.getName(), propertyName, defaultValue, currentValue, description));
+                builder.add(new ConfigAttribute(attribute.getName(), propertyName, defaultValue, currentValue, description, attribute.isRedact()));
             }
             attributes = builder.build();
         }
@@ -172,7 +172,7 @@ public class ConfigurationInspector
 
         // todo this class needs to be updated to include the concept of deprecated property names
 
-        private ConfigAttribute(String attributeName, String propertyName, String defaultValue, String currentValue, String description)
+        private ConfigAttribute(String attributeName, String propertyName, String defaultValue, String currentValue, String description, boolean redact)
         {
             requireNonNull(attributeName, "attributeName");
             requireNonNull(propertyName, "propertyName");
@@ -182,8 +182,21 @@ public class ConfigurationInspector
 
             this.attributeName = attributeName;
             this.propertyName = propertyName;
-            this.defaultValue = defaultValue;
-            this.currentValue = currentValue;
+
+            if (redact && defaultValue != null) {
+                this.defaultValue = "[REDACTED]";
+            }
+            else {
+                this.defaultValue = defaultValue;
+            }
+
+            if (redact && currentValue != null) {
+                this.currentValue = "[REDACTED]";
+            }
+            else {
+                this.currentValue = currentValue;
+            }
+
             this.description = description;
         }
 

--- a/configuration/src/main/java/io/airlift/configuration/ConfigurationMetadata.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigurationMetadata.java
@@ -269,7 +269,10 @@ public class ConfigurationMetadata<T>
         // determine the attribute name
         String attributeName = configMethod.getName().substring(3);
 
-        AttributeMetaDataBuilder builder = new AttributeMetaDataBuilder(configClass, attributeName);
+        AttributeMetaDataBuilder builder = new AttributeMetaDataBuilder(
+                configClass,
+                attributeName,
+                configMethod.getAnnotation(Config.class).redact());
 
         if (configMethod.isAnnotationPresent(ConfigDescription.class)) {
             builder.setDescription(configMethod.getAnnotation(ConfigDescription.class).value());
@@ -423,13 +426,14 @@ public class ConfigurationMetadata<T>
         private final Class<?> configClass;
         private final String name;
         private final String description;
+        private final boolean redact;
         private final Method getter;
 
         private final InjectionPointMetaData injectionPoint;
         private final Set<InjectionPointMetaData> legacyInjectionPoints;
 
-        public AttributeMetadata(Class<?> configClass, String name, String description, Method getter,
-                InjectionPointMetaData injectionPoint, Set<InjectionPointMetaData> legacyInjectionPoints)
+        public AttributeMetadata(Class<?> configClass, String name, String description, boolean redact, Method getter,
+                                 InjectionPointMetaData injectionPoint, Set<InjectionPointMetaData> legacyInjectionPoints)
         {
             requireNonNull(configClass);
             requireNonNull(name);
@@ -440,6 +444,7 @@ public class ConfigurationMetadata<T>
             this.configClass = configClass;
             this.name = name;
             this.description = description;
+            this.redact = redact;
             this.getter = getter;
 
             this.injectionPoint = injectionPoint;
@@ -459,6 +464,10 @@ public class ConfigurationMetadata<T>
         public String getDescription()
         {
             return description;
+        }
+
+        public boolean isRedact() {
+            return redact;
         }
 
         public Method getGetter()
@@ -521,11 +530,12 @@ public class ConfigurationMetadata<T>
         private final String name;
 
         private String description;
+        private final boolean redact;
         private Method getter;
         private InjectionPointMetaData injectionPoint;
         private final Set<InjectionPointMetaData> legacyInjectionPoints = new HashSet<>();
 
-        public AttributeMetaDataBuilder(Class<?> configClass, String name)
+        public AttributeMetaDataBuilder(Class<?> configClass, String name, boolean redact)
         {
             requireNonNull(configClass);
             requireNonNull(name);
@@ -533,6 +543,7 @@ public class ConfigurationMetadata<T>
 
             this.configClass = configClass;
             this.name = name;
+            this.redact = redact;
         }
 
         public void setDescription(String description)
@@ -574,7 +585,7 @@ public class ConfigurationMetadata<T>
                 return null;
             }
 
-            return new AttributeMetadata(configClass, name, description, getter, injectionPoint, legacyInjectionPoints);
+            return new AttributeMetadata(configClass, name, description, redact, getter, injectionPoint, legacyInjectionPoints);
         }
     }
 


### PR DESCRIPTION
When a configuration property is annotated with @Config, add an ability to mark the property as something that should be kept as secret. Do not print properties annotated with "secret=true".

This is useful to prevent logging of properties such as passwords or secret keys.

Fixes https://github.com/prestodb/presto/issues/7635.