### PR TITLE
Update createHttpRequestEvent to check the token header first

### DIFF
--- a/http-server/src/main/java/io/airlift/http/server/HttpRequestEvent.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpRequestEvent.java
@@ -29,6 +29,7 @@ import java.time.Instant;
 import java.util.Enumeration;
 
 import static io.airlift.event.client.EventField.EventFieldMapping.TIMESTAMP;
+import static io.airlift.http.server.TraceTokenFilter.TRACETOKEN_HEADER;
 import static java.lang.Math.max;
 
 @EventType("HttpRequest")
@@ -42,8 +43,9 @@ public class HttpRequestEvent
             user = principal.getName();
         }
 
-        String token = null;
-        if (traceTokenManager != null) {
+        // This is required, because async responses are processed in a different thread.
+        String token = request.getHeader(TRACETOKEN_HEADER);
+        if (token == null && traceTokenManager != null) {
             token = traceTokenManager.getCurrentRequestToken();
         }
 

--- a/http-server/src/main/java/io/airlift/http/server/TraceTokenFilter.java
+++ b/http-server/src/main/java/io/airlift/http/server/TraceTokenFilter.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 class TraceTokenFilter
         implements Filter
 {
+    public static final String TRACETOKEN_HEADER = "X-Airlift-TraceToken";
     private final TraceTokenManager traceTokenManager;
 
     @Inject
@@ -53,7 +54,7 @@ class TraceTokenFilter
         HttpServletRequest request = (HttpServletRequest) servletRequest;
         HttpServletResponse response = (HttpServletResponse) servletResponse;
 
-        String token = request.getHeader("X-Airlift-TraceToken");
+        String token = request.getHeader(TRACETOKEN_HEADER);
         if (token != null) {
             traceTokenManager.registerRequestToken(token);
         }


### PR DESCRIPTION
Currently, HttpRequestEvent::createHttpRequestEvent() does not check
whether the request has the "X-Airlift-TraceToken" header. This change
first checks that HTTP header and uses it if present. Otherwise, it
gets the current token in the traceTokenManager if available.

Without this change tokens set by clients will not be logged.