### PR TITLE
Make HyperLogLog indexBitLength more efficient

### DIFF
--- a/stats/src/main/java/io/airlift/stats/cardinality/Utils.java
+++ b/stats/src/main/java/io/airlift/stats/cardinality/Utils.java
@@ -44,7 +44,8 @@ final class Utils
     public static int indexBitLength(int numberOfBuckets)
     {
         Preconditions.checkArgument(isPowerOf2(numberOfBuckets), "numberOfBuckets must be a power of 2, actual: %s", numberOfBuckets);
-        return (int) (Math.log(numberOfBuckets) / Math.log(2));
+        // 2**N has N trailing zeros, and we've asserted numberOfBuckets == 2**N
+        return Integer.numberOfTrailingZeros(numberOfBuckets);
     }
 
     public static int numberOfBuckets(int indexBitLength)


### PR DESCRIPTION
Previously, it calculated the Log2 of an integer `n` known to be a power of
two by `(int) Log(n)/Log(2)`, which is two slow log ops, a float
division, and a cast.  This replaces it with `Integer.numberOfTrailingZeros(n)`,
which is one int machine instruction.