### PR TITLE
Jetty upgrade to 9.4.30.v20200611 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
         <dep.airlift.version>202-SNAPSHOT</dep.airlift.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
-        <dep.jetty.version>9.4.27.v20200227</dep.jetty.version>
+        <dep.jetty.version>9.4.30.v20200611</dep.jetty.version>
         <dep.jersey.version>2.26</dep.jersey.version>
     </properties>
 


### PR DESCRIPTION
As the  max request header size and response heder size are configurable in airlift, CVE-2019-17638 (https://nvd.nist.gov/vuln/detail/CVE-2019-17638) might affect it.
Jetty version update to 9.4.30.v20200611 will fix the issue in lights of CVE-2019-17638 and https://github.com/eclipse/jetty.project/issues/4936.