### PR TITLE
Add future callback overloads with executor

### DIFF
--- a/concurrent/src/main/java/io/airlift/concurrent/MoreFutures.java
+++ b/concurrent/src/main/java/io/airlift/concurrent/MoreFutures.java
@@ -19,6 +19,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -493,7 +494,19 @@ public final class MoreFutures
         return future;
     }
 
+    /**
+     * Invokes the callback if the future completes successfully. Note, this uses the direct
+     * executor, so the callback should not be resource intensive.
+     */
     public static <T> void addSuccessCallback(ListenableFuture<T> future, Consumer<T> successCallback)
+    {
+        addSuccessCallback(future, successCallback, directExecutor());
+    }
+
+    /**
+     * Invokes the callback, using the specified executor, if the future completes successfully.
+     */
+    public static <T> void addSuccessCallback(ListenableFuture<T> future, Consumer<T> successCallback, Executor executor)
     {
         requireNonNull(future, "future is null");
         requireNonNull(successCallback, "successCallback is null");
@@ -509,17 +522,41 @@ public final class MoreFutures
             @Override
             public void onFailure(Throwable t) {}
         };
-        Futures.addCallback(future, callback, directExecutor());
+        Futures.addCallback(future, callback, executor);
     }
 
+    /**
+     * Invokes the callback if the future completes successfully. Note, this uses the direct
+     * executor, so the callback should not be resource intensive.
+     */
     public static <T> void addSuccessCallback(ListenableFuture<T> future, Runnable successCallback)
+    {
+        addSuccessCallback(future, successCallback, directExecutor());
+    }
+
+    /**
+     * Invokes the callback, using the specified executor, if the future completes successfully.
+     */
+    public static <T> void addSuccessCallback(ListenableFuture<T> future, Runnable successCallback, Executor executor)
     {
         requireNonNull(successCallback, "successCallback is null");
 
-        addSuccessCallback(future, t -> successCallback.run());
+        addSuccessCallback(future, t -> successCallback.run(), executor);
     }
 
+    /**
+     * Invokes the callback if the future fails. Note, this uses the direct
+     * executor, so the callback should not be resource intensive.
+     */
     public static <T> void addExceptionCallback(ListenableFuture<T> future, Consumer<Throwable> exceptionCallback)
+    {
+        addExceptionCallback(future, exceptionCallback, directExecutor());
+    }
+
+    /**
+     * Invokes the callback, using the specified executor, if the future fails.
+     */
+    public static <T> void addExceptionCallback(ListenableFuture<T> future, Consumer<Throwable> exceptionCallback, Executor executor)
     {
         requireNonNull(future, "future is null");
         requireNonNull(exceptionCallback, "exceptionCallback is null");
@@ -535,14 +572,26 @@ public final class MoreFutures
                 exceptionCallback.accept(t);
             }
         };
-        Futures.addCallback(future, callback, directExecutor());
+        Futures.addCallback(future, callback, executor);
     }
 
+    /**
+     * Invokes the callback if the future fails. Note, this uses the direct
+     * executor, so the callback should not be resource intensive.
+     */
     public static <T> void addExceptionCallback(ListenableFuture<T> future, Runnable exceptionCallback)
+    {
+        addExceptionCallback(future, exceptionCallback, directExecutor());
+    }
+
+    /**
+     * Invokes the callback, using the specified executor, if the future fails.
+     */
+    public static <T> void addExceptionCallback(ListenableFuture<T> future, Runnable exceptionCallback, Executor executor)
     {
         requireNonNull(exceptionCallback, "exceptionCallback is null");
 
-        addExceptionCallback(future, t -> exceptionCallback.run());
+        addExceptionCallback(future, t -> exceptionCallback.run(), executor);
     }
 
     private static class UnmodifiableCompletableFuture<V>


### PR DESCRIPTION
Add overloaded versions of addSuccessCallback and addExceptionCallback that take an executor.