### PR TITLE
Fix wrong array index

### DIFF
--- a/stats/src/main/java/io/airlift/stats/TDigest.java
+++ b/stats/src/main/java/io/airlift/stats/TDigest.java
@@ -301,7 +301,9 @@ public class TDigest
             while (currentCentroid < centroidCount - 1 && weightSoFar + delta <= offsets.get(index)) {
                 weightSoFar += delta;
                 currentCentroid++;
-                delta = (weights[currentCentroid] + weights[currentCentroid + 1]) / 2;
+                if (currentCentroid < centroidCount - 1) {
+                    delta = (weights[currentCentroid] + weights[currentCentroid + 1]) / 2;
+                }
             }
             // past the last centroid
             if (currentCentroid == centroidCount - 1) {

--- a/stats/src/test/java/io/airlift/stats/TestTDigest.java
+++ b/stats/src/test/java/io/airlift/stats/TestTDigest.java
@@ -164,6 +164,18 @@ public class TestTDigest
     }
 
     @Test
+    public void testFirstInnerAndLastCentroid()
+    {
+        TDigest digest = new TDigest();
+        digest.add(1);
+        digest.add(2);
+        digest.add(3);
+        digest.add(4);
+
+        assertEquals(digest.valuesAt(ImmutableList.of(0d, 0.6d, 1d)), ImmutableList.of(1.0, 3.0, 4.0));
+    }
+
+    @Test
     public void testSerializationEmpty()
     {
         TDigest digest = new TDigest();


### PR DESCRIPTION
Fix potential Array index out of bound exception in
`TDigest.valuesAt()`.
If a searched quantile fell past the last centroid,
and some prevoiusly processed quantile fell in the inner
part of the distribution, the algorithm would try
to compute delta weight between the last centroid and the next,
which caused error.