### PR TITLE
Fix SSL context factory reloading

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+206
+
+- Fix SNI handling for HTTP server.
+
 205
 
 - Add form data body builder for HTTP client.

--- a/http-server/pom.xml
+++ b/http-server/pom.xml
@@ -180,6 +180,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk15on</artifactId>
+            <version>1.68</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/http-server/src/main/java/io/airlift/http/server/HttpServer.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServer.java
@@ -88,7 +88,8 @@ import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
 
 public class HttpServer
 {
-    public enum ClientCertificate {
+    public enum ClientCertificate
+    {
         NONE, REQUESTED, REQUIRED
     }
 

--- a/http-server/src/main/java/io/airlift/http/server/HttpServer.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServer.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.event.client.EventClient;
 import io.airlift.http.server.HttpServerBinder.HttpResourceBinding;
+import io.airlift.log.Logger;
 import io.airlift.node.NodeInfo;
 import io.airlift.tracetoken.TraceTokenManager;
 import org.eclipse.jetty.http2.server.HTTP2CServerConnectionFactory;
@@ -90,6 +91,8 @@ public class HttpServer
     public enum ClientCertificate {
         NONE, REQUESTED, REQUIRED
     }
+
+    private static final Logger log = Logger.get(HttpServer.class);
 
     private final Server server;
     private final boolean registerErrorHandler;
@@ -438,7 +441,8 @@ public class HttpServer
                     }
                 }
             }
-            catch (Exception ignored) {
+            catch (Exception e) {
+                log.error(e, "Error reading certificates");
             }
         });
 

--- a/http-server/src/main/java/io/airlift/http/server/HttpServer.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServer.java
@@ -429,7 +429,8 @@ public class HttpServer
                 config.isLogCompressionEnabled());
     }
 
-    private Set<X509Certificate> getCertificates()
+    @VisibleForTesting
+    Set<X509Certificate> getCertificates()
     {
         ImmutableSet.Builder<X509Certificate> certificates = ImmutableSet.builder();
         this.sslContextFactory.ifPresent(factory -> {

--- a/http-server/src/main/java/io/airlift/http/server/ReloadableSslContextFactoryProvider.java
+++ b/http-server/src/main/java/io/airlift/http/server/ReloadableSslContextFactoryProvider.java
@@ -166,7 +166,7 @@ final class ReloadableSslContextFactoryProvider
      */
     public SslContextFactory.Server getSslContextFactory()
     {
-        return this.sslContextFactory;
+        return sslContextFactory;
     }
 
     private synchronized void reload()

--- a/http-server/src/test/java/io/airlift/http/server/TestHttpServerProvider.java
+++ b/http-server/src/test/java/io/airlift/http/server/TestHttpServerProvider.java
@@ -50,7 +50,6 @@ import java.security.cert.X509Certificate;
 import java.util.Base64;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 
 import static com.google.common.io.Files.asCharSink;
 import static com.google.common.io.MoreFiles.deleteRecursively;
@@ -67,6 +66,7 @@ import static io.airlift.testing.Assertions.assertContains;
 import static io.airlift.testing.Assertions.assertInstanceOf;
 import static io.airlift.testing.Assertions.assertNotEquals;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -493,7 +493,7 @@ public class TestHttpServerProvider
             HttpResponseFuture<?> future = client.executeAsync(request, createStatusResponseHandler());
 
             // wait until the servlet starts processing the request
-            servlet.getLatch().await(1, TimeUnit.SECONDS);
+            servlet.getLatch().await(1, SECONDS);
 
             // stop server while the request is still active
             server.stop();
@@ -503,7 +503,7 @@ public class TestHttpServerProvider
 
             // request should fail rather than sleeping the full duration
             try {
-                future.get(5, TimeUnit.SECONDS);
+                future.get(5, SECONDS);
                 fail("expected exception");
             }
             catch (ExecutionException e) {


### PR DESCRIPTION
Setting the SSL context while reloading was actually disabling the part of the reload that sets the necessary information for SNI handling. It also did not set the keystore on the factory, so the JMX method `getDaysUntilCertificateExpiration()` was broken.