### PR TITLE
Adding support for Jackson afterburner module

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 0.179
 
 - Update to BVal 2.0.0
+- Adding support for Jackson afterburner module
 
 0.178
 

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -15,6 +15,12 @@
     </properties>
 
     <dependencies>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
@@ -64,6 +70,11 @@
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-parameter-names</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-afterburner</artifactId>
         </dependency>
 
         <dependency>

--- a/json/src/main/java/io/airlift/json/JsonCodecConfig.java
+++ b/json/src/main/java/io/airlift/json/JsonCodecConfig.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.json;
+
+import io.airlift.configuration.Config;
+
+public class JsonCodecConfig
+{
+    private boolean includeAfterBurnerModule;
+
+    @Config("json.module.after-burner.enabled")
+    public JsonCodecConfig setIncludeAfterBurnerModule(boolean includeAfterBurnerModule)
+    {
+        this.includeAfterBurnerModule = includeAfterBurnerModule;
+        return this;
+    }
+
+    public boolean isIncludeAfterBurnerModule()
+    {
+        return includeAfterBurnerModule;
+    }
+}

--- a/json/src/main/java/io/airlift/json/JsonModule.java
+++ b/json/src/main/java/io/airlift/json/JsonModule.java
@@ -20,6 +20,8 @@ import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
 
+import static io.airlift.configuration.ConfigBinder.configBinder;
+
 public class JsonModule
         implements Module
 {
@@ -31,7 +33,7 @@ public class JsonModule
         // NOTE: this MUST NOT be a singleton because ObjectMappers are mutable.  This means
         // one component could reconfigure the mapper and break all other components
         binder.bind(ObjectMapper.class).toProvider(ObjectMapperProvider.class);
-
+        configBinder(binder).bindConfig(JsonCodecConfig.class);
         binder.bind(JsonCodecFactory.class).in(Scopes.SINGLETON);
     }
 }

--- a/json/src/main/java/io/airlift/json/ObjectMapperProvider.java
+++ b/json/src/main/java/io/airlift/json/ObjectMapperProvider.java
@@ -31,6 +31,7 @@ import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
@@ -57,12 +58,17 @@ public class ObjectMapperProvider
     private final Set<Module> modules = new HashSet<>();
 
     @Inject
-    public ObjectMapperProvider()
+    public ObjectMapperProvider(JsonCodecConfig config)
     {
-        this(new JsonFactory());
+        this(new JsonFactory(), config.isIncludeAfterBurnerModule());
     }
 
-    public ObjectMapperProvider(JsonFactory jsonFactory)
+    public ObjectMapperProvider()
+    {
+        this(new JsonFactory(), false);
+    }
+
+    public ObjectMapperProvider(JsonFactory jsonFactory, boolean includeAfterBurnerModule)
     {
         this.jsonFactory = requireNonNull(jsonFactory, "jsonFactory is null");
 
@@ -76,6 +82,10 @@ public class ObjectMapperProvider
             modules.add(new JodaModule());
         }
         catch (ClassNotFoundException ignored) {
+        }
+
+        if (includeAfterBurnerModule) {
+            modules.add(new AfterburnerModule());
         }
     }
 

--- a/json/src/test/java/io/airlift/json/TestJsonCodecConfig.java
+++ b/json/src/test/java/io/airlift/json/TestJsonCodecConfig.java
@@ -1,0 +1,29 @@
+package io.airlift.json;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.configuration.testing.ConfigAssertions;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+public class TestJsonCodecConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(JsonCodecConfig.class)
+                .setIncludeAfterBurnerModule(false));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("json.module.after-burner.enabled", "true")
+                .build();
+
+        JsonCodecConfig expected = new JsonCodecConfig()
+                .setIncludeAfterBurnerModule(true);
+        ConfigAssertions.assertFullMapping(properties, expected);
+    }
+}

--- a/json/src/test/java/io/airlift/json/TestJsonModule.java
+++ b/json/src/test/java/io/airlift/json/TestJsonModule.java
@@ -29,9 +29,12 @@ import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import io.airlift.configuration.ConfigurationFactory;
+import io.airlift.configuration.ConfigurationModule;
 import org.joda.time.DateTime;
 import org.joda.time.format.ISODateTimeFormat;
 import org.testng.annotations.BeforeClass;
@@ -64,7 +67,10 @@ public class TestJsonModule
     public void setUp()
             throws Exception
     {
-        Injector injector = Guice.createInjector(new JsonModule(),
+        ConfigurationFactory configurationFactory = new ConfigurationFactory(ImmutableMap.of());
+        Injector injector = Guice.createInjector(
+                new JsonModule(),
+                new ConfigurationModule(configurationFactory),
                 binder -> {
                     jsonBinder(binder).addSerializerBinding(SuperDuperNameList.class).toInstance(ToStringSerializer.instance);
                     jsonBinder(binder).addDeserializerBinding(SuperDuperNameList.class).to(SuperDuperNameListDeserializer.class);
@@ -76,7 +82,11 @@ public class TestJsonModule
     public void testJsonCodecFactoryBinding()
             throws Exception
     {
-        Injector injector = Guice.createInjector(new JsonModule());
+        ConfigurationFactory configurationFactory = new ConfigurationFactory(ImmutableMap.of());
+
+        Injector injector = Guice.createInjector(
+                new JsonModule(),
+                new ConfigurationModule(configurationFactory));
         JsonCodecFactory codecFactory = injector.getInstance(JsonCodecFactory.class);
 
         Person.validatePersonJsonCodec(codecFactory.jsonCodec(Person.class));

--- a/json/src/test/java/io/airlift/json/TestObjectMapperProvider.java
+++ b/json/src/test/java/io/airlift/json/TestObjectMapperProvider.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.json;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.testng.annotations.Test;
+
+import java.util.Objects;
+import java.util.Set;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestObjectMapperProvider
+{
+    @Test
+    public void testAfterburnerIncluded()
+            throws Exception
+    {
+        JsonCodecConfig config = new JsonCodecConfig()
+                .setIncludeAfterBurnerModule(true);
+
+        ObjectMapperProvider objectMapperProvider = new ObjectMapperProvider(config);
+        Set<Object> registeredModuleIds = objectMapperProvider.get().getRegisteredModuleIds();
+        boolean afterBurnerModuleIncluded = false;
+        for (Object registeredModuleId : registeredModuleIds) {
+            if (registeredModuleId.equals("com.fasterxml.jackson.module.afterburner.AfterburnerModule")) {
+                afterBurnerModuleIncluded = true;
+            }
+        }
+        assertTrue(afterBurnerModuleIncluded);
+    }
+
+    @Test
+    public void testAfterburnerCodec()
+            throws Exception
+    {
+        JsonCodecConfig config = new JsonCodecConfig()
+                .setIncludeAfterBurnerModule(true);
+
+        ObjectMapperProvider objectMapperProvider = new ObjectMapperProvider(config);
+        DummyClass dummyClass = new DummyClass().setVal1("val1").setVal2(100);
+        ObjectMapper objectMapper = objectMapperProvider.get();
+        assertEquals(dummyClass, dummyClass);
+        String json = objectMapper.writeValueAsString(dummyClass);
+        DummyClass actual = objectMapper.readValue(json, DummyClass.class);
+        assertEquals(actual, dummyClass);
+    }
+
+    public static class DummyClass
+    {
+        // These fields are public to make sure that Jackson is ignoring them
+        public String val1;
+        public int val2;
+
+        @JsonProperty
+        public String getVal1()
+        {
+            return val1;
+        }
+
+        @JsonProperty
+        public DummyClass setVal1(String val1)
+        {
+            this.val1 = val1;
+            return this;
+        }
+
+        @JsonProperty
+        public int getVal2()
+        {
+            return val2;
+        }
+
+        @JsonProperty
+        public DummyClass setVal2(int val2)
+        {
+            this.val2 = val2;
+            return this;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            DummyClass that = (DummyClass) o;
+            return val2 == that.val2 &&
+                    Objects.equals(val1, that.val1);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(val1, val2);
+        }
+    }
+}

--- a/json/src/test/java/io/airlift/json/isolated/TestJsonCodecBinder.java
+++ b/json/src/test/java/io/airlift/json/isolated/TestJsonCodecBinder.java
@@ -15,8 +15,11 @@
  */
 package io.airlift.json.isolated;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import io.airlift.configuration.ConfigurationFactory;
+import io.airlift.configuration.ConfigurationModule;
 import io.airlift.json.JsonCodec;
 import io.airlift.json.JsonCodecBinder;
 import io.airlift.json.JsonModule;
@@ -44,7 +47,11 @@ public class TestJsonCodecBinder
     public void test()
             throws Exception
     {
-        Injector injector = Guice.createInjector(new JsonModule(),
+        ConfigurationFactory configurationFactory = new ConfigurationFactory(ImmutableMap.of());
+
+        Injector injector = Guice.createInjector(
+                new JsonModule(),
+                new ConfigurationModule(configurationFactory),
                 binder -> {
                     JsonCodecBinder codecBinder = jsonCodecBinder(binder);
                     codecBinder.bindJsonCodec(Person.class);

--- a/pom.xml
+++ b/pom.xml
@@ -222,6 +222,12 @@
             </dependency>
 
             <dependency>
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-afterburner</artifactId>
+                <version>${dep.jackson.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>io.airlift</groupId>
                 <artifactId>units</artifactId>
                 <version>1.0</version>


### PR DESCRIPTION
Support for Jackson afterburner is added with optional class filter.
Filter can be used for incompatible classes.