### PR TITLE
Improve startup time.

### DIFF
--- a/discovery/src/main/java/io/airlift/discovery/client/CachingServiceSelector.java
+++ b/discovery/src/main/java/io/airlift/discovery/client/CachingServiceSelector.java
@@ -80,7 +80,7 @@ public class CachingServiceSelector
 
             // if discovery is available, get the initial set of servers before starting
             try {
-                refresh().get(30, TimeUnit.SECONDS);
+                refresh().get(1, TimeUnit.SECONDS);
             }
             catch (Exception ignored) {
             }


### PR DESCRIPTION
30 seconds seems arbitrary and the PostConstruct method will return once the future times out. Looks like refresh continues asynchronously after timeout. This change reduces the wait time. This seems to improve startup time of Presto when running in dev environment.