### PR TITLE
Add additional columns to the HTTP server logs

### DIFF
--- a/http-server/src/main/java/io/airlift/http/server/DoubleSummaryStats.java
+++ b/http-server/src/main/java/io/airlift/http/server/DoubleSummaryStats.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.http.server;
+
+import io.airlift.event.client.EventField;
+import io.airlift.event.client.EventType;
+
+import java.util.DoubleSummaryStatistics;
+
+import static java.util.Objects.requireNonNull;
+
+@EventType
+public class DoubleSummaryStats
+{
+    private final DoubleSummaryStatistics stats;
+
+    public DoubleSummaryStats(DoubleSummaryStatistics stats)
+    {
+        this.stats = requireNonNull(stats, "stats is null");
+    }
+
+    @EventField
+    public double getMin()
+    {
+        return stats.getMin();
+    }
+
+    @EventField
+    public double getMax()
+    {
+        return stats.getMax();
+    }
+
+    @EventField
+    public double getAverage()
+    {
+        return stats.getAverage();
+    }
+
+    @EventField
+    public long getCount()
+    {
+        return stats.getCount();
+    }
+}

--- a/http-server/src/main/java/io/airlift/http/server/HttpLogLayout.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpLogLayout.java
@@ -5,6 +5,7 @@ import ch.qos.logback.core.LayoutBase;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 
+import static java.lang.String.format;
 import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
 
 public class HttpLogLayout
@@ -16,6 +17,14 @@ public class HttpLogLayout
     public String doLayout(HttpRequestEvent event)
     {
         StringBuilder builder = new StringBuilder();
+
+        // format content interarrival time [ms] stats
+        String contentInterarrivalStats = null;
+        DoubleSummaryStats stats = event.getResponseContentInterarrivalStats();
+        if (stats != null) {
+            contentInterarrivalStats = format("%.2f, %.2f, %.2f, %d", stats.getMin(), stats.getAverage(), stats.getMax(), stats.getCount());
+        }
+
         builder.append(ISO_FORMATTER.format(event.getTimeStamp()))
                 .append('\t')
                 .append(event.getClientAddress())
@@ -37,6 +46,16 @@ public class HttpLogLayout
                 .append(event.getTimeToLastByte())
                 .append('\t')
                 .append(event.getTraceToken())
+                .append('\t')
+                .append(event.getProtocolVersion())
+                .append('\t')
+                .append(event.getBeginToDispatchMillis())
+                .append('\t')
+                .append(event.getBeginToEndMillis())
+                .append('\t')
+                .append(event.getFirstToLastContentTimeInMillis())
+                .append('\t')
+                .append(contentInterarrivalStats)
                 .append('\n');
 
         return builder.toString();

--- a/http-server/src/main/java/io/airlift/http/server/HttpRequestEvent.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpRequestEvent.java
@@ -35,7 +35,15 @@ import static java.lang.Math.max;
 @EventType("HttpRequest")
 public class HttpRequestEvent
 {
-    public static HttpRequestEvent createHttpRequestEvent(Request request, Response response, TraceTokenManager traceTokenManager, long currentTimeInMillis)
+    public static HttpRequestEvent createHttpRequestEvent(
+            Request request,
+            Response response,
+            TraceTokenManager traceTokenManager,
+            long currentTimeInMillis,
+            long beginToDispatchMillis,
+            long beginToEndMillis,
+            long firstToLastContentTimeInMillis,
+            DoubleSummaryStats responseContentInterarrivalStats)
     {
         String user = null;
         Principal principal = request.getUserPrincipal();
@@ -120,7 +128,12 @@ public class HttpRequestEvent
                 response.getHeader("Content-Type"),
                 timeToDispatch,
                 timeToFirstByte,
-                timeToLastByte);
+                timeToLastByte,
+                beginToDispatchMillis,
+                beginToEndMillis,
+                firstToLastContentTimeInMillis,
+                responseContentInterarrivalStats,
+                request.getHttpVersion().toString());
     }
 
     private final Instant timeStamp;
@@ -140,6 +153,11 @@ public class HttpRequestEvent
     private final long timeToDispatch;
     private final Long timeToFirstByte;
     private final long timeToLastByte;
+    private final long beginToDispatchMillis;
+    private final long beginToEndMillis;
+    private final long firstToLastContentTimeInMillis;
+    private final DoubleSummaryStats responseContentInterarrivalStats;
+    private final String protocolVersion;
 
     public HttpRequestEvent(
             Instant timeStamp,
@@ -158,7 +176,12 @@ public class HttpRequestEvent
             String responseContentType,
             long timeToDispatch,
             Long timeToFirstByte,
-            long timeToLastByte)
+            long timeToLastByte,
+            long beginToDispatchMillis,
+            long beginToEndMillis,
+            long firstToLastContentTimeInMillis,
+            DoubleSummaryStats responseContentInterarrivalStats,
+            String protocolVersion)
     {
         this.timeStamp = timeStamp;
         this.traceToken = traceToken;
@@ -177,6 +200,11 @@ public class HttpRequestEvent
         this.timeToDispatch = timeToDispatch;
         this.timeToFirstByte = timeToFirstByte;
         this.timeToLastByte = timeToLastByte;
+        this.beginToDispatchMillis = beginToDispatchMillis;
+        this.beginToEndMillis = beginToEndMillis;
+        this.firstToLastContentTimeInMillis = firstToLastContentTimeInMillis;
+        this.responseContentInterarrivalStats = responseContentInterarrivalStats;
+        this.protocolVersion = protocolVersion;
     }
 
     @EventField(fieldMapping = TIMESTAMP)
@@ -279,5 +307,35 @@ public class HttpRequestEvent
     public long getTimeToLastByte()
     {
         return timeToLastByte;
+    }
+
+    @EventField
+    public long getBeginToDispatchMillis()
+    {
+        return beginToDispatchMillis;
+    }
+
+    @EventField
+    public long getBeginToEndMillis()
+    {
+        return beginToEndMillis;
+    }
+
+    @EventField
+    public long getFirstToLastContentTimeInMillis()
+    {
+        return firstToLastContentTimeInMillis;
+    }
+
+    @EventField
+    public DoubleSummaryStats getResponseContentInterarrivalStats()
+    {
+        return responseContentInterarrivalStats;
+    }
+
+    @EventField
+    public String getProtocolVersion()
+    {
+        return protocolVersion;
     }
 }

--- a/http-server/src/main/java/io/airlift/http/server/HttpServerChannelListener.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServerChannelListener.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.http.server;
+
+import org.eclipse.jetty.server.HttpChannel.Listener;
+import org.eclipse.jetty.server.Request;
+
+import javax.annotation.Nullable;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.DoubleSummaryStatistics;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+public class HttpServerChannelListener
+        implements Listener
+{
+    private static final String REQUEST_BEGIN_ATTRIBUTE = HttpServerChannelListener.class.getName() + ".begin";
+    private static final String REQUEST_BEGIN_TO_DISPATCH_ATTRIBUTE = HttpServerChannelListener.class.getName() + ".begin_to_dispatch";
+    private static final String REQUEST_BEGIN_TO_END_ATTRIBUTE = HttpServerChannelListener.class.getName() + ".begin_to_end";
+    private static final String RESPONSE_CONTENT_TIMESTAMPS_ATTRIBUTE = HttpServerChannelListener.class.getName() + ".response_content_timestamps";
+
+    private final DelimitedRequestLog logger;
+
+    public HttpServerChannelListener(DelimitedRequestLog logger)
+    {
+        this.logger = requireNonNull(logger, "logger is null");
+    }
+
+    @Override
+    public void onRequestBegin(Request request)
+    {
+        request.setAttribute(REQUEST_BEGIN_ATTRIBUTE, System.nanoTime());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void onBeforeDispatch(Request request)
+    {
+        long requestBeginTime = (Long) request.getAttribute(REQUEST_BEGIN_ATTRIBUTE);
+        request.setAttribute(REQUEST_BEGIN_TO_DISPATCH_ATTRIBUTE, System.nanoTime() - requestBeginTime);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void onRequestEnd(Request request)
+    {
+        long requestBeginTime = (Long) request.getAttribute(REQUEST_BEGIN_ATTRIBUTE);
+        request.setAttribute(REQUEST_BEGIN_TO_END_ATTRIBUTE, System.nanoTime() - requestBeginTime);
+    }
+
+    @Override
+    public void onResponseBegin(Request request)
+    {
+        request.setAttribute(RESPONSE_CONTENT_TIMESTAMPS_ATTRIBUTE, new ArrayList<Long>());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void onResponseContent(Request request, ByteBuffer content)
+    {
+        List<Long> contentTimestamps = (List<Long>) request.getAttribute(RESPONSE_CONTENT_TIMESTAMPS_ATTRIBUTE);
+        contentTimestamps.add(System.nanoTime());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void onComplete(Request request)
+    {
+        List<Long> contentTimestamps = (List<Long>) request.getAttribute(RESPONSE_CONTENT_TIMESTAMPS_ATTRIBUTE);
+        long firstToLastContentTimeInMillis = -1;
+        if (contentTimestamps.size() > 0) {
+            firstToLastContentTimeInMillis = NANOSECONDS.toMillis(contentTimestamps.get(contentTimestamps.size() - 1) - contentTimestamps.get(0));
+        }
+        long beginToDispatchMillis = NANOSECONDS.toMillis((Long) request.getAttribute(REQUEST_BEGIN_TO_DISPATCH_ATTRIBUTE));
+        long beginToEndMillis = NANOSECONDS.toMillis((Long) request.getAttribute(REQUEST_BEGIN_TO_END_ATTRIBUTE));
+        logger.log(request,
+                request.getResponse(),
+                beginToDispatchMillis,
+                beginToEndMillis,
+                firstToLastContentTimeInMillis,
+                processContentTimestamps(contentTimestamps));
+    }
+
+    /**
+     * Calculate the summary statistics for the interarrival time of the onResponseContent callbacks.
+     */
+    @Nullable
+    private static DoubleSummaryStats processContentTimestamps(List<Long> contentTimestamps)
+    {
+        requireNonNull(contentTimestamps, "contentTimestamps is null");
+
+        // no content (HTTP 204) or there was a single response chunk (so no interarrival time)
+        if (contentTimestamps.size() == 0 || contentTimestamps.size() == 1) {
+            return null;
+        }
+
+        DoubleSummaryStatistics statistics = new DoubleSummaryStatistics();
+        long previousTimestamp = contentTimestamps.get(0);
+        for (int i = 1; i < contentTimestamps.size(); i++) {
+            long timestamp = contentTimestamps.get(i);
+            statistics.accept(NANOSECONDS.toMillis(timestamp - previousTimestamp));
+            previousTimestamp = timestamp;
+        }
+        return new DoubleSummaryStats(statistics);
+    }
+}


### PR DESCRIPTION
This change adds the following columns to the HTTP server logs:

- stream id: stream identifier for HTTP/2 requests, -1 otherwise.
- protocol version: version of the HTTP protocol specified by the
request.
- request begin-to-dispatch time [ms]: time from when the request is
received to when the request is dispatched to the application.
- request begin-to-end time [ms]: time from when the request is received
to when the request has been fully consumed/parsed.
- first-to-last-content-time [ms]: time from when the first chunk of the
response content has been written to the network to when the last
chunk of the response content has been written.
- response content interarrival time stats: the summary statistics
for the interarrival time of the response content writes. For example,
if three response content chunks have been written by the HTTP server
at t=0, t=3, and t=20, then this field will contain the summary
statistics for the values {3, 17}.

/cc @martint 