### PR TITLE
Update HttpDiscoveryAnnouncementClient to use HttpUriBuilder

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 0.191
 
 - Do not require keystore password for HTTPS.
+- Allow trailing slash in discovery URI configuration.
 
 0.190
 

--- a/discovery/src/test/java/io/airlift/discovery/client/TestHttpDiscoveryAnnouncementClient.java
+++ b/discovery/src/test/java/io/airlift/discovery/client/TestHttpDiscoveryAnnouncementClient.java
@@ -1,0 +1,20 @@
+package io.airlift.discovery.client;
+
+import org.testng.annotations.Test;
+
+import java.net.URI;
+
+import static io.airlift.discovery.client.HttpDiscoveryAnnouncementClient.createAnnouncementLocation;
+import static org.testng.Assert.assertEquals;
+
+public class TestHttpDiscoveryAnnouncementClient
+{
+    @Test
+    public void testCreateAnnouncementLocation()
+    {
+        String nodeId = "ffff";
+        URI expected = URI.create("http://example.com:8080/v1/announcement/" + nodeId);
+        assertEquals(createAnnouncementLocation(URI.create("http://example.com:8080"), nodeId), expected);
+        assertEquals(createAnnouncementLocation(URI.create("http://example.com:8080/"), nodeId), expected);
+    }
+}


### PR DESCRIPTION
The String concatenation approach was causing issues when a trailing slash was included from the config, causing a double slash and a 404 error. The Builder properly handles this case.

For example `http://localhost:8080/` is currently transformed to `http://localhost:8080//v1/...` 