### PR TITLE
Add sanity checks in HttpUriBuilder

### DIFF
--- a/http-client/src/main/java/io/airlift/http/client/HttpUriBuilder.java
+++ b/http-client/src/main/java/io/airlift/http/client/HttpUriBuilder.java
@@ -17,6 +17,7 @@ import java.nio.charset.CharacterCodingException;
 import java.nio.charset.CodingErrorAction;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.google.common.base.CharMatcher.ascii;
 import static java.lang.Character.forDigit;
@@ -55,7 +56,7 @@ public class HttpUriBuilder
         scheme = previous.getScheme();
         host = previous.getHost();
         port = previous.getPort();
-        path = percentDecode(previous.getRawPath());
+        path = Optional.ofNullable(previous.getRawPath()).map(HttpUriBuilder::percentDecode).orElse(null);
         params.putAll(parseParams(previous.getRawQuery()));
     }
 
@@ -280,6 +281,7 @@ public class HttpUriBuilder
      */
     private static String percentDecode(String encoded)
     {
+        requireNonNull(encoded, "encoded is null");
         Preconditions.checkArgument(ascii().matchesAllOf(encoded), "string must be ASCII");
 
         ByteArrayOutputStream out = new ByteArrayOutputStream(encoded.length());

--- a/http-client/src/test/java/io/airlift/http/client/TestHttpUriBuilder.java
+++ b/http-client/src/test/java/io/airlift/http/client/TestHttpUriBuilder.java
@@ -4,6 +4,7 @@ import com.google.common.net.HostAndPort;
 import org.testng.annotations.Test;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 
 import static io.airlift.http.client.HttpUriBuilder.uriBuilder;
 import static io.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
@@ -115,6 +116,15 @@ public class TestHttpUriBuilder
                 .build();
 
         assertEquals(uri.toASCIIString(), "http://www.example.com/a/b/c/x/y/z");
+    }
+
+    @Test
+    public void testNullPath()
+            throws URISyntaxException
+    {
+        URI uri = new URI("test-server:8080");
+        assertEquals(uri.getRawPath(), null);
+        assertEquals(uri.toASCIIString(), "test-server:8080");
     }
 
     @Test


### PR DESCRIPTION
We saw failure of a Presto product test on an EMR cluster with the following stack trace:
```18:22:17 Jul 11, 2017 6:19:28 PM com.teradata.tempto.internal.listeners.ProgressLoggingListener onTestFailure
18:22:17 SEVERE: Failure cause:
18:22:17 java.lang.NullPointerException
18:22:17 	at com.google.common.base.CharMatcher.matchesAllOf(CharMatcher.java:635)
18:22:17 	at io.airlift.http.client.HttpUriBuilder.percentDecode(HttpUriBuilder.java:283)
18:22:17 	at io.airlift.http.client.HttpUriBuilder.<init>(HttpUriBuilder.java:58)
18:22:17 	at io.airlift.http.client.HttpUriBuilder.uriBuilderFrom(HttpUriBuilder.java:71)
18:22:17 	at com.facebook.presto.tests.querystats.HttpQueryStatsClient.getQueryStats(HttpQueryStatsClient.java:54)
18:22:17 	at com.facebook.presto.tests.hive.HivePartitioningTest.getProcessedLinesCount(HivePartitioningTest.java:53)
18:22:17 	at com.facebook.presto.tests.hive.TestTablePartitioningInsertInto.testQuerySplitsNumber(TestTablePartitioningInsertInto.java:83)
18:22:17 	at com.facebook.presto.tests.hive.TestTablePartitioningInsertInto.selectFromPartitionedNation(TestTablePartitioningInsertInto.java:54)
```
The reason I believe is, `null` value is being passed to `percentDecode()` in `HttpUriBuilder()`, but `percentDecode()` makes an assumption that the input is non-null.

I believe the checks added in this commit should fix this.