### PR TITLE
[PROTOTYPE] Add support for binding custom HTTP client providers

### DIFF
--- a/http-client/src/main/java/io/airlift/http/client/AbstractHttpClientProvider.java
+++ b/http-client/src/main/java/io/airlift/http/client/AbstractHttpClientProvider.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.airlift.http.client;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.TypeLiteral;
+import io.airlift.http.client.spnego.KerberosConfig;
+
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import java.lang.annotation.Annotation;
+import java.util.List;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+public abstract class AbstractHttpClientProvider
+        implements Provider<HttpClient>
+{
+    protected final String name;
+    protected final Class<? extends Annotation> annotation;
+    protected Injector injector;
+
+    public AbstractHttpClientProvider(String name, Class<? extends Annotation> annotation)
+    {
+        this.name = requireNonNull(name, "name is null");
+        this.annotation = requireNonNull(annotation, "annotation is null");
+    }
+
+    public void initialize() {}
+
+    @Inject
+    public void setInjector(Injector injector)
+    {
+        this.injector = requireNonNull(injector, "injector is null");
+        initialize();
+    }
+
+    @PreDestroy
+    public void close() {}
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public Class<? extends Annotation> getAnnotation()
+    {
+        return annotation;
+    }
+
+    protected HttpClientConfig getHttpClientConfig()
+    {
+        return injector.getInstance(Key.get(HttpClientConfig.class, annotation));
+    }
+
+    protected KerberosConfig getKerberosConfig()
+    {
+        return injector.getInstance(KerberosConfig.class);
+    }
+
+    protected List<HttpRequestFilter> getHttpRequestFilters()
+    {
+        Set<HttpRequestFilter> filters = ImmutableSet.<HttpRequestFilter>builder()
+                .addAll(injector.getInstance(Key.get(new TypeLiteral<Set<HttpRequestFilter>>() {}, GlobalFilter.class)))
+                .addAll(injector.getInstance(Key.get(new TypeLiteral<Set<HttpRequestFilter>>() {}, annotation)))
+                .build();
+        return ImmutableList.copyOf(filters);
+    }
+}

--- a/http-client/src/main/java/io/airlift/http/client/DefaultHttpClientProvider.java
+++ b/http-client/src/main/java/io/airlift/http/client/DefaultHttpClientProvider.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.airlift.http.client;
+
+import io.airlift.http.client.jetty.JettyHttpClient;
+
+import java.lang.annotation.Annotation;
+
+class DefaultHttpClientProvider
+        extends AbstractHttpClientProvider
+{
+    private HttpClient client;
+
+    public DefaultHttpClientProvider(String name, Class<? extends Annotation> annotation)
+    {
+        super(name, annotation);
+    }
+
+    @Override
+    public HttpClient get()
+    {
+        return client;
+    }
+
+    @Override
+    public void initialize()
+    {
+        client = new JettyHttpClient(name, getHttpClientConfig(), getKerberosConfig(), getHttpRequestFilters());
+    }
+
+    @Override
+    public void close()
+    {
+        client.close();
+    }
+}

--- a/http-client/src/main/java/io/airlift/http/client/HttpClientBinder.java
+++ b/http-client/src/main/java/io/airlift/http/client/HttpClientBinder.java
@@ -17,6 +17,7 @@ package io.airlift.http.client;
 
 import com.google.common.annotations.Beta;
 import com.google.inject.Binder;
+import com.google.inject.Scope;
 import com.google.inject.Scopes;
 import com.google.inject.binder.LinkedBindingBuilder;
 import com.google.inject.multibindings.Multibinder;
@@ -49,6 +50,13 @@ public class HttpClientBinder
         HttpClientModule module = new HttpClientModule(name, annotation);
         binder.install(module);
         return new HttpClientBindingBuilder(module, newSetBinder(binder, HttpRequestFilter.class, annotation));
+    }
+
+    public HttpClientBindingBuilder bindHttpClient(AbstractHttpClientProvider httpClientProvider, Scope scope)
+    {
+        HttpClientModule module = new HttpClientModule(httpClientProvider, scope);
+        binder.install(module);
+        return new HttpClientBindingBuilder(module, newSetBinder(binder, HttpRequestFilter.class, httpClientProvider.getAnnotation()));
     }
 
     public LinkedBindingBuilder<HttpRequestFilter> addGlobalFilterBinding()


### PR DESCRIPTION
With this change it's now possible to customize the HTTP client
provider logic and customize the scope that the HTTP client(s) are
bound in. Previously, it was only possible to bind a singleton
HTTP client for a single annotation. This change enables providing
multiple HTTP clients for a single annotation.