### PR TITLE
Add joda-to-java-time-bridge module

### DIFF
--- a/joda-to-java-time-bridge/pom.xml
+++ b/joda-to-java-time-bridge/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>joda-to-java-time-bridge</artifactId>
+    <packaging>jar</packaging>
+    <name>jaxrs-testing</name>
+
+    <parent>
+        <groupId>io.airlift</groupId>
+        <artifactId>airlift</artifactId>
+        <version>0.177-SNAPSHOT</version>
+    </parent>
+
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- for testing -->
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/joda-to-java-time-bridge/src/main/java/io/airlift/jaxrs/jodabridge/JdkBasedDateTimeZone.java
+++ b/joda-to-java-time-bridge/src/main/java/io/airlift/jaxrs/jodabridge/JdkBasedDateTimeZone.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.jaxrs.jodabridge;
+
+import org.joda.time.DateTimeZone;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.zone.ZoneOffsetTransition;
+import java.time.zone.ZoneRules;
+import java.util.Objects;
+
+public class JdkBasedDateTimeZone
+        extends DateTimeZone
+{
+    private final ZoneRules zoneRules;
+
+    public JdkBasedDateTimeZone(String zoneId)
+    {
+        super(zoneId);
+        this.zoneRules = ZoneId.of(zoneId).getRules();
+    }
+
+    @Override
+    public String getNameKey(long instant)
+    {
+        // It is ok to return a dummy value here.
+        // getNameKey is used in 6 instances in Joda
+        // * `DateTimeZone.getShortName`. Assuming DefaultNameProvider is being used,
+        //   it then invokes `DefaultNameProvider.getShortName`, which in turn invokes
+        //   `DefaultNameProvider.getNameSet`, which ignores the passed in nameKey,
+        //   other than validating that it's not null.
+        // * `DateTimeZone.getName`. Same as above.
+        // * `CachedDateTimeZone.Info.getNameKey`. It is used to implement getNameKey.
+        // * `DateTimeZoneBuilder.PrecalculatedZone.getNameKey`. Same as above.
+        // * `DateTimeZoneBuilder.writeTo`. It only uses getNameKey when the object
+        //   is an instance of `FixedDateTimeZone`.
+        // * `ZoneInfoCompiler.test`. It's only invoked with built-in implementations
+        //   of `DateTimeZone`.
+
+        // Use an obviously incorrect and easily searchable value here
+        return "presto-name-key-not-provided";
+    }
+
+    @Override
+    public int getOffset(long instant)
+    {
+        return zoneRules.getOffset(Instant.ofEpochMilli(instant)).getTotalSeconds() * 1000;
+    }
+
+    @Override
+    public int getStandardOffset(long instant)
+    {
+        return zoneRules.getStandardOffset(Instant.ofEpochMilli(instant)).getTotalSeconds() * 1000;
+    }
+
+    @Override
+    public boolean isFixed()
+    {
+        return zoneRules.isFixedOffset();
+    }
+
+    @Override
+    public long nextTransition(long instant)
+    {
+        ZoneOffsetTransition nextTransition = zoneRules.nextTransition(Instant.ofEpochMilli(instant));
+        if (nextTransition == null) {
+            // this is after the last transition
+            return instant;
+        }
+        return nextTransition.toEpochSecond() * 1000;
+    }
+
+    @Override
+    public long previousTransition(long instant)
+    {
+        // +1 and -1 is necessary here because java.time API expects/returns ......00000 for previousTransition,
+        // whereas joda API expects/returns ......99999 for previousTransition.
+        // This adjustment is only needed for previousTransition because both expects/returns ......00000 for nextTransitions.
+        ZoneOffsetTransition previousTransition = zoneRules.previousTransition(Instant.ofEpochMilli(instant + 1));
+        if (previousTransition == null) {
+            // this is before the first transition
+            return instant;
+        }
+        return previousTransition.toEpochSecond() * 1000 - 1;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        JdkBasedDateTimeZone that = (JdkBasedDateTimeZone) o;
+        return Objects.equals(getID(), that.getID());
+    }
+
+    @Override
+    public int hashCode()
+    {
+        // Same as super.hashCode. Overridden here explicitly for code readability, and in case of code changes in super.
+        return 57 + getID().hashCode();
+    }
+}

--- a/joda-to-java-time-bridge/src/main/java/io/airlift/jaxrs/jodabridge/JdkBasedZoneInfoProvider.java
+++ b/joda-to-java-time-bridge/src/main/java/io/airlift/jaxrs/jodabridge/JdkBasedZoneInfoProvider.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.airlift.jaxrs.jodabridge;
+
+import com.google.common.collect.ImmutableMap;
+import org.joda.time.DateTimeZone;
+import org.joda.time.tz.CachedDateTimeZone;
+import org.joda.time.tz.Provider;
+
+import java.time.zone.ZoneRulesProvider;
+import java.util.Map;
+import java.util.Set;
+
+import static com.google.common.base.Verify.verify;
+
+public class JdkBasedZoneInfoProvider
+        implements Provider
+{
+    private static final Map<String, DateTimeZone> zones;
+
+    static {
+        ImmutableMap.Builder<String, DateTimeZone> zonesBuilder = ImmutableMap.builder();
+
+        for (String zoneId : ZoneRulesProvider.getAvailableZoneIds()) {
+            DateTimeZone zone;
+            if (zoneId.equals("UTC")) {
+                // Joda requires that this particular zone implementation be used for UTC.
+                zone = DateTimeZone.UTC;
+                verify(zone.isFixed());
+            }
+            else {
+                zone = new JdkBasedDateTimeZone(zoneId);
+            }
+            if (!zone.isFixed()) {
+                // Joda's default Provider implementation, ZoneInfoProvider, caches a zone
+                // most of the time if the zone is not fixed. The exception being zones that
+                // isn't worthwhile from a performance perspective. The actual check is in
+                // `DateTimeZoneBuilder.isCachable` check (a zone would fail if on average
+                // it has a transition less than every 25 days).
+                // This implementation caches everything for simplicity.
+                zone = CachedDateTimeZone.forZone(zone);
+            }
+            zonesBuilder.put(zoneId, zone);
+        }
+
+        zones = zonesBuilder.build();
+    }
+
+    @Override
+    public DateTimeZone getZone(String id)
+    {
+        if (id.startsWith("+") || id.startsWith("-")) {
+            // DateTimeZone.forID takes care of this case after this method returns null
+            return null;
+        }
+        return zones.get(id);
+    }
+
+    @Override
+    public Set<String> getAvailableIDs()
+    {
+        return ZoneRulesProvider.getAvailableZoneIds();
+    }
+
+    public static void registerAsJodaZoneInfoProvider()
+    {
+        // An alternative way of registering this Provider is by calling `DateTimeZone.setProvider`.
+        // However, that way, it won't be possible to tell whether any one has used DateTimeZone before this method is invoked.
+        // Setting it through the system property allows one to validate that.
+        System.setProperty("org.joda.time.DateTimeZone.Provider", JdkBasedZoneInfoProvider.class.getName());
+        if (!(DateTimeZone.getProvider() instanceof JdkBasedZoneInfoProvider)) {
+            throw new RuntimeException("This method must be invoked before any use of Joda");
+        }
+    }
+}

--- a/joda-to-java-time-bridge/src/test/java/io/airlift/jaxrs/testing/TestJdkBasedZoneInfoProvider.java
+++ b/joda-to-java-time-bridge/src/test/java/io/airlift/jaxrs/testing/TestJdkBasedZoneInfoProvider.java
@@ -1,0 +1,239 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.airlift.jaxrs.testing;
+
+import io.airlift.jaxrs.jodabridge.JdkBasedZoneInfoProvider;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.IllegalInstantException;
+import org.joda.time.LocalDateTime;
+import org.joda.time.format.DateTimeFormat;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+public class TestJdkBasedZoneInfoProvider
+{
+    @BeforeClass
+    protected void validateJodaZoneInfoProvider()
+    {
+        try {
+            JdkBasedZoneInfoProvider.registerAsJodaZoneInfoProvider();
+        }
+        catch (RuntimeException e) {
+            throw new RuntimeException("Set the following system property to JVM running the test: -Dorg.joda.time.DateTimeZone.Provider=com.facebook.presto.tz.JdkBasedZoneInfoProvider");
+        }
+    }
+
+    @Test
+    public void test()
+    {
+        // This test puts extra focus on zone names because of how JdkBasedDateTimeZone.getNameKey is implemented.
+
+        DateTime dateTimePST = new DateTime(2018, 1, 1, 2, 30, DateTimeZone.forID("America/Los_Angeles"));
+        assertEquals(dateTimePST.toString(), "2018-01-01T02:30:00.000-08:00");
+        assertEquals(DateTimeFormat.fullDateTime().print(dateTimePST), "Monday, January 1, 2018 2:30:00 AM PST");
+        assertEquals(DateTimeFormat.forPattern("z',' zzzz',' Z',' ZZ',' ZZZ").print(dateTimePST), "PST, Pacific Standard Time, -0800, -08:00, America/Los_Angeles");
+        assertEquals(dateTimePST.plusMonths(6).toString(), "2018-07-01T02:30:00.000-07:00");
+
+        DateTime dateTimeUTC = new DateTime(2018, 1, 1, 2, 30, DateTimeZone.forID("UTC"));
+        assertEquals(dateTimeUTC.toString(), "2018-01-01T02:30:00.000Z");
+        assertEquals(DateTimeFormat.fullDateTime().print(dateTimeUTC), "Monday, January 1, 2018 2:30:00 AM UTC");
+        assertEquals(DateTimeFormat.forPattern("z',' zzzz',' Z',' ZZ',' ZZZ").print(dateTimeUTC), "UTC, Coordinated Universal Time, +0000, +00:00, UTC");
+        assertEquals(dateTimeUTC.plusMonths(6).toString(), "2018-07-01T02:30:00.000Z");
+
+        DateTime dateTimeOffset = new DateTime(2018, 1, 1, 2, 30, DateTimeZone.forOffsetHours(-8));
+        assertEquals(dateTimeOffset.toString(), "2018-01-01T02:30:00.000-08:00");
+        assertEquals(DateTimeFormat.fullDateTime().print(dateTimeOffset), "Monday, January 1, 2018 2:30:00 AM -08:00");
+        assertEquals(DateTimeFormat.forPattern("z',' zzzz',' Z',' ZZ',' ZZZ").print(dateTimeOffset), "-08:00, -08:00, -0800, -08:00, -08:00");
+        assertEquals(dateTimeOffset.plusMonths(6).toString(), "2018-07-01T02:30:00.000-08:00");
+
+        DateTime dateTimeWeird = new DateTime(2018, 1, 1, 2, 30, DateTimeZone.forID("+07:09"));
+        assertEquals(dateTimeWeird.toString(), "2018-01-01T02:30:00.000+07:09");
+        assertEquals(DateTimeFormat.fullDateTime().print(dateTimeWeird), "Monday, January 1, 2018 2:30:00 AM +07:09");
+        assertEquals(DateTimeFormat.forPattern("z',' zzzz',' Z',' ZZ',' ZZZ").print(dateTimeWeird), "+07:09, +07:09, +0709, +07:09, +07:09");
+        assertEquals(dateTimeWeird.plusMonths(6).toString(), "2018-07-01T02:30:00.000+07:09");
+    }
+
+    @Test
+    public void testEarlierInstantForLiteralInOverlaps()
+    {
+        // DateTime constructor behavior for overlaps is not documented in joda.
+        // In java.time, the corresponding method is documented to return the earlier instant.
+        // Nevertheless, the implemented behavior matches java.time.
+        // In addition, if the behavior changes, even though it is NOT a violation of contract in itself,
+        // a method that this constructor delegates likely violated its contract.
+
+        // overlap in Los_Angeles: 2013-11-3 1:00:00 to 1:59:59 repeats
+        DateTime dateTimeLosAngeles = new DateTime(2013, 11, 3, 1, 30, DateTimeZone.forID("America/Los_Angeles"));
+        assertEquals(dateTimeLosAngeles.minusHours(1).getHourOfDay(), 0);
+        assertEquals(dateTimeLosAngeles.plusHours(1).getHourOfDay(), 1);
+
+        // overlap in Berlin: 2013-10-27 2:00:00 to 2:59:59 repeats
+        DateTime dateTimeBerlin = new DateTime(2013, 10, 27, 2, 30, DateTimeZone.forID("Europe/Berlin"));
+        assertEquals(dateTimeBerlin.minusHours(1).getHourOfDay(), 1);
+        assertEquals(dateTimeBerlin.plusHours(1).getHourOfDay(), 2);
+    }
+
+    @Test
+    public void testFailureForLiteralInGaps()
+    {
+        // DateTime constructor behavior for gaps is not documented in joda.
+        // Nevertheless, the implemented behavior is throw.
+
+        try {
+            // gap in Los_Angeles: 2013-03-10 2:00:00 to 2:59:59 doesn't exist
+            new DateTime(2013, 3, 10, 2, 30, DateTimeZone.forID("America/Los_Angeles"));
+            fail("Expect IllegalInstantException");
+        }
+        catch (IllegalInstantException e) {
+            // do nothing
+        }
+
+        try {
+            // gap in Berlin: 2013-3-31 2:00:00 to 2:59:59 doesn't exist
+            new DateTime(2013, 3, 31, 2, 30, DateTimeZone.forID("Europe/Berlin"));
+            fail("Expect IllegalInstantException");
+        }
+        catch (IllegalInstantException e) {
+            // do nothing
+        }
+    }
+
+    @Test
+    public void testPrevNextTransition()
+    {
+        // This method tests previous/nextTransition directly because it's otherwise hard to catch off-by-1 errors.
+
+        // The exact behavior is not documented, but we must match behavior of joda implementation here.
+        // Otherwise testGetOffsetFromLocal fails.
+
+        // In this test:
+        // * Use java.time to calculate all the function inputs and expect results.
+        // * Use ofStrict to explicitly choose the earlier of latter one whenever in overlap.
+
+        DateTimeZone zoneLosAngeles = DateTimeZone.forID("America/Los_Angeles");
+        DateTimeZone zoneBerlin = DateTimeZone.forID("Europe/Berlin");
+
+        // gap in Los_Angeles: 2013-03-10 2:00:00 to 2:59:59 doesn't exist
+        assertEquals(
+                zoneLosAngeles.previousTransition(ZonedDateTime.of(2013, 3, 10, 1, 59, 59, 999_000_000, ZoneId.of("America/Los_Angeles")).toInstant().toEpochMilli()),
+                ZonedDateTime.ofStrict(java.time.LocalDateTime.of(2012, 11, 4, 1, 59, 59, 999_000_000), ZoneOffset.ofHours(-7), ZoneId.of("America/Los_Angeles")).toInstant().toEpochMilli());
+        assertEquals(
+                zoneLosAngeles.previousTransition(ZonedDateTime.of(2013, 3, 10, 3, 0, 0, 0, ZoneId.of("America/Los_Angeles")).toInstant().toEpochMilli()),
+                ZonedDateTime.of(2013, 3, 10, 1, 59, 59, 999_000_000, ZoneId.of("America/Los_Angeles")).toInstant().toEpochMilli());
+        assertEquals(
+                zoneLosAngeles.nextTransition(ZonedDateTime.of(2013, 3, 10, 1, 59, 59, 999_000_000, ZoneId.of("America/Los_Angeles")).toInstant().toEpochMilli()),
+                ZonedDateTime.of(2013, 3, 10, 3, 0, 0, 0, ZoneId.of("America/Los_Angeles")).toInstant().toEpochMilli());
+        assertEquals(
+                zoneLosAngeles.nextTransition(ZonedDateTime.of(2013, 3, 10, 3, 0, 0, 0, ZoneId.of("America/Los_Angeles")).toInstant().toEpochMilli()),
+                ZonedDateTime.ofStrict(java.time.LocalDateTime.of(2013, 11, 3, 1, 0, 0, 0), ZoneOffset.ofHours(-8), ZoneId.of("America/Los_Angeles")).toInstant().toEpochMilli());
+
+        // overlap in Los_Angeles: 2013-11-3 1:00:00 to 1:59:59 repeats
+        assertEquals(
+                zoneLosAngeles.previousTransition(ZonedDateTime.ofStrict(java.time.LocalDateTime.of(2013, 11, 3, 1, 59, 59, 999_000_000), ZoneOffset.ofHours(-7), ZoneId.of("America/Los_Angeles")).toInstant().toEpochMilli()),
+                ZonedDateTime.of(2013, 3, 10, 1, 59, 59, 999_000_000, ZoneId.of("America/Los_Angeles")).toInstant().toEpochMilli());
+        assertEquals(
+                zoneLosAngeles.previousTransition(ZonedDateTime.of(2013, 11, 3, 2, 0, 0, 0, ZoneId.of("America/Los_Angeles")).toInstant().toEpochMilli()),
+                ZonedDateTime.ofStrict(java.time.LocalDateTime.of(2013, 11, 3, 1, 59, 59, 999_000_000), ZoneOffset.ofHours(-7), ZoneId.of("America/Los_Angeles")).toInstant().toEpochMilli());
+        assertEquals(
+                zoneLosAngeles.nextTransition(ZonedDateTime.ofStrict(java.time.LocalDateTime.of(2013, 11, 3, 1, 59, 59, 999_000_000), ZoneOffset.ofHours(-7), ZoneId.of("America/Los_Angeles")).toInstant().toEpochMilli()),
+                ZonedDateTime.ofStrict(java.time.LocalDateTime.of(2013, 11, 3, 1, 0, 0, 0), ZoneOffset.ofHours(-8), ZoneId.of("America/Los_Angeles")).toInstant().toEpochMilli());
+        assertEquals(
+                zoneLosAngeles.nextTransition(ZonedDateTime.ofStrict(java.time.LocalDateTime.of(2013, 11, 3, 1, 0, 0, 0), ZoneOffset.ofHours(-8), ZoneId.of("America/Los_Angeles")).toInstant().toEpochMilli()),
+                ZonedDateTime.of(java.time.LocalDateTime.of(2014, 3, 9, 3, 0, 0, 0), ZoneId.of("America/Los_Angeles")).toInstant().toEpochMilli());
+
+        // gap in Berlin: 2013-3-31 2:00:00 to 2:59:59 doesn't exist
+        assertEquals(
+                zoneBerlin.previousTransition(ZonedDateTime.of(2013, 3, 31, 1, 59, 59, 999_000_000, ZoneId.of("Europe/Berlin")).toInstant().toEpochMilli()),
+                ZonedDateTime.ofStrict(java.time.LocalDateTime.of(2012, 10, 28, 2, 59, 59, 999_000_000), ZoneOffset.ofHours(2), ZoneId.of("Europe/Berlin")).toInstant().toEpochMilli());
+        assertEquals(
+                zoneBerlin.previousTransition(ZonedDateTime.of(2013, 3, 31, 3, 0, 0, 0, ZoneId.of("Europe/Berlin")).toInstant().toEpochMilli()),
+                ZonedDateTime.of(2013, 3, 31, 1, 59, 59, 999_000_000, ZoneId.of("Europe/Berlin")).toInstant().toEpochMilli());
+        assertEquals(
+                zoneBerlin.nextTransition(ZonedDateTime.of(2013, 3, 31, 1, 59, 59, 999_000_000, ZoneId.of("Europe/Berlin")).toInstant().toEpochMilli()),
+                ZonedDateTime.of(2013, 3, 31, 3, 0, 0, 0, ZoneId.of("Europe/Berlin")).toInstant().toEpochMilli());
+        assertEquals(
+                zoneBerlin.nextTransition(ZonedDateTime.of(2013, 3, 31, 3, 0, 0, 0, ZoneId.of("Europe/Berlin")).toInstant().toEpochMilli()),
+                ZonedDateTime.ofStrict(java.time.LocalDateTime.of(2013, 10, 27, 2, 0, 0, 0), ZoneOffset.ofHours(1), ZoneId.of("Europe/Berlin")).toInstant().toEpochMilli());
+
+        // overlap in Berlin: 2013-10-27 2:00:00 to 2:59:59 repeats
+        assertEquals(
+                zoneBerlin.previousTransition(ZonedDateTime.ofStrict(java.time.LocalDateTime.of(2013, 10, 27, 2, 59, 59, 999_000_000), ZoneOffset.ofHours(2), ZoneId.of("Europe/Berlin")).toInstant().toEpochMilli()),
+                ZonedDateTime.of(2013, 3, 31, 1, 59, 59, 999_000_000, ZoneId.of("Europe/Berlin")).toInstant().toEpochMilli());
+        assertEquals(
+                zoneBerlin.previousTransition(ZonedDateTime.of(2013, 10, 27, 3, 0, 0, 0, ZoneId.of("Europe/Berlin")).toInstant().toEpochMilli()),
+                ZonedDateTime.ofStrict(java.time.LocalDateTime.of(2013, 10, 27, 2, 59, 59, 999_000_000), ZoneOffset.ofHours(2), ZoneId.of("Europe/Berlin")).toInstant().toEpochMilli());
+        assertEquals(
+                zoneBerlin.nextTransition(ZonedDateTime.ofStrict(java.time.LocalDateTime.of(2013, 10, 27, 2, 59, 59, 999_000_000), ZoneOffset.ofHours(2), ZoneId.of("Europe/Berlin")).toInstant().toEpochMilli()),
+                ZonedDateTime.ofStrict(java.time.LocalDateTime.of(2013, 10, 27, 2, 0, 0, 0), ZoneOffset.ofHours(1), ZoneId.of("Europe/Berlin")).toInstant().toEpochMilli());
+        assertEquals(
+                zoneBerlin.nextTransition(ZonedDateTime.ofStrict(java.time.LocalDateTime.of(2013, 10, 27, 2, 0, 0, 0), ZoneOffset.ofHours(1), ZoneId.of("Europe/Berlin")).toInstant().toEpochMilli()),
+                ZonedDateTime.of(2014, 3, 30, 3, 0, 0, 0, ZoneId.of("Europe/Berlin")).toInstant().toEpochMilli());
+    }
+
+    @Test
+    public void testGetOffsetFromLocal()
+    {
+        // getOffsetFromLocal is documented to return
+        // * the "summer" offset for overlaps
+        // * the "winter" offset for gaps
+
+        DateTimeZone zoneLosAngeles = DateTimeZone.forID("America/Los_Angeles");
+        // gap in Los_Angeles: 2013-03-10 2:00:00 to 2:59:59 doesn't exist
+        assertEquals(zoneLosAngeles.getOffsetFromLocal(new LocalDateTime(2013, 3, 10, 2, 30).toDateTime(DateTimeZone.UTC).toInstant().getMillis()), -8 * 3_600_000);
+        // overlap in Los_Angeles: 2013-11-3 1:00:00 to 1:59:59 repeats
+        assertEquals(zoneLosAngeles.getOffsetFromLocal(new LocalDateTime(2013, 11, 3, 1, 30).toDateTime(DateTimeZone.UTC).toInstant().getMillis()), -7 * 3_600_000);
+
+        DateTimeZone zoneBerlin = DateTimeZone.forID("Europe/Berlin");
+        // gap in Berlin: 2013-3-31 2:00:00 to 2:59:59 doesn't exist
+        assertEquals(zoneBerlin.getOffsetFromLocal(new LocalDateTime(2013, 3, 31, 2, 30).toDateTime(DateTimeZone.UTC).toInstant().getMillis()), 3_600_000);
+        // overlap in Berlin: 2013-10-27 2:00:00 to 2:59:59 repeats
+        assertEquals(zoneBerlin.getOffsetFromLocal(new LocalDateTime(2013, 10, 27, 2, 30).toDateTime(DateTimeZone.UTC).toInstant().getMillis()), 2 * 3_600_000);
+    }
+
+    @Test
+    public void testInstantiationOfAllZones()
+    {
+        DateTimeZone.forID("-13:00");
+
+        for (String zoneId : ZoneId.getAvailableZoneIds()) {
+            if (zoneId.startsWith("Etc/") || zoneId.startsWith("GMT") || zoneId.startsWith("SystemV/")) {
+                continue;
+            }
+
+            if (zoneId.equals("Canada/East-Saskatchewan")) {
+                // Removed from tzdata since 2017c.
+                // Java updated to 2017c since 8u161, 9.0.4.
+                // All Java 10+ are on later versions
+                continue;
+            }
+
+            DateTimeZone.forID(zoneId);
+        }
+
+        for (int offsetHours = -13; offsetHours < 14; offsetHours++) {
+            for (int offsetMinutes = 0; offsetMinutes < 60; offsetMinutes++) {
+                DateTimeZone.forOffsetHoursMinutes(offsetHours, offsetMinutes);
+            }
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
         <module>http-server</module>
         <module>jaxrs</module>
         <module>jaxrs-testing</module>
+        <module>joda-to-java-time-bridge</module>
         <module>jmx-http-rpc</module>
         <module>jmx-http</module>
         <module>jmx</module>


### PR DESCRIPTION
Mixed use of joda and java.time results in two different versions of
tzdata being used at the same time. This inconsistencies can often
lead to result that is incorrect in any tzdata version. For example,
operations as simple as casting a string representation of zoned
date time to unixtime and back will not roundtrip.

This modules make it possible to mix usage of joda and java.time
without the above problem. Implementation wise, it makes joda
delegate to java.time for tz rules.

It is expected to work with any reasonable version of joda.