### PR TITLE
Limit total size of server.log

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 0.188
 
+- Limit the total size of server.log by log.max-history * log.max-size
 - Fix IndexOutOfBounds when updating t-digest after copy.
 - Remove status message support from HTTP client.
 - Update to Jetty 9.4.24.v20191120.

--- a/log-manager/src/main/java/io/airlift/log/RollingFileHandler.java
+++ b/log-manager/src/main/java/io/airlift/log/RollingFileHandler.java
@@ -7,6 +7,7 @@ import ch.qos.logback.core.rolling.RollingFileAppender;
 import ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP;
 import ch.qos.logback.core.rolling.TimeBasedRollingPolicy;
 import ch.qos.logback.core.util.FileSize;
+import com.google.common.math.LongMath;
 import io.airlift.units.DataSize;
 
 import java.io.File;
@@ -47,6 +48,10 @@ final class RollingFileHandler
         rollingPolicy.setMaxHistory(maxHistory);
         rollingPolicy.setTimeBasedFileNamingAndTriggeringPolicy(triggeringPolicy);
         rollingPolicy.setParent(fileAppender);
+
+        // Limit total log files occupancy on disk. Ideally we would keep exactly
+        // `maxHistory` files (not logging periods). This is closest currently possible.
+        rollingPolicy.setTotalSizeCap(new FileSize(LongMath.saturatedMultiply(maxSizeInBytes, maxHistory)));
 
         triggeringPolicy.setContext(context);
         triggeringPolicy.setTimeBasedRollingPolicy(rollingPolicy);


### PR DESCRIPTION
Users expect & need the following semantics of config properties:

- `log.max-history` to limit number of log files
- `log.max-size` to limit the size of log files (compression aside)

However, these get passed to logback where max history is treated as
"number of logging periods to keep". The logging period is derived
from log file name pattern, i.e. day in our case.

This commit introduces additional limit, bringing the actual behavior to
be in line with common expectations.

Documentation reference: https://logback.qos.ch/manual/appenders.html#tbrpTotalSizeCap