### PR TITLE
Only forbid binder.install() for ConfigurationAwareModule

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 0.195
 
+- Only forbid binder.install() for ConfigurationAwareModule.
 - Publish Maven BOM.
 
 0.194

--- a/bootstrap/src/test/java/io/airlift/bootstrap/TestConfigurationAwareModule.java
+++ b/bootstrap/src/test/java/io/airlift/bootstrap/TestConfigurationAwareModule.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.bootstrap;
+
+import com.google.inject.Binder;
+import com.google.inject.CreationException;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.Module;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.airlift.configuration.Config;
+import org.testng.annotations.Test;
+
+import static com.google.inject.name.Names.named;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestConfigurationAwareModule
+{
+    @Test
+    public void testConfigAvailable()
+    {
+        Injector injector = new Bootstrap(new FooModule())
+                .strictConfig()
+                .doNotInitializeLogging()
+                .setRequiredConfigurationProperty("foo.enabled", "true")
+                .setRequiredConfigurationProperty("bar.enabled", "true")
+                .initialize();
+
+        assertEquals(injector.getInstance(Key.get(String.class, named("foo"))), "fooInstance");
+        assertEquals(injector.getInstance(Key.get(String.class, named("bar"))), "barInstance");
+        assertEquals(injector.getInstance(Key.get(String.class, named("abc"))), "abcInstance");
+    }
+
+    @Test
+    public void testInvalidInstall()
+    {
+        Bootstrap bootstrap = new Bootstrap(new BrokenInstallModule())
+                .strictConfig()
+                .doNotInitializeLogging();
+
+        assertThatThrownBy(bootstrap::initialize).isInstanceOfSatisfying(CreationException.class, e ->
+                assertThat(e.getErrorMessages()).hasOnlyOneElementSatisfying(m ->
+                        assertThat(m.getMessage()).endsWith("Use super.install() for ConfigurationAwareModule, not binder.install()")));
+    }
+
+    public static class FooModule
+            extends AbstractConfigurationAwareModule
+    {
+        @Override
+        protected void setup(Binder binder)
+        {
+            assertTrue(buildConfigObject(FooConfig.class).isFoo());
+            install(new BarModule());
+            binder.bind(String.class).annotatedWith(named("foo")).toInstance("fooInstance");
+            binder.install(new AbcModule());
+        }
+    }
+
+    public static class BarModule
+            extends AbstractConfigurationAwareModule
+    {
+        @Override
+        protected void setup(Binder binder)
+        {
+            assertTrue(buildConfigObject(BarConfig.class).isBar());
+            binder.bind(String.class).annotatedWith(named("bar")).toInstance("barInstance");
+        }
+    }
+
+    public static class AbcModule
+            implements Module
+    {
+        @Override
+        public void configure(Binder binder)
+        {
+            binder.bind(String.class).annotatedWith(named("abc")).toInstance("abcInstance");
+        }
+    }
+
+    public static class BrokenInstallModule
+            extends AbstractConfigurationAwareModule
+    {
+        @Override
+        protected void setup(Binder binder)
+        {
+            binder.install(new FooModule());
+        }
+    }
+
+    public static class FooConfig
+    {
+        private boolean foo;
+
+        public boolean isFoo()
+        {
+            return foo;
+        }
+
+        @Config("foo.enabled")
+        public FooConfig setFoo(boolean foo)
+        {
+            this.foo = foo;
+            return this;
+        }
+    }
+
+    public static class BarConfig
+    {
+        private boolean bar;
+
+        public boolean isBar()
+        {
+            return bar;
+        }
+
+        @Config("bar.enabled")
+        public BarConfig setBar(boolean bar)
+        {
+            this.bar = bar;
+            return this;
+        }
+    }
+}

--- a/configuration/src/main/java/io/airlift/configuration/AbstractConfigurationAwareModule.java
+++ b/configuration/src/main/java/io/airlift/configuration/AbstractConfigurationAwareModule.java
@@ -106,8 +106,8 @@ public abstract class AbstractConfigurationAwareModule
         protected Object handleInvocation(Object proxy, Method method, Object[] args)
                 throws Throwable
         {
-            if (INSTALL_METHOD.equals(method)) {
-                throw new RuntimeException("binder.install() should not be called, use super.install() instead");
+            if (INSTALL_METHOD.equals(method) && (args[0] instanceof ConfigurationAwareModule)) {
+                throw new IllegalStateException("Use super.install() for ConfigurationAwareModule, not binder.install()");
             }
 
             return method.invoke(delegate, args);


### PR DESCRIPTION
This prevents invalid usages without breaking nested installs.