### PR TITLE
Allow setting config values from environment variables

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+0.186
+
+- Allow setting config values from environment variables.
+
 0.185
 
 - Fix a bug introduced in 0.184 causing Enum's fromString(String) method to be

--- a/bootstrap/pom.xml
+++ b/bootstrap/pom.xml
@@ -60,6 +60,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
Config values may be of the form `${ENV:XXX}` where `XXX` is the name
of an environment variable. The value is replaced in `Bootstrap` with
the value of that environment variable.