### PR TITLE
Makes JsonFactory used for ObjectMapperProvider configurable

### DIFF
--- a/json/src/main/java/io/airlift/json/ObjectMapperProvider.java
+++ b/json/src/main/java/io/airlift/json/ObjectMapperProvider.java
@@ -53,6 +53,7 @@ public class ObjectMapperProvider
 
     private final Set<Module> modules = new HashSet<>();
 
+    @Inject
     public ObjectMapperProvider() {
         this(new JsonFactory());
     }

--- a/json/src/main/java/io/airlift/json/ObjectMapperProvider.java
+++ b/json/src/main/java/io/airlift/json/ObjectMapperProvider.java
@@ -16,6 +16,7 @@
 package io.airlift.json;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonDeserializer;
@@ -43,6 +44,8 @@ import java.util.Set;
 public class ObjectMapperProvider
         implements Provider<ObjectMapper>
 {
+    private final JsonFactory jsonFactory;
+
     private Map<Class<?>, JsonSerializer<?>> keySerializers;
     private Map<Class<?>, KeyDeserializer> keyDeserializers;
     private Map<Class<?>, JsonSerializer<?>> jsonSerializers;
@@ -50,8 +53,13 @@ public class ObjectMapperProvider
 
     private final Set<Module> modules = new HashSet<>();
 
-    public ObjectMapperProvider()
-    {
+    public ObjectMapperProvider() {
+        this(new JsonFactory());
+    }
+
+    public ObjectMapperProvider(JsonFactory jsonFactory) {
+        this.jsonFactory = jsonFactory;
+
         modules.add(new Jdk8Module());
         modules.add(new JavaTimeModule());
         modules.add(new GuavaModule());


### PR DESCRIPTION
this allows using the ObjectMapperProvider for other formats than Json:

```java
public void configure(Binder binder) {
    binder.bind(ObjectMapper.class).annotatedWith(Json.class).toProvider(ObjectMapperProvider.class);
    binder.bind(ObjectMapper.class).annotatedWith(Smile.class).toProvider(new ObjectMapperProvider(new SmileFactory()));
}
```

while all the serializers, modules etc. are configured in the same way for all ObjectMappers independently from the output format.
