### PR TITLE
Add option to disable recording HTTP request complete info

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@
 - Add a Jetty SocketAddressResolver that doesn't dispatch address
   resolution to the executor for IP address literals.
 - Rename HTTP client selector config parameter to "http-client.selector-count".
+- Add an option to disable recording HTTP request complete information.
 
 * 0.157
 

--- a/http-client/src/main/java/io/airlift/http/client/HttpClientConfig.java
+++ b/http-client/src/main/java/io/airlift/http/client/HttpClientConfig.java
@@ -60,6 +60,7 @@ public class HttpClientConfig
     private String kerberosPrincipal;
     private String kerberosRemoteServiceName;
     private int selectorCount = 2;
+    private boolean recordRequestComplete = true;
 
     private boolean http2Enabled;
     private DataSize http2InitialSessionReceiveWindowSize = new DataSize(16, MEGABYTE);
@@ -357,6 +358,18 @@ public class HttpClientConfig
     public HttpClientConfig setSelectorCount(int selectorCount)
     {
         this.selectorCount = selectorCount;
+        return this;
+    }
+
+    public boolean getRecordRequestComplete()
+    {
+        return recordRequestComplete;
+    }
+
+    @Config("http-client.record-request-complete")
+    public HttpClientConfig setRecordRequestComplete(boolean recordRequestComplete)
+    {
+        this.recordRequestComplete = recordRequestComplete;
         return this;
     }
 }

--- a/http-client/src/test/java/io/airlift/http/client/AbstractHttpClientTest.java
+++ b/http-client/src/test/java/io/airlift/http/client/AbstractHttpClientTest.java
@@ -234,7 +234,7 @@ public abstract class AbstractHttpClientTest
         int port = findUnusedPort();
 
         HttpClientConfig config = createClientConfig();
-        config.setConnectTimeout(new Duration(5, MILLISECONDS));
+        config.setConnectTimeout(new Duration(5, SECONDS));
 
         Request request = prepareGet()
                 .setUri(new URI(scheme, null, host, port, "/", null, null))

--- a/http-client/src/test/java/io/airlift/http/client/TestHttpClientConfig.java
+++ b/http-client/src/test/java/io/airlift/http/client/TestHttpClientConfig.java
@@ -64,7 +64,8 @@ public class TestHttpClientConfig
                 .setHttp2InitialSessionReceiveWindowSize(new DataSize(16, MEGABYTE))
                 .setHttp2InitialStreamReceiveWindowSize(new DataSize(16, MEGABYTE))
                 .setHttp2InputBufferSize(new DataSize(8, KILOBYTE))
-                .setSelectorCount(2));
+                .setSelectorCount(2)
+                .setRecordRequestComplete(true));
     }
 
     @Test
@@ -93,6 +94,7 @@ public class TestHttpClientConfig
                 .put("http-client.http2.stream-receive-window-size", "7MB")
                 .put("http-client.http2.input-buffer-size", "1MB")
                 .put("http-client.selector-count", "16")
+                .put("http-client.record-request-complete", "false")
                 .build();
 
         HttpClientConfig expected = new HttpClientConfig()
@@ -117,7 +119,8 @@ public class TestHttpClientConfig
                 .setHttp2InitialSessionReceiveWindowSize(new DataSize(7, MEGABYTE))
                 .setHttp2InitialStreamReceiveWindowSize(new DataSize(7, MEGABYTE))
                 .setHttp2InputBufferSize(new DataSize(1, MEGABYTE))
-                .setSelectorCount(16);
+                .setSelectorCount(16)
+                .setRecordRequestComplete(false);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
By default, an HTTP request records stats on completion. However, adding
counters to stats can be expensive given the lock contention in the
stats. Add an option to disable recording the completion info.