### PR TITLE
Remove LifeCycleManager shutdown hook when stop() is called

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+* 0.155
+
+- Remove LifeCycleManager shutdown hook when stop() is called.
+
 * 0.154
 
 - Upgrade to Airbase 74.


### PR DESCRIPTION
This prevents memory leaks when used explicitly such as in tests.