### PR TITLE
Increase timeout for HTTP server stop test

### DIFF
--- a/http-server/src/test/java/io/airlift/http/server/TestHttpServerProvider.java
+++ b/http-server/src/test/java/io/airlift/http/server/TestHttpServerProvider.java
@@ -402,7 +402,7 @@ public class TestHttpServerProvider
             server.stop();
 
             try {
-                future.get(1, TimeUnit.SECONDS);
+                future.get(5, TimeUnit.SECONDS);
                 fail("expected exception");
             }
             catch (ExecutionException e) {


### PR DESCRIPTION
We often see this failure:

```
[ERROR] testStop(io.airlift.http.server.TestHttpServerProvider)  Time elapsed: 1.167 s  <<< FAILURE!
java.util.concurrent.TimeoutException
	at io.airlift.http.server.TestHttpServerProvider.testStop(TestHttpServerProvider.java:405)
```