### PR TITLE
added config property to enable/disable ssl hostname verification

### DIFF
--- a/http-client/src/main/java/io/airlift/http/client/HttpClientConfig.java
+++ b/http-client/src/main/java/io/airlift/http/client/HttpClientConfig.java
@@ -102,6 +102,20 @@ public class HttpClientConfig
     private DataSize logBufferSize = new DataSize(1, MEGABYTE);
     private Duration logFlushInterval = new Duration(10, SECONDS);
     private boolean logCompressionEnabled = true;
+    private boolean verifyHostname = true;
+
+    public boolean isVerifyHostname()
+    {
+        return verifyHostname;
+    }
+
+    @Config("http-client.https.hostname-verification")
+    @ConfigDescription("Verify that server hostname matches the server certificate")
+    public HttpClientConfig setVerifyHostname(boolean verifyHostname)
+    {
+        this.verifyHostname = verifyHostname;
+        return this;
+    }
 
     public boolean isHttp2Enabled()
     {

--- a/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
@@ -158,7 +158,8 @@ public class JettyHttpClient
         creationLocation.fillInStackTrace();
 
         SslContextFactory.Client sslContextFactory = new SslContextFactory.Client();
-        sslContextFactory.setEndpointIdentificationAlgorithm("HTTPS");
+        sslContextFactory.setEndpointIdentificationAlgorithm(config.isVerifyHostname() ? "HTTPS" : null);
+
         if (config.getKeyStorePath() != null) {
             Optional<KeyStore> pemKeyStore = tryLoadPemKeyStore(config);
             if (pemKeyStore.isPresent()) {

--- a/http-client/src/test/java/io/airlift/http/client/TestHttpClientConfig.java
+++ b/http-client/src/test/java/io/airlift/http/client/TestHttpClientConfig.java
@@ -49,6 +49,7 @@ public class TestHttpClientConfig
     public void testDefaults()
     {
         ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(HttpClientConfig.class)
+                .setVerifyHostname(true)
                 .setHttp2Enabled(false)
                 .setConnectTimeout(new Duration(5, SECONDS))
                 .setRequestTimeout(new Duration(5, MINUTES))
@@ -97,6 +98,7 @@ public class TestHttpClientConfig
     public void testExplicitPropertyMappings()
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("http-client.https.hostname-verification", "false")
                 .put("http-client.http2.enabled", "true")
                 .put("http-client.connect-timeout", "4s")
                 .put("http-client.request-timeout", "15s")
@@ -142,6 +144,7 @@ public class TestHttpClientConfig
                 .build();
 
         HttpClientConfig expected = new HttpClientConfig()
+                .setVerifyHostname(false)
                 .setHttp2Enabled(true)
                 .setConnectTimeout(new Duration(4, SECONDS))
                 .setRequestTimeout(new Duration(15, SECONDS))


### PR DESCRIPTION
Embedded Jetty allows enabling / disabling SSL hostname verification through config mechanisms; actually looks like the default behaviour is for this to be disabled as SslContextFactory has no default endpoint identification algorithm (ref.: https://github.com/eclipse/jetty.project/issues/2520)

Within Airlift, the "setEndpointIdentificationAlgorithm" method is hardcoded with an "HTTPS" value, which ensures hostname verification will always be performed. As a result of this, any system which uses airlift as a foundation for internal communication won't have any control over this, even if it configures its own trust manager or uses the available JVM property on startup (-Djdk.internal.httpclient.disableHostnameVerification)

This is a very simple change adding a config property which allows airlift users to leverage embedded Jetty's configuration possibilities.

The justification is that there are use cases which require disabling the hostname verification for SSL (or don't really need it), without bypassing the whole certificate chain trust process. A good example is a system or application which subscribes to the SPIFFE / SPIRE standard, where certificate chain trust is enforced but vanilla hostname verification (based on certificate CN) is not necessary as the SPIFFE URI in the certificate's SAN is a much more effective and flexible way to prevent the man-in-the-middle attack.

