### PR TITLE
Fix VERSION_NUMBER pattern in JavaVersion

### DIFF
--- a/jmx/src/main/java/io/airlift/jmx/JavaVersion.java
+++ b/jmx/src/main/java/io/airlift/jmx/JavaVersion.java
@@ -28,7 +28,7 @@ import static java.lang.String.format;
 class JavaVersion
 {
     // As described in JEP-223
-    private static final String VERSION_NUMBER = "(?<MAJOR>[1-9][0-9]*)(\\.(?<MINOR>(0|[1-9][0-9]*))(\\.(?:(0|[1-9][0-9]*)))?)?";
+    private static final String VERSION_NUMBER = "(?<MAJOR>[1-9][0-9]*)(\\.(?<MINOR>(0|[1-9][0-9]*))(\\.(?:(0|[1-9][0-9]*)))?)*";
     private static final String PRE = "(?:-(?:[a-zA-Z0-9]+))?";
     private static final String BUILD = "(?:(?:\\+)(?:0|[1-9][0-9]*)?)?";
     private static final String OPT = "(?:-(?:[-a-zA-Z0-9.]+))?";

--- a/jmx/src/test/java/io/airlift/jmx/TestJavaVersion.java
+++ b/jmx/src/test/java/io/airlift/jmx/TestJavaVersion.java
@@ -42,5 +42,6 @@ public class TestJavaVersion
         assertEquals(JavaVersion.parse("9+100"), new JavaVersion(9, 0));
         assertEquals(JavaVersion.parse("9.0.1+20"), new JavaVersion(9, 0));
         assertEquals(JavaVersion.parse("9.1.1+20"), new JavaVersion(9, 1));
+        assertEquals(JavaVersion.parse("11.0.1.0.1"), new JavaVersion(11, 0));
     }
 }


### PR DESCRIPTION
The version string pattern in JEP-223 (https://openjdk.java.net/jeps/223) defines the version number format to be:

```[1-9][0-9]*((\.0)*\.[1-9][0-9]*)*```

This allows an arbitrary length sequence separated by `.` and only the first three elements are assigned specific meanings.

The implementation in `JavaVersion` uses incorrect pattern string that limits the length to at most 3 elements in the version number.