### PR TITLE
Fix UnknownFormatConversionException for config errors

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+* 0.149
+
+- Fix UnknownFormatConversionException for config errors.
+
 * 0.148
 
 - Add @ConfigSecuritySensitive annotation to prevent printing config values.

--- a/configuration/src/main/java/io/airlift/configuration/ConfigurationFactory.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigurationFactory.java
@@ -463,7 +463,7 @@ public class ConfigurationFactory
             if (e instanceof InvocationTargetException && e.getCause() != null) {
                 e = e.getCause();
             }
-            throw new InvalidConfigurationException(e, "Error invoking configuration method [%s]", injectionPoint.getSetter().toGenericString());
+            throw new InvalidConfigurationException(e, format("Error invoking configuration method [%s]", injectionPoint.getSetter().toGenericString()));
         }
     }
 

--- a/configuration/src/main/java/io/airlift/configuration/InvalidConfigurationException.java
+++ b/configuration/src/main/java/io/airlift/configuration/InvalidConfigurationException.java
@@ -18,13 +18,13 @@ package io.airlift.configuration;
 public class InvalidConfigurationException
         extends Exception
 {
-    public InvalidConfigurationException(String message, Object... args)
+    public InvalidConfigurationException(String message)
     {
-        super(String.format(message, args));
+        super(message);
     }
 
-    public InvalidConfigurationException(Throwable cause, String message, Object... args)
+    public InvalidConfigurationException(Throwable cause, String message)
     {
-        super(String.format(message, args), cause);
+        super(message, cause);
     }
 }


### PR DESCRIPTION
An already formatted string was erroneously treated as a format
string and thus would prevent proper reporting of config errors.