### PR TITLE
Various changes to airlift http client/server

### DIFF
--- a/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
@@ -623,7 +623,7 @@ public class JettyHttpClient
     {
         long now = System.nanoTime();
         return getRequestListenersForDestination(destination).stream()
-                .map(request -> dumpRequest(now, request))
+                .map(listener -> dumpRequest(now, listener))
                 .sorted()
                 .collect(Collectors.joining("\n"));
     }

--- a/http-client/src/main/java/io/airlift/http/client/jetty/JettyIoPool.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/JettyIoPool.java
@@ -130,7 +130,7 @@ public final class JettyIoPool
         private final ScheduledExecutorService[] schedulers;
         private final ThreadFactory threadFactory;
 
-        public ConcurrentScheduler(int schedulerCount, int threadsPerScheduler, String threadBaseName)
+        ConcurrentScheduler(int schedulerCount, int threadsPerScheduler, String threadBaseName)
         {
             checkArgument(schedulerCount > 0, "schedulerCount must be at least one");
             this.schedulers = new ScheduledThreadPoolExecutor[schedulerCount];
@@ -142,7 +142,6 @@ public final class JettyIoPool
 
         @Override
         protected void doStart()
-                throws Exception
         {
             for (int i = 0; i < schedulers.length; i++) {
                 ScheduledThreadPoolExecutor scheduledExecutorService = new ScheduledThreadPoolExecutor(threadsPerScheduler, threadFactory);
@@ -153,7 +152,6 @@ public final class JettyIoPool
 
         @Override
         protected void doStop()
-                throws Exception
         {
             for (int i = 0; i < schedulers.length; i++) {
                 schedulers[i].shutdownNow();

--- a/http-client/src/test/java/io/airlift/http/client/AbstractHttpClientTest.java
+++ b/http-client/src/test/java/io/airlift/http/client/AbstractHttpClientTest.java
@@ -1038,7 +1038,7 @@ public abstract class AbstractHttpClientTest
 
             // some systems like Linux have a large minimum backlog
             int i = 0;
-            while (i <= 40) {
+            while (i <= 256) {
                 if (!connect()) {
                     return;
                 }

--- a/http-server/src/main/java/io/airlift/http/server/HttpServer.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServer.java
@@ -128,16 +128,17 @@ public class HttpServer
             server.addBean(mbeanContainer);
         }
 
+        HttpConfiguration baseHttpConfiguration = new HttpConfiguration();
+        baseHttpConfiguration.setSendServerVersion(false);
+        baseHttpConfiguration.setSendXPoweredBy(false);
+        if (config.getMaxRequestHeaderSize() != null) {
+            baseHttpConfiguration.setRequestHeaderSize(toIntExact(config.getMaxRequestHeaderSize().toBytes()));
+        }
+
         // set up HTTP connector
         ServerConnector httpConnector;
         if (config.isHttpEnabled()) {
-            HttpConfiguration httpConfiguration = new HttpConfiguration();
-            httpConfiguration.setSendServerVersion(false);
-            httpConfiguration.setSendXPoweredBy(false);
-            if (config.getMaxRequestHeaderSize() != null) {
-                httpConfiguration.setRequestHeaderSize(Ints.checkedCast(config.getMaxRequestHeaderSize().toBytes()));
-            }
-
+            HttpConfiguration httpConfiguration = new HttpConfiguration(baseHttpConfiguration);
             // if https is enabled, set the CONFIDENTIAL and INTEGRAL redirection information
             if (config.isHttpsEnabled()) {
                 httpConfiguration.setSecureScheme("https");
@@ -172,12 +173,7 @@ public class HttpServer
         // set up NIO-based HTTPS connector
         ServerConnector httpsConnector;
         if (config.isHttpsEnabled()) {
-            HttpConfiguration httpsConfiguration = new HttpConfiguration();
-            httpsConfiguration.setSendServerVersion(false);
-            httpsConfiguration.setSendXPoweredBy(false);
-            if (config.getMaxRequestHeaderSize() != null) {
-                httpsConfiguration.setRequestHeaderSize(Ints.checkedCast(config.getMaxRequestHeaderSize().toBytes()));
-            }
+            HttpConfiguration httpsConfiguration = new HttpConfiguration(baseHttpConfiguration);
             httpsConfiguration.addCustomizer(new SecureRequestCustomizer());
 
             SslContextFactory sslContextFactory = new SslContextFactory();
@@ -216,12 +212,7 @@ public class HttpServer
         // set up NIO-based Admin connector
         ServerConnector adminConnector;
         if (theAdminServlet != null && config.isAdminEnabled()) {
-            HttpConfiguration adminConfiguration = new HttpConfiguration();
-            adminConfiguration.setSendServerVersion(false);
-            adminConfiguration.setSendXPoweredBy(false);
-            if (config.getMaxRequestHeaderSize() != null) {
-                adminConfiguration.setRequestHeaderSize(Ints.checkedCast(config.getMaxRequestHeaderSize().toBytes()));
-            }
+            HttpConfiguration adminConfiguration = new HttpConfiguration(baseHttpConfiguration);
 
             QueuedThreadPool adminThreadPool = new QueuedThreadPool(config.getAdminMaxThreads());
             adminThreadPool.setName("http-admin-worker");

--- a/http-server/src/main/java/io/airlift/http/server/HttpServer.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServer.java
@@ -135,6 +135,9 @@ public class HttpServer
             baseHttpConfiguration.setRequestHeaderSize(toIntExact(config.getMaxRequestHeaderSize().toBytes()));
         }
 
+        // disable async error notifications to work around https://github.com/jersey/jersey/issues/3691
+        baseHttpConfiguration.setNotifyRemoteAsyncErrors(false);
+
         // set up HTTP connector
         ServerConnector httpConnector;
         if (config.isHttpEnabled()) {

--- a/http-server/src/main/java/io/airlift/http/server/HttpServer.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServer.java
@@ -156,6 +156,7 @@ public class HttpServer
             http2c.setInitialStreamRecvWindow(toIntExact(config.getHttp2InitialStreamReceiveWindowSize().toBytes()));
             http2c.setMaxConcurrentStreams(config.getHttp2MaxConcurrentStreams());
             http2c.setInputBufferSize(toIntExact(config.getHttp2InputBufferSize().toBytes()));
+            http2c.setStreamIdleTimeout(config.getHttp2StreamIdleTimeout().toMillis());
             httpConnector = createServerConnector(
                     httpServerInfo.getHttpChannel(),
                     server,

--- a/http-server/src/main/java/io/airlift/http/server/HttpServerConfig.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServerConfig.java
@@ -89,6 +89,7 @@ public class HttpServerConfig
     private DataSize http2InitialSessionReceiveWindowSize = new DataSize(16, MEGABYTE);
     private DataSize http2InitialStreamReceiveWindowSize = new DataSize(16, MEGABYTE);
     private DataSize http2InputBufferSize = new DataSize(8, KILOBYTE);
+    private Duration http2StreamIdleTimeout = new Duration(15, SECONDS);
 
     private String userAuthFile;
 
@@ -534,6 +535,18 @@ public class HttpServerConfig
     public HttpServerConfig setHttp2InputBufferSize(DataSize http2InputBufferSize)
     {
         this.http2InputBufferSize = http2InputBufferSize;
+        return this;
+    }
+
+    public Duration getHttp2StreamIdleTimeout()
+    {
+        return http2StreamIdleTimeout;
+    }
+
+    @Config("http-server.http2.stream-idle-timeout")
+    public HttpServerConfig setHttp2StreamIdleTimeout(Duration http2StreamIdleTimeout)
+    {
+        this.http2StreamIdleTimeout = http2StreamIdleTimeout;
         return this;
     }
 }

--- a/http-server/src/test/java/io/airlift/http/server/TestHttpServerConfig.java
+++ b/http-server/src/test/java/io/airlift/http/server/TestHttpServerConfig.java
@@ -70,6 +70,7 @@ public class TestHttpServerConfig
                 .setHttp2InitialSessionReceiveWindowSize(new DataSize(16, MEGABYTE))
                 .setHttp2InputBufferSize(new DataSize(8, KILOBYTE))
                 .setHttp2InitialStreamReceiveWindowSize(new DataSize(16, MEGABYTE))
+                .setHttp2StreamIdleTimeout(new Duration(15, SECONDS))
         );
     }
 
@@ -111,6 +112,7 @@ public class TestHttpServerConfig
                 .put("http-server.http2.session-receive-window-size", "4MB")
                 .put("http-server.http2.stream-receive-window-size", "4MB")
                 .put("http-server.http2.input-buffer-size", "4MB")
+                .put("http-server.http2.stream-idle-timeout", "23s")
                 .build();
 
         HttpServerConfig expected = new HttpServerConfig()
@@ -147,7 +149,8 @@ public class TestHttpServerConfig
                 .setShowStackTrace(false)
                 .setHttp2InitialSessionReceiveWindowSize(new DataSize(4, MEGABYTE))
                 .setHttp2InitialStreamReceiveWindowSize(new DataSize(4, MEGABYTE))
-                .setHttp2InputBufferSize(new DataSize(4, MEGABYTE));
+                .setHttp2InputBufferSize(new DataSize(4, MEGABYTE))
+                .setHttp2StreamIdleTimeout(new Duration(23, SECONDS));
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Depends on #587.

There are two main changes:
- Disable remote async error notifications in HttpServer. This is a workaround for https://github.com/jersey/jersey/issues/3691 for HTTP/2
- Add HTTP/2 stream idle timeout config to HTTP server. 