### PR TITLE
Add method to clear a set log level

### DIFF
--- a/log-manager/src/test/java/io/airlift/log/TestLogging.java
+++ b/log-manager/src/test/java/io/airlift/log/TestLogging.java
@@ -135,4 +135,17 @@ public class TestLogging
         assertFalse(logger.isDebugEnabled());
         assertFalse(logger.isInfoEnabled());
     }
+
+    @Test
+    public void testClearLevel()
+            throws Exception
+    {
+        Logging logging = Logging.initialize();
+        Logger logger = Logger.get("testClearLevel");
+
+        logging.setLevel("testClearLevel", Level.DEBUG);
+        assertTrue(logger.isDebugEnabled());
+        logging.clearLevel("testClearLevel");
+        assertFalse(logger.isDebugEnabled());
+    }
 }


### PR DESCRIPTION
Java Logging supports clearing override log levels previously set by
calling setLevel(). Expose an Airlift method for doing this.