### PR TITLE
Support custom Java verison string

### DIFF
--- a/jmx/src/main/java/io/airlift/jmx/JavaVersion.java
+++ b/jmx/src/main/java/io/airlift/jmx/JavaVersion.java
@@ -35,7 +35,7 @@ class JavaVersion
     private static final Pattern PATTERN = Pattern.compile(VERSION_NUMBER + PRE + BUILD + OPT);
 
     // For Java 8 and below
-    private static final Pattern LEGACY_PATTERN = Pattern.compile("1\\.(?<MAJOR>[0-9]+)(\\.(?<MINOR>(0|[1-9][0-9]*)))?(_(?<UPDATE>[1-9][0-9]*))?(?:-ea)?");
+    private static final Pattern LEGACY_PATTERN = Pattern.compile("1\\.(?<MAJOR>[0-9]+)(\\.(?<MINOR>(0|[1-9][0-9]*)))?(_(?<UPDATE>[1-9][0-9]*))?(?:-(?:[a-zA-Z0-9.]+))*");
 
     private final int major;
     private final int minor;

--- a/jmx/src/test/java/io/airlift/jmx/TestJavaVersion.java
+++ b/jmx/src/test/java/io/airlift/jmx/TestJavaVersion.java
@@ -31,6 +31,7 @@ public class TestJavaVersion
         assertEquals(JavaVersion.parse("1.8.0_20"), new JavaVersion(8, 0, OptionalInt.of(20)));
         assertEquals(JavaVersion.parse("1.8.1_25"), new JavaVersion(8, 1, OptionalInt.of(25)));
         assertEquals(JavaVersion.parse("1.8.0_60-ea"), new JavaVersion(8, 0, OptionalInt.of(60)));
+        assertEquals(JavaVersion.parse("1.8.0_131-foo-bar-baz-qux"), new JavaVersion(8, 0, OptionalInt.of(131)));
     }
 
     @Test


### PR DESCRIPTION
Besides legacy Java version string and the new one introduced in Java 9, we still need to support Java version string like `1.8.0_131-foo-bar-baz`. This provides more flexibility for developers.