### PR TITLE
Handle PostConstruct and PreDestroy Exceptions in LifeCycleManager

### DIFF
--- a/bootstrap/src/main/java/io/airlift/bootstrap/LifeCycleManager.java
+++ b/bootstrap/src/main/java/io/airlift/bootstrap/LifeCycleManager.java
@@ -27,7 +27,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+
+import static java.lang.String.format;
 
 /**
  * Manages PostConstruct and PreDestroy life cycles
@@ -39,6 +42,16 @@ public final class LifeCycleManager
     private final Queue<Object> managedInstances = new ConcurrentLinkedQueue<>();
     private final LifeCycleMethodsMap methodsMap;
     private final AtomicReference<Thread> shutdownHook = new AtomicReference<>();
+
+    /**
+     * Provides a mechanism to handle exceptions raised from {@link PreDestroy} methods in
+     * whatever way makes the most sense. Implementations should not raise exceptions of
+     * their own
+     */
+    private interface LifeCycleStopFailureHandler
+    {
+        void handlePreDestroyException(Class<?> klass, Method method, Exception exception);
+    }
 
     private enum State
     {
@@ -52,10 +65,10 @@ public final class LifeCycleManager
     /**
      * @param managedInstances list of objects that have life cycle annotations
      * @param methodsMap existing or new methods map
-     * @throws Exception exceptions starting instances (depending on mode)
+     * @throws LifeCycleStartException exceptions starting instances (depending on mode)
      */
     public LifeCycleManager(List<Object> managedInstances, LifeCycleMethodsMap methodsMap)
-            throws Exception
+            throws LifeCycleStartException
     {
         this.methodsMap = (methodsMap != null) ? methodsMap : new LifeCycleMethodsMap();
         for (Object instance : managedInstances) {
@@ -74,15 +87,13 @@ public final class LifeCycleManager
     }
 
     /**
-     * Start the life cycle - all instances will have their {@link javax.annotation.PostConstruct} method(s) called
-     *
-     * @throws Exception errors
+     * Start the life cycle - all instances will have their {@link PostConstruct} method(s) called
      */
     public void start()
-            throws Exception
+            throws LifeCycleStartException
     {
         if (!state.compareAndSet(State.LATENT, State.STARTING)) {
-            throw new Exception("System already starting");
+            throw new LifeCycleStartException("System already starting");
         }
         log.info("Life cycle starting...");
 
@@ -110,11 +121,53 @@ public final class LifeCycleManager
 
     /**
      * Stop the life cycle - all instances will have their {@link javax.annotation.PreDestroy} method(s) called
+     * and any exceptions raised will be collected and thrown in a wrapped {@link LifeCycleStopException} as
+     * suppressed exceptions. Those failures will not be logged and are the responsibility of the caller to
+     * handle appropriately.
      *
-     * @throws Exception errors
+     * @throws LifeCycleStopException If any failure occurs during the clean up process
+     */
+    public void stopWithoutFailureLogging()
+            throws LifeCycleStopException
+    {
+        List<Exception> failures = new ArrayList<>();
+        stop((klass, method, exception) -> failures.add(exception));
+        if (!failures.isEmpty()) {
+            LifeCycleStopException stopException = new LifeCycleStopException();
+            for (Exception e : failures) {
+                stopException.addSuppressed(e);
+            }
+            throw stopException;
+        }
+    }
+
+    /**
+     * Stop the life cycle - all instances will have their {@link PreDestroy} method(s) called
+     * and any exceptions raised will be immediately logged. If any such exceptions occur, a single
+     * {@link LifeCycleStopException} will be raised at the end of processing which will <b>not</b>
+     * contain any reference to exceptions already logged.
+     *
+     * @throws LifeCycleStopException If any failure occurs during the clean up process
      */
     public void stop()
-            throws Exception
+            throws LifeCycleStopException
+    {
+        AtomicBoolean failure = new AtomicBoolean(false);
+        stop((klass, method, exception) -> {
+            failure.set(true);
+            log.error(exception, "Exception in PreDestroy method %s::%s()", klass.getName(), method.getName());
+        });
+
+        if (failure.get()) {
+            throw new LifeCycleStopException();
+        }
+    }
+
+    /**
+     * Stop the life cycle - all instances will have their {@link PreDestroy} method(s) called and any
+     * exceptions raised will be passed to the provided {@link LifeCycleStopFailureHandler} to collect.
+     */
+    private void stop(LifeCycleStopFailureHandler handler)
     {
         if (!state.compareAndSet(State.STARTED, State.STOPPING)) {
             return;
@@ -135,12 +188,7 @@ public final class LifeCycleManager
         Collections.reverse(reversedInstances);
 
         for (Object obj : reversedInstances) {
-            log.debug("Stopping %s", obj.getClass().getName());
-            LifeCycleMethods methods = methodsMap.get(obj.getClass());
-            for (Method preDestroy : methods.methodsFor(PreDestroy.class)) {
-                log.debug("\t%s()", preDestroy.getName());
-                preDestroy.invoke(obj);
-            }
+            stopInstance(obj, handler);
         }
 
         state.set(State.STOPPED);
@@ -151,10 +199,10 @@ public final class LifeCycleManager
      * Add an additional managed instance
      *
      * @param instance instance to add
-     * @throws Exception errors
+     * @throws LifeCycleStartException errors during {@link PostConstruct} method invocation
      */
     public void addInstance(Object instance)
-            throws Exception
+            throws LifeCycleStartException
     {
         State currentState = state.get();
         if ((currentState == State.STOPPING) || (currentState == State.STOPPED)) {
@@ -168,14 +216,49 @@ public final class LifeCycleManager
         }
     }
 
+    private void stopInstance(Object obj, LifeCycleStopFailureHandler handler)
+    {
+        log.debug("Stopping %s", obj.getClass().getName());
+        LifeCycleMethods methods = methodsMap.get(obj.getClass());
+        for (Method preDestroy : methods.methodsFor(PreDestroy.class)) {
+            log.debug("\t%s()", preDestroy.getName());
+            try {
+                preDestroy.invoke(obj);
+            }
+            catch (Exception e) {
+                handler.handlePreDestroyException(obj.getClass(), preDestroy, unwrapInvocationTargetException(e));
+            }
+        }
+    }
+
     private void startInstance(Object obj)
-            throws IllegalAccessException, InvocationTargetException
+            throws LifeCycleStartException
     {
         log.debug("Starting %s", obj.getClass().getName());
         LifeCycleMethods methods = methodsMap.get(obj.getClass());
         for (Method postConstruct : methods.methodsFor(PostConstruct.class)) {
             log.debug("\t%s()", postConstruct.getName());
-            postConstruct.invoke(obj);
+            try {
+                postConstruct.invoke(obj);
+            }
+            catch (Exception e) {
+                LifeCycleStartException failure = new LifeCycleStartException(
+                        format("Exception in PostConstruct method %s::%s()", obj.getClass().getName(), postConstruct.getName()),
+                        unwrapInvocationTargetException(e));
+                stopInstance(obj, (Class<?> klass, Method method, Exception exception) -> {
+                    String message = format("Exception in PreDestroy method %1$s::%2$s() after PostConstruct failure in %1$s::%3$s()", klass.getName(), method.getName(), postConstruct.getName());
+                    failure.addSuppressed(new RuntimeException(message, exception));
+                });
+                throw failure;
+            }
         }
+    }
+
+    /**
+     * Unwraps {@link InvocationTargetException} instances to their underlying cause, otherwise returns the provided Exception
+     */
+    private static Exception unwrapInvocationTargetException(Exception e)
+    {
+        return (e instanceof InvocationTargetException && e.getCause() instanceof Exception) ? (Exception) e.getCause() : e;
     }
 }

--- a/bootstrap/src/main/java/io/airlift/bootstrap/LifeCycleStartException.java
+++ b/bootstrap/src/main/java/io/airlift/bootstrap/LifeCycleStartException.java
@@ -1,0 +1,15 @@
+package io.airlift.bootstrap;
+
+public class LifeCycleStartException
+        extends RuntimeException
+{
+    public LifeCycleStartException(String message)
+    {
+        super(message);
+    }
+
+    public LifeCycleStartException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+}

--- a/bootstrap/src/main/java/io/airlift/bootstrap/LifeCycleStopException.java
+++ b/bootstrap/src/main/java/io/airlift/bootstrap/LifeCycleStopException.java
@@ -1,0 +1,10 @@
+package io.airlift.bootstrap;
+
+public class LifeCycleStopException
+        extends RuntimeException
+{
+    public LifeCycleStopException()
+    {
+        super("Exceptions occurred during lifecycle stop");
+    }
+}

--- a/bootstrap/src/test/java/io/airlift/bootstrap/DestroyExceptionInstance.java
+++ b/bootstrap/src/test/java/io/airlift/bootstrap/DestroyExceptionInstance.java
@@ -1,0 +1,27 @@
+package io.airlift.bootstrap;
+
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+
+public class DestroyExceptionInstance
+{
+    @Inject
+    public DestroyExceptionInstance(DependentInstance ignored)
+    {
+        // the constructor exists to force injection of the dependent instance
+    }
+
+    @PreDestroy
+    public void preDestroyExceptionOne()
+    {
+        TestLifeCycleManager.note("preDestroyExceptionOne");
+        throw new IllegalStateException("preDestroyExceptionOne");
+    }
+
+    @PreDestroy
+    public void preDestroyExceptionTwo()
+    {
+        TestLifeCycleManager.note("preDestroyExceptionTwo");
+        throw new IllegalStateException("preDestroyExceptionTwo");
+    }
+}

--- a/bootstrap/src/test/java/io/airlift/bootstrap/PostConstructExceptionInstance.java
+++ b/bootstrap/src/test/java/io/airlift/bootstrap/PostConstructExceptionInstance.java
@@ -1,0 +1,28 @@
+package io.airlift.bootstrap;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+
+public class PostConstructExceptionInstance
+{
+    @PostConstruct
+    public void postConstructFailure()
+    {
+        TestLifeCycleManager.note("postConstructFailure");
+        throw new IllegalArgumentException("postConstructFailure");
+    }
+
+    @PreDestroy
+    public void preDestroyFailureAfterPostConstructFailureOne()
+    {
+        TestLifeCycleManager.note("preDestroyFailureAfterPostConstructFailureOne");
+        throw new IllegalArgumentException("preDestroyFailureAfterPostConstructFailureOne");
+    }
+
+    @PreDestroy
+    public void preDestroyFailureAfterPostConstructFailureTwo()
+    {
+        TestLifeCycleManager.note("preDestroyFailureAfterPostConstructFailureTwo");
+        throw new IllegalArgumentException("preDestroyFailureAfterPostConstructFailureTwo");
+    }
+}


### PR DESCRIPTION
Handle catch and log exceptions thrown from `@PreDestroy` methods in`LifeCycleManager::stop()` so that other stop behaviors have a chance to run.