### PR TITLE
Use colon as separator in launcher for LD_PRELOAD

### DIFF
--- a/launcher/src/main/scripts/bin/launcher.py
+++ b/launcher/src/main/scripts/bin/launcher.py
@@ -227,7 +227,7 @@ def build_java_execution(options, daemon):
         system = platform.system() + '-' + platform.machine()
         shim = pathjoin(options.install_path, 'bin', 'procname', system, 'libprocname.so')
         if exists(shim):
-            env['LD_PRELOAD'] = (env.get('LD_PRELOAD', '') + ' ' + shim).strip()
+            env['LD_PRELOAD'] = (env.get('LD_PRELOAD', '') + ':' + shim).strip()
             env['PROCNAME'] = process_name
 
     return command, env


### PR DESCRIPTION
While both colon and space are valid separators for LD_PRELOAD,
they cannot be used together.

This causes issue when launching shell command that appending other
libraries into LD_PRELOAD with colon separated.

As colon is more commonly used separator, switching to use colon
will reduce such potential issues.