### PR TITLE
Add instance sizes to HyperLogLog and SparseHll

### DIFF
--- a/stats/src/main/java/io/airlift/stats/cardinality/HyperLogLog.java
+++ b/stats/src/main/java/io/airlift/stats/cardinality/HyperLogLog.java
@@ -16,12 +16,14 @@ package io.airlift.stats.cardinality;
 import com.google.common.annotations.VisibleForTesting;
 import io.airlift.slice.Murmur3Hash128;
 import io.airlift.slice.Slice;
+import org.openjdk.jol.info.ClassLayout;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.stats.cardinality.Utils.indexBitLength;
 
 public class HyperLogLog
 {
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(HyperLogLog.class).instanceSize();
     private static final int MAX_NUMBER_OF_BUCKETS = 65536;
     private HllInstance instance;
 
@@ -97,7 +99,7 @@ public class HyperLogLog
 
     public int estimatedInMemorySize()
     {
-        return instance.estimatedInMemorySize();
+        return instance.estimatedInMemorySize() + INSTANCE_SIZE;
     }
 
     public int estimatedSerializedSize()

--- a/stats/src/main/java/io/airlift/stats/cardinality/SparseHll.java
+++ b/stats/src/main/java/io/airlift/stats/cardinality/SparseHll.java
@@ -28,10 +28,12 @@ import java.util.Arrays;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.slice.SizeOf.sizeOf;
 import static io.airlift.stats.cardinality.Utils.computeIndex;
 import static io.airlift.stats.cardinality.Utils.linearCounting;
 import static io.airlift.stats.cardinality.Utils.numberOfBuckets;
 import static io.airlift.stats.cardinality.Utils.numberOfLeadingZeros;
+import static java.lang.Math.toIntExact;
 import static java.util.Comparator.comparingInt;
 
 @NotThreadSafe
@@ -189,7 +191,7 @@ final class SparseHll
     @Override
     public int estimatedInMemorySize()
     {
-        return SPARSE_INSTANCE_SIZE + (SizeOf.SIZE_OF_INT * numberOfEntries);
+        return SPARSE_INSTANCE_SIZE + toIntExact(sizeOf(entries));
     }
 
     @Override

--- a/stats/src/test/java/io/airlift/stats/cardinality/TestHyperLogLog.java
+++ b/stats/src/test/java/io/airlift/stats/cardinality/TestHyperLogLog.java
@@ -14,6 +14,7 @@
 package io.airlift.stats.cardinality;
 
 import io.airlift.slice.Slice;
+import org.openjdk.jol.info.ClassLayout;
 import org.testng.annotations.Test;
 
 import java.util.HashMap;
@@ -71,6 +72,15 @@ public class TestHyperLogLog
                                 entry.getValue().stdev()));
             }
         }
+    }
+
+    @Test
+    public void testRetainedSize()
+            throws Exception
+    {
+        assertEquals(
+                HyperLogLog.newInstance(8).estimatedInMemorySize(),
+                ClassLayout.parseClass(HyperLogLog.class).instanceSize() + (new SparseHll(10)).estimatedInMemorySize());
     }
 
     @Test


### PR DESCRIPTION
We observed 3X retained size in heap dump than the calculated one. Add
instance sizes to fill the gap.