### PR TITLE
Change HTTP PEM support to fail on bad PEM files

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+0.170
+
+- Improve error handling for HTTP client and HTTP server PEM files.
+
 0.169
 
 - Fix configuration error messages for prefixed configs.

--- a/http-server/src/test/java/io/airlift/http/server/TestHttpServerProvider.java
+++ b/http-server/src/test/java/io/airlift/http/server/TestHttpServerProvider.java
@@ -250,7 +250,7 @@ public class TestHttpServerProvider
         config.setHttpEnabled(false)
                 .setHttpsEnabled(true)
                 .setHttpsPort(0)
-                .setKeystorePath(getResource("test.keystore.with.two.passwords").toString())
+                .setKeystorePath(getResource("test.keystore.with.two.passwords").getPath())
                 .setKeystorePassword("airlift")
                 .setKeyManagerPassword("airliftkey");
 
@@ -258,7 +258,7 @@ public class TestHttpServerProvider
 
         HttpClientConfig http1ClientConfig = new HttpClientConfig()
                 .setHttp2Enabled(false)
-                .setTrustStorePath(getResource("test.truststore").toString())
+                .setTrustStorePath(getResource("test.truststore").getPath())
                 .setTrustStorePassword("airlift");
 
         try (JettyHttpClient httpClient = new JettyHttpClient(http1ClientConfig)) {
@@ -317,15 +317,15 @@ public class TestHttpServerProvider
                 .setAdminEnabled(false)
                 .setHttpsEnabled(true)
                 .setHttpsPort(0)
-                .setKeystorePath(getResource("clientcert-java/server.keystore").toString())
+                .setKeystorePath(getResource("clientcert-java/server.keystore").getPath())
                 .setKeystorePassword("airlift");
 
         createAndStartServer(createCertTestServlet());
 
         HttpClientConfig clientConfig = new HttpClientConfig()
-                .setKeyStorePath(getResource("clientcert-java/client.keystore").toString())
+                .setKeyStorePath(getResource("clientcert-java/client.keystore").getPath())
                 .setKeyStorePassword("airlift")
-                .setTrustStorePath(getResource("clientcert-java/client.truststore").toString())
+                .setTrustStorePath(getResource("clientcert-java/client.truststore").getPath())
                 .setTrustStorePassword("airlift");
 
         try (JettyHttpClient httpClient = new JettyHttpClient(clientConfig)) {
@@ -470,7 +470,7 @@ public class TestHttpServerProvider
         config.setHttpEnabled(false)
                 .setHttpsEnabled(true)
                 .setHttpsPort(0)
-                .setKeystorePath(getResource("test.keystore").toString())
+                .setKeystorePath(getResource("test.keystore").getPath())
                 .setKeystorePassword("airlift")
                 .setMaxThreads(1);
         createAndStartServer();
@@ -483,7 +483,7 @@ public class TestHttpServerProvider
         config.setHttpEnabled(false)
                 .setHttpsEnabled(true)
                 .setHttpsPort(0)
-                .setKeystorePath(getResource("test.keystore.with.two.passwords").toString())
+                .setKeystorePath(getResource("test.keystore.with.two.passwords").getPath())
                 .setKeystorePassword("airlift");
         createAndStartServer();
     }

--- a/security/src/main/java/io/airlift/security/pem/PemReader.java
+++ b/security/src/main/java/io/airlift/security/pem/PemReader.java
@@ -70,6 +70,19 @@ public final class PemReader
 
     private PemReader() {}
 
+    public static boolean isPem(File file)
+            throws IOException
+    {
+        return isPem(asCharSource(file, US_ASCII).read());
+    }
+
+    public static boolean isPem(String data)
+    {
+        return CERT_PATTERN.matcher(data).find() ||
+                PUBLIC_KEY_PATTERN.matcher(data).find() ||
+                PRIVATE_KEY_PATTERN.matcher(data).find();
+    }
+
     public static KeyStore loadTrustStore(File certificateChainFile)
             throws IOException, GeneralSecurityException
     {


### PR DESCRIPTION
Instead of falling back to guessing the file is a Java key store, check
if the file contains any PEM keys or certificates and either load them
or fail with a clean error message.