### PR TITLE
Improve naming and documentation of DER utilities

### DIFF
--- a/security/src/main/java/io/airlift/security/csr/CertificationRequest.java
+++ b/security/src/main/java/io/airlift/security/csr/CertificationRequest.java
@@ -24,8 +24,8 @@ import java.util.Objects;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.io.BaseEncoding.base16;
 import static io.airlift.security.csr.SignatureAlgorithmIdentifier.findSignatureAlgorithmIdentifier;
-import static io.airlift.security.der.DerEncoder.encodeBitString;
-import static io.airlift.security.der.DerEncoder.encodeSequence;
+import static io.airlift.security.der.DerUtils.encodeBitString;
+import static io.airlift.security.der.DerUtils.encodeSequence;
 import static java.util.Base64.getMimeEncoder;
 import static java.util.Objects.requireNonNull;
 

--- a/security/src/main/java/io/airlift/security/csr/CertificationRequestInfo.java
+++ b/security/src/main/java/io/airlift/security/csr/CertificationRequestInfo.java
@@ -22,7 +22,7 @@ import java.security.Signature;
 import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
-import static io.airlift.security.der.DerEncoder.encodeSequence;
+import static io.airlift.security.der.DerUtils.encodeSequence;
 import static java.util.Objects.requireNonNull;
 
 public class CertificationRequestInfo

--- a/security/src/main/java/io/airlift/security/csr/SignatureAlgorithmIdentifier.java
+++ b/security/src/main/java/io/airlift/security/csr/SignatureAlgorithmIdentifier.java
@@ -31,7 +31,7 @@ import java.util.Objects;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static io.airlift.security.der.DerEncoder.encodeLength;
+import static io.airlift.security.der.DerUtils.encodeLength;
 import static java.util.Objects.requireNonNull;
 
 public final class SignatureAlgorithmIdentifier

--- a/security/src/main/java/io/airlift/security/der/DerUtils.java
+++ b/security/src/main/java/io/airlift/security/der/DerUtils.java
@@ -20,6 +20,7 @@ import com.google.common.io.ByteStreams;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.List;
 
@@ -220,7 +221,7 @@ public final class DerUtils
         }
         catch (IOException e) {
             // this won't happen with byte array output streams
-            throw new RuntimeException(e);
+            throw new UncheckedIOException(e);
         }
     }
 

--- a/security/src/main/java/io/airlift/security/der/DerUtils.java
+++ b/security/src/main/java/io/airlift/security/der/DerUtils.java
@@ -28,16 +28,17 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * ASN.1 DER encoder methods necessary to write a certificate request.
+ * ASN.1 DER encoder methods necessary to process PEM files and to write a certificate signing request.
+ * NOTE: this API is only present for the two mentioned use cases, and is subject to change without warning.
  */
-public final class DerEncoder
+public final class DerUtils
 {
     private static final int SEQUENCE_TAG = 0x30;
     private static final int BIT_STRING_TAG = 0x03;
     private static final int OCTET_STRING_TAG = 0x04;
     private static final int OBJECT_IDENTIFIER_TAG = 0x06;
 
-    private DerEncoder() {}
+    private DerUtils() {}
 
     /**
      * Encodes a sequence of encoded values.
@@ -60,7 +61,7 @@ public final class DerEncoder
     }
 
     /**
-     * Encodes a sequence of encoded values.
+     * Decodes a sequence of encoded values.
      */
     public static List<byte[]> decodeSequence(byte[] sequence)
     {
@@ -95,7 +96,7 @@ public final class DerEncoder
     }
 
     /**
-     * Encodes a optional element of a sequence.
+     * Decodes a optional element of a sequence.
      */
     public static byte[] decodeSequenceOptionalElement(byte[] element)
     {

--- a/security/src/main/java/io/airlift/security/pem/PemReader.java
+++ b/security/src/main/java/io/airlift/security/pem/PemReader.java
@@ -52,11 +52,11 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static com.google.common.io.Files.asCharSource;
-import static io.airlift.security.der.DerEncoder.decodeSequence;
-import static io.airlift.security.der.DerEncoder.decodeSequenceOptionalElement;
-import static io.airlift.security.der.DerEncoder.encodeOctetString;
-import static io.airlift.security.der.DerEncoder.encodeOid;
-import static io.airlift.security.der.DerEncoder.encodeSequence;
+import static io.airlift.security.der.DerUtils.decodeSequence;
+import static io.airlift.security.der.DerUtils.decodeSequenceOptionalElement;
+import static io.airlift.security.der.DerUtils.encodeOctetString;
+import static io.airlift.security.der.DerUtils.encodeOid;
+import static io.airlift.security.der.DerUtils.encodeSequence;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.util.Base64.getMimeDecoder;


### PR DESCRIPTION
Rename DerEncoding to DerUtils
Note that the DerUtils is not a stable public API