### PR TITLE
Ensure Jetty client request doesn't live past synchronous return

### DIFF
--- a/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
@@ -359,11 +359,13 @@ public class JettyHttpClient
         }
         catch (InterruptedException e) {
             stats.recordRequestFailed();
+            jettyRequest.abort(e);
             Thread.currentThread().interrupt();
             return responseHandler.handleException(request, e);
         }
         catch (TimeoutException e) {
             stats.recordRequestFailed();
+            jettyRequest.abort(e);
             return responseHandler.handleException(request, e);
         }
         catch (ExecutionException e) {


### PR DESCRIPTION
Otherwise Jetty might later access objects in the BodyGenerator that are no longer valid.