### PR TITLE
Add jaxrs-testing module

### DIFF
--- a/jaxrs-testing/pom.xml
+++ b/jaxrs-testing/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>jaxrs-testing</artifactId>
+    <packaging>jar</packaging>
+    <name>jaxrs-testing</name>
+
+    <parent>
+        <groupId>io.airlift</groupId>
+        <artifactId>airlift</artifactId>
+        <version>0.147-SNAPSHOT</version>
+    </parent>
+
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>http-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish.jersey.test-framework</groupId>
+            <artifactId>jersey-test-framework-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish.jersey.test-framework.providers</groupId>
+            <artifactId>jersey-test-framework-provider-inmemory</artifactId>
+        </dependency>
+
+        <!-- for testing -->
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/jaxrs-testing/src/main/java/io/airlift/jaxrs/testing/JaxrsTestingHttpProcessor.java
+++ b/jaxrs-testing/src/main/java/io/airlift/jaxrs/testing/JaxrsTestingHttpProcessor.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.airlift.jaxrs.testing;
+
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.http.client.HttpStatus;
+import io.airlift.http.client.Request;
+import io.airlift.http.client.Response;
+import io.airlift.http.client.testing.TestingHttpClient;
+import io.airlift.http.client.testing.TestingResponse;
+import io.airlift.log.Logger;
+import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.client.JerseyClientBuilder;
+import org.glassfish.jersey.test.DeploymentContext;
+import org.glassfish.jersey.test.inmemory.InMemoryTestContainerFactory;
+import org.glassfish.jersey.test.spi.TestContainer;
+
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import java.io.ByteArrayOutputStream;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+
+public class JaxrsTestingHttpProcessor
+        implements TestingHttpClient.Processor
+{
+    private static final Logger log = Logger.get(JaxrsTestingHttpProcessor.class);
+
+    private final Client client;
+
+    private boolean trace;
+
+    public JaxrsTestingHttpProcessor(URI baseUri, Object... jaxRsSingletons)
+    {
+        Set<Object> jaxRsSingletonsSet = ImmutableSet.copyOf(jaxRsSingletons);
+        Application application = new Application() {
+            @Override
+            public Set<Object> getSingletons()
+            {
+                return jaxRsSingletonsSet;
+            }
+        };
+        TestContainer testContainer = new InMemoryTestContainerFactory()
+                .create(baseUri, DeploymentContext.newInstance(application));
+        ClientConfig clientConfig = testContainer.getClientConfig();
+        this.client = JerseyClientBuilder.createClient(clientConfig);
+    }
+
+    public JaxrsTestingHttpProcessor setTrace(boolean enabled)
+    {
+        this.trace = enabled;
+        return this;
+    }
+
+    @Override
+    public Response handle(Request request)
+            throws Exception
+    {
+        // prepare request to jax-rs resource
+        MultivaluedMap<String, Object> requestHeaders = new MultivaluedHashMap<>();
+        for (Map.Entry<String, String> entry : request.getHeaders().entries()) {
+            requestHeaders.add(entry.getKey(), entry.getValue());
+        }
+        Invocation.Builder invocationBuilder = client.target(request.getUri()).request().headers(requestHeaders);
+        Invocation invocation;
+        if (request.getBodyGenerator() == null) {
+            invocation = invocationBuilder.build(request.getMethod());
+        }
+        else {
+            ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+            request.getBodyGenerator().write(byteArrayOutputStream);
+            byteArrayOutputStream.close();
+            byte[] bytes = byteArrayOutputStream.toByteArray();
+            Entity<byte[]> entity = Entity.entity(bytes, (String) getOnlyElement(requestHeaders.get("Content-Type")));
+            invocation = invocationBuilder.build(request.getMethod(), entity);
+        }
+
+        // issue request, and handle exceptions
+        javax.ws.rs.core.Response result;
+        try {
+            result = invocation.invoke(javax.ws.rs.core.Response.class);
+        }
+        catch (ProcessingException exception) {
+            if (trace) {
+                log.warn(exception.getCause(), "%-8s %s -> Exception", request.getMethod(), request.getUri());
+            }
+            // Peel out the exception we threw in jax-rs resource implementation
+            // to facilitate testing exceptional paths
+            if (exception.getCause() instanceof Exception) {
+                throw (Exception) exception.getCause();
+            }
+            throw exception;
+        }
+        catch (Throwable throwable) {
+            if (trace) {
+                log.warn(throwable, "%-8s %s -> Fail", request.getMethod(), request.getUri());
+            }
+            throw throwable;
+        }
+
+        // process response from jax-rs resource
+        ImmutableListMultimap.Builder<String, String> responseHeaders = ImmutableListMultimap.builder();
+        for (Map.Entry<String, List<String>> headerEntry : result.getStringHeaders().entrySet()) {
+            for (String value : headerEntry.getValue()) {
+                responseHeaders.put(headerEntry.getKey(), value);
+            }
+        }
+
+        if (trace) {
+            log.warn("%-8s %s -> OK", request.getMethod(), request.getUri());
+        }
+        return new TestingResponse(HttpStatus.OK, responseHeaders.build(), result.readEntity(byte[].class));
+    }
+}

--- a/jaxrs-testing/src/test/java/io/airlift/jaxrs/testing/TestJaxrsTestingHttpProcessor.java
+++ b/jaxrs-testing/src/test/java/io/airlift/jaxrs/testing/TestJaxrsTestingHttpProcessor.java
@@ -1,0 +1,85 @@
+package io.airlift.jaxrs.testing;
+
+import io.airlift.http.client.HttpStatus;
+import io.airlift.http.client.Request;
+import io.airlift.http.client.StringResponseHandler.StringResponse;
+import io.airlift.http.client.testing.TestingHttpClient;
+import org.testng.annotations.Test;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import java.net.URI;
+
+import static io.airlift.http.client.Request.Builder.prepareGet;
+import static io.airlift.http.client.StringResponseHandler.createStringResponseHandler;
+import static java.lang.String.format;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+@Test
+public class TestJaxrsTestingHttpProcessor
+{
+    private static final TestingHttpClient HTTP_CLIENT =
+            new TestingHttpClient(new JaxrsTestingHttpProcessor(URI.create("http://fake.invalid/"), new GetItResource()));
+
+    @Test
+    public void test()
+            throws Exception
+    {
+        Request request = prepareGet()
+                .setUri(URI.create("http://fake.invalid/get-it/get/xyz"))
+                .build();
+
+        StringResponse response = HTTP_CLIENT.execute(request, createStringResponseHandler());
+
+        assertEquals(response.getStatusCode(), HttpStatus.OK.code());
+        assertEquals(response.getBody(), "Got xyz");
+    }
+
+    @Test
+    public void testException()
+            throws Exception
+    {
+        Request request = prepareGet()
+                .setUri(URI.create("http://fake.invalid/get-it/fail/testException"))
+                .build();
+
+        try {
+            HTTP_CLIENT.execute(request, createStringResponseHandler());
+            fail("expected exception");
+        }
+        catch (TestingException e) {
+            assertEquals(e.getMessage(), "testException");
+        }
+    }
+
+    @Path("get-it")
+    public static class GetItResource
+    {
+        @Path("get/{id}")
+        @GET
+        @Produces(MediaType.TEXT_PLAIN)
+        public String getId(@PathParam("id") String id)
+        {
+            return format("Got %s", id);
+        }
+
+        @Path("fail/{message}")
+        @GET
+        @Produces(MediaType.TEXT_PLAIN)
+        public String fail(@PathParam("message") String errorMessage)
+        {
+            throw new TestingException(errorMessage);
+        }
+    }
+
+    private static class TestingException extends RuntimeException
+    {
+        public TestingException(String message) {
+            super(message);
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -363,6 +363,58 @@
                 <version>${dep.jersey.version}</version>
             </dependency>
 
+            <dependency>
+                <groupId>org.glassfish.jersey.core</groupId>
+                <artifactId>jersey-client</artifactId>
+                <version>${dep.jersey.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>junit</groupId>
+                        <artifactId>junit</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.glassfish.hk2.external</groupId>
+                        <artifactId>javax.inject</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.glassfish.hk2.external</groupId>
+                        <artifactId>aopalliance-repackaged</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.glassfish.jersey.test-framework</groupId>
+                <artifactId>jersey-test-framework-core</artifactId>
+                <version>${dep.jersey.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>junit</groupId>
+                        <artifactId>junit</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.ow2.asm</groupId>
+                        <artifactId>asm-debug-all</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.glassfish.jersey.test-framework.providers</groupId>
+                <artifactId>jersey-test-framework-provider-inmemory</artifactId>
+                <version>${dep.jersey.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>junit</groupId>
+                        <artifactId>junit</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.ow2.asm</groupId>
+                        <artifactId>asm-debug-all</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
             <!-- bval depends on commons-lang3 3.3.2, which is incompatible with Java 9 -->
             <dependency>
                 <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
It adds an implementation of TestingHttpClient.Processor that delegates to
JAX-RS resources.

`mvn dependency:tree`: https://gist.github.com/haozhun/107a0c98dda3dee64b037fce97b05e62

It looks like it's possible to put this in http-client (instead of a separate module). Should I do that instead?