### PR TITLE
Add HTTP client selector thread count config

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+* 0.156
+
+- Add HTTP client selector thread count config.
+
 * 0.155
 
 - Remove LifeCycleManager shutdown hook when stop() is called.

--- a/http-client/src/main/java/io/airlift/http/client/HttpClientConfig.java
+++ b/http-client/src/main/java/io/airlift/http/client/HttpClientConfig.java
@@ -59,6 +59,7 @@ public class HttpClientConfig
     private boolean authenticationEnabled;
     private String kerberosPrincipal;
     private String kerberosRemoteServiceName;
+    private int selectorThreads = 2;
 
     private boolean http2Enabled;
     private DataSize http2InitialSessionReceiveWindowSize = new DataSize(16, MEGABYTE);
@@ -343,6 +344,19 @@ public class HttpClientConfig
     public HttpClientConfig setHttp2InputBufferSize(DataSize http2InputBufferSize)
     {
         this.http2InputBufferSize = http2InputBufferSize;
+        return this;
+    }
+
+    @Min(1)
+    public int getSelectorThreads()
+    {
+        return selectorThreads;
+    }
+
+    @Config("http-client.selector-thread-count")
+    public HttpClientConfig setSelectorThreads(int selectorThreads)
+    {
+        this.selectorThreads = selectorThreads;
         return this;
     }
 }

--- a/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
@@ -113,7 +113,6 @@ public class JettyHttpClient
     private static final String PRESTO_STATS_KEY = "presto_stats";
     private static final long SWEEP_PERIOD_MILLIS = 5000;
     private static final String REALM_IN_CHALLENGE = "X-Airlift-Realm-In-Challenge";
-    private static final int CLIENT_TRANSPORT_SELECTORS = 2;
 
     private final Optional<JettyIoPool> anonymousPool;
     private final HttpClient httpClient;
@@ -191,11 +190,11 @@ public class JettyHttpClient
             client.setInitialSessionRecvWindow(toIntExact(config.getHttp2InitialSessionReceiveWindowSize().toBytes()));
             client.setInitialStreamRecvWindow(toIntExact(config.getHttp2InitialStreamReceiveWindowSize().toBytes()));
             client.setInputBufferSize(toIntExact(config.getHttp2InputBufferSize().toBytes()));
-            client.setSelectors(CLIENT_TRANSPORT_SELECTORS);
+            client.setSelectors(config.getSelectorThreads());
             transport = new HttpClientTransportOverHTTP2(client);
         }
         else {
-            transport = new HttpClientTransportOverHTTP(CLIENT_TRANSPORT_SELECTORS);
+            transport = new HttpClientTransportOverHTTP(config.getSelectorThreads());
         }
 
         if (authenticationEnabled) {

--- a/http-client/src/test/java/io/airlift/http/client/TestHttpClientConfig.java
+++ b/http-client/src/test/java/io/airlift/http/client/TestHttpClientConfig.java
@@ -63,7 +63,8 @@ public class TestHttpClientConfig
                 .setKerberosPrincipal(null)
                 .setHttp2InitialSessionReceiveWindowSize(new DataSize(16, MEGABYTE))
                 .setHttp2InitialStreamReceiveWindowSize(new DataSize(16, MEGABYTE))
-                .setHttp2InputBufferSize(new DataSize(8, KILOBYTE)));
+                .setHttp2InputBufferSize(new DataSize(8, KILOBYTE))
+                .setSelectorThreads(2));
     }
 
     @Test
@@ -91,6 +92,7 @@ public class TestHttpClientConfig
                 .put("http-client.http2.session-receive-window-size", "7MB")
                 .put("http-client.http2.stream-receive-window-size", "7MB")
                 .put("http-client.http2.input-buffer-size", "1MB")
+                .put("http-client.selector-thread-count", "16")
                 .build();
 
         HttpClientConfig expected = new HttpClientConfig()
@@ -114,7 +116,8 @@ public class TestHttpClientConfig
                 .setKerberosPrincipal("airlift-client")
                 .setHttp2InitialSessionReceiveWindowSize(new DataSize(7, MEGABYTE))
                 .setHttp2InitialStreamReceiveWindowSize(new DataSize(7, MEGABYTE))
-                .setHttp2InputBufferSize(new DataSize(1, MEGABYTE));
+                .setHttp2InputBufferSize(new DataSize(1, MEGABYTE))
+                .setSelectorThreads(16);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Currently we hardcode `2` selectors for the HTTP clients and this may not be sufficient under high load (two selector threads cannot keep up with the rate of async events under load).