### PR TITLE
Get jquery script from https instead of http

### DIFF
--- a/jmx-http/src/main/resources/io/airlift/jmx/mbeans.html
+++ b/jmx-http/src/main/resources/io/airlift/jmx/mbeans.html
@@ -54,7 +54,7 @@
         }
     </style>
 
-    <script type="text/javascript" src="http://code.jquery.com/jquery-1.5.2.js"></script>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-1.5.2.js"></script>
 </head>
 <body>
 


### PR DESCRIPTION
Get jquery script from https instead of http

https://github.com/prestodb/presto/issues/13693
