### PR TITLE
Fix race condition in HTTP server stop test

### DIFF
--- a/http-server/src/main/java/io/airlift/http/server/HttpServer.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServer.java
@@ -15,6 +15,7 @@
  */
 package io.airlift.http.server;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.Ints;
@@ -466,6 +467,13 @@ public class HttpServer
         }
         catch (TimeoutException ignored) {
         }
+    }
+
+    @VisibleForTesting
+    void join()
+            throws InterruptedException
+    {
+        server.join();
     }
 
     private static Set<X509Certificate> loadAllX509Certificates(HttpServerConfig config)

--- a/http-server/src/test/java/io/airlift/http/server/DummyServlet.java
+++ b/http-server/src/test/java/io/airlift/http/server/DummyServlet.java
@@ -21,10 +21,13 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
 
 class DummyServlet
         extends HttpServlet
 {
+    private final CountDownLatch latch = new CountDownLatch(1);
+
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp)
             throws ServletException, IOException
@@ -37,11 +40,17 @@ class DummyServlet
 
         try {
             if (req.getParameter("sleep") != null) {
+                latch.countDown();
                 Thread.sleep(Long.parseLong(req.getParameter("sleep")));
             }
         }
         catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         }
+    }
+
+    public CountDownLatch getLatch()
+    {
+        return latch;
     }
 }


### PR DESCRIPTION
The test was not waiting for the request to start, so the server could
    shutdown before the request started sleeping, and thus the fetch of the
    HTTP client future could timeout.