### PR TITLE
Make format exceptions for config errors impossible

### DIFF
--- a/configuration/src/main/java/io/airlift/configuration/ConfigurationFactory.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigurationFactory.java
@@ -370,7 +370,7 @@ public class ConfigurationFactory
                 setConfigProperty(instance, attribute, prefix, problems);
             }
             catch (InvalidConfigurationException e) {
-                problems.addError(e.getCause(), "%s", e.getMessage());
+                problems.addError(e.getCause(), e.getMessage());
             }
         }
 

--- a/configuration/src/main/java/io/airlift/configuration/Problems.java
+++ b/configuration/src/main/java/io/airlift/configuration/Problems.java
@@ -20,9 +20,9 @@ import com.google.inject.ConfigurationException;
 import com.google.inject.spi.Message;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
-import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 
 class Problems
@@ -138,5 +138,18 @@ class Problems
         Problems problems = new Problems();
         problems.addError(e, format, params);
         return problems.getException();
+    }
+
+    private static String format(String format, Object... params)
+    {
+        if (format == null || params.length == 0) {
+            return format;
+        }
+
+        try {
+            return String.format(format, params);
+        } catch (RuntimeException e) {
+            return String.format("%s %s^%s", format, Arrays.toString(params), e);
+        }
     }
 }

--- a/configuration/src/test/java/io/airlift/configuration/ProblemsTest.java
+++ b/configuration/src/test/java/io/airlift/configuration/ProblemsTest.java
@@ -72,6 +72,28 @@ public class ProblemsTest
     }
 
     @Test
+    public void TestFormatError()
+    {
+        Problems problems = new Problems();
+        problems.addError("message %d", "NaN");
+
+        Message [] errors = problems.getErrors().toArray(new Message[]{});
+        Assert.assertEquals(errors.length, 1);
+        Assertions.assertContainsAllOf(errors[0].toString(), "Error", "message %d", "NaN", "IllegalFormatConversionException");
+
+        Assert.assertEquals(problems.getWarnings().size(), 0, "Found unexpected warnings in problem object");
+
+        try {
+            problems.throwIfHasErrors();
+            Assert.fail("Expected exception from problems object");
+        }
+        catch(ConfigurationException e)
+        {
+            Assertions.assertContainsAllOf(e.getMessage(), "message %d [NaN]");
+        }
+    }
+
+    @Test
     public void TestOneWarning()
     {
         Problems problems = new Problems();
@@ -105,6 +127,27 @@ public class ProblemsTest
         Assert.assertEquals(warnings.length, 2);
         Assertions.assertContainsAllOf(warnings[0].toString(), "Warning", "message 1");
         Assertions.assertContainsAllOf(warnings[1].toString(), "Warning", "message 2");
+
+        try {
+            problems.throwIfHasErrors();
+        }
+        catch(ConfigurationException cause)
+        {
+            Assert.fail("Didn't expect problems object to throw", cause);
+        }
+    }
+
+    @Test
+    public void TestFormatWarning()
+    {
+        Problems problems = new Problems();
+        problems.addWarning("message %d", "NaN");
+
+        Assert.assertEquals(problems.getErrors().size(), 0, "Found unexpected errors in problem object");
+
+        Message [] warnings = problems.getWarnings().toArray(new Message[]{});
+        Assert.assertEquals(warnings.length, 1);
+        Assertions.assertContainsAllOf(warnings[0].toString(), "Warning", "message %d", "NaN", "IllegalFormatConversionException");
 
         try {
             problems.throwIfHasErrors();


### PR DESCRIPTION
Instead of making it the responsibility of the caller, make `Problems` smarter:
- If it gets a format string but no params, then it can't be a format string.
- Even if the format string is bogus, preserve the original message.