### PR TITLE
Add @SlatedForRemoval

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+0.193
+
+- Add @SlatedForRemoval to support additional deprecation step when
+  configuration property is being removed.
+
 0.192
 
 - Update to Jetty 9.4.26.v20200117.

--- a/configuration/src/main/java/io/airlift/configuration/ConfigurationFactory.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigurationFactory.java
@@ -365,6 +365,15 @@ public class ConfigurationFactory
 
         Problems problems = new Problems(monitor);
 
+        configurationMetadata.getReplacedProperties().forEach((replacedProperty, newProperty) -> {
+            if (properties.containsKey(prefix + replacedProperty)) {
+                problems.addError(
+                        "Configuration property '%s' has been replaced with '%s'",
+                        prefix + replacedProperty,
+                        prefix + newProperty);
+            }
+        });
+
         for (AttributeMetadata attribute : configurationMetadata.getAttributes().values()) {
             Problems attributeProblems = new Problems(monitor);
             try {

--- a/configuration/src/main/java/io/airlift/configuration/ConfigurationMetadata.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigurationMetadata.java
@@ -15,12 +15,12 @@
  */
 package io.airlift.configuration;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.inject.ConfigurationException;
 import io.airlift.configuration.Problems.Monitor;
 
+import javax.annotation.Nullable;
 import javax.validation.Constraint;
 
 import java.lang.annotation.Annotation;
@@ -36,6 +36,8 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Strings.emptyToNull;
 import static java.util.Objects.requireNonNull;
 
 public class ConfigurationMetadata<T>
@@ -271,7 +273,7 @@ public class ConfigurationMetadata<T>
 
     private AttributeMetadata buildAttributeMetadata(Class<T> configClass, Method configMethod)
     {
-        Preconditions.checkArgument(configMethod.isAnnotationPresent(Config.class));
+        checkArgument(configMethod.isAnnotationPresent(Config.class));
 
         if (!validateAnnotations(configMethod)) {
             return null;
@@ -375,14 +377,9 @@ public class ConfigurationMetadata<T>
 
         private InjectionPointMetaData(Class<?> configClass, String property, Method setter, boolean current)
         {
-            requireNonNull(configClass);
-            requireNonNull(property);
-            requireNonNull(setter);
-            Preconditions.checkArgument(!property.isEmpty());
-
-            this.configClass = configClass;
-            this.property = property;
-            this.setter = setter;
+            this.configClass = requireNonNull(configClass, "configClass is null");
+            this.property = requireNonNull(emptyToNull(property), "property is null or empty");
+            this.setter = requireNonNull(setter, "setter is null");
             this.current = current;
         }
 
@@ -448,23 +445,23 @@ public class ConfigurationMetadata<T>
         private final InjectionPointMetaData injectionPoint;
         private final Set<InjectionPointMetaData> legacyInjectionPoints;
 
-        public AttributeMetadata(Class<?> configClass, String name, String description, boolean securitySensitive, Method getter,
-                InjectionPointMetaData injectionPoint, Set<InjectionPointMetaData> legacyInjectionPoints)
+        public AttributeMetadata(
+                Class<?> configClass,
+                String name,
+                @Nullable String description,
+                boolean securitySensitive,
+                Method getter,
+                InjectionPointMetaData injectionPoint,
+                Set<InjectionPointMetaData> legacyInjectionPoints)
         {
-            requireNonNull(configClass);
-            requireNonNull(name);
-            requireNonNull(getter);
-            requireNonNull(injectionPoint);
-            requireNonNull(legacyInjectionPoints);
-
-            this.configClass = configClass;
-            this.name = name;
+            this.configClass = requireNonNull(configClass, "configClass is null");
+            this.name = requireNonNull(name, "name is null");
             this.description = description;
             this.securitySensitive = securitySensitive;
-            this.getter = getter;
+            this.getter = requireNonNull(getter, "getter is null");
 
-            this.injectionPoint = injectionPoint;
-            this.legacyInjectionPoints = ImmutableSet.copyOf(legacyInjectionPoints);
+            this.injectionPoint = requireNonNull(injectionPoint, "injectionPoint is null");
+            this.legacyInjectionPoints = ImmutableSet.copyOf(requireNonNull(legacyInjectionPoints, "legacyInjectionPoints is null"));
         }
 
         public Class<?> getConfigClass()
@@ -477,6 +474,7 @@ public class ConfigurationMetadata<T>
             return name;
         }
 
+        @Nullable
         public String getDescription()
         {
             return description;
@@ -554,32 +552,24 @@ public class ConfigurationMetadata<T>
 
         public AttributeMetaDataBuilder(Class<?> configClass, String name, boolean securitySensitive)
         {
-            requireNonNull(configClass);
-            requireNonNull(name);
-            Preconditions.checkArgument(!name.isEmpty());
-
-            this.configClass = configClass;
-            this.name = name;
+            this.configClass = requireNonNull(configClass, "configClass is null");
+            this.name = requireNonNull(emptyToNull(name), "name is null or empty");
             this.securitySensitive = securitySensitive;
         }
 
         public void setDescription(String description)
         {
-            requireNonNull(description);
-
-            this.description = description;
+            this.description = requireNonNull(description, "description is null");
         }
 
         public void setGetter(Method getter)
         {
-            requireNonNull(getter);
-
-            this.getter = getter;
+            this.getter = requireNonNull(getter, "getter is null");
         }
 
         public void addInjectionPoint(InjectionPointMetaData injectionPointMetaData)
         {
-            requireNonNull(injectionPointMetaData);
+            requireNonNull(injectionPointMetaData, "injectionPointMetaData is null");
 
             if (injectionPointMetaData.isLegacy()) {
                 this.legacyInjectionPoints.add(injectionPointMetaData);

--- a/configuration/src/main/java/io/airlift/configuration/SlatedForRemoval.java
+++ b/configuration/src/main/java/io/airlift/configuration/SlatedForRemoval.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.configuration;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+
+/**
+ * Annotated configuration setting is slated for removal.
+ * The annotated property name is suffixed with {@value #PROPERTY_SUFFIX}
+ * and removal date in {@link #PROPERTY_DATE_FORMAT}.
+ * Must be on same method as {@code @Config}.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface SlatedForRemoval
+{
+    DateTimeFormatter VALUE_DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM", Locale.US);
+    String PROPERTY_SUFFIX = ".slated-for-removal-";
+    DateTimeFormatter PROPERTY_DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM", Locale.US);
+
+    /**
+     * Describes date after which config can be removed.
+     * <p>
+     * Must be in the format accepted by {@link #VALUE_DATE_FORMAT}, for example {@code "2042-10"}.
+     */
+    String after();
+}

--- a/configuration/src/test/java/io/airlift/configuration/Config1.java
+++ b/configuration/src/test/java/io/airlift/configuration/Config1.java
@@ -53,6 +53,8 @@ public class Config1
 
     ValueClass valueClassOption;
 
+    String slatedForRemovalOption;
+
     public String getStringOption()
     {
         return stringOption;
@@ -266,6 +268,21 @@ public class Config1
     public Config1 setValueClassOption(ValueClass valueClassOption)
     {
         this.valueClassOption = valueClassOption;
+        return this;
+    }
+
+    @Deprecated
+    public String getSlatedForRemovalOption()
+    {
+        return slatedForRemovalOption;
+    }
+
+    @Config("slatedForRemovalOption")
+    @SlatedForRemoval(after = "2018-01")
+    @Deprecated
+    public Config1 setSlatedForRemovalOption(String slatedForRemovalOption)
+    {
+        this.slatedForRemovalOption = slatedForRemovalOption;
         return this;
     }
 }

--- a/configuration/src/test/java/io/airlift/configuration/TestConfig.java
+++ b/configuration/src/test/java/io/airlift/configuration/TestConfig.java
@@ -76,6 +76,7 @@ public class TestConfig
             .put("myEnumOption", "FOO")
             .put("myEnumSecondOption", "bar") // lowercase
             .put("valueClassOption", "a value class")
+            .put("slatedForRemovalOption.slated-for-removal-2018-01", "an option being removed")
             .build();
 
     @Test
@@ -188,6 +189,7 @@ public class TestConfig
         assertEquals(MyEnum.FOO, config.getMyEnumOption());
         assertEquals(MyEnum.BAR, config.getMyEnumSecondOption());
         assertEquals(config.getValueClassOption().getValue(), "a value class");
+        assertEquals(config.getSlatedForRemovalOption(), "an option being removed");
     }
 
     @Test

--- a/configuration/src/test/java/io/airlift/configuration/TestConfigurationMetadata.java
+++ b/configuration/src/test/java/io/airlift/configuration/TestConfigurationMetadata.java
@@ -645,6 +645,16 @@ public class TestConfigurationMetadata
     }
 
     @Test
+    public void testSlatedForRemovalOnNonDeprecatedSetterClass()
+    {
+        TestMonitor monitor = new TestMonitor();
+        ConfigurationMetadata.getConfigurationMetadata(SlatedForRemovalOnNonDeprecatedSetterClass.class, monitor);
+        monitor.assertNumberOfErrors(0);
+        monitor.assertNumberOfWarnings(1);
+        monitor.assertMatchingWarningRecorded("@SlatedForRemoval method", "setValue(java.lang.String)", "should be @Deprecated");
+    }
+
+    @Test
     public void testDeprecatedConfigClass()
             throws Exception
     {
@@ -1547,6 +1557,23 @@ public class TestConfigurationMetadata
         public void setIntValue(int value)
         {
             this.value = Integer.toString(value);
+        }
+    }
+
+    public static class SlatedForRemovalOnNonDeprecatedSetterClass
+    {
+        private String value;
+
+        public String getValue()
+        {
+            return value;
+        }
+
+        @Config("value")
+        @SlatedForRemoval(after = "2018-01")
+        public void setValue(String value)
+        {
+            this.value = value;
         }
     }
 

--- a/configuration/src/test/java/io/airlift/configuration/testing/TestConfigAssertions.java
+++ b/configuration/src/test/java/io/airlift/configuration/testing/TestConfigAssertions.java
@@ -489,7 +489,8 @@ public class TestConfigAssertions
                 .setMyEnumSecondOption(null)
                 .setShortOption((short) 0)
                 .setStringOption(null)
-                .setValueClassOption(null));
+                .setValueClassOption(null)
+                .setSlatedForRemovalOption(null));
     }
 
     @Test


### PR DESCRIPTION
`@Config` property annotated with `@SlatedForRemoval` is automatically
renamed with addition of a suffix indicating removal date. This feature
is similar to `@LegacyConfig` and `@Deprecated` methods, with important
differences.

`@LegacyConfig` is suitable when configuration property is renamed, but
functionality is retained.

`@Deprecated` is suitable when configuration property is considered
deprecated, but is not being removed yet. Using `@Deprecated` properties
generates a warning.

`@SlatedForRemoval` is suitable when configuration property has been
deprecated for some time and is being removed. Provides additional step
in the deprecation process during which the deprecated functionality is
still accessible, but unlocking it requires manual intervention. This
enforces awareness of the fact that configuration property is deprecated
and being removed (warning generated by use of a `@Deprecated` property
can be ignored) and also awareness of the date after which the property
is no longer guaranteed to exist.

For example for config annotations:

    @Config("some-option")
    @SlatedForRemoval(notEarlierThan = "Jan 2020")

When configuration uses `some-option` property, an error is generated
informing that `some-option` has been replaced with
`some-option.slated-for-removal-2020-01`.

When configuration uses `some-option.slated-for-removal-2020-01`, the
configured value is accepted, but still a warning is generated.