### PR TITLE
Enable detailed dumps for QueuedThreadPool

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+* 0.150
+- Enable detailed dumps for Jetty thread pools, which will help getting
+  more information when debugging with the JMX dump operation.
+
 * 0.149
 
 - Upgrade to Jetty 9.4.6.v20170531

--- a/http-client/src/main/java/io/airlift/http/client/jetty/JettyIoPool.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/JettyIoPool.java
@@ -37,6 +37,7 @@ public final class JettyIoPool
             threadPool.setDaemon(true);
             threadPool.start();
             threadPool.setStopTimeout(2000);
+            threadPool.setDetailedDump(true);
             executor = threadPool;
 
             scheduler = new ScheduledExecutorScheduler(baseName + "-scheduler", true, currentThread().getContextClassLoader());

--- a/http-server/src/main/java/io/airlift/http/server/HttpServer.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServer.java
@@ -119,6 +119,7 @@ public class HttpServer
         threadPool.setMinThreads(config.getMinThreads());
         threadPool.setIdleTimeout(Ints.checkedCast(config.getThreadMaxIdleTime().toMillis()));
         threadPool.setName("http-worker");
+        threadPool.setDetailedDump(true);
         server = new Server(threadPool);
         registerErrorHandler = config.isShowStackTrace();
 


### PR DESCRIPTION
This is useful when debugging Jetty with JMX dump() operations.

There won't be any overhead.