### PR TITLE
Provide clear error messaging when Java is not installed

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+0.193
+
+- Present explicit error messaging from launcher.py when Java is not installed.
+
 0.192
 
 - Update to Jetty 9.4.26.v20200117.

--- a/launcher/src/main/scripts/bin/launcher.py
+++ b/launcher/src/main/scripts/bin/launcher.py
@@ -3,6 +3,7 @@
 import errno
 import os
 import platform
+import subprocess
 import sys
 import traceback
 
@@ -188,6 +189,11 @@ def build_java_execution(options, daemon):
         raise Exception('Launcher config file is missing: %s' % options.launcher_config)
     if options.log_levels_set and not exists(options.log_levels):
         raise Exception('Log levels file is missing: %s' % options.log_levels)
+
+    try:
+        subprocess.check_output(['java', '-version'], stderr=subprocess.STDOUT)
+    except (OSError, subprocess.CalledProcessError):
+        raise Exception('Java is not installed')
 
     properties = options.properties.copy()
 


### PR DESCRIPTION
If Java is not found `launcher.py` fails with an error message `[Errno 2] No such file or directory`, this adds an explicit error message for that case. 