### PR TITLE
Add support for using sync socket address resolution in HTTP client

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 * 0.158
 
+- Add config for using HTTP client synchronous socket address resolution.
 - Rename HTTP client selector config parameter to "http-client.selector-count".
 
 * 0.157

--- a/http-client/src/main/java/io/airlift/http/client/HttpClientConfig.java
+++ b/http-client/src/main/java/io/airlift/http/client/HttpClientConfig.java
@@ -60,6 +60,7 @@ public class HttpClientConfig
     private String kerberosPrincipal;
     private String kerberosRemoteServiceName;
     private int selectorCount = 2;
+    private boolean useSyncSocketAddressResolution;
 
     private boolean http2Enabled;
     private DataSize http2InitialSessionReceiveWindowSize = new DataSize(16, MEGABYTE);
@@ -357,6 +358,18 @@ public class HttpClientConfig
     public HttpClientConfig setSelectorCount(int selectorCount)
     {
         this.selectorCount = selectorCount;
+        return this;
+    }
+
+    public boolean getUseSyncSocketAddressResolution()
+    {
+        return useSyncSocketAddressResolution;
+    }
+
+    @Config("http-client.use-sync-socket-address-resolution")
+    public HttpClientConfig setUseSyncSocketAddressResolution(boolean useSyncSocketAddressResolution)
+    {
+        this.useSyncSocketAddressResolution = useSyncSocketAddressResolution;
         return this;
     }
 }

--- a/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
@@ -52,6 +52,7 @@ import org.eclipse.jetty.http2.client.HTTP2Client;
 import org.eclipse.jetty.http2.client.http.HttpClientTransportOverHTTP2;
 import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.util.HttpCookieStore;
+import org.eclipse.jetty.util.SocketAddressResolver;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.Sweeper;
 import org.weakref.jmx.Flatten;
@@ -217,6 +218,10 @@ public class JettyHttpClient
         httpClient.setIdleTimeout(idleTimeoutMillis);
         httpClient.setConnectTimeout(config.getConnectTimeout().toMillis());
         httpClient.setAddressResolutionTimeout(config.getConnectTimeout().toMillis());
+
+        if (config.getUseSyncSocketAddressResolution()) {
+            httpClient.setSocketAddressResolver(new SocketAddressResolver.Sync());
+        }
 
         HostAndPort socksProxy = config.getSocksProxy();
         if (socksProxy != null) {

--- a/http-client/src/test/java/io/airlift/http/client/TestHttpClientConfig.java
+++ b/http-client/src/test/java/io/airlift/http/client/TestHttpClientConfig.java
@@ -64,7 +64,8 @@ public class TestHttpClientConfig
                 .setHttp2InitialSessionReceiveWindowSize(new DataSize(16, MEGABYTE))
                 .setHttp2InitialStreamReceiveWindowSize(new DataSize(16, MEGABYTE))
                 .setHttp2InputBufferSize(new DataSize(8, KILOBYTE))
-                .setSelectorCount(2));
+                .setSelectorCount(2)
+                .setUseSyncSocketAddressResolution(false));
     }
 
     @Test
@@ -93,6 +94,7 @@ public class TestHttpClientConfig
                 .put("http-client.http2.stream-receive-window-size", "7MB")
                 .put("http-client.http2.input-buffer-size", "1MB")
                 .put("http-client.selector-count", "16")
+                .put("http-client.use-sync-socket-address-resolution", "true")
                 .build();
 
         HttpClientConfig expected = new HttpClientConfig()
@@ -117,7 +119,8 @@ public class TestHttpClientConfig
                 .setHttp2InitialSessionReceiveWindowSize(new DataSize(7, MEGABYTE))
                 .setHttp2InitialStreamReceiveWindowSize(new DataSize(7, MEGABYTE))
                 .setHttp2InputBufferSize(new DataSize(1, MEGABYTE))
-                .setSelectorCount(16);
+                .setSelectorCount(16)
+                .setUseSyncSocketAddressResolution(true);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Per discussion with the Jetty team, this will reduce the load on the client selector thread pool. This will also help when IP addresses are used instead of host names, because the calls to
InetAddress.getAllByName() will still need to be dispatched to the selector threads
by the default async socket address resolver.