### PR TITLE
Validate HTTPS configuration settings

### DIFF
--- a/http-server/pom.xml
+++ b/http-server/pom.xml
@@ -193,6 +193,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
         </dependency>

--- a/http-server/src/main/java/io/airlift/http/server/HttpServerConfig.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServerConfig.java
@@ -27,6 +27,7 @@ import io.airlift.units.MaxDataSize;
 import io.airlift.units.MinDataSize;
 import io.airlift.units.MinDuration;
 
+import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
@@ -223,6 +224,12 @@ public class HttpServerConfig
     {
         this.keystorePassword = keystorePassword;
         return this;
+    }
+
+    @AssertTrue(message = "Keystore path/password must be provided when HTTPS is enabled")
+    public boolean isHttpsConfigurationValid()
+    {
+        return !isHttpsEnabled() || (getKeystorePath() != null && getKeystorePassword() != null);
     }
 
     public String getKeyManagerPassword()

--- a/http-server/src/test/java/io/airlift/http/server/TestHttpServerConfig.java
+++ b/http-server/src/test/java/io/airlift/http/server/TestHttpServerConfig.java
@@ -22,10 +22,13 @@ import io.airlift.units.Duration;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.testng.annotations.Test;
 
+import javax.validation.constraints.AssertTrue;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import static io.airlift.testing.ValidationAssertions.assertFailsValidation;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static io.airlift.units.DataSize.Unit.KILOBYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
@@ -176,6 +179,19 @@ public class TestHttpServerConfig
                 .setHttp2StreamIdleTimeout(new Duration(23, SECONDS));
 
         ConfigAssertions.assertFullMapping(properties, expected);
+    }
+
+    @Test
+    public void testInvalidHttpsConfiguration()
+    {
+        assertFailsValidation(
+                new HttpServerConfig()
+                        .setHttpsEnabled(true)
+                        // keystore path not set
+                        .setKeystorePassword("keystore password"),
+                "httpsConfigurationValid",
+                "Keystore path/password must be provided when HTTPS is enabled",
+                AssertTrue.class);
     }
 
     private List<String> getJettyDefaultExcludedCiphers()


### PR DESCRIPTION
If `http-server.https.enabled` is true, but `http-server.https.keystore.path` is not specified, `HttpServer` blows up with a non-descriptive NPE at startup. Adding a bit of validation to help diagnose the misconfiguration.