### PR TITLE
Remove @Inject from Logger

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@
 - Upgrade to Jetty 9.4.6.v20170531
 - Fix UnknownFormatConversionException for config errors.
 - Allow specifying etc directory for launcher.
+- Remove @Inject from Logger.
 
 * 0.148
 

--- a/log/pom.xml
+++ b/log/pom.xml
@@ -16,11 +16,6 @@
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
-        </dependency>
-
         <!-- for testing -->
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/log/src/main/java/io/airlift/log/Logger.java
+++ b/log/src/main/java/io/airlift/log/Logger.java
@@ -15,8 +15,6 @@
  */
 package io.airlift.log;
 
-import javax.inject.Inject;
-
 import java.util.IllegalFormatException;
 
 import static java.lang.String.format;
@@ -30,7 +28,6 @@ public class Logger
 {
     private final java.util.logging.Logger logger;
 
-    @Inject
     Logger(java.util.logging.Logger logger)
     {
         this.logger = logger;


### PR DESCRIPTION
The injected Logger instance will have the class of the Logger itself
and not class of the injection target (as would be expected).