### PR TITLE
Do not require keystore password for HTTPS

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+0.191
+
+- Do not require keystore password for HTTPS.
+
 0.190
 
 - Allow using servlet filters for static resources.

--- a/http-server/src/main/java/io/airlift/http/server/HttpServerConfig.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServerConfig.java
@@ -226,10 +226,10 @@ public class HttpServerConfig
         return this;
     }
 
-    @AssertTrue(message = "Keystore path/password must be provided when HTTPS is enabled")
+    @AssertTrue(message = "Keystore path must be provided when HTTPS is enabled")
     public boolean isHttpsConfigurationValid()
     {
-        return !isHttpsEnabled() || (getKeystorePath() != null && getKeystorePassword() != null);
+        return !isHttpsEnabled() || getKeystorePath() != null;
     }
 
     public String getKeyManagerPassword()

--- a/http-server/src/test/java/io/airlift/http/server/TestHttpServerConfig.java
+++ b/http-server/src/test/java/io/airlift/http/server/TestHttpServerConfig.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 
 import static io.airlift.testing.ValidationAssertions.assertFailsValidation;
+import static io.airlift.testing.ValidationAssertions.assertValidates;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static io.airlift.units.DataSize.Unit.KILOBYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
@@ -182,15 +183,18 @@ public class TestHttpServerConfig
     }
 
     @Test
-    public void testInvalidHttpsConfiguration()
+    public void testHttpsConfigurationValidation()
     {
-        assertFailsValidation(
+        assertValidates(
                 new HttpServerConfig()
                         .setHttpsEnabled(true)
-                        // keystore path not set
-                        .setKeystorePassword("keystore password"),
+                        .setKeystorePath("/test/keystore"));
+
+        assertFailsValidation(
+                new HttpServerConfig()
+                        .setHttpsEnabled(true),
                 "httpsConfigurationValid",
-                "Keystore path/password must be provided when HTTPS is enabled",
+                "Keystore path must be provided when HTTPS is enabled",
                 AssertTrue.class);
     }
 


### PR DESCRIPTION
PEM files used as the keystore do not require a password.

The validation introduced in https://github.com/airlift/airlift/pull/773 was too strict.