### PR TITLE
Relax max concurrent streams constraint

### DIFF
--- a/http-server/src/main/java/io/airlift/http/server/HttpServerConfig.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServerConfig.java
@@ -477,7 +477,7 @@ public class HttpServerConfig
         return this;
     }
 
-    @Min(100) // per RFC 7540 section 6.5.2
+    @Min(0)
     public int getHttp2MaxConcurrentStreams()
     {
         return http2MaxConcurrentStreams;


### PR DESCRIPTION
It's possible that we need testing with a very small number of concurrent streams (which I had to and failed), so I am relaxing this constraint.