### PR TITLE
Use async appender to log events

### DIFF
--- a/http-server/src/main/java/io/airlift/http/server/DelimitedRequestLog.java
+++ b/http-server/src/main/java/io/airlift/http/server/DelimitedRequestLog.java
@@ -19,6 +19,7 @@ import ch.qos.logback.core.ContextBase;
 import ch.qos.logback.core.rolling.RollingFileAppender;
 import ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP;
 import ch.qos.logback.core.rolling.TimeBasedRollingPolicy;
+import ch.qos.logback.core.util.FileSize;
 import io.airlift.event.client.EventClient;
 import io.airlift.log.Logger;
 import io.airlift.tracetoken.TraceTokenManager;
@@ -76,18 +77,19 @@ class DelimitedRequestLog
         rollingPolicy.setMaxHistory(maxHistory);
         rollingPolicy.setTimeBasedFileNamingAndTriggeringPolicy(triggeringPolicy);
         rollingPolicy.setParent(fileAppender);
-        rollingPolicy.start();
 
         triggeringPolicy.setContext(context);
         triggeringPolicy.setTimeBasedRollingPolicy(rollingPolicy);
-        triggeringPolicy.setMaxFileSize(String.valueOf(maxFileSizeInBytes));
-        triggeringPolicy.start();
+        triggeringPolicy.setMaxFileSize(new FileSize(maxFileSizeInBytes));
 
         fileAppender.setContext(context);
         fileAppender.setFile(filename);
         fileAppender.setAppend(true);
         fileAppender.setLayout(httpLogLayout);
         fileAppender.setRollingPolicy(rollingPolicy);
+
+        rollingPolicy.start();
+        triggeringPolicy.start();
         fileAppender.start();
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>io.airlift</groupId>
         <artifactId>airbase</artifactId>
-        <version>72</version>
+        <version>74</version>
     </parent>
 
     <inceptionYear>2010</inceptionYear>


### PR DESCRIPTION
Logging events while holding a thread from a thread pool can quickly
drain the pool given IO is in general slow. Use async appender to fast
release the thread if applicable. Also, increase the buffer size of the
appender from 8KB to 1MB.