### PR TITLE
Rename HTTP client selector config

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+* 0.158
+
+- Rename HTTP client selector config parameter to "http-client.selector-count".
+
 * 0.157
 
 - Fix Kerberos SPNEGO handling in HTTP client.

--- a/http-client/src/main/java/io/airlift/http/client/HttpClientConfig.java
+++ b/http-client/src/main/java/io/airlift/http/client/HttpClientConfig.java
@@ -59,7 +59,7 @@ public class HttpClientConfig
     private boolean authenticationEnabled;
     private String kerberosPrincipal;
     private String kerberosRemoteServiceName;
-    private int selectorThreads = 2;
+    private int selectorCount = 2;
 
     private boolean http2Enabled;
     private DataSize http2InitialSessionReceiveWindowSize = new DataSize(16, MEGABYTE);
@@ -348,15 +348,15 @@ public class HttpClientConfig
     }
 
     @Min(1)
-    public int getSelectorThreads()
+    public int getSelectorCount()
     {
-        return selectorThreads;
+        return selectorCount;
     }
 
-    @Config("http-client.selector-thread-count")
-    public HttpClientConfig setSelectorThreads(int selectorThreads)
+    @Config("http-client.selector-count")
+    public HttpClientConfig setSelectorCount(int selectorCount)
     {
-        this.selectorThreads = selectorThreads;
+        this.selectorCount = selectorCount;
         return this;
     }
 }

--- a/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
@@ -189,11 +189,11 @@ public class JettyHttpClient
             client.setInitialSessionRecvWindow(toIntExact(config.getHttp2InitialSessionReceiveWindowSize().toBytes()));
             client.setInitialStreamRecvWindow(toIntExact(config.getHttp2InitialStreamReceiveWindowSize().toBytes()));
             client.setInputBufferSize(toIntExact(config.getHttp2InputBufferSize().toBytes()));
-            client.setSelectors(config.getSelectorThreads());
+            client.setSelectors(config.getSelectorCount());
             transport = new HttpClientTransportOverHTTP2(client);
         }
         else {
-            transport = new HttpClientTransportOverHTTP(config.getSelectorThreads());
+            transport = new HttpClientTransportOverHTTP(config.getSelectorCount());
         }
 
         if (config.getAuthenticationEnabled()) {

--- a/http-client/src/test/java/io/airlift/http/client/TestHttpClientConfig.java
+++ b/http-client/src/test/java/io/airlift/http/client/TestHttpClientConfig.java
@@ -64,7 +64,7 @@ public class TestHttpClientConfig
                 .setHttp2InitialSessionReceiveWindowSize(new DataSize(16, MEGABYTE))
                 .setHttp2InitialStreamReceiveWindowSize(new DataSize(16, MEGABYTE))
                 .setHttp2InputBufferSize(new DataSize(8, KILOBYTE))
-                .setSelectorThreads(2));
+                .setSelectorCount(2));
     }
 
     @Test
@@ -92,7 +92,7 @@ public class TestHttpClientConfig
                 .put("http-client.http2.session-receive-window-size", "7MB")
                 .put("http-client.http2.stream-receive-window-size", "7MB")
                 .put("http-client.http2.input-buffer-size", "1MB")
-                .put("http-client.selector-thread-count", "16")
+                .put("http-client.selector-count", "16")
                 .build();
 
         HttpClientConfig expected = new HttpClientConfig()
@@ -117,7 +117,7 @@ public class TestHttpClientConfig
                 .setHttp2InitialSessionReceiveWindowSize(new DataSize(7, MEGABYTE))
                 .setHttp2InitialStreamReceiveWindowSize(new DataSize(7, MEGABYTE))
                 .setHttp2InputBufferSize(new DataSize(1, MEGABYTE))
-                .setSelectorThreads(16);
+                .setSelectorCount(16);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
We should rename this one as it's really not setting thread count it's setting the number of selector objects, which are run by the client executors.

Do we want to add a `LegacyConfig` annotation?