### PR TITLE
Allow custom content listener in HttpClient.executeAsync

### DIFF
--- a/http-client/src/main/java/io/airlift/http/client/HttpClient.java
+++ b/http-client/src/main/java/io/airlift/http/client/HttpClient.java
@@ -29,6 +29,8 @@ public interface HttpClient
 
     <T, E extends Exception> HttpResponseFuture<T> executeAsync(Request request, ResponseHandler<T, E> responseHandler);
 
+    <T, E extends Exception> HttpResponseFuture<T> executeAsync(Request request, ResponseHandler<T, E> responseHandler, ResponseListener responseListener);
+
     RequestStats getStats();
 
     long getMaxContentLength();

--- a/http-client/src/main/java/io/airlift/http/client/ResponseListener.java
+++ b/http-client/src/main/java/io/airlift/http/client/ResponseListener.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.http.client;
+
+import com.google.common.annotations.Beta;
+
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+
+@Beta
+public interface ResponseListener
+{
+    void onContent(ByteBuffer content);
+
+    InputStream onComplete();
+}

--- a/http-client/src/main/java/io/airlift/http/client/jetty/BufferingResponseListener.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/BufferingResponseListener.java
@@ -1,35 +1,29 @@
 package io.airlift.http.client.jetty;
 
 import io.airlift.http.client.GatheringByteArrayInputStream;
-import io.airlift.http.client.ResponseTooLargeException;
+import io.airlift.http.client.ResponseListener;
 import io.airlift.units.DataSize;
-import org.eclipse.jetty.client.api.Response;
-import org.eclipse.jetty.client.api.Result;
-import org.eclipse.jetty.http.HttpHeader;
 
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
+import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static io.airlift.units.DataSize.Unit.KILOBYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
-import static java.util.Objects.requireNonNull;
 
 @ThreadSafe
 class BufferingResponseListener
-        extends Response.Listener.Adapter
+        implements ResponseListener
 {
     private static final long BUFFER_MAX_BYTES = new DataSize(1, MEGABYTE).toBytes();
     private static final long BUFFER_MIN_BYTES = new DataSize(1, KILOBYTE).toBytes();
-    private final JettyResponseFuture<?, ?> future;
-    private final int maxLength;
 
     @GuardedBy("this")
     private byte[] currentBuffer = new byte[0];
@@ -40,31 +34,15 @@ class BufferingResponseListener
     @GuardedBy("this")
     private long size;
 
-    public BufferingResponseListener(JettyResponseFuture<?, ?> future, int maxLength)
+    public BufferingResponseListener()
     {
-        this.future = requireNonNull(future, "future is null");
-        checkArgument(maxLength > 0, "maxLength must be greater than zero");
-        this.maxLength = maxLength;
     }
 
     @Override
-    public synchronized void onHeaders(Response response)
-    {
-        long length = response.getHeaders().getLongField(HttpHeader.CONTENT_LENGTH.asString());
-        if (length > maxLength) {
-            response.abort(new ResponseTooLargeException());
-        }
-    }
-
-    @Override
-    public synchronized void onContent(Response response, ByteBuffer content)
+    public synchronized void onContent(ByteBuffer content)
     {
         int length = content.remaining();
         size += length;
-        if (size > maxLength) {
-            response.abort(new ResponseTooLargeException());
-            return;
-        }
 
         while (length > 0) {
             if (currentBufferPosition >= currentBuffer.length) {
@@ -78,25 +56,14 @@ class BufferingResponseListener
     }
 
     @Override
-    public synchronized void onComplete(Result result)
+    public synchronized InputStream onComplete()
     {
-        Throwable throwable = result.getFailure();
-        if (throwable != null) {
-            future.failed(throwable);
-        }
-        else {
-            currentBuffer = new byte[0];
-            currentBufferPosition = 0;
-            future.completed(result.getResponse(), new GatheringByteArrayInputStream(buffers, size));
-            buffers = new ArrayList<>();
-            size = 0;
-        }
+        return new GatheringByteArrayInputStream(buffers, size);
     }
 
     private synchronized void allocateCurrentBuffer()
     {
         checkState(currentBufferPosition >= currentBuffer.length, "there is still remaining space in currentBuffer");
-
         currentBuffer = new byte[(int) min(BUFFER_MAX_BYTES, max(2 * currentBuffer.length, BUFFER_MIN_BYTES))];
         buffers.add(currentBuffer);
         currentBufferPosition = 0;

--- a/http-client/src/main/java/io/airlift/http/client/jetty/DelegatingResponseListener.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/DelegatingResponseListener.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.http.client.jetty;
+
+import io.airlift.http.client.ResponseListener;
+import io.airlift.http.client.ResponseTooLargeException;
+import org.eclipse.jetty.client.api.Response;
+import org.eclipse.jetty.client.api.Result;
+import org.eclipse.jetty.http.HttpHeader;
+
+import javax.annotation.concurrent.GuardedBy;
+
+import java.nio.ByteBuffer;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public class DelegatingResponseListener
+        extends Response.Listener.Adapter
+{
+    private final JettyResponseFuture<?, ?> future;
+    private final int maxLength;
+    private final ResponseListener delegate;
+
+    @GuardedBy("this")
+    private long size;
+
+    public DelegatingResponseListener(JettyResponseFuture<?, ?> future, int maxLength, ResponseListener delegate)
+    {
+        this.future = requireNonNull(future, "future is null");
+        checkArgument(maxLength > 0, "maxLength must be greater than zero");
+        this.maxLength = maxLength;
+        this.delegate = requireNonNull(delegate, "delegate is null");
+    }
+
+    @Override
+    public synchronized void onHeaders(Response response)
+    {
+        long length = response.getHeaders().getLongField(HttpHeader.CONTENT_LENGTH.asString());
+        if (length > maxLength) {
+            response.abort(new ResponseTooLargeException());
+        }
+    }
+
+    @Override
+    public synchronized void onContent(Response response, ByteBuffer content)
+    {
+        int length = content.remaining();
+        size += length;
+        if (size > maxLength) {
+            response.abort(new ResponseTooLargeException());
+            return;
+        }
+
+        delegate.onContent(content);
+    }
+
+    @Override
+    public synchronized void onComplete(Result result)
+    {
+        Throwable throwable = result.getFailure();
+        if (throwable != null) {
+            future.failed(throwable);
+        }
+        else {
+            future.completed(result.getResponse(), delegate.onComplete());
+            size = 0;
+        }
+    }
+}

--- a/http-client/src/main/java/io/airlift/http/client/testing/TestingHttpClient.java
+++ b/http-client/src/main/java/io/airlift/http/client/testing/TestingHttpClient.java
@@ -9,6 +9,7 @@ import io.airlift.http.client.Request;
 import io.airlift.http.client.RequestStats;
 import io.airlift.http.client.Response;
 import io.airlift.http.client.ResponseHandler;
+import io.airlift.http.client.ResponseListener;
 import io.airlift.units.Duration;
 
 import java.util.concurrent.ExecutorService;
@@ -39,6 +40,12 @@ public class TestingHttpClient
     {
         this.processor = requireNonNull(processor, "processor is null");
         this.executor = listeningDecorator(requireNonNull(executor, "executor is null"));
+    }
+
+    @Override
+    public <T, E extends Exception> HttpResponseFuture<T> executeAsync(Request request, ResponseHandler<T, E> responseHandler, ResponseListener responseListener)
+    {
+        throw new UnsupportedOperationException();
     }
 
     @Override


### PR DESCRIPTION
Extend HttpClient.executeAsync to allow callers to provide custom content listener. We'd like to use this to modify memory allocation currently happening in BufferingResponseListener.allocateCurrentBuffer to use shared pull of buffers to reduce GC activity.

CC: @oerling @nezihyigitbasi @tdcmeehan @elonazoulay @yingsu00 

@electrum @dain David, Dain, do you think this would be a reasonable addition?