### PR TITLE
Bind HttpServerConfig in TestingHttpServerModule

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 0.166
 
 - Update to Guava 24.1 and Guice 4.2.
+- Bind HttpServerConfig in TestingHttpServerModule to allow for HTTPS testing.
 
 0.165
 

--- a/http-server/src/main/java/io/airlift/http/server/testing/TestingHttpServer.java
+++ b/http-server/src/main/java/io/airlift/http/server/testing/TestingHttpServer.java
@@ -95,4 +95,9 @@ public class TestingHttpServer
     {
         return httpServerInfo.getHttpUri().getPort();
     }
+
+    public HttpServerInfo getHttpServerInfo()
+    {
+        return httpServerInfo;
+    }
 }

--- a/http-server/src/main/java/io/airlift/http/server/testing/TestingHttpServerModule.java
+++ b/http-server/src/main/java/io/airlift/http/server/testing/TestingHttpServerModule.java
@@ -29,6 +29,7 @@ import io.airlift.http.server.TheServlet;
 import javax.servlet.Filter;
 
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
+import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.http.server.HttpServerBinder.HttpResourceBinding;
 
 public class TestingHttpServerModule
@@ -51,9 +52,14 @@ public class TestingHttpServerModule
     {
         binder.disableCircularProxies();
 
-        HttpServerConfig config = new HttpServerConfig().setHttpPort(httpPort);
+        configBinder(binder).bindConfig(HttpServerConfig.class);
+        configBinder(binder).bindConfigDefaults(HttpServerConfig.class, config -> {
+            config.setHttpPort(httpPort);
+            if (httpPort == 0) {
+                config.setHttpsPort(0);
+            }
+        });
 
-        binder.bind(HttpServerConfig.class).toInstance(config);
         binder.bind(HttpServerInfo.class).in(Scopes.SINGLETON);
         binder.bind(TestingHttpServer.class).in(Scopes.SINGLETON);
         binder.bind(HttpServer.class).to(Key.get(TestingHttpServer.class));

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -117,6 +117,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>bootstrap</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
Configuration of http server is necessary when testing with https.
The HttpServerInfo is now exposed from TestingHttpServer, so https
properties can be accessed.