### PR TITLE
Prevent "Address already in use" for HTTP server

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 * 0.150
 
 - Upgrade to Jetty 9.4.7.RC0.
+- Prevent "Address already in use" for HTTP server.
 - Remove @Inject from Logger.
 - Add HTTP/2 input buffer size config.
 - Add support for monitoring the Jetty client shared thread pool.

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 * 0.150
 
+- Upgrade to Jetty 9.4.7.RC0.
 - Remove @Inject from Logger.
 - Add HTTP/2 input buffer size config.
 - Add support for monitoring the Jetty client shared thread pool.

--- a/http-server/src/main/java/io/airlift/http/server/ClassPathResourceHandler.java
+++ b/http-server/src/main/java/io/airlift/http/server/ClassPathResourceHandler.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2012 Ness Computing, Inc.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/http-server/src/main/java/io/airlift/http/server/HttpServer.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServer.java
@@ -160,7 +160,8 @@ public class HttpServer
             httpConnector.setAcceptQueueSize(config.getHttpAcceptQueueSize());
 
             server.addConnector(httpConnector);
-        } else {
+        }
+        else {
             httpConnector = null;
         }
 
@@ -193,7 +194,8 @@ public class HttpServer
             httpsConnector.setAcceptQueueSize(config.getHttpAcceptQueueSize());
 
             server.addConnector(httpsConnector);
-        } else {
+        }
+        else {
             httpsConnector = null;
         }
 
@@ -219,7 +221,8 @@ public class HttpServer
                 sslContextFactory.setSecureRandomAlgorithm(config.getSecureRandomAlgorithm());
                 SslConnectionFactory sslConnectionFactory = new SslConnectionFactory(sslContextFactory, "http/1.1");
                 adminConnector = new ServerConnector(server, adminThreadPool, null, null, 0, -1, sslConnectionFactory, new HttpConnectionFactory(adminConfiguration));
-            } else {
+            }
+            else {
                 HttpConnectionFactory http1 = new HttpConnectionFactory(adminConfiguration);
                 HTTP2CServerConnectionFactory http2c = new HTTP2CServerConnectionFactory(adminConfiguration);
                 http2c.setMaxConcurrentStreams(config.getHttp2MaxConcurrentStreams());
@@ -233,11 +236,12 @@ public class HttpServer
             adminConnector.setAcceptQueueSize(config.getHttpAcceptQueueSize());
 
             server.addConnector(adminConnector);
-        } else {
+        }
+        else {
             adminConnector = null;
         }
 
-        /**
+        /*
          * structure is:
          *
          * server

--- a/http-server/src/main/java/io/airlift/http/server/HttpServer.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServer.java
@@ -29,6 +29,7 @@ import org.eclipse.jetty.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.security.LoginService;
 import org.eclipse.jetty.security.SecurityHandler;
 import org.eclipse.jetty.security.authentication.BasicAuthenticator;
+import org.eclipse.jetty.server.ConnectionFactory;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
@@ -61,6 +62,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.channels.ServerSocketChannel;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.cert.Certificate;
@@ -74,6 +76,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Executor;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkState;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
@@ -152,7 +155,14 @@ public class HttpServer
             http2c.setInitialStreamRecvWindow(toIntExact(config.getHttp2InitialStreamReceiveWindowSize().toBytes()));
             http2c.setMaxConcurrentStreams(config.getHttp2MaxConcurrentStreams());
             http2c.setInputBufferSize(toIntExact(config.getHttp2InputBufferSize().toBytes()));
-            httpConnector = new ServerConnector(server, null, null, null, acceptors == null ? -1 : acceptors, selectors == null ? -1 : selectors, http1, http2c);
+            httpConnector = createServerConnector(
+                    httpServerInfo.getHttpChannel(),
+                    server,
+                    null,
+                    firstNonNull(acceptors, -1),
+                    firstNonNull(selectors, -1),
+                    http1,
+                    http2c);
             httpConnector.setName("http");
             httpConnector.setPort(httpServerInfo.getHttpUri().getPort());
             httpConnector.setIdleTimeout(config.getNetworkMaxIdleTime().toMillis());
@@ -186,7 +196,14 @@ public class HttpServer
 
             Integer acceptors = config.getHttpsAcceptorThreads();
             Integer selectors = config.getHttpsSelectorThreads();
-            httpsConnector = new ServerConnector(server, null, null, null, acceptors == null ? -1 : acceptors, selectors == null ? -1 : selectors, sslConnectionFactory, new HttpConnectionFactory(httpsConfiguration));
+            httpsConnector = createServerConnector(
+                    httpServerInfo.getHttpsChannel(),
+                    server,
+                    null,
+                    firstNonNull(acceptors, -1),
+                    firstNonNull(selectors, -1),
+                    sslConnectionFactory,
+                    new HttpConnectionFactory(httpsConfiguration));
             httpsConnector.setName("https");
             httpsConnector.setPort(httpServerInfo.getHttpsUri().getPort());
             httpsConnector.setIdleTimeout(config.getNetworkMaxIdleTime().toMillis());
@@ -220,13 +237,27 @@ public class HttpServer
                 sslContextFactory.setKeyStorePassword(config.getKeystorePassword());
                 sslContextFactory.setSecureRandomAlgorithm(config.getSecureRandomAlgorithm());
                 SslConnectionFactory sslConnectionFactory = new SslConnectionFactory(sslContextFactory, "http/1.1");
-                adminConnector = new ServerConnector(server, adminThreadPool, null, null, 0, -1, sslConnectionFactory, new HttpConnectionFactory(adminConfiguration));
+                adminConnector = createServerConnector(
+                        httpServerInfo.getAdminChannel(),
+                        server,
+                        adminThreadPool,
+                        0,
+                        -1,
+                        sslConnectionFactory,
+                        new HttpConnectionFactory(adminConfiguration));
             }
             else {
                 HttpConnectionFactory http1 = new HttpConnectionFactory(adminConfiguration);
                 HTTP2CServerConnectionFactory http2c = new HTTP2CServerConnectionFactory(adminConfiguration);
                 http2c.setMaxConcurrentStreams(config.getHttp2MaxConcurrentStreams());
-                adminConnector = new ServerConnector(server, adminThreadPool, null, null, -1, -1, http1, http2c);
+                adminConnector = createServerConnector(
+                        httpServerInfo.getAdminChannel(),
+                        server,
+                        adminThreadPool,
+                        -1,
+                        -1,
+                        http1,
+                        http2c);
             }
 
             adminConnector.setName("admin");
@@ -447,5 +478,19 @@ public class HttpServer
             }
         }
         return certificates.build();
+    }
+
+    private static ServerConnector createServerConnector(
+            ServerSocketChannel channel,
+            Server server,
+            Executor executor,
+            int acceptors,
+            int selectors,
+            ConnectionFactory... factories)
+            throws IOException
+    {
+        ServerConnector connector = new ServerConnector(server, executor, null, null, acceptors, selectors, factories);
+        connector.open(channel);
+        return connector;
     }
 }

--- a/http-server/src/main/java/io/airlift/http/server/HttpServerInfo.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServerInfo.java
@@ -15,15 +15,18 @@
  */
 package io.airlift.http.server;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.airlift.node.NodeInfo;
 
 import javax.inject.Inject;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.net.ServerSocket;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.channels.ServerSocketChannel;
 
 public class HttpServerInfo
 {
@@ -34,38 +37,48 @@ public class HttpServerInfo
     private final URI adminUri;
     private final URI adminExternalUri;
 
+    private final ServerSocketChannel httpChannel;
+    private final ServerSocketChannel httpsChannel;
+    private final ServerSocketChannel adminChannel;
+
     @Inject
     public HttpServerInfo(HttpServerConfig config, NodeInfo nodeInfo)
     {
         if (config.isHttpEnabled()) {
-            httpUri = buildUri("http", nodeInfo.getInternalAddress(), config.getHttpPort());
+            httpChannel = createChannel(nodeInfo.getBindIp(), config.getHttpPort(), config.getHttpAcceptQueueSize());
+            httpUri = buildUri("http", nodeInfo.getInternalAddress(), port(httpChannel));
             httpExternalUri = buildUri("http", nodeInfo.getExternalAddress(), httpUri.getPort());
         }
         else {
+            httpChannel = null;
             httpUri = null;
             httpExternalUri = null;
         }
 
         if (config.isHttpsEnabled()) {
-            httpsUri = buildUri("https", nodeInfo.getInternalAddress(), config.getHttpsPort());
+            httpsChannel = createChannel(nodeInfo.getBindIp(), config.getHttpsPort(), config.getHttpAcceptQueueSize());
+            httpsUri = buildUri("https", nodeInfo.getInternalAddress(), port(httpsChannel));
             httpsExternalUri = buildUri("https", nodeInfo.getExternalAddress(), httpsUri.getPort());
         }
         else {
+            httpsChannel = null;
             httpsUri = null;
             httpsExternalUri = null;
         }
 
         if (config.isAdminEnabled()) {
+            adminChannel = createChannel(nodeInfo.getBindIp(), config.getAdminPort(), config.getHttpAcceptQueueSize());
             if (config.isHttpsEnabled()) {
-                adminUri = buildUri("https", nodeInfo.getInternalAddress(), config.getAdminPort());
+                adminUri = buildUri("https", nodeInfo.getInternalAddress(), port(adminChannel));
                 adminExternalUri = buildUri("https", nodeInfo.getExternalAddress(), adminUri.getPort());
             }
             else {
-                adminUri = buildUri("http", nodeInfo.getInternalAddress(), config.getAdminPort());
+                adminUri = buildUri("http", nodeInfo.getInternalAddress(), port(adminChannel));
                 adminExternalUri = buildUri("http", nodeInfo.getExternalAddress(), adminUri.getPort());
             }
         }
         else {
+            adminChannel = null;
             adminUri = null;
             adminExternalUri = null;
         }
@@ -101,13 +114,23 @@ public class HttpServerInfo
         return adminExternalUri;
     }
 
+    ServerSocketChannel getHttpChannel()
+    {
+        return httpChannel;
+    }
+
+    ServerSocketChannel getHttpsChannel()
+    {
+        return httpsChannel;
+    }
+
+    ServerSocketChannel getAdminChannel()
+    {
+        return adminChannel;
+    }
+
     private static URI buildUri(String scheme, String host, int port)
     {
-        // 0 means select a random port
-        if (port == 0) {
-            port = findUnusedPort();
-        }
-
         try {
             return new URI(scheme, null, host, port, null, null, null);
         }
@@ -116,10 +139,24 @@ public class HttpServerInfo
         }
     }
 
-    private static int findUnusedPort()
+    @VisibleForTesting
+    static int port(ServerSocketChannel channel)
     {
-        try (ServerSocket socket = new ServerSocket(0)) {
-            return socket.getLocalPort();
+        try {
+            return ((InetSocketAddress) channel.getLocalAddress()).getPort();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static ServerSocketChannel createChannel(InetAddress address, int port, int acceptQueueSize)
+    {
+        try {
+            ServerSocketChannel channel = ServerSocketChannel.open();
+            channel.socket().setReuseAddress(true);
+            channel.socket().bind(new InetSocketAddress(address, port), acceptQueueSize);
+            return channel;
         }
         catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/http-server/src/main/java/io/airlift/http/server/HttpServerInfo.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServerInfo.java
@@ -59,7 +59,8 @@ public class HttpServerInfo
             if (config.isHttpsEnabled()) {
                 adminUri = buildUri("https", nodeInfo.getInternalAddress(), config.getAdminPort());
                 adminExternalUri = buildUri("https", nodeInfo.getExternalAddress(), adminUri.getPort());
-            } else {
+            }
+            else {
                 adminUri = buildUri("http", nodeInfo.getInternalAddress(), config.getAdminPort());
                 adminExternalUri = buildUri("http", nodeInfo.getExternalAddress(), adminUri.getPort());
             }

--- a/http-server/src/main/java/io/airlift/http/server/HttpServerProvider.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServerProvider.java
@@ -23,6 +23,7 @@ import io.airlift.http.server.HttpServerBinder.HttpResourceBinding;
 import io.airlift.node.NodeInfo;
 import io.airlift.tracetoken.TraceTokenManager;
 import org.eclipse.jetty.security.LoginService;
+import org.eclipse.jetty.server.ServerConnector;
 
 import javax.annotation.Nullable;
 import javax.inject.Provider;
@@ -30,6 +31,7 @@ import javax.management.MBeanServer;
 import javax.servlet.Filter;
 import javax.servlet.Servlet;
 
+import java.lang.reflect.Field;
 import java.util.Map;
 import java.util.Set;
 

--- a/http-server/src/main/java/io/airlift/http/server/Inet4Network.java
+++ b/http-server/src/main/java/io/airlift/http/server/Inet4Network.java
@@ -19,7 +19,8 @@ import com.google.common.net.InetAddresses;
 
 import java.net.Inet4Address;
 
-final class Inet4Network implements Comparable<Inet4Network>
+final class Inet4Network
+        implements Comparable<Inet4Network>
 {
     private final Inet4Address address;
     private final int bits;

--- a/http-server/src/main/java/io/airlift/http/server/Inet4Networks.java
+++ b/http-server/src/main/java/io/airlift/http/server/Inet4Networks.java
@@ -33,7 +33,6 @@ class Inet4Networks
             fromCidr("10.0.0.0/8")
     );
 
-
     public static boolean isPrivateNetworkAddress(String inetAddress)
     {
         Inet4Address address = InetAddresses.getCoercedIPv4Address(InetAddresses.forString(inetAddress));

--- a/http-server/src/main/java/io/airlift/http/server/LocalAnnouncementHttpServerInfo.java
+++ b/http-server/src/main/java/io/airlift/http/server/LocalAnnouncementHttpServerInfo.java
@@ -21,7 +21,8 @@ import javax.inject.Inject;
 
 import java.net.URI;
 
-public class LocalAnnouncementHttpServerInfo implements AnnouncementHttpServerInfo
+public class LocalAnnouncementHttpServerInfo
+        implements AnnouncementHttpServerInfo
 {
     private final HttpServerInfo httpServerInfo;
 

--- a/http-server/src/main/java/io/airlift/http/server/SystemCurrentTimeMillisProvider.java
+++ b/http-server/src/main/java/io/airlift/http/server/SystemCurrentTimeMillisProvider.java
@@ -15,7 +15,8 @@
  */
 package io.airlift.http.server;
 
-public class SystemCurrentTimeMillisProvider implements CurrentTimeMillisProvider
+public class SystemCurrentTimeMillisProvider
+        implements CurrentTimeMillisProvider
 {
     @Override
     public long getCurrentTimeMillis()

--- a/http-server/src/main/java/io/airlift/http/server/TimingFilter.java
+++ b/http-server/src/main/java/io/airlift/http/server/TimingFilter.java
@@ -64,7 +64,8 @@ class TimingFilter
     {
     }
 
-    private static class TimedResponse extends HttpServletResponseWrapper
+    private static class TimedResponse
+            extends HttpServletResponseWrapper
     {
         private TimedServletOutputStream outputStream;
         private TimedPrintWriter printWriter;
@@ -108,7 +109,8 @@ class TimingFilter
         }
     }
 
-    private static class TimedServletOutputStream extends ServletOutputStream
+    private static class TimedServletOutputStream
+            extends ServletOutputStream
     {
         private final ServletOutputStream delegate;
         private Long firstByteTime;
@@ -301,7 +303,8 @@ class TimingFilter
         }
     }
 
-    private static class TimedPrintWriter extends PrintWriter
+    private static class TimedPrintWriter
+            extends PrintWriter
     {
         private Long firstByteTime;
 

--- a/http-server/src/test/java/io/airlift/http/server/MockCurrentTimeMillisProvider.java
+++ b/http-server/src/test/java/io/airlift/http/server/MockCurrentTimeMillisProvider.java
@@ -15,7 +15,8 @@
  */
 package io.airlift.http.server;
 
-public class MockCurrentTimeMillisProvider implements CurrentTimeMillisProvider
+public class MockCurrentTimeMillisProvider
+        implements CurrentTimeMillisProvider
 {
     private long time;
 
@@ -24,7 +25,8 @@ public class MockCurrentTimeMillisProvider implements CurrentTimeMillisProvider
         this.time = time;
     }
 
-    public void incrementTime(long delta) {
+    public void incrementTime(long delta)
+    {
         time += delta;
     }
 

--- a/http-server/src/test/java/io/airlift/http/server/TestDelimitedRequestLog.java
+++ b/http-server/src/test/java/io/airlift/http/server/TestDelimitedRequestLog.java
@@ -89,7 +89,6 @@ public class TestDelimitedRequestLog
         final String responseContentType = "response/type";
         final HttpURI uri = new HttpURI("http://www.example.com/aaa+bbb/ccc?param=hello%20there&other=true");
 
-
         final TraceTokenManager tokenManager = new TraceTokenManager();
         InMemoryEventClient eventClient = new InMemoryEventClient();
         MockCurrentTimeMillisProvider currentTimeMillisProvider = new MockCurrentTimeMillisProvider(timestamp + timeToLastByte);
@@ -121,7 +120,6 @@ public class TestDelimitedRequestLog
         Assert.assertEquals(events.size(), 1);
         HttpRequestEvent event = (HttpRequestEvent) events.get(0);
 
-
         Assert.assertEquals(event.getTimeStamp().toEpochMilli(), timestamp);
         Assert.assertEquals(event.getClientAddress(), ip);
         Assert.assertEquals(event.getProtocol(), protocol);
@@ -135,7 +133,7 @@ public class TestDelimitedRequestLog
         Assert.assertEquals(event.getResponseSize(), responseSize);
         Assert.assertEquals(event.getResponseCode(), responseCode);
         Assert.assertEquals(event.getResponseContentType(), responseContentType);
-        Assert.assertEquals(event.getTimeToFirstByte(), (Long)timeToFirstByte);
+        Assert.assertEquals(event.getTimeToFirstByte(), (Long) timeToFirstByte);
         Assert.assertEquals(event.getTimeToLastByte(), timeToLastByte);
         Assert.assertEquals(event.getTraceToken(), tokenManager.getCurrentRequestToken());
 

--- a/http-server/src/test/java/io/airlift/http/server/TestHttpServerInfo.java
+++ b/http-server/src/test/java/io/airlift/http/server/TestHttpServerInfo.java
@@ -23,7 +23,7 @@ import java.net.URI;
 
 import static org.testng.Assert.assertEquals;
 
-public class HttpServerInfoTest
+public class TestHttpServerInfo
 {
     @Test
     public void testIPv6Url()

--- a/http-server/src/test/java/io/airlift/http/server/TestHttpServerModule.java
+++ b/http-server/src/test/java/io/airlift/http/server/TestHttpServerModule.java
@@ -329,7 +329,6 @@ public class TestHttpServerModule
         Assert.assertEquals(events.size(), 1);
         HttpRequestEvent event = (HttpRequestEvent) events.get(0);
 
-
         Assert.assertEquals(event.getClientAddress(), echoServlet.remoteAddress);
         Assert.assertEquals(event.getProtocol(), "http");
         Assert.assertEquals(event.getMethod(), "POST");
@@ -353,7 +352,8 @@ public class TestHttpServerModule
         Assert.assertTrue(event.getTimeToFirstByte() <= event.getTimeToLastByte());
     }
 
-    private static final class EchoServlet extends HttpServlet
+    private static final class EchoServlet
+            extends HttpServlet
     {
         private int responseStatusCode = 300;
         private final ListMultimap<String, String> responseHeaders = ArrayListMultimap.create();

--- a/http-server/src/test/java/io/airlift/http/server/TestInet4Network.java
+++ b/http-server/src/test/java/io/airlift/http/server/TestInet4Network.java
@@ -48,7 +48,7 @@ public class TestInet4Network
     @DataProvider(name = "invalidCidr")
     public Object[][] invalidCidrProvider()
     {
-        return new Object[][]{
+        return new Object[][] {
                 {" 0.0.0.0/0"},
                 {"0.0.0.0/0 "},
                 {"x.0.0.0/0"},
@@ -65,7 +65,7 @@ public class TestInet4Network
                 {"8.0.0.0.0"},
                 {"-8.1.0.0"},
                 {"8.-1.0.0"},
-        };
+                };
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class, dataProvider = "invalidCidr")

--- a/http-server/src/test/java/io/airlift/http/server/testing/TestTestingHttpServer.java
+++ b/http-server/src/test/java/io/airlift/http/server/testing/TestTestingHttpServer.java
@@ -181,6 +181,7 @@ public class TestTestingHttpServer
             lifeCycleManager.stop();
         }
     }
+
     @Test
     public void testGuiceInjectionWithFilters()
             throws Exception

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
         <dep.airlift.version>0.150-SNAPSHOT</dep.airlift.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
-        <dep.jetty.version>9.4.6.v20170531</dep.jetty.version>
+        <dep.jetty.version>9.4.7.RC0</dep.jetty.version>
         <dep.jersey.version>2.22.2</dep.jersey.version>
     </properties>
 


### PR DESCRIPTION
When using automatic port selection, the port is bound once and kept bound
rather than unbinding and hoping the OS does not reuse the port number
before it can be explicitly bound again.