### PR TITLE
Add an optimized async Jetty SocketAddressResolver

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,7 @@
 * 0.158
 
+- Add a Jetty SocketAddressResolver that doesn't dispatch address
+  resolution to the executor for IP address literals.
 - Rename HTTP client selector config parameter to "http-client.selector-count".
 
 * 0.157

--- a/http-client/src/main/java/io/airlift/http/client/jetty/JettyAsyncSocketAddressResolver.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/JettyAsyncSocketAddressResolver.java
@@ -1,0 +1,49 @@
+package io.airlift.http.client.jetty;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.net.InetAddresses;
+import org.eclipse.jetty.util.Promise;
+import org.eclipse.jetty.util.SocketAddressResolver;
+import org.eclipse.jetty.util.thread.Scheduler;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Executor;
+
+/**
+ * For IP address literals this SocketAddressResolver implementation does not dispatch the address resolution
+ * to the executor. Under high load this helps offloading the executor, which may be shared by multiple different
+ * HTTP clients.
+ */
+class JettyAsyncSocketAddressResolver
+        extends SocketAddressResolver.Async
+{
+    public JettyAsyncSocketAddressResolver(Executor executor, Scheduler scheduler, long timeout)
+    {
+        super(executor, scheduler, timeout);
+    }
+
+    @Override
+    public void resolve(String host, int port, Promise<List<InetSocketAddress>> promise)
+    {
+        Optional<InetAddress> address = resolve(host);
+        if (address.isPresent()) {
+            promise.succeeded(ImmutableList.of(new InetSocketAddress(address.get(), port)));
+            return;
+        }
+        super.resolve(host, port, promise);
+    }
+
+    private static Optional<InetAddress> resolve(String host)
+    {
+        try {
+            return Optional.of(InetAddresses.forString(host));
+        }
+        catch (IllegalArgumentException ignored) {
+            // not an IP address literal
+            return Optional.empty();
+        }
+    }
+}

--- a/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
@@ -52,6 +52,7 @@ import org.eclipse.jetty.http2.client.HTTP2Client;
 import org.eclipse.jetty.http2.client.http.HttpClientTransportOverHTTP2;
 import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.util.HttpCookieStore;
+import org.eclipse.jetty.util.SocketAddressResolver;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.Sweeper;
 import org.weakref.jmx.Flatten;
@@ -236,6 +237,8 @@ public class JettyHttpClient
         httpClient.setExecutor(pool.getExecutor());
         httpClient.setByteBufferPool(pool.getByteBufferPool());
         httpClient.setScheduler(pool.getScheduler());
+
+        httpClient.setSocketAddressResolver(new JettyAsyncSocketAddressResolver(pool.getExecutor(), pool.getScheduler(), config.getConnectTimeout().toMillis()));
 
         // Jetty client connections can sometimes get stuck while closing which reduces
         // the available connections.  The Jetty Sweeper periodically scans the active


### PR DESCRIPTION
When IP address literals are used this new SocketAddressResolver will not dispatch
the address resolution to the client executor, which will help reduce the load on
that executor. This especially helps under high load and when the executor is shared
by multiple HTTP clients.