### PR TITLE
Periodically flush HTTP server and HTTP client logs

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+0.171
+
+- Periodically flush HTTP server and HTTP client logs.
+
 0.170
 
 - Improve error handling for HTTP client and HTTP server PEM files.

--- a/http-client/pom.xml
+++ b/http-client/pom.xml
@@ -146,6 +146,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>bootstrap</artifactId>
             <scope>test</scope>

--- a/http-client/src/main/java/io/airlift/http/client/HttpClientConfig.java
+++ b/http-client/src/main/java/io/airlift/http/client/HttpClientConfig.java
@@ -80,6 +80,7 @@ public class HttpClientConfig
     private int logQueueSize = 10_000;
     private DataSize logMaxFileSize = new DataSize(1, GIGABYTE);
     private DataSize logBufferSize = new DataSize(1, MEGABYTE);
+    private Duration logFlushInterval = new Duration(10, SECONDS);
     private boolean logCompressionEnabled = true;
 
     public boolean isHttp2Enabled()
@@ -528,6 +529,19 @@ public class HttpClientConfig
     public HttpClientConfig setLogBufferSize(DataSize logBufferSize)
     {
         this.logBufferSize = logBufferSize;
+        return this;
+    }
+
+    @NotNull
+    public Duration getLogFlushInterval()
+    {
+        return logFlushInterval;
+    }
+
+    @Config("http-client.log.flush-interval")
+    public HttpClientConfig setLogFlushInterval(Duration logFlushInterval)
+    {
+        this.logFlushInterval = logFlushInterval;
         return this;
     }
 

--- a/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
@@ -252,6 +252,7 @@ public class JettyHttpClient
                     config.getLogHistory(),
                     config.getLogQueueSize(),
                     config.getLogBufferSize(),
+                    config.getLogFlushInterval(),
                     config.getLogMaxFileSize().toBytes(),
                     config.isLogCompressionEnabled());
         }

--- a/http-client/src/test/java/io/airlift/http/client/TestHttpClientConfig.java
+++ b/http-client/src/test/java/io/airlift/http/client/TestHttpClientConfig.java
@@ -78,6 +78,7 @@ public class TestHttpClientConfig
                 .setLogPath("var/log/")
                 .setLogQueueSize(10_000)
                 .setLogBufferSize(new DataSize(1, MEGABYTE))
+                .setLogFlushInterval(new Duration(10, SECONDS))
                 .setLogCompressionEnabled(true));
     }
 
@@ -119,6 +120,7 @@ public class TestHttpClientConfig
                 .put("http-client.log.path", "/tmp/log/")
                 .put("http-client.log.queue-size", "12345")
                 .put("http-client.log.buffer-size", "3MB")
+                .put("http-client.log.flush-interval", "99s")
                 .put("http-client.log.compression.enabled", "false")
                 .build();
 
@@ -157,6 +159,7 @@ public class TestHttpClientConfig
                 .setLogPath("/tmp/log/")
                 .setLogQueueSize(12345)
                 .setLogBufferSize(new DataSize(3, MEGABYTE))
+                .setLogFlushInterval(new Duration(99, SECONDS))
                 .setLogCompressionEnabled(false);
 
         ConfigAssertions.assertFullMapping(properties, expected);


### PR DESCRIPTION
The large buffer used for logs requires logging many messages before the
buffer fills up and writes the logs to disk. Flushing periodically makes
debugging low traffic servers and clients easier, and reduces the chance
of log messages getting lost on an unclean shutdown.