### PR TITLE
Fix Kerberos SPNEGO handling in HTTP client

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+* 0.157
+
+- Fix Kerberos SPNEGO handling in HTTP client.
+
 * 0.156
 
 - Add HTTP client selector thread count config.

--- a/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
@@ -21,6 +21,7 @@ import io.airlift.http.client.ResponseTooLargeException;
 import io.airlift.http.client.StaticBodyGenerator;
 import io.airlift.http.client.spnego.KerberosConfig;
 import io.airlift.http.client.spnego.SpnegoAuthentication;
+import io.airlift.http.client.spnego.SpnegoAuthenticationProtocolHandler;
 import io.airlift.http.client.spnego.SpnegoAuthenticationStore;
 import io.airlift.log.Logger;
 import io.airlift.stats.Distribution;
@@ -33,6 +34,7 @@ import org.eclipse.jetty.client.HttpExchange;
 import org.eclipse.jetty.client.HttpRequest;
 import org.eclipse.jetty.client.PoolingHttpDestination;
 import org.eclipse.jetty.client.Socks4Proxy;
+import org.eclipse.jetty.client.WWWAuthenticationProtocolHandler;
 import org.eclipse.jetty.client.api.AuthenticationStore;
 import org.eclipse.jetty.client.api.ContentProvider;
 import org.eclipse.jetty.client.api.Destination;
@@ -198,6 +200,8 @@ public class JettyHttpClient
             requireNonNull(kerberosConfig.getConfig(), "kerberos config path is null");
             requireNonNull(config.getKerberosRemoteServiceName(), "kerberos remote service name is null");
             httpClient = new SpnegoHttpClient(kerberosConfig, config, transport, sslContextFactory);
+            httpClient.getProtocolHandlers().remove(WWWAuthenticationProtocolHandler.NAME);
+            httpClient.getProtocolHandlers().put(new SpnegoAuthenticationProtocolHandler(httpClient));
         }
         else {
             httpClient = new HttpClient(transport, sslContextFactory);

--- a/http-client/src/main/java/io/airlift/http/client/spnego/ForwardingResponseListener.java
+++ b/http-client/src/main/java/io/airlift/http/client/spnego/ForwardingResponseListener.java
@@ -1,0 +1,69 @@
+package io.airlift.http.client.spnego;
+
+import org.eclipse.jetty.client.api.Response;
+import org.eclipse.jetty.client.api.Result;
+import org.eclipse.jetty.http.HttpField;
+import org.eclipse.jetty.util.Callback;
+
+import java.nio.ByteBuffer;
+
+import static java.util.Objects.requireNonNull;
+
+class ForwardingResponseListener
+        implements Response.Listener
+{
+    private final Response.Listener delegate;
+
+    public ForwardingResponseListener(Response.Listener delegate)
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+    }
+
+    @Override
+    public void onBegin(Response response)
+    {
+        delegate.onBegin(response);
+    }
+
+    @Override
+    public boolean onHeader(Response response, HttpField field)
+    {
+        return delegate.onHeader(response, field);
+    }
+
+    @Override
+    public void onHeaders(Response response)
+    {
+        delegate.onHeaders(response);
+    }
+
+    @Override
+    public void onContent(Response response, ByteBuffer content)
+    {
+        delegate.onContent(response, content);
+    }
+
+    @Override
+    public void onContent(Response response, ByteBuffer content, Callback callback)
+    {
+        delegate.onContent(response, content, callback);
+    }
+
+    @Override
+    public void onSuccess(Response response)
+    {
+        delegate.onSuccess(response);
+    }
+
+    @Override
+    public void onFailure(Response response, Throwable failure)
+    {
+        delegate.onFailure(response, failure);
+    }
+
+    @Override
+    public void onComplete(Result result)
+    {
+        delegate.onComplete(result);
+    }
+}

--- a/http-client/src/main/java/io/airlift/http/client/spnego/SpnegoAuthenticationProtocolHandler.java
+++ b/http-client/src/main/java/io/airlift/http/client/spnego/SpnegoAuthenticationProtocolHandler.java
@@ -1,0 +1,53 @@
+package io.airlift.http.client.spnego;
+
+import org.eclipse.jetty.client.AuthenticationProtocolHandler;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.WWWAuthenticationProtocolHandler;
+import org.eclipse.jetty.client.api.Response;
+import org.eclipse.jetty.client.api.Result;
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpHeader;
+
+/**
+ * Jetty {@link AuthenticationProtocolHandler} requires that the
+ * {@code "WWW-Authenticate"} header contains a realm, but the
+ * {@code "Negotiate"} scheme will not have one. This hacks around that by
+ * adding a new header value for that scheme which contains a dummy realm,
+ * allowing the rest of the authentication handling to work as normal.
+ * Unfortunately, there is no easier way as all of the related code in
+ * that class is private.
+ */
+public class SpnegoAuthenticationProtocolHandler
+        extends WWWAuthenticationProtocolHandler
+{
+    private static final String NEGOTIATE = HttpHeader.NEGOTIATE.asString();
+
+    public SpnegoAuthenticationProtocolHandler(HttpClient client)
+    {
+        super(client);
+    }
+
+    @Override
+    public String getName()
+    {
+        return "spnego";
+    }
+
+    @Override
+    public Response.Listener getResponseListener()
+    {
+        return new ForwardingResponseListener(super.getResponseListener())
+        {
+            @Override
+            public void onComplete(Result result)
+            {
+                HttpHeader header = getAuthenticateHeader();
+                HttpFields headers = result.getResponse().getHeaders();
+                if (headers.getValuesList(header).stream().anyMatch(NEGOTIATE::equalsIgnoreCase)) {
+                    headers.put(header, NEGOTIATE + " realm=\"dummy\"");
+                }
+                super.onComplete(result);
+            }
+        };
+    }
+}

--- a/http-client/src/test/java/io/airlift/http/client/jetty/TestJettyHttpsClient.java
+++ b/http-client/src/test/java/io/airlift/http/client/jetty/TestJettyHttpsClient.java
@@ -3,16 +3,17 @@ package io.airlift.http.client.jetty;
 import com.google.common.collect.ImmutableList;
 import io.airlift.http.client.AbstractHttpClientTest;
 import io.airlift.http.client.HttpClientConfig;
-import io.airlift.http.client.HttpRequestFilter;
 import io.airlift.http.client.Request;
 import io.airlift.http.client.ResponseHandler;
 import io.airlift.http.client.TestingRequestFilter;
+import io.airlift.http.client.spnego.KerberosConfig;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.Optional;
 import java.util.concurrent.TimeoutException;
 
 import static com.google.common.io.Resources.getResource;
@@ -34,7 +35,7 @@ public class TestJettyHttpsClient
     public void setUpHttpClient()
     {
         jettyIoPool = new JettyIoPool("test-shared", new JettyIoPoolConfig());
-        httpClient = new JettyHttpClient(createClientConfig(), jettyIoPool, ImmutableList.<HttpRequestFilter>of(new TestingRequestFilter()));
+        httpClient = new JettyHttpClient(createClientConfig(), createKerberosConfig(), Optional.of(jettyIoPool), ImmutableList.of(new TestingRequestFilter()));
     }
 
     @AfterClass(alwaysRun = true)
@@ -56,6 +57,11 @@ public class TestJettyHttpsClient
                 .setTrustStorePassword("changeit");
     }
 
+    protected KerberosConfig createKerberosConfig()
+    {
+        return new KerberosConfig();
+    }
+
     @Override
     public <T, E extends Exception> T executeRequest(Request request, ResponseHandler<T, E> responseHandler)
             throws Exception
@@ -74,7 +80,7 @@ public class TestJettyHttpsClient
 
         try (
                 JettyIoPool jettyIoPool = new JettyIoPool("test-private", new JettyIoPoolConfig());
-                JettyHttpClient client = new JettyHttpClient(config, jettyIoPool, ImmutableList.<HttpRequestFilter>of(new TestingRequestFilter()))
+                JettyHttpClient client = new JettyHttpClient(config, createKerberosConfig(), Optional.of(jettyIoPool), ImmutableList.of(new TestingRequestFilter()))
         ) {
             return client.execute(request, responseHandler);
         }

--- a/http-client/src/test/java/io/airlift/http/client/jetty/TestJettyHttpsClientSpengo.java
+++ b/http-client/src/test/java/io/airlift/http/client/jetty/TestJettyHttpsClientSpengo.java
@@ -1,0 +1,47 @@
+package io.airlift.http.client.jetty;
+
+import io.airlift.http.client.HttpClientConfig;
+import io.airlift.http.client.Request;
+import io.airlift.http.client.spnego.KerberosConfig;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.UncheckedIOException;
+
+import static com.google.common.net.HttpHeaders.WWW_AUTHENTICATE;
+import static io.airlift.http.client.HttpStatus.UNAUTHORIZED;
+import static io.airlift.http.client.Request.Builder.prepareGet;
+import static io.airlift.http.client.StringResponseHandler.createStringResponseHandler;
+import static org.eclipse.jetty.http.HttpHeader.NEGOTIATE;
+
+public class TestJettyHttpsClientSpengo
+        extends TestJettyHttpsClient
+{
+    @Override
+    protected HttpClientConfig createClientConfig()
+    {
+        return super.createClientConfig()
+                .setAuthenticationEnabled(true)
+                .setKerberosPrincipal("invalid-for-testing")
+                .setKerberosRemoteServiceName("test");
+    }
+
+    @Override
+    protected KerberosConfig createKerberosConfig()
+    {
+        return super.createKerberosConfig()
+                .setConfig(new File("/etc/krb5.conf"));
+    }
+
+    @Test(expectedExceptions = UncheckedIOException.class, expectedExceptionsMessageRegExp = ".* Failed to establish LoginContext for request .*")
+    public void testNegotiateAuthScheme()
+            throws Exception
+    {
+        servlet.addResponseHeader(WWW_AUTHENTICATE, NEGOTIATE.asString());
+        servlet.setResponseStatusCode(UNAUTHORIZED.code());
+
+        Request request = prepareGet().setUri(baseURI).build();
+
+        executeRequest(request, createStringResponseHandler());
+    }
+}


### PR DESCRIPTION
The client ignored the Negotiate scheme if a realm was not provided,
causing it to fail with the following error:

HTTP protocol violation: Authentication challenge without WWW-Authenticate header