### PR TITLE
Monitor log queue

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+0.165
+
+- Add log buffer size config to HTTP client.
+
 0.164
 
 - Fix HTTP server log of trace tokens when using async responses.

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 0.165
 
 - Add log buffer size config to HTTP client.
+- Add support for monitoring the HTTP client and server logger queue size.
 
 0.164
 

--- a/http-client/src/main/java/io/airlift/http/client/HttpClientConfig.java
+++ b/http-client/src/main/java/io/airlift/http/client/HttpClientConfig.java
@@ -79,6 +79,7 @@ public class HttpClientConfig
     private int logHistory = 15;
     private int logQueueSize = 10_000;
     private DataSize logMaxFileSize = new DataSize(1, GIGABYTE);
+    private DataSize logBufferSize = new DataSize(1, MEGABYTE);
 
     public boolean isHttp2Enabled()
     {
@@ -511,6 +512,21 @@ public class HttpClientConfig
     public HttpClientConfig setLogQueueSize(int logQueueSize)
     {
         this.logQueueSize = logQueueSize;
+        return this;
+    }
+
+    @NotNull
+    @MinDataSize("1MB")
+    @MaxDataSize("1GB")
+    public DataSize getLogBufferSize()
+    {
+        return logBufferSize;
+    }
+
+    @Config("http-client.log.buffer-size")
+    public HttpClientConfig setLogBufferSize(DataSize logBufferSize)
+    {
+        this.logBufferSize = logBufferSize;
         return this;
     }
 }

--- a/http-client/src/main/java/io/airlift/http/client/jetty/DefaultHttpClientLogger.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/DefaultHttpClientLogger.java
@@ -64,6 +64,7 @@ class DefaultHttpClientLogger
         fileAppender.setBufferSize(BUFFER_SIZE_IN_BYTES);
         fileAppender.setLayout(httpLogLayout);
         fileAppender.setRollingPolicy(rollingPolicy);
+        fileAppender.setImmediateFlush(false);
 
         asyncAppender = new AsyncAppenderBase<>();
         asyncAppender.setContext(context);

--- a/http-client/src/main/java/io/airlift/http/client/jetty/DefaultHttpClientLogger.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/DefaultHttpClientLogger.java
@@ -25,7 +25,6 @@ import io.airlift.units.DataSize;
 import java.io.File;
 
 import static io.airlift.http.client.jetty.HttpRequestEvent.createHttpRequestEvent;
-import static io.airlift.units.DataSize.Unit.MEGABYTE;
 
 class DefaultHttpClientLogger
         implements HttpClientLogger
@@ -33,11 +32,10 @@ class DefaultHttpClientLogger
     private static final Logger LOG = Logger.get(DefaultHttpClientLogger.class);
     private static final String TEMP_FILE_EXTENSION = ".tmp";
     private static final String LOG_FILE_EXTENSION = ".log";
-    private static final FileSize BUFFER_SIZE_IN_BYTES = new FileSize(new DataSize(1, MEGABYTE).toBytes());
 
     private final AsyncAppenderBase<HttpRequestEvent> asyncAppender;
 
-    DefaultHttpClientLogger(String filename, int maxHistory, int queueSize, long maxFileSizeInBytes)
+    DefaultHttpClientLogger(String filename, int maxHistory, int queueSize, DataSize bufferSize, long maxFileSizeInBytes)
     {
         ContextBase context = new ContextBase();
         HttpClientLogLayout httpLogLayout = new HttpClientLogLayout();
@@ -61,7 +59,7 @@ class DefaultHttpClientLogger
         fileAppender.setContext(context);
         fileAppender.setFile(filename);
         fileAppender.setAppend(true);
-        fileAppender.setBufferSize(BUFFER_SIZE_IN_BYTES);
+        fileAppender.setBufferSize(new FileSize(bufferSize.toBytes()));
         fileAppender.setLayout(httpLogLayout);
         fileAppender.setRollingPolicy(rollingPolicy);
         fileAppender.setImmediateFlush(false);

--- a/http-client/src/main/java/io/airlift/http/client/jetty/DefaultHttpClientLogger.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/DefaultHttpClientLogger.java
@@ -87,6 +87,12 @@ class DefaultHttpClientLogger
         asyncAppender.stop();
     }
 
+    @Override
+    public int getQueueSize()
+    {
+        return asyncAppender.getNumberOfElementsInQueue();
+    }
+
     private static void recoverTempFiles(String logPath)
     {
         // logback has a tendency to leave around temp files if it is interrupted

--- a/http-client/src/main/java/io/airlift/http/client/jetty/DefaultHttpClientLogger.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/DefaultHttpClientLogger.java
@@ -27,17 +27,17 @@ import java.io.File;
 import static io.airlift.http.client.jetty.HttpRequestEvent.createHttpRequestEvent;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 
-class DefaulHttpClientLogger
+class DefaultHttpClientLogger
         implements HttpClientLogger
 {
-    private static final Logger LOG = Logger.get(DefaulHttpClientLogger.class);
+    private static final Logger LOG = Logger.get(DefaultHttpClientLogger.class);
     private static final String TEMP_FILE_EXTENSION = ".tmp";
     private static final String LOG_FILE_EXTENSION = ".log";
     private static final FileSize BUFFER_SIZE_IN_BYTES = new FileSize(new DataSize(1, MEGABYTE).toBytes());
 
     private final AsyncAppenderBase<HttpRequestEvent> asyncAppender;
 
-    DefaulHttpClientLogger(String filename, int maxHistory, int queueSize, long maxFileSizeInBytes)
+    DefaultHttpClientLogger(String filename, int maxHistory, int queueSize, long maxFileSizeInBytes)
     {
         ContextBase context = new ContextBase();
         HttpClientLogLayout httpLogLayout = new HttpClientLogLayout();

--- a/http-client/src/main/java/io/airlift/http/client/jetty/HttpClientLogger.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/HttpClientLogger.java
@@ -25,6 +25,7 @@ public interface HttpClientLogger
 {
     void log(RequestInfo requestInfo, ResponseInfo responseInfo);
     void close();
+    int getQueueSize();
 
     class RequestInfo
     {

--- a/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
@@ -663,6 +663,12 @@ public class JettyHttpClient
                         .collect(Collectors.joining("\n"));
     }
 
+    @Managed
+    public int getLoggerQueueSize()
+    {
+        return requestLogger.getQueueSize();
+    }
+
     // todo this should be @Managed but operations with parameters are broken in jmx utils https://github.com/martint/jmxutils/issues/27
     @SuppressWarnings("UnusedDeclaration")
     public String dumpDestination(URI uri)

--- a/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
@@ -226,7 +226,12 @@ public class JettyHttpClient
         // configure logging
         if (config.isLogEnabled()) {
             String logFilePath = Paths.get(config.getLogPath(), format("%s-http-client.log", name)).toAbsolutePath().toString();
-            requestLogger = new DefaultHttpClientLogger(logFilePath, config.getLogHistory(), config.getLogQueueSize(), config.getLogMaxFileSize().toBytes());
+            requestLogger = new DefaultHttpClientLogger(
+                    logFilePath,
+                    config.getLogHistory(),
+                    config.getLogQueueSize(),
+                    config.getLogBufferSize(),
+                    config.getLogMaxFileSize().toBytes());
         }
         else {
             requestLogger = new NoopLogger();

--- a/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
@@ -226,7 +226,7 @@ public class JettyHttpClient
         // configure logging
         if (config.isLogEnabled()) {
             String logFilePath = Paths.get(config.getLogPath(), format("%s-http-client.log", name)).toAbsolutePath().toString();
-            requestLogger = new DefaulHttpClientLogger(logFilePath, config.getLogHistory(), config.getLogQueueSize(), config.getLogMaxFileSize().toBytes());
+            requestLogger = new DefaultHttpClientLogger(logFilePath, config.getLogHistory(), config.getLogQueueSize(), config.getLogMaxFileSize().toBytes());
         }
         else {
             requestLogger = new NoopLogger();

--- a/http-client/src/main/java/io/airlift/http/client/jetty/NoopLogger.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/NoopLogger.java
@@ -25,4 +25,10 @@ public class NoopLogger
     public void close()
     {
     }
+
+    @Override
+    public int getQueueSize()
+    {
+        return 0;
+    }
 }

--- a/http-client/src/test/java/io/airlift/http/client/TestHttpClientConfig.java
+++ b/http-client/src/test/java/io/airlift/http/client/TestHttpClientConfig.java
@@ -76,7 +76,8 @@ public class TestHttpClientConfig
                 .setLogHistory(15)
                 .setLogMaxFileSize(new DataSize(1, GIGABYTE))
                 .setLogPath("var/log/")
-                .setLogQueueSize(10_000));
+                .setLogQueueSize(10_000)
+                .setLogBufferSize(new DataSize(1, MEGABYTE)));
     }
 
     @Test
@@ -116,6 +117,7 @@ public class TestHttpClientConfig
                 .put("http-client.log.max-size", "2GB")
                 .put("http-client.log.path", "/tmp/log/")
                 .put("http-client.log.queue-size", "12345")
+                .put("http-client.log.buffer-size", "3MB")
                 .build();
 
         HttpClientConfig expected = new HttpClientConfig()
@@ -151,7 +153,8 @@ public class TestHttpClientConfig
                 .setLogHistory(22)
                 .setLogMaxFileSize(new DataSize(2, GIGABYTE))
                 .setLogPath("/tmp/log/")
-                .setLogQueueSize(12345);
+                .setLogQueueSize(12345)
+                .setLogBufferSize(new DataSize(3, MEGABYTE));
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/http-client/src/test/java/io/airlift/http/client/jetty/TestHttpClientLogger.java
+++ b/http-client/src/test/java/io/airlift/http/client/jetty/TestHttpClientLogger.java
@@ -16,6 +16,7 @@ package io.airlift.http.client.jetty;
 import com.google.common.io.Files;
 import io.airlift.http.client.jetty.HttpClientLogger.RequestInfo;
 import io.airlift.http.client.jetty.HttpClientLogger.ResponseInfo;
+import io.airlift.units.DataSize;
 import org.eclipse.jetty.client.api.ContentProvider;
 import org.eclipse.jetty.client.api.ContentResponse;
 import org.eclipse.jetty.client.api.Request;
@@ -48,6 +49,7 @@ import java.util.concurrent.TimeoutException;
 import static io.airlift.http.client.TraceTokenRequestFilter.TRACETOKEN_HEADER;
 import static io.airlift.http.client.jetty.HttpRequestEvent.NO_RESPONSE;
 import static io.airlift.http.client.jetty.HttpRequestEvent.getFailureReason;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
 import static java.util.Objects.requireNonNull;
@@ -94,7 +96,7 @@ public class TestHttpClientLogger
         Request request = new TestRequest(HTTP_2, method, uri, headers);
         Response response = new TestResponse(status);
 
-        DefaultHttpClientLogger logger = new DefaultHttpClientLogger(file.getAbsolutePath(), 1, 256, Long.MAX_VALUE);
+        DefaultHttpClientLogger logger = new DefaultHttpClientLogger(file.getAbsolutePath(), 1, 256, new DataSize(1, MEGABYTE), Long.MAX_VALUE);
         RequestInfo requestInfo = RequestInfo.from(request, requestTimestamp);
         ResponseInfo responseInfo = ResponseInfo.from(Optional.of(response), responseSize);
         logger.log(requestInfo, responseInfo);
@@ -124,7 +126,7 @@ public class TestHttpClientLogger
         headers.add(TRACETOKEN_HEADER, "test-token");
         Request request = new TestRequest(HTTP_1_1, method, uri, headers);
 
-        DefaultHttpClientLogger logger = new DefaultHttpClientLogger(file.getAbsolutePath(), 1, 256, Long.MAX_VALUE);
+        DefaultHttpClientLogger logger = new DefaultHttpClientLogger(file.getAbsolutePath(), 1, 256, new DataSize(1, MEGABYTE), Long.MAX_VALUE);
         RequestInfo requestInfo = RequestInfo.from(request, requestTimestamp);
         ResponseInfo responseInfo = ResponseInfo.failed(Optional.empty(), Optional.of(new TimeoutException("timeout")));
         logger.log(requestInfo, responseInfo);

--- a/http-client/src/test/java/io/airlift/http/client/jetty/TestHttpClientLogger.java
+++ b/http-client/src/test/java/io/airlift/http/client/jetty/TestHttpClientLogger.java
@@ -94,7 +94,7 @@ public class TestHttpClientLogger
         Request request = new TestRequest(HTTP_2, method, uri, headers);
         Response response = new TestResponse(status);
 
-        DefaulHttpClientLogger logger = new DefaulHttpClientLogger(file.getAbsolutePath(), 1, 256, Long.MAX_VALUE);
+        DefaultHttpClientLogger logger = new DefaultHttpClientLogger(file.getAbsolutePath(), 1, 256, Long.MAX_VALUE);
         RequestInfo requestInfo = RequestInfo.from(request, requestTimestamp);
         ResponseInfo responseInfo = ResponseInfo.from(Optional.of(response), responseSize);
         logger.log(requestInfo, responseInfo);
@@ -124,7 +124,7 @@ public class TestHttpClientLogger
         headers.add(TRACETOKEN_HEADER, "test-token");
         Request request = new TestRequest(HTTP_1_1, method, uri, headers);
 
-        DefaulHttpClientLogger logger = new DefaulHttpClientLogger(file.getAbsolutePath(), 1, 256, Long.MAX_VALUE);
+        DefaultHttpClientLogger logger = new DefaultHttpClientLogger(file.getAbsolutePath(), 1, 256, Long.MAX_VALUE);
         RequestInfo requestInfo = RequestInfo.from(request, requestTimestamp);
         ResponseInfo responseInfo = ResponseInfo.failed(Optional.empty(), Optional.of(new TimeoutException("timeout")));
         logger.log(requestInfo, responseInfo);

--- a/http-server/src/main/java/io/airlift/http/server/DelimitedRequestLog.java
+++ b/http-server/src/main/java/io/airlift/http/server/DelimitedRequestLog.java
@@ -92,6 +92,7 @@ class DelimitedRequestLog
         fileAppender.setBufferSize(BUFFER_SIZE_IN_BYTES);
         fileAppender.setLayout(httpLogLayout);
         fileAppender.setRollingPolicy(rollingPolicy);
+        fileAppender.setImmediateFlush(false);
 
         asyncAppender = new AsyncAppenderBase<>();
         asyncAppender.setContext(context);

--- a/http-server/src/main/java/io/airlift/http/server/DelimitedRequestLog.java
+++ b/http-server/src/main/java/io/airlift/http/server/DelimitedRequestLog.java
@@ -175,6 +175,11 @@ class DelimitedRequestLog
     {
     }
 
+    public int getQueueSize()
+    {
+        return asyncAppender.getNumberOfElementsInQueue();
+    }
+
     private static void recoverTempFiles(String logPath)
     {
         // logback has a tendency to leave around temp files if it is interrupted

--- a/http-server/src/main/java/io/airlift/http/server/HttpServer.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServer.java
@@ -91,6 +91,7 @@ public class HttpServer
 {
     private final Server server;
     private final boolean registerErrorHandler;
+    private final RequestLogHandler logHandler;
     private ConnectionStats httpConnectionStats;
     private ConnectionStats httpsConnectionStats;
 
@@ -309,7 +310,11 @@ public class HttpServer
 
         handlers.addHandler(createServletContext(theServlet, parameters, filters, tokenManager, loginService, "http", "https"));
         if (config.isLogEnabled()) {
-            handlers.addHandler(createLogHandler(config, tokenManager, eventClient));
+            logHandler = createLogHandler(config, tokenManager, eventClient);
+            handlers.addHandler(logHandler);
+        }
+        else {
+            logHandler = null;
         }
 
         RequestLogHandler statsRecorder = new RequestLogHandler();
@@ -442,6 +447,15 @@ public class HttpServer
     public ConnectionStats getHttpsConnectionStats()
     {
         return httpsConnectionStats;
+    }
+
+    @Managed
+    public int getLoggerQueueSize()
+    {
+        if (logHandler == null) {
+            return 0;
+        }
+        return ((DelimitedRequestLog) logHandler.getRequestLog()).getQueueSize();
     }
 
     @PostConstruct


### PR DESCRIPTION
We have seen that the new HTTP client logger can become a bottleneck under load with a large number of HTTP client threads logging events.

Before exploring more complex solutions, this PR first adds support for tuning the logger buffer size and adds monitoring support to the underlying logger queue.