### PR TITLE
Record complete URI in http server logs

### DIFF
--- a/http-server/src/main/java/io/airlift/http/server/HttpRequestEvent.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpRequestEvent.java
@@ -96,6 +96,10 @@ public class HttpRequestEvent
         String requestUri = null;
         if (request.getRequestURI() != null) {
             requestUri = request.getRequestURI();
+            String parameters = request.getQueryString();
+            if (parameters != null) {
+                requestUri += "?" + parameters;
+            }
         }
 
         String method = request.getMethod();


### PR DESCRIPTION
The switch to logback lost the query parameters from the request URI.