### PR TITLE
Fix use of injected SslContextFactory

### DIFF
--- a/http-server/src/main/java/io/airlift/http/server/HttpServer.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServer.java
@@ -98,7 +98,7 @@ public class HttpServer
     private ConnectionStats httpConnectionStats;
     private ConnectionStats httpsConnectionStats;
     private ScheduledExecutorService scheduledExecutorService;
-    private Optional<SslContextFactory.Server> sslContextFactory = Optional.empty();
+    private Optional<SslContextFactory.Server> sslContextFactory;
 
     public HttpServer(HttpServerInfo httpServerInfo,
             NodeInfo nodeInfo,
@@ -133,6 +133,8 @@ public class HttpServer
         threadPool.setDetailedDump(true);
         server = new Server(threadPool);
         registerErrorHandler = config.isShowStackTrace();
+
+        this.sslContextFactory = maybeSslContextFactory;
 
         if (mbeanServer != null) {
             // export jmx mbeans if a server was provided


### PR DESCRIPTION
The SslContextFactory that was injected was always being ignored and the default behavior of creating a new ReloadableSslContextFactory was always in effect. 

In later lines you can see that the way the sslContextFactory was used was by using whichever was there or else creating a new ReloadableSslContextFactory. Since `this.sslContextFactory` was defaulted to Empty and the injected value `maybeSslContextFactory` was ignored this value would never be used.

Example:
```java
this.sslContextFactory = Optional.of(this.sslContextFactory.orElseGet(() -> createReloadingSslContextFactory(config, clientCertificate)));
```

I validated that existing tests would catch that `sslContextFactory` is not set after removing the default value.