### PR TITLE
Add a concurrent timeout scheduler for Jetty Client

### DIFF
--- a/http-client/src/main/java/io/airlift/http/client/jetty/JettyIoPool.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/JettyIoPool.java
@@ -1,7 +1,9 @@
 package io.airlift.http.client.jetty;
 
+import io.airlift.concurrent.Threads;
 import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.io.MappedByteBufferPool;
+import org.eclipse.jetty.util.component.AbstractLifeCycle;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.jetty.util.thread.ScheduledExecutorScheduler;
@@ -9,10 +11,19 @@ import org.eclipse.jetty.util.thread.Scheduler;
 
 import java.io.Closeable;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Throwables.throwIfUnchecked;
+import static java.lang.Math.max;
 import static java.lang.Thread.currentThread;
+import static java.util.Objects.requireNonNull;
 
 public final class JettyIoPool
         implements Closeable
@@ -40,7 +51,15 @@ public final class JettyIoPool
             threadPool.setDetailedDump(true);
             executor = threadPool;
 
-            scheduler = new ScheduledExecutorScheduler(baseName + "-scheduler", true, currentThread().getContextClassLoader());
+            if (config.getTimeoutConcurrency() == 1 && config.getTimeoutThreads() == 1) {
+                scheduler = new ScheduledExecutorScheduler(baseName + "-scheduler", true, currentThread().getContextClassLoader());
+            }
+            else {
+                scheduler = new ConcurrentScheduler(
+                        config.getTimeoutConcurrency(),
+                        max(1, config.getTimeoutThreads() / config.getTimeoutConcurrency()),
+                        baseName + "-scheduler");
+            }
             scheduler.start();
 
             byteBufferPool = new MappedByteBufferPool();
@@ -100,5 +119,55 @@ public final class JettyIoPool
         return toStringHelper(this)
                 .add("name", name)
                 .toString();
+    }
+
+    // based on ScheduledExecutorScheduler
+    private static class ConcurrentScheduler
+            extends AbstractLifeCycle
+            implements Scheduler
+    {
+        private final int threadsPerScheduler;
+        private final ScheduledExecutorService[] schedulers;
+        private final String threadBaseName;
+
+        public ConcurrentScheduler(int schedulerCount, int threadsPerScheduler, String threadBaseName)
+        {
+            checkArgument(schedulerCount > 0, "schedulerCount must be at least one");
+            this.schedulers = new ScheduledThreadPoolExecutor[schedulerCount];
+            checkArgument(threadsPerScheduler > 0, "threadsPerScheduler must be at least one");
+            this.threadsPerScheduler = threadsPerScheduler;
+            this.threadBaseName = requireNonNull(threadBaseName, "threadBaseName is null");
+        }
+
+        @Override
+        protected void doStart()
+                throws Exception
+        {
+            for (int i = 0; i < schedulers.length; i++) {
+                schedulers[i] = Executors.newScheduledThreadPool(threadsPerScheduler, Threads.daemonThreadsNamed(threadBaseName + "-timeout-%s" + i));
+            }
+        }
+
+        @Override
+        protected void doStop()
+                throws Exception
+        {
+            for (int i = 0; i < schedulers.length; i++) {
+                schedulers[i].shutdownNow();
+                schedulers[i] = null;
+            }
+        }
+
+        @Override
+        public Task schedule(Runnable task, long delay, TimeUnit unit)
+        {
+            ScheduledExecutorService scheduler = schedulers[ThreadLocalRandom.current().nextInt(schedulers.length)];
+            if (scheduler == null) {
+                return () -> false;
+            }
+
+            ScheduledFuture<?> result = scheduler.schedule(task, delay, unit);
+            return () -> result.cancel(false);
+        }
     }
 }

--- a/http-client/src/main/java/io/airlift/http/client/jetty/JettyIoPoolConfig.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/JettyIoPoolConfig.java
@@ -1,6 +1,7 @@
 package io.airlift.http.client.jetty;
 
 import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.LegacyConfig;
 
 import javax.validation.constraints.Min;
@@ -9,6 +10,8 @@ public class JettyIoPoolConfig
 {
     private int maxThreads = 200;
     private int minThreads = 8;
+    private int timeoutThreads = 32;
+    private int timeoutConcurrency = 16;
 
     @Min(1)
     public int getMaxThreads()
@@ -34,6 +37,34 @@ public class JettyIoPoolConfig
     public JettyIoPoolConfig setMinThreads(int minThreads)
     {
         this.minThreads = minThreads;
+        return this;
+    }
+
+    @Min(1)
+    public int getTimeoutThreads()
+    {
+        return timeoutThreads;
+    }
+
+    @Config("http-client.timeout-threads")
+    @ConfigDescription("Total number of timeout threads")
+    public JettyIoPoolConfig setTimeoutThreads(int timeoutThreads)
+    {
+        this.timeoutThreads = timeoutThreads;
+        return this;
+    }
+
+    @Min(1)
+    public int getTimeoutConcurrency()
+    {
+        return timeoutConcurrency;
+    }
+
+    @Config("http-client.timeout-concurrency")
+    @ConfigDescription("Number of concurrent locks for timeout")
+    public JettyIoPoolConfig setTimeoutConcurrency(int timeoutConcurrency)
+    {
+        this.timeoutConcurrency = timeoutConcurrency;
         return this;
     }
 }

--- a/http-client/src/test/java/io/airlift/http/client/jetty/TestJettyIoPoolConfig.java
+++ b/http-client/src/test/java/io/airlift/http/client/jetty/TestJettyIoPoolConfig.java
@@ -13,7 +13,9 @@ public class TestJettyIoPoolConfig
     {
         ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(JettyIoPoolConfig.class)
                 .setMaxThreads(200)
-                .setMinThreads(8));
+                .setMinThreads(8)
+                .setTimeoutConcurrency(16)
+                .setTimeoutThreads(32));
     }
 
     @Test
@@ -22,11 +24,15 @@ public class TestJettyIoPoolConfig
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("http-client.max-threads", "33")
                 .put("http-client.min-threads", "11")
+                .put("http-client.timeout-concurrency", "33")
+                .put("http-client.timeout-threads", "44")
                 .build();
 
         JettyIoPoolConfig expected = new JettyIoPoolConfig()
                 .setMaxThreads(33)
-                .setMinThreads(11);
+                .setMinThreads(11)
+                .setTimeoutConcurrency(33)
+                .setTimeoutThreads(44);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Use multiple scheduler instances to reduce contention Jetty client for timeout executor
when under heavy.