### PR TITLE
Optimize qdigest histogram, allow for custom long-to-float conversion for middle

### DIFF
--- a/stats/src/test/java/io/airlift/stats/BenchmarkQuantileDigest.java
+++ b/stats/src/test/java/io/airlift/stats/BenchmarkQuantileDigest.java
@@ -1,5 +1,6 @@
 package io.airlift.stats;
 
+import com.google.common.collect.ImmutableList;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
@@ -16,6 +17,7 @@ import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.VerboseMode;
 
+import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
@@ -101,6 +103,13 @@ public class BenchmarkQuantileDigest
         QuantileDigest merged = new QuantileDigest(data.digest1);
         merged.merge(data.digest2);
         return merged;
+    }
+
+    @Benchmark
+    public List<QuantileDigest.Bucket> benchmarkHistogram(Digest data)
+    {
+        return data.digest1.getHistogram(
+                ImmutableList.of(0L, 100_000_000L, 200_000_000L, 300_000_000L, 400_000_000L, 500_000_000L, 600_000_000L, 700_000_000L, 800_000_000L, 900_000_000L, 1_000_000_000L));
     }
 
     public static void main(String[] args)


### PR DESCRIPTION
Here are some benchmarks.

New:

```
Benchmark                                                                     Mode  Cnt      Score     Error   Units
BenchmarkQuantileDigest.benchmarkHistogram                                   thrpt   30  40014.014 ± 468.709   ops/s
BenchmarkQuantileDigest.benchmarkHistogram:·gc.alloc.rate                    thrpt   30     25.622 ±   0.296  MB/sec
BenchmarkQuantileDigest.benchmarkHistogram:·gc.alloc.rate.norm               thrpt   30   1008.044 ±   0.068    B/op
BenchmarkQuantileDigest.benchmarkHistogram:·gc.churn.PS_Eden_Space           thrpt   30     26.961 ±  12.018  MB/sec
BenchmarkQuantileDigest.benchmarkHistogram:·gc.churn.PS_Eden_Space.norm      thrpt   30   1059.251 ± 472.383    B/op
BenchmarkQuantileDigest.benchmarkHistogram:·gc.churn.PS_Survivor_Space       thrpt   30      0.172 ±   0.326  MB/sec
BenchmarkQuantileDigest.benchmarkHistogram:·gc.churn.PS_Survivor_Space.norm  thrpt   30      6.737 ±  12.821    B/op
BenchmarkQuantileDigest.benchmarkHistogram:·gc.count                         thrpt   30     21.000            counts
BenchmarkQuantileDigest.benchmarkHistogram:·gc.time                          thrpt   30     21.000                ms
```

Old:

```
Benchmark                                                                     Mode  Cnt      Score      Error   Units
BenchmarkQuantileDigest.benchmarkHistogram                                   thrpt   30  21228.284 ±  629.031   ops/s
BenchmarkQuantileDigest.benchmarkHistogram:·gc.alloc.rate                    thrpt   30     14.348 ±    0.427  MB/sec
BenchmarkQuantileDigest.benchmarkHistogram:·gc.alloc.rate.norm               thrpt   30   1064.082 ±    0.126    B/op
BenchmarkQuantileDigest.benchmarkHistogram:·gc.churn.PS_Eden_Space           thrpt   30     16.697 ±   13.900  MB/sec
BenchmarkQuantileDigest.benchmarkHistogram:·gc.churn.PS_Eden_Space.norm      thrpt   30   1232.183 ± 1027.360    B/op
BenchmarkQuantileDigest.benchmarkHistogram:·gc.churn.PS_Survivor_Space       thrpt   30      0.165 ±    0.331  MB/sec
BenchmarkQuantileDigest.benchmarkHistogram:·gc.churn.PS_Survivor_Space.norm  thrpt   30     12.065 ±   24.129    B/op
BenchmarkQuantileDigest.benchmarkHistogram:·gc.count                         thrpt   30     12.000             counts
BenchmarkQuantileDigest.benchmarkHistogram:·gc.time                          thrpt   30     25.000                 ms
```

The increase in throughput is likely due to the removal of the unnecessary `Atomic` variables, instead a private struct, `HistogramBuilderStateHolder`, holds the intermediate state as plain member variables.

This also introduces a simple lambda passed to the histogram function to allow one to properly convert the middle for the upper and lower bound of a bucket.  This allows the results to be correct when the long bits actually represent something else, like `double`s or `float`s whose bits are represented as sortable longs.

The real intent for this PR was to allow this overrideable interpretation of the long bits for calculating the mean, and the performance refactoring made that easier and cleaner.

CC: @martint 