### PR TITLE
Validate validation

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@
 - When a class defines fromString(String) method, valueOf(String) method or
   a String-parameterized constructor, attempt the conversion using only first
   available conversion method.
+- Validate placement of bean validation annotation in configuration classes.
 - Add TDigest and DecayTDigest data structures.
 
 0.184

--- a/configuration/src/main/java/io/airlift/configuration/ConfigurationMetadata.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigurationMetadata.java
@@ -21,6 +21,9 @@ import com.google.common.collect.ImmutableSortedMap;
 import com.google.inject.ConfigurationException;
 import io.airlift.configuration.Problems.Monitor;
 
+import javax.validation.Constraint;
+
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -168,6 +171,13 @@ public class ConfigurationMetadata<T>
         if (config.value().isEmpty()) {
             problems.addError("@Config method [%s] annotation has an empty value", configMethod.toGenericString());
             isValid = false;
+        }
+
+        for (Annotation annotation : configMethod.getDeclaredAnnotations()) {
+            if (annotation.annotationType().isAnnotationPresent(Constraint.class)) {
+                problems.addError("@Config method [%s] annotation %s should be placed on a getter", configMethod.toGenericString(), annotation);
+                isValid = false;
+            }
         }
 
         if (legacyConfig != null) {

--- a/configuration/src/test/java/io/airlift/configuration/ConfigurationMetadataTest.java
+++ b/configuration/src/test/java/io/airlift/configuration/ConfigurationMetadataTest.java
@@ -20,6 +20,8 @@ import com.google.inject.ConfigurationException;
 import io.airlift.configuration.ConfigurationMetadata.AttributeMetadata;
 import org.testng.annotations.Test;
 
+import javax.validation.constraints.Min;
+
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -806,6 +808,16 @@ public class ConfigurationMetadataTest
         monitor.assertNumberOfErrors(1);
         monitor.assertNumberOfWarnings(0);
         monitor.assertMatchingErrorRecorded("@ConfigSecuritySensitive method", "setValue", "is not annotated with @Config.");
+    }
+
+    @Test
+    public void testMisplacedValidationAnnotation()
+    {
+        TestMonitor monitor = new TestMonitor();
+        ConfigurationMetadata.getConfigurationMetadata(MisplacedValidationAnnotationClass.class, monitor);
+        monitor.assertNumberOfErrors(1);
+        monitor.assertNumberOfWarnings(0);
+        monitor.assertMatchingErrorRecorded("@Config method", "MisplacedValidationAnnotationClass.setValue(int)", "annotation @javax.validation.constraints.Min", "should be placed on a getter");
     }
 
     private void verifyMetaData(ConfigurationMetadata<?> metadata, Class<?> configClass, String description, boolean securitySensitive, Map<String, Set<String>> attributeProperties)
@@ -1780,6 +1792,23 @@ public class ConfigurationMetadataTest
         public void setValue(int value)
         {
             this.value = Integer.toString(value);
+        }
+    }
+
+    public static class MisplacedValidationAnnotationClass
+    {
+        private int value;
+
+        public int getValue()
+        {
+            return value;
+        }
+
+        @Config("value")
+        @Min(10)
+        public void setValue(int value)
+        {
+            this.value = value;
         }
     }
 }


### PR DESCRIPTION
Validation annotation must be placed on a getter. When placed on a
setter, it is silently ignored. After this change, a misplaced validation
annotation in a Config class will be treated as an error.