### PR TITLE
Make launcher.py Python 3 compatible.

### DIFF
--- a/launcher/src/main/scripts/bin/launcher.py
+++ b/launcher/src/main/scripts/bin/launcher.py
@@ -270,12 +270,11 @@ def start(process, options):
         process.write_pid(pid)
         print('Started as %s' % pid)
         return
-    try:
+
+    if hasattr(os, "set_inheritable"):
         # See https://docs.python.org/3/library/os.html#inheritance-of-file-descriptors
         # Since Python 3.4
         os.set_inheritable(process.pid_file.fileno(), True)
-    except AttributeError as e:
-        pass
 
     os.setsid()
 


### PR DESCRIPTION
This means loosing compatibility with versions < 2.6, as `except OSError, e:` is not valid in Python 3, while its replacement `except OSError as e:` is only valid for 2.6+.

However, Python 2.6 and earlier are no longer supported, and have been out for a very long time, so it should be time to upgrade.

The most non-trivial thing was the need to set the file descriptor for launcher.pid as inheritable, otherwise it would be lost in the switch from the python to the java process, and the status checks would not work. This is needed for Python versions 3.4+ (see https://docs.python.org/3/library/os.html#inheritance-of-file-descriptors).