### PR TITLE
update airbase version to 104

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>io.airlift</groupId>
         <artifactId>airbase</artifactId>
-        <version>100</version>
+        <version>104</version>
     </parent>
 
     <inceptionYear>2010</inceptionYear>


### PR DESCRIPTION
In order to update `Gauva` to 30.0,  we need to update the `airbase` version to the latest version 104.