### PR TITLE
Add client executor as a managed bean to have it in dumps

### DIFF
--- a/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
@@ -201,7 +201,10 @@ public class JettyHttpClient
         }
 
         httpClient.setByteBufferPool(new MappedByteBufferPool());
-        httpClient.setExecutor(createExecutor(name, config.getMinThreads(), config.getMaxThreads()));
+        QueuedThreadPool queuedThreadPool = createExecutor(name, config.getMinThreads(), config.getMaxThreads());
+        httpClient.setExecutor(queuedThreadPool);
+        // add queuedThreadPool as a managed bean to get its state in the client dumps
+        httpClient.addBean(queuedThreadPool, true);
         httpClient.setScheduler(createScheduler(name, config.getTimeoutConcurrency(), config.getTimeoutThreads()));
 
         httpClient.setSocketAddressResolver(new JettyAsyncSocketAddressResolver(


### PR DESCRIPTION
Otherwise, we don't get the state of the executor in the client dumps.

```
 += QueuedThreadPool@http-client-test-shared{STARTED,8<=8<=200,i=6,q=0} - STARTED
 |   +- 19 http-client-test-shared-19 IDLE TIMED_WAITING
 |   +- 21 http-client-test-shared-21 IDLE TIMED_WAITING
 |   +- 14 http-client-test-shared-14 SELECTING RUNNABLE
 |   +- 17 http-client-test-shared-17 IDLE TIMED_WAITING
 |   +- 20 http-client-test-shared-20 IDLE TIMED_WAITING
 |   +- 16 http-client-test-shared-16 IDLE TIMED_WAITING
 |   +- 18 http-client-test-shared-18 IDLE TIMED_WAITING
 |   +- 15 http-client-test-shared-15 SELECTING RUNNABLE
 |   +- jobs
```