### PR TITLE
Fix AbstractHttpClientTest.testConnectTimeout for HTTP/2

### DIFF
--- a/http-client/src/test/java/io/airlift/http/client/AbstractHttpClientTest.java
+++ b/http-client/src/test/java/io/airlift/http/client/AbstractHttpClientTest.java
@@ -43,6 +43,7 @@ import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
+import java.nio.channels.ClosedChannelException;
 import java.nio.channels.UnresolvedAddressException;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -219,7 +220,7 @@ public abstract class AbstractHttpClientTest
             }
             catch (CapturedException e) {
                 Throwable t = e.getCause();
-                if (!isConnectTimeout(t)) {
+                if (!(isConnectTimeout(t) || t instanceof ClosedChannelException)) {
                     fail(format("unexpected exception: [%s]", getStackTraceAsString(t)));
                 }
                 assertLessThan(nanosSince(start), new Duration(300, MILLISECONDS));


### PR DESCRIPTION
The request sent in this test can also fail with a ClosedChannelException
for HTTP/2.

```
[ERROR] Tests run: 360, Failures: 1, Errors: 0, Skipped: 23, Time elapsed: 36.522 s <<< FAILURE! - in TestSuite
[ERROR] testConnectTimeout(io.airlift.http.client.jetty.TestAsyncJettyHttpClientHttp2)  Time elapsed: 0.036 s  <<< FAILURE!
java.lang.AssertionError: 
unexpected exception: [java.nio.channels.ClosedChannelException
    at org.eclipse.jetty.http2.HTTP2Session.onShutdown(HTTP2Session.java:878)
    at org.eclipse.jetty.http2.HTTP2Connection$HTTP2Producer.produce(HTTP2Connection.java:231)
    at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:179)
    at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.produce(EatWhatYouKill.java:140)
    at org.eclipse.jetty.http2.HTTP2Connection.onOpen(HTTP2Connection.java:97)
    at org.eclipse.jetty.http2.client.HTTP2ClientConnectionFactory$HTTP2ClientConnection.onOpen(HTTP2ClientConnectionFactory.java:148)
    at org.eclipse.jetty.io.SelectorManager.connectionOpened(SelectorManager.java:322)
    at org.eclipse.jetty.io.ManagedSelector.createEndPoint(ManagedSelector.java:213)
    at org.eclipse.jetty.io.ManagedSelector.access$1600(ManagedSelector.java:60)
    at org.eclipse.jetty.io.ManagedSelector$CreateEndPoint.run(ManagedSelector.java:650)
    at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:708)
    at org.eclipse.jetty.util.thread.QueuedThreadPool$2.run(QueuedThreadPool.java:626)
    at java.lang.Thread.run(Thread.java:748)
```