### PR TITLE
Increase default HTTP client connect timeout

### DIFF
--- a/http-client/src/main/java/io/airlift/http/client/HttpClientConfig.java
+++ b/http-client/src/main/java/io/airlift/http/client/HttpClientConfig.java
@@ -43,7 +43,7 @@ public class HttpClientConfig
     public static final String JAVAX_NET_SSL_TRUST_STORE = "javax.net.ssl.trustStore";
     public static final String JAVAX_NET_SSL_TRUST_STORE_PASSWORD = "javax.net.ssl.trustStorePassword";
 
-    private Duration connectTimeout = new Duration(1, SECONDS);
+    private Duration connectTimeout = new Duration(5, SECONDS);
     private Duration requestTimeout = new Duration(5, MINUTES);
     private Duration idleTimeout = new Duration(1, MINUTES);
     private Duration keepAliveInterval;

--- a/http-client/src/test/java/io/airlift/http/client/TestHttpClientConfig.java
+++ b/http-client/src/test/java/io/airlift/http/client/TestHttpClientConfig.java
@@ -45,7 +45,7 @@ public class TestHttpClientConfig
     {
         ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(HttpClientConfig.class)
                 .setHttp2Enabled(false)
-                .setConnectTimeout(new Duration(1, SECONDS))
+                .setConnectTimeout(new Duration(5, SECONDS))
                 .setRequestTimeout(new Duration(5, MINUTES))
                 .setIdleTimeout(new Duration(1, MINUTES))
                 .setKeepAliveInterval(null)


### PR DESCRIPTION
BTW the default request/idle timeouts don't make sense, they are too high. I think we should decrease them.