### PR TITLE
Support multilingual encoding in property files

### DIFF
--- a/configuration/src/main/java/io/airlift/configuration/ConfigurationLoader.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigurationLoader.java
@@ -22,7 +22,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
@@ -30,6 +29,7 @@ import java.util.TreeMap;
 
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.Maps.fromProperties;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public final class ConfigurationLoader
 {
@@ -60,8 +60,7 @@ public final class ConfigurationLoader
             throws IOException
     {
         Properties properties = new Properties();
-        try (Reader reader = new BufferedReader(new InputStreamReader(new FileInputStream(path),
-            StandardCharsets.UTF_8))) {
+        try (Reader reader = new BufferedReader(new InputStreamReader(new FileInputStream(path), UTF_8))) {
             properties.load(reader);
         }
 

--- a/configuration/src/main/java/io/airlift/configuration/ConfigurationLoader.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigurationLoader.java
@@ -17,9 +17,12 @@ package io.airlift.configuration;
 
 import com.google.common.collect.ImmutableSortedMap;
 
+import java.io.BufferedReader;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
@@ -57,8 +60,9 @@ public final class ConfigurationLoader
             throws IOException
     {
         Properties properties = new Properties();
-        try (InputStream inputStream = new FileInputStream(path)) {
-            properties.load(inputStream);
+        try (Reader reader = new BufferedReader(new InputStreamReader(new FileInputStream(path),
+            StandardCharsets.UTF_8))) {
+            properties.load(reader);
         }
 
         return fromProperties(properties).entrySet().stream()

--- a/configuration/src/test/java/io/airlift/configuration/TestConfigurationLoader.java
+++ b/configuration/src/test/java/io/airlift/configuration/TestConfigurationLoader.java
@@ -126,7 +126,7 @@ public class TestConfigurationLoader
 
     @Test
     public void testSpecialCharacterFromFile()
-        throws IOException
+            throws IOException
     {
         File file = createConfigFile(out -> {
             out.println("english-key: user");

--- a/configuration/src/test/java/io/airlift/configuration/TestConfigurationLoader.java
+++ b/configuration/src/test/java/io/airlift/configuration/TestConfigurationLoader.java
@@ -30,6 +30,7 @@ import java.util.function.Consumer;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static io.airlift.configuration.ConfigurationLoader.loadProperties;
+import static io.airlift.configuration.ConfigurationLoader.loadPropertiesFrom;
 import static org.testng.Assert.assertEquals;
 
 public class TestConfigurationLoader
@@ -121,6 +122,29 @@ public class TestConfigurationLoader
 
         System.clearProperty("key1");
         System.clearProperty("config");
+    }
+
+    @Test
+    public void testSpecialCharacterFromFile()
+        throws IOException
+    {
+        File file = createConfigFile(out -> {
+            out.println("english-key: user");
+            out.println("korean-key: 사용자");
+            out.println("chinese-key: 用户");
+            out.println("arabic-key: المستعمل");
+            out.println("japanese-key: ユーザー");
+            out.println("special-character-key: ~!@#$%^^&**()_+-=<>?:{}[];:',.");
+        });
+
+        Map<String, String> properties = loadPropertiesFrom(file.getAbsolutePath());
+
+        assertEquals(properties.get("english-key"), "user");
+        assertEquals(properties.get("korean-key"), "사용자");
+        assertEquals(properties.get("chinese-key"), "用户");
+        assertEquals(properties.get("arabic-key"), "المستعمل");
+        assertEquals(properties.get("japanese-key"), "ユーザー");
+        assertEquals(properties.get("special-character-key"), "~!@#$%^^&**()_+-=<>?:{}[];:',.");
     }
 
     private File createConfigFile(Consumer<PrintStream> contentProvider)


### PR DESCRIPTION
I'm a Trino user, I'm reading the value from the property file for LDAP password authentication .

To read the property value, the airlift ConfigurationLoader is being used.

However if a value of Property file is not an English value, there is a bug that can not be read properly.

To support various countries and usecase, multilingual encoding support is required.

ex)
property value : ldap.user-bind-pattern=OU=사용자,DC=example,DC=com
compiled value : OU=ì�¬ì�©ì��,DC=example,DC=com