### PR TITLE
Convert to boolean strictly

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,8 @@
 
 - Fix a bug introduced in 0.184 causing Enum's fromString(String) method to be
   ignored.
+- Convert to boolean strictly in configuration. For example "yes" value
+  will now be rejected, previously it would be parsed as false.
 - Trim whitespace when loading configuration.
 - When a class defines fromString(String) method, valueOf(String) method or
   a String-parameterized constructor, attempt the conversion using only first

--- a/configuration/src/main/java/io/airlift/configuration/ConfigurationFactory.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigurationFactory.java
@@ -555,28 +555,28 @@ public class ConfigurationFactory
         }
 
         try {
-            if (String.class.isAssignableFrom(type)) {
+            if (String.class == type) {
                 return value;
             }
-            else if (Boolean.class.isAssignableFrom(type) || Boolean.TYPE.isAssignableFrom(type)) {
+            else if (Boolean.class == type || boolean.class == type) {
                 return Boolean.valueOf(value);
             }
-            else if (Byte.class.isAssignableFrom(type) || Byte.TYPE.isAssignableFrom(type)) {
+            else if (Byte.class == type || byte.class == type) {
                 return Byte.valueOf(value);
             }
-            else if (Short.class.isAssignableFrom(type) || Short.TYPE.isAssignableFrom(type)) {
+            else if (Short.class == type || short.class == type) {
                 return Short.valueOf(value);
             }
-            else if (Integer.class.isAssignableFrom(type) || Integer.TYPE.isAssignableFrom(type)) {
+            else if (Integer.class == type || int.class == type) {
                 return Integer.valueOf(value);
             }
-            else if (Long.class.isAssignableFrom(type) || Long.TYPE.isAssignableFrom(type)) {
+            else if (Long.class == type || long.class == type) {
                 return Long.valueOf(value);
             }
-            else if (Float.class.isAssignableFrom(type) || Float.TYPE.isAssignableFrom(type)) {
+            else if (Float.class == type || float.class == type) {
                 return Float.valueOf(value);
             }
-            else if (Double.class.isAssignableFrom(type) || Double.TYPE.isAssignableFrom(type)) {
+            else if (Double.class == type || double.class == type) {
                 return Double.valueOf(value);
             }
         }

--- a/configuration/src/main/java/io/airlift/configuration/ConfigurationFactory.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigurationFactory.java
@@ -559,7 +559,14 @@ public class ConfigurationFactory
                 return value;
             }
             if (Boolean.class == type || boolean.class == type) {
-                return Boolean.valueOf(value);
+                // Boolean.valueOf returns `false` when called with `"true "` argument
+                if ("true".equalsIgnoreCase(value)) {
+                    return Boolean.TRUE;
+                }
+                if ("false".equalsIgnoreCase(value)) {
+                    return Boolean.FALSE;
+                }
+                return null;
             }
             if (Byte.class == type || byte.class == type) {
                 return Byte.valueOf(value);

--- a/configuration/src/main/java/io/airlift/configuration/ConfigurationFactory.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigurationFactory.java
@@ -558,25 +558,25 @@ public class ConfigurationFactory
             if (String.class == type) {
                 return value;
             }
-            else if (Boolean.class == type || boolean.class == type) {
+            if (Boolean.class == type || boolean.class == type) {
                 return Boolean.valueOf(value);
             }
-            else if (Byte.class == type || byte.class == type) {
+            if (Byte.class == type || byte.class == type) {
                 return Byte.valueOf(value);
             }
-            else if (Short.class == type || short.class == type) {
+            if (Short.class == type || short.class == type) {
                 return Short.valueOf(value);
             }
-            else if (Integer.class == type || int.class == type) {
+            if (Integer.class == type || int.class == type) {
                 return Integer.valueOf(value);
             }
-            else if (Long.class == type || long.class == type) {
+            if (Long.class == type || long.class == type) {
                 return Long.valueOf(value);
             }
-            else if (Float.class == type || float.class == type) {
+            if (Float.class == type || float.class == type) {
                 return Float.valueOf(value);
             }
-            else if (Double.class == type || double.class == type) {
+            if (Double.class == type || double.class == type) {
                 return Double.valueOf(value);
             }
         }

--- a/configuration/src/test/java/io/airlift/configuration/TestConfigurationFactory.java
+++ b/configuration/src/test/java/io/airlift/configuration/TestConfigurationFactory.java
@@ -42,7 +42,7 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.fail;
 
-public class ConfigurationFactoryTest
+public class TestConfigurationFactory
 {
     @Test
     public void testAnnotatedGettersThrows()

--- a/configuration/src/test/java/io/airlift/configuration/TestConfigurationMetadata.java
+++ b/configuration/src/test/java/io/airlift/configuration/TestConfigurationMetadata.java
@@ -31,7 +31,7 @@ import static io.airlift.testing.EquivalenceTester.equivalenceTester;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
-public class ConfigurationMetadataTest
+public class TestConfigurationMetadata
 {
     @Test
     public void testEquivalence()


### PR DESCRIPTION
Change how booleans are parsed from configuration / configuration files

Case Name | Input | Before Change | After Change | Comment
--------- | ----- | ------------- | ------------ | -------
plain | `"true"` | `true` | `true` | _no change_
plain | `"false"` | `false` | `false` | _no change_
mixed case | `"tRuE"` | `true` | `true` | _no change_
whitespace | `"true "` | `false` | _error_; `true` after #758 | This case is a common configuration mistake, as trailing whitespace is not stripped when reading `.properties`
whitespace | `"false "` | `false` | _error_; `false` after #758 | _no change_ when combined with #758
unrecognized | `"yes"` | `false` | _error_
unrecognized | `"no"` | `false` | _error_


Addresses major pain point of https://github.com/airlift/airlift/issues/738 / https://github.com/prestosql/presto/issues/1546
