### PR TITLE
Fix double logging in JettyHttpClient::execute()

### DIFF
--- a/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
@@ -523,11 +523,6 @@ public class JettyHttpClient
                 recordRequestComplete(stats, request, requestStart, jettyResponse, responseStart);
             }
         }
-        ResponseInfo responseInfo = ResponseInfo.from(Optional.of(response),
-                jettyResponse.getBytesRead(),
-                requestListener.getResponseStarted(),
-                requestListener.getResponseFinished());
-        requestLogger.log(requestInfo, responseInfo);
         return value;
     }
 


### PR DESCRIPTION
The request is already logged by the HttpClientLoggingListener, and also
the info previously logged in the execute() method was incorrect as it
wasn't setting the request creation timestamp (and some other timestamps)
properly.