### PR TITLE
Add background file resource loader

### DIFF
--- a/concurrent/src/main/java/io/airlift/concurrent/ResourceLoader.java
+++ b/concurrent/src/main/java/io/airlift/concurrent/ResourceLoader.java
@@ -1,0 +1,224 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.concurrent;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.airlift.log.Logger;
+import io.airlift.units.Duration;
+
+import javax.annotation.PreDestroy;
+import javax.annotation.concurrent.GuardedBy;
+
+import java.io.File;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+public final class ResourceLoader<T>
+{
+    private static final Logger log = Logger.get(ResourceLoader.class);
+
+    private final File file;
+    private final FileLoader<T> fileLoader;
+    private final Duration refreshPeriod;
+    private final Consumer<Exception> exceptionHandler;
+    private final AtomicReference<Runnable> stopRefresh = new AtomicReference<>();
+
+    @GuardedBy("this")
+    private T value;
+
+    private static <T> ResourceLoader<T> createResourceLoader(
+            File file,
+            FileLoader<T> fileLoader,
+            Duration refreshPeriod,
+            SimpleRecurringTaskRunner recurringTaskRunner,
+            Consumer<Exception> exceptionHandler)
+            throws Exception
+    {
+        requireNonNull(recurringTaskRunner, "recurringTaskRunner is null");
+        ResourceLoader<T> resourceLoader = new ResourceLoader<>(
+                fileLoader,
+                file,
+                refreshPeriod,
+                exceptionHandler);
+        resourceLoader.start(recurringTaskRunner);
+        return resourceLoader;
+    }
+
+    private ResourceLoader(FileLoader<T> fileLoader, File file, Duration refreshPeriod, Consumer<Exception> exceptionHandler)
+            throws Exception
+    {
+        this.fileLoader = requireNonNull(fileLoader, "fileLoader is null");
+        this.file = requireNonNull(file, "file is null");
+        this.refreshPeriod = requireNonNull(refreshPeriod, "refreshPeriod is null");
+        this.exceptionHandler = requireNonNull(exceptionHandler, "exceptionHandler is null");
+        refreshNow();
+    }
+
+    private void start(SimpleRecurringTaskRunner recurringTaskRunner)
+    {
+        stopRefresh.set(recurringTaskRunner.scheduleTask(this::refreshInternal, refreshPeriod));
+    }
+
+    @PreDestroy
+    public void stop()
+    {
+        Runnable stopRefresh = this.stopRefresh.getAndSet(null);
+        if (stopRefresh != null) {
+            stopRefresh.run();
+        }
+    }
+
+    public synchronized T getValue()
+    {
+        return value;
+    }
+
+    public synchronized void refreshNow()
+            throws Exception
+    {
+        value = fileLoader.loadFile(file);
+    }
+
+    private void refreshInternal()
+    {
+        try {
+            refreshNow();
+        }
+        catch (Exception e) {
+            exceptionHandler.accept(e);
+        }
+    }
+
+    public interface FileLoader<T>
+    {
+        T loadFile(File file)
+                throws Exception;
+    }
+
+    public interface SimpleRecurringTaskRunner
+    {
+        Runnable scheduleTask(Runnable runnable, Duration fixedDelay);
+    }
+
+    private static class InternalScheduledRecurringTaskRunner
+            implements SimpleRecurringTaskRunner
+    {
+        private final String name;
+
+        private InternalScheduledRecurringTaskRunner(String name)
+        {
+            this.name = requireNonNull(name, "name is null");
+        }
+
+        @Override
+        public Runnable scheduleTask(Runnable runnable, Duration fixedDelay)
+        {
+            ScheduledExecutorService executor = newSingleThreadScheduledExecutor(daemonThreadsNamed(name + "-background-loader"));
+            long fixedDelayNanos = fixedDelay.roundTo(NANOSECONDS);
+            executor.scheduleAtFixedRate(runnable, fixedDelayNanos, fixedDelayNanos, NANOSECONDS);
+            return executor::shutdownNow;
+        }
+    }
+
+    private static class NoOpScheduledRecurringTaskRunner
+            implements SimpleRecurringTaskRunner
+    {
+        @Override
+        public Runnable scheduleTask(Runnable runnable, Duration fixedDelay)
+        {
+            return () -> {};
+        }
+    }
+
+    public static <T> ResourceLoaderBuilder<T> builder(FileLoader<T> fileLoader)
+    {
+        return new ResourceLoaderBuilder<>(fileLoader);
+    }
+
+    public static final class ResourceLoaderBuilder<T>
+    {
+        private final FileLoader<T> fileLoader;
+        private String name;
+        private File file;
+        private Duration refreshPeriod = new Duration(0, NANOSECONDS);
+        private SimpleRecurringTaskRunner recurringTaskRunner;
+        private Consumer<Exception> exceptionHandler = exception -> log.error("Error refreshing " + name, exception);
+
+        private ResourceLoaderBuilder(FileLoader<T> fileLoader)
+        {
+            this.fileLoader = requireNonNull(fileLoader, "fileLoader is null");
+        }
+
+        public ResourceLoaderBuilder<T> setName(String name)
+        {
+            this.name = requireNonNull(name, "name is null");
+            return this;
+        }
+
+        public ResourceLoaderBuilder<T> setFile(File file)
+        {
+            this.file = requireNonNull(file, "file is null");
+            return this;
+        }
+
+        public ResourceLoaderBuilder<T> setRefreshPeriod(Duration refreshPeriod)
+        {
+            this.refreshPeriod = requireNonNull(refreshPeriod, "refreshPeriod is null");
+            return this;
+        }
+
+        @VisibleForTesting
+        ResourceLoaderBuilder<T> setRecurringTaskRunner(SimpleRecurringTaskRunner recurringTaskRunner)
+        {
+            this.recurringTaskRunner = requireNonNull(recurringTaskRunner, "recurringTaskRunner is null");
+            return this;
+        }
+
+        public ResourceLoaderBuilder<T> setExceptionHandler(Consumer<Exception> exceptionHandler)
+        {
+            this.exceptionHandler = exceptionHandler;
+            return this;
+        }
+
+        public ResourceLoader<T> build()
+                throws Exception
+        {
+            checkArgument(name != null, "name not set");
+            checkArgument(file != null, "file not set");
+
+            SimpleRecurringTaskRunner recurringTaskRunner = this.recurringTaskRunner;
+            if (recurringTaskRunner == null) {
+                if (refreshPeriod.roundTo(NANOSECONDS) > 0) {
+                    recurringTaskRunner = new InternalScheduledRecurringTaskRunner(name);
+                }
+                else {
+                    recurringTaskRunner = new NoOpScheduledRecurringTaskRunner();
+                }
+            }
+            return createResourceLoader(
+                    file,
+                    fileLoader,
+                    refreshPeriod,
+                    recurringTaskRunner,
+                    exceptionHandler);
+        }
+    }
+}

--- a/concurrent/src/test/java/io/airlift/concurrent/TestResourceLoader.java
+++ b/concurrent/src/test/java/io/airlift/concurrent/TestResourceLoader.java
@@ -1,0 +1,255 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.concurrent;
+
+import com.google.common.io.Files;
+import io.airlift.concurrent.ResourceLoader.FileLoader;
+import io.airlift.concurrent.ResourceLoader.SimpleRecurringTaskRunner;
+import io.airlift.testing.TempFile;
+import io.airlift.units.Duration;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.airlift.testing.Assertions.assertGreaterThan;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+
+public class TestResourceLoader
+{
+    @Test
+    public void testManualRefresh()
+            throws Exception
+    {
+        try (TempFile tempFile = new TempFile()) {
+            Files.write("data".getBytes(UTF_8), tempFile.file());
+
+            ResourceLoader<String> loader = ResourceLoader.builder(file -> Files.asCharSource(file, UTF_8).read())
+                    .setName("test")
+                    .setFile(tempFile.file())
+                    .build();
+
+            assertEquals(loader.getValue(), "data");
+
+            Files.write("new-data".getBytes(UTF_8), tempFile.file());
+            assertEquals(loader.getValue(), "data");
+
+            loader.refreshNow();
+            assertEquals(loader.getValue(), "new-data");
+
+            loader.stop();
+        }
+    }
+
+    @Test
+    public void testBackgroundRefresh()
+            throws Exception
+    {
+        try (TempFile tempFile = new TempFile()) {
+            Files.write("data".getBytes(UTF_8), tempFile.file());
+
+            Duration refreshDuration = new Duration(123, SECONDS);
+            TestingRecurringTaskRunner taskRunner = new TestingRecurringTaskRunner(refreshDuration);
+            ResourceLoader<String> loader = ResourceLoader.builder(file -> Files.asCharSource(file, UTF_8).read())
+                    .setName("test")
+                    .setFile(tempFile.file())
+                    .setRefreshPeriod(refreshDuration)
+                    .setRecurringTaskRunner(taskRunner)
+                    .build();
+
+            assertEquals(loader.getValue(), "data");
+
+            Files.write("new-data".getBytes(UTF_8), tempFile.file());
+            assertEquals(loader.getValue(), "data");
+
+            taskRunner.runTask();
+            assertEquals(loader.getValue(), "new-data");
+
+            loader.stop();
+            assertTrue(taskRunner.isStopped(), "Expected task to be stopped");
+
+            assertEquals(loader.getValue(), "new-data");
+        }
+    }
+
+    @Test
+    public void testBuiltinRefresh()
+            throws Exception
+    {
+        try (TempFile tempFile = new TempFile()) {
+            Files.write("data".getBytes(UTF_8), tempFile.file());
+
+            LoaderWaiter loaderWaiter = new LoaderWaiter();
+            Duration refreshDuration = new Duration(10, MILLISECONDS);
+            ResourceLoader<Long> loader = ResourceLoader.builder(loaderWaiter)
+                    .setName("test")
+                    .setFile(tempFile.file())
+                    .setRefreshPeriod(refreshDuration)
+                    .build();
+
+            long initialValue = loader.getValue();
+            assertGreaterThan(initialValue, 0L);
+
+            // verify load called in background
+            loaderWaiter.waitForLoad();
+            long firstWaitValue = loader.getValue();
+            assertGreaterThan(firstWaitValue, initialValue);
+
+            // verify again
+            loaderWaiter.waitForLoad();
+            long secondWaitValue = loader.getValue();
+            assertGreaterThan(secondWaitValue, firstWaitValue);
+
+            loader.stop();
+        }
+    }
+
+    private static class LoaderWaiter
+            implements FileLoader<Long>
+    {
+        private final AtomicLong loadCount = new AtomicLong();
+        private final AtomicReference<CompletableFuture<?>> waiter = new AtomicReference<>();
+
+        @Override
+        public Long loadFile(File file)
+        {
+            CompletableFuture<?> future = waiter.getAndSet(null);
+            if (future != null) {
+                future.complete(null);
+            }
+            return loadCount.incrementAndGet();
+        }
+
+        public void waitForLoad()
+                throws Exception
+        {
+            CompletableFuture<Object> future = new CompletableFuture<>();
+            CompletableFuture<?> currentWaiter = waiter.getAndSet(future);
+            assertNull(currentWaiter);
+            future.get(30, SECONDS);
+        }
+    }
+
+    @Test
+    public void testRefreshException()
+            throws Exception
+    {
+        try (TempFile tempFile = new TempFile()) {
+            Files.write("initial".getBytes(UTF_8), tempFile.file());
+
+            // exception from construction throws directly
+            assertThrows(
+                    SecurityException.class,
+                    () -> ResourceLoader.builder(file -> { throw new SecurityException(); })
+                            .setName("test")
+                            .setFile(tempFile.file())
+                            .build());
+
+            AtomicReference<Exception> nextException = new AtomicReference<>();
+            AtomicReference<Exception> exceptionHandler = new AtomicReference<>();
+            Duration refreshDuration = new Duration(123, SECONDS);
+            TestingRecurringTaskRunner taskRunner = new TestingRecurringTaskRunner(refreshDuration);
+            ResourceLoader<String> loader = ResourceLoader.builder(
+                    file -> {
+                        Exception exception = nextException.get();
+                        if (exception != null) {
+                            throw exception;
+                        }
+                        return Files.asCharSource(file, UTF_8).read();
+                    })
+                    .setName("test")
+                    .setFile(tempFile.file())
+                    .setRefreshPeriod(refreshDuration)
+                    .setRecurringTaskRunner(taskRunner)
+                    .setExceptionHandler(exceptionHandler::set)
+                    .build();
+
+            assertEquals(loader.getValue(), "initial");
+
+            // manually refresh throws exception directly
+            Files.write("manual".getBytes(UTF_8), tempFile.file());
+            nextException.set(new NumberFormatException());
+            assertThrows(NumberFormatException.class, loader::refreshNow);
+            assertNull(exceptionHandler.get());
+            assertEquals(loader.getValue(), "initial");
+
+            // verify refresh after exception works
+            nextException.set(null);
+            exceptionHandler.set(null);
+            loader.refreshNow();
+            assertNull(exceptionHandler.get());
+            assertEquals(loader.getValue(), "manual");
+
+            // background refresh calls exception handler
+            Files.write("background".getBytes(UTF_8), tempFile.file());
+            nextException.set(new SecurityException());
+            taskRunner.runTask();
+            assertSame(exceptionHandler.get(), nextException.get());
+            assertEquals(loader.getValue(), "manual");
+
+            // verify refresh after exception works
+            nextException.set(null);
+            exceptionHandler.set(null);
+            taskRunner.runTask();
+            assertNull(exceptionHandler.get());
+            assertEquals(loader.getValue(), "background");
+
+            loader.stop();
+        }
+    }
+
+    private static class TestingRecurringTaskRunner
+            implements SimpleRecurringTaskRunner
+    {
+        private final Duration expectedFixDelay;
+        private Runnable runnable;
+        private boolean stopped;
+
+        public TestingRecurringTaskRunner(Duration expectedFixDelay)
+        {
+            this.expectedFixDelay = requireNonNull(expectedFixDelay, "expectedFixDelay is null");
+        }
+
+        @Override
+        public Runnable scheduleTask(Runnable runnable, Duration fixedDelay)
+        {
+            assertNotNull(runnable, "Runnable already set");
+            assertEquals(fixedDelay, expectedFixDelay);
+            this.runnable = runnable;
+            return () -> stopped = true;
+        }
+
+        public void runTask()
+        {
+            assertNotNull(runnable, "Runnable already set");
+            runnable.run();
+        }
+
+        public boolean isStopped()
+        {
+            return stopped;
+        }
+    }
+}


### PR DESCRIPTION
This is a proposal based on the many resource loaders in Presto.  The loader details:
* Value is always present
* Failed loads retain existing value
* Initial load is in constructor, which if fails throws directly
* Manual reload with `refreshNow` method
* Optional timed loading in background thread
* Optional exception handler for background loads (default logs)
* Builder syntax for future extensions