### PR TITLE
Add missing javax.annotations dependency

### DIFF
--- a/bootstrap/pom.xml
+++ b/bootstrap/pom.xml
@@ -41,6 +41,11 @@
             <artifactId>guice</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+        </dependency>
+
         <!-- used by tests but also needed transitively -->
         <dependency>
             <groupId>javax.inject</groupId>

--- a/discovery/pom.xml
+++ b/discovery/pom.xml
@@ -86,6 +86,11 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
             <optional>true</optional>

--- a/http-client/pom.xml
+++ b/http-client/pom.xml
@@ -111,6 +111,11 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
             <optional>true</optional>

--- a/http-server/pom.xml
+++ b/http-server/pom.xml
@@ -126,6 +126,11 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
             <optional>true</optional>


### PR DESCRIPTION
This works around compatibility issues in Java 9 due to
split package enforcement.