### PR TITLE
Set response complete timestamp for failed requests

### DIFF
--- a/http-client/src/main/java/io/airlift/http/client/jetty/HttpClientLogger.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/HttpClientLogger.java
@@ -118,7 +118,7 @@ public interface HttpClientLogger
         {
             requireNonNull(response, "response is null");
             requireNonNull(failureCause, "failureCause is null");
-            return new ResponseInfo(response, 0L, 0L, 0L, failureCause);
+            return new ResponseInfo(response, 0L, 0L, System.nanoTime(), failureCause);
         }
 
         public static ResponseInfo failed(Optional<Response> response, Optional<Throwable> failureCause, long responseBeginTimestamp, long responseCompleteTimestamp)

--- a/http-client/src/test/java/io/airlift/http/client/jetty/TestHttpClientLogger.java
+++ b/http-client/src/test/java/io/airlift/http/client/jetty/TestHttpClientLogger.java
@@ -62,6 +62,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.jetty.http.HttpVersion.HTTP_1_1;
 import static org.eclipse.jetty.http.HttpVersion.HTTP_2;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
 
 @Test(singleThreaded = true)
 public class TestHttpClientLogger
@@ -173,7 +174,7 @@ public class TestHttpClientLogger
         assertEquals(columns[3], uri.toString());
         assertEquals(columns[4], getFailureReason(responseInfo).get());
         assertEquals(columns[5], Integer.toString(NO_RESPONSE));
-        assertEquals(columns[6], Long.toString(0));
+        assertNotEquals(columns[6], Long.toString(0));
         assertEquals(columns[7], Long.toString(0));
         assertEquals(columns[8], Long.toString(0));
         assertEquals(columns[9], Long.toString(0));


### PR DESCRIPTION
This change sets the response complete timestamp for failed requests
that go through the ResponseInfo.failed(response, failureCause)
method.