### PR TITLE
Limit total size of http-client.log

### DIFF
--- a/http-client/src/main/java/io/airlift/http/client/jetty/DefaultHttpClientLogger.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/DefaultHttpClientLogger.java
@@ -20,6 +20,7 @@ import ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP;
 import ch.qos.logback.core.rolling.TimeBasedRollingPolicy;
 import ch.qos.logback.core.status.ErrorStatus;
 import ch.qos.logback.core.util.FileSize;
+import com.google.common.math.LongMath;
 import io.airlift.log.Logger;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
@@ -59,13 +60,17 @@ class DefaultHttpClientLogger
         TimeBasedRollingPolicy<HttpRequestEvent> rollingPolicy = new TimeBasedRollingPolicy<>();
 
         rollingPolicy.setContext(context);
-        rollingPolicy.setMaxHistory(maxHistory);
+        rollingPolicy.setMaxHistory(maxHistory); // limits number of logging periods (i.e. days) kept
         rollingPolicy.setTimeBasedFileNamingAndTriggeringPolicy(triggeringPolicy);
         rollingPolicy.setParent(fileAppender);
         rollingPolicy.setFileNamePattern(filename + "-%d{yyyy-MM-dd}.%i.log");
         if (compressionEnabled) {
             rollingPolicy.setFileNamePattern(rollingPolicy.getFileNamePattern() + ".gz");
         }
+
+        // Limit total log files occupancy on disk. Ideally we would keep exactly
+        // `maxHistory` files (not logging periods). This is closest currently possible.
+        rollingPolicy.setTotalSizeCap(new FileSize(LongMath.saturatedMultiply(maxFileSizeInBytes, maxHistory)));
 
         triggeringPolicy.setContext(context);
         triggeringPolicy.setTimeBasedRollingPolicy(rollingPolicy);


### PR DESCRIPTION
Fixes [894](https://github.com/airlift/airlift/issues/894)
Fixes https://github.com/trinodb/trino/issues/7018