### PR TITLE
Forbid direct binder.install()

### DIFF
--- a/configuration/src/main/java/io/airlift/configuration/AbstractConfigurationAwareModule.java
+++ b/configuration/src/main/java/io/airlift/configuration/AbstractConfigurationAwareModule.java
@@ -14,8 +14,12 @@
 package io.airlift.configuration;
 
 import com.google.common.annotations.Beta;
+import com.google.common.reflect.AbstractInvocationHandler;
 import com.google.inject.Binder;
 import com.google.inject.Module;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
 
 import static com.google.common.base.Preconditions.checkState;
 import static io.airlift.configuration.ConfigBinder.configBinder;
@@ -40,7 +44,7 @@ public abstract class AbstractConfigurationAwareModule
         checkState(this.binder == null, "re-entry not allowed");
         this.binder = requireNonNull(binder, "binder is null");
         try {
-            setup(binder);
+            setup(ForbidInstallBinder.proxy(binder));
         }
         finally {
             this.binder = null;
@@ -68,4 +72,45 @@ public abstract class AbstractConfigurationAwareModule
     }
 
     protected abstract void setup(Binder binder);
+
+    private static class ForbidInstallBinder
+            extends AbstractInvocationHandler
+    {
+        private static final Method INSTALL_METHOD;
+
+        static {
+            try {
+                INSTALL_METHOD = Binder.class.getMethod("install", Module.class);
+            }
+            catch (NoSuchMethodException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        static Binder proxy(Binder binder)
+        {
+            return (Binder) Proxy.newProxyInstance(
+                    ForbidInstallBinder.class.getClassLoader(),
+                    new Class<?>[] {Binder.class},
+                    new ForbidInstallBinder(binder));
+        }
+
+        private final Binder delegate;
+
+        public ForbidInstallBinder(Binder delegate)
+        {
+            this.delegate = requireNonNull(delegate, "delegate is null");
+        }
+
+        @Override
+        protected Object handleInvocation(Object proxy, Method method, Object[] args)
+                throws Throwable
+        {
+            if (INSTALL_METHOD.equals(method)) {
+                throw new RuntimeException("binder.install() should not be called, use super.install() instead");
+            }
+
+            return method.invoke(delegate, args);
+        }
+    }
 }


### PR DESCRIPTION
Child classes need access to `binder`, but they should not use its
`install` method. Instead, the `AbstractInvocationHandler#install`
should be used, to make sure configuration is bound properly.