### PR TITLE
Fix SSL context factory reloading

### DIFF
--- a/http-server/pom.xml
+++ b/http-server/pom.xml
@@ -180,6 +180,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk15on</artifactId>
+            <version>1.58</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/http-server/src/main/java/io/airlift/http/server/HttpServer.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServer.java
@@ -88,7 +88,8 @@ import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
 
 public class HttpServer
 {
-    public enum ClientCertificate {
+    public enum ClientCertificate
+    {
         NONE, REQUESTED, REQUIRED
     }
 

--- a/http-server/src/main/java/io/airlift/http/server/HttpServer.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServer.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.event.client.EventClient;
 import io.airlift.http.server.HttpServerBinder.HttpResourceBinding;
+import io.airlift.log.Logger;
 import io.airlift.node.NodeInfo;
 import io.airlift.tracetoken.TraceTokenManager;
 import org.eclipse.jetty.http2.server.HTTP2CServerConnectionFactory;
@@ -90,6 +91,8 @@ public class HttpServer
     public enum ClientCertificate {
         NONE, REQUESTED, REQUIRED
     }
+
+    private static final Logger log = Logger.get(HttpServer.class);
 
     private final Server server;
     private final boolean registerErrorHandler;
@@ -439,7 +442,8 @@ public class HttpServer
                     }
                 }
             }
-            catch (Exception ignored) {
+            catch (Exception e) {
+                log.error(e, "Error reading certificates");
             }
         });
 

--- a/http-server/src/main/java/io/airlift/http/server/HttpServer.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServer.java
@@ -425,7 +425,8 @@ public class HttpServer
                 config.isLogCompressionEnabled());
     }
 
-    private Set<X509Certificate> getCertificates()
+    @VisibleForTesting
+    Set<X509Certificate> getCertificates()
     {
         ImmutableSet.Builder<X509Certificate> certificates = ImmutableSet.builder();
         this.sslContextFactory.ifPresent(factory -> {

--- a/http-server/src/main/java/io/airlift/http/server/ReloadableSslContextFactoryProvider.java
+++ b/http-server/src/main/java/io/airlift/http/server/ReloadableSslContextFactoryProvider.java
@@ -65,7 +65,7 @@ final class ReloadableSslContextFactoryProvider
 
         this.clientCertificate = requireNonNull(clientCertificate, "clientCertificate is null");
 
-        this.sslContextFactory = buildContextFactory();
+        sslContextFactory = buildContextFactory();
         long refreshTime = config.getSslContextRefreshTime().toMillis();
         scheduledExecutor.scheduleWithFixedDelay(this::reload, refreshTime, refreshTime, MILLISECONDS);
     }
@@ -166,13 +166,13 @@ final class ReloadableSslContextFactoryProvider
      */
     public SslContextFactory.Server getSslContextFactory()
     {
-        return this.sslContextFactory;
+        return sslContextFactory;
     }
 
     private synchronized void reload()
     {
         try {
-            this.sslContextFactory.reload(factory -> {});
+            sslContextFactory.reload(factory -> {});
         }
         catch (Exception e) {
             log.warn(e, "Unable to reload SslContext.");

--- a/http-server/src/main/java/io/airlift/http/server/ReloadableSslContextFactoryProvider.java
+++ b/http-server/src/main/java/io/airlift/http/server/ReloadableSslContextFactoryProvider.java
@@ -172,9 +172,7 @@ final class ReloadableSslContextFactoryProvider
     private synchronized void reload()
     {
         try {
-            SslContextFactory.Server updatedFactory = buildContextFactory();
-            updatedFactory.start();
-            this.sslContextFactory.reload(factory -> factory.setSslContext(updatedFactory.getSslContext()));
+            this.sslContextFactory.reload(factory -> {});
         }
         catch (Exception e) {
             log.warn(e, "Unable to reload SslContext.");

--- a/http-server/src/test/java/io/airlift/http/server/TestHttpServerProvider.java
+++ b/http-server/src/test/java/io/airlift/http/server/TestHttpServerProvider.java
@@ -71,7 +71,6 @@ import java.util.Base64;
 import java.util.Date;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 
 import static com.google.common.io.Files.asCharSink;
 import static com.google.common.io.MoreFiles.deleteRecursively;
@@ -88,6 +87,7 @@ import static io.airlift.testing.Assertions.assertContains;
 import static io.airlift.testing.Assertions.assertInstanceOf;
 import static io.airlift.testing.Assertions.assertNotEquals;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -514,7 +514,7 @@ public class TestHttpServerProvider
             HttpResponseFuture<?> future = client.executeAsync(request, createStatusResponseHandler());
 
             // wait until the servlet starts processing the request
-            servlet.getLatch().await(1, TimeUnit.SECONDS);
+            servlet.getLatch().await(1, SECONDS);
 
             // stop server while the request is still active
             server.stop();
@@ -524,7 +524,7 @@ public class TestHttpServerProvider
 
             // request should fail rather than sleeping the full duration
             try {
-                future.get(5, TimeUnit.SECONDS);
+                future.get(5, SECONDS);
                 fail("expected exception");
             }
             catch (ExecutionException e) {
@@ -607,7 +607,7 @@ public class TestHttpServerProvider
         File keyStoreFile = File.createTempFile("test", ".keystore");
         try {
             appendCertificate(keyStoreFile, "certificate-1");
-            config.setSslContextRefreshTime(new Duration(5, TimeUnit.SECONDS))
+            config.setSslContextRefreshTime(new Duration(5, SECONDS))
                     .setKeystorePath(keyStoreFile.getAbsolutePath())
                     .setKeystorePassword("airlift")
                     .setHttpsEnabled(true)
@@ -698,7 +698,7 @@ public class TestHttpServerProvider
     private static void assertEventually(Runnable assertion)
     {
         long start = System.nanoTime();
-        Duration timeout = new Duration(30, TimeUnit.SECONDS);
+        Duration timeout = new Duration(30, SECONDS);
         while (!Thread.currentThread().isInterrupted()) {
             try {
                 assertion.run();

--- a/http-server/src/test/java/io/airlift/http/server/TestHttpServerProvider.java
+++ b/http-server/src/test/java/io/airlift/http/server/TestHttpServerProvider.java
@@ -33,6 +33,13 @@ import io.airlift.log.Logging;
 import io.airlift.node.NodeConfig;
 import io.airlift.node.NodeInfo;
 import io.airlift.tracetoken.TraceTokenManager;
+import io.airlift.units.Duration;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeSuite;
@@ -42,12 +49,26 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import java.io.EOFException;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.UncheckedIOException;
+import java.math.BigInteger;
 import java.net.URI;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Base64;
+import java.util.Date;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -579,6 +600,28 @@ public class TestHttpServerProvider
         createAndStartServer();
     }
 
+    @Test
+    public void testKeystoreReloading()
+            throws Exception
+    {
+        File keyStoreFile = File.createTempFile("test", ".keystore");
+        try {
+            appendCertificate(keyStoreFile, "certificate-1");
+            config.setSslContextRefreshTime(new Duration(5, TimeUnit.SECONDS))
+                    .setKeystorePath(keyStoreFile.getAbsolutePath())
+                    .setKeystorePassword("airlift")
+                    .setHttpsEnabled(true)
+                    .setHttpEnabled(false);
+            createAndStartServer();
+            assertEventually(() -> assertEquals(server.getCertificates().size(), 1));
+            appendCertificate(keyStoreFile, "certificate-2");
+            assertEventually(() -> assertEquals(server.getCertificates().size(), 2));
+        }
+        finally {
+            keyStoreFile.delete();
+        }
+    }
+
     private void createAndStartServer()
             throws Exception
     {
@@ -618,5 +661,61 @@ public class TestHttpServerProvider
         serverProvider.setLoginService(loginServiceProvider.get());
         serverProvider.setTokenManager(new TraceTokenManager());
         server = serverProvider.get();
+    }
+
+    private static void appendCertificate(File keyStoreFile, String alias)
+            throws Exception
+    {
+        KeyStore keyStore = KeyStore.getInstance("JKS");
+        char[] password = "airlift".toCharArray();
+        try (InputStream inStream = new FileInputStream(keyStoreFile)) {
+            keyStore.load(inStream, password);
+        }
+        catch (EOFException ignored) { // reading an empty file produces EOFException
+            keyStore.load(null, password);
+        }
+        KeyPairGenerator kpGenerator = KeyPairGenerator.getInstance("RSA");
+        kpGenerator.initialize(2048);
+        KeyPair keyPair = kpGenerator.generateKeyPair();
+        PrivateKey privateKey = keyPair.getPrivate();
+        X500Name issuerName = new X500Name("CN=Airlift Test, OU=Airlift, O=Airlift, L=Palo Alto, ST=CA, C=US");
+        JcaX509v3CertificateBuilder builder = new JcaX509v3CertificateBuilder(
+                issuerName,
+                BigInteger.valueOf(System.currentTimeMillis()),
+                Date.from(Instant.now()),
+                Date.from(Instant.now().plus(365, ChronoUnit.DAYS)),
+                issuerName,
+                keyPair.getPublic());
+        ContentSigner signer = new JcaContentSignerBuilder("SHA256WithRSA").build(privateKey);
+        X509CertificateHolder certHolder = builder.build(signer);
+        Certificate cert = new JcaX509CertificateConverter().getCertificate(certHolder);
+        keyStore.setKeyEntry(alias, privateKey, password, new Certificate[] {cert});
+        try (OutputStream outStream = new FileOutputStream(keyStoreFile)) {
+            keyStore.store(outStream, password);
+        }
+    }
+
+    private static void assertEventually(Runnable assertion)
+    {
+        long start = System.nanoTime();
+        Duration timeout = new Duration(30, TimeUnit.SECONDS);
+        while (!Thread.currentThread().isInterrupted()) {
+            try {
+                assertion.run();
+                return;
+            }
+            catch (Exception | AssertionError e) {
+                if (Duration.nanosSince(start).compareTo(timeout) > 0) {
+                    throw e;
+                }
+            }
+            try {
+                Thread.sleep(50);
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+        }
     }
 }


### PR DESCRIPTION
Setting the SSL context while reloading was actually disabling the actual SSL
context factory reload. org.eclipse.jetty.util.ssl.SslContextFactory#load method
skips the most important part of the reloading process if the SSL context is set.
Added a missing test.