### PR TITLE
Expose IndexBitLength in HLL

### DIFF
--- a/stats/src/main/java/io/airlift/stats/cardinality/HyperLogLog.java
+++ b/stats/src/main/java/io/airlift/stats/cardinality/HyperLogLog.java
@@ -117,6 +117,11 @@ public class HyperLogLog
         instance = instance.toDense();
     }
 
+    public int getIndexBitLength()
+    {
+        return instance.getIndexBitLength();
+    }
+
     @VisibleForTesting
     void verify()
     {


### PR DESCRIPTION
Useful when merging HLLs so the bucket sizes can be compared, since it is not possibly to safely merge HLLs of different bucket sizing.

Needed for https://github.com/prestodb/presto/issues/12506