### PR TITLE
Migrate to ListenableFuture<Void>

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@
 - Deprecate ConfigurationModule.installModules.
 - Deprecate ConditionalModule.installModuleIf and introduce
   ConditionalModule.conditionalModule.
+- Migrate to ListenableFuture<Void> for future signaling.
 
 206
 

--- a/concurrent/src/main/java/io/airlift/concurrent/AsyncSemaphore.java
+++ b/concurrent/src/main/java/io/airlift/concurrent/AsyncSemaphore.java
@@ -54,7 +54,7 @@ public class AsyncSemaphore<T>
         this.submitter = requireNonNull(submitter, "submitter is null");
     }
 
-    public ListenableFuture<?> submit(T task)
+    public ListenableFuture<Void> submit(T task)
     {
         QueuedTask<T> queuedTask = new QueuedTask<>(task);
         queuedTasks.add(queuedTask);
@@ -118,7 +118,7 @@ public class AsyncSemaphore<T>
     private static class QueuedTask<T>
     {
         private final T task;
-        private final SettableFuture<?> settableFuture = SettableFuture.create();
+        private final SettableFuture<Void> settableFuture = SettableFuture.create();
 
         private QueuedTask(T task)
         {
@@ -140,7 +140,7 @@ public class AsyncSemaphore<T>
             settableFuture.set(null);
         }
 
-        public ListenableFuture<?> getCompletionFuture()
+        public ListenableFuture<Void> getCompletionFuture()
         {
             return settableFuture;
         }

--- a/concurrent/src/main/java/io/airlift/concurrent/MoreFutures.java
+++ b/concurrent/src/main/java/io/airlift/concurrent/MoreFutures.java
@@ -45,6 +45,30 @@ public final class MoreFutures
     private MoreFutures() {}
 
     /**
+     * Transforms a ListenableFuture&lt;T&gt; to ListenableFuture&lt;Void&gt;.
+     */
+    public static <T> ListenableFuture<Void> asVoid(ListenableFuture<T> future)
+    {
+        return Futures.transform(future, MoreFutures::toVoid, directExecutor());
+    }
+
+    /**
+     * Converts a value to Void.
+     *
+     * This is useful for providing named fluent style Future transforms to Void values.
+     * <p>
+     * Example:
+     * <pre>
+     * ListenableFuture<Void> voidFuture = FluentFuture.from(future)
+     *         .transform(MoreFutures::toVoid, directExecutor())
+     * </pre>
+     */
+    public static <T> Void toVoid(T value)
+    {
+        return null;
+    }
+
+    /**
      * Cancels the destination Future if the source Future is cancelled.
      */
     public static <X, Y> void propagateCancellation(ListenableFuture<? extends X> source, Future<? extends Y> destination, boolean mayInterruptIfRunning)

--- a/concurrent/src/test/java/io/airlift/concurrent/TestAsyncSemaphore.java
+++ b/concurrent/src/test/java/io/airlift/concurrent/TestAsyncSemaphore.java
@@ -52,7 +52,7 @@ public class TestAsyncSemaphore
 
         AtomicInteger count = new AtomicInteger();
 
-        List<ListenableFuture<?>> futures = new ArrayList<>();
+        List<ListenableFuture<Void>> futures = new ArrayList<>();
         for (int i = 0; i < 1000; i++) {
             futures.add(asyncSemaphore.submit(count::incrementAndGet));
         }
@@ -72,7 +72,7 @@ public class TestAsyncSemaphore
         AtomicInteger count = new AtomicInteger();
         AtomicInteger concurrency = new AtomicInteger();
 
-        List<ListenableFuture<?>> futures = new ArrayList<>();
+        List<ListenableFuture<Void>> futures = new ArrayList<>();
         for (int i = 0; i < 1000; i++) {
             futures.add(asyncSemaphore.submit((Runnable) () -> {
                 count.incrementAndGet();
@@ -98,7 +98,7 @@ public class TestAsyncSemaphore
         AtomicInteger count = new AtomicInteger();
         AtomicInteger concurrency = new AtomicInteger();
 
-        List<ListenableFuture<?>> futures = new ArrayList<>();
+        List<ListenableFuture<Void>> futures = new ArrayList<>();
         for (int i = 0; i < 1000; i++) {
             futures.add(asyncSemaphore.submit(() -> {
                 count.incrementAndGet();
@@ -159,9 +159,9 @@ public class TestAsyncSemaphore
         AtomicInteger concurrency = new AtomicInteger();
         CountDownLatch completionLatch = new CountDownLatch(1000);
 
-        List<ListenableFuture<?>> futures = new ArrayList<>();
+        List<ListenableFuture<Void>> futures = new ArrayList<>();
         for (int i = 0; i < 1000; i++) {
-            ListenableFuture<?> future = asyncSemaphore.submit(() -> assertFailedConcurrency(concurrency));
+            ListenableFuture<Void> future = asyncSemaphore.submit(() -> assertFailedConcurrency(concurrency));
             addCallback(future, completionCallback(successCount, failureCount, completionLatch), directExecutor());
             futures.add(future);
         }
@@ -169,7 +169,7 @@ public class TestAsyncSemaphore
         // Wait for all tasks and callbacks to complete
         completionLatch.await(1, TimeUnit.MINUTES);
 
-        for (ListenableFuture<?> future : futures) {
+        for (ListenableFuture<Void> future : futures) {
             try {
                 future.get();
                 fail();
@@ -194,10 +194,10 @@ public class TestAsyncSemaphore
             throw assertFailedConcurrency(concurrency);
         });
 
-        List<ListenableFuture<?>> futures = new ArrayList<>();
+        List<ListenableFuture<Void>> futures = new ArrayList<>();
         for (int i = 0; i < 1000; i++) {
             // Should never execute this future
-            ListenableFuture<?> future = asyncSemaphore.submit(() -> fail(null));
+            ListenableFuture<Void> future = asyncSemaphore.submit(() -> fail(null));
             addCallback(future, completionCallback(successCount, failureCount, completionLatch), directExecutor());
             futures.add(future);
         }
@@ -205,7 +205,7 @@ public class TestAsyncSemaphore
         // Wait for all tasks and callbacks to complete
         completionLatch.await(1, TimeUnit.MINUTES);
 
-        for (ListenableFuture<?> future : futures) {
+        for (ListenableFuture<Void> future : futures) {
             try {
                 future.get();
                 fail();
@@ -232,12 +232,12 @@ public class TestAsyncSemaphore
             throw assertFailedConcurrency(concurrency);
         });
 
-        Queue<ListenableFuture<?>> futures = new ConcurrentLinkedQueue<>();
+        Queue<ListenableFuture<Void>> futures = new ConcurrentLinkedQueue<>();
         for (int i = 0; i < 100; i++) {
             executor.execute(() -> {
                 Uninterruptibles.awaitUninterruptibly(startLatch, 1, TimeUnit.MINUTES);
                 // Should never execute this future
-                ListenableFuture<?> future = asyncSemaphore.submit(() -> fail(null));
+                ListenableFuture<Void> future = asyncSemaphore.submit(() -> fail(null));
                 futures.add(future);
                 addCallback(future, completionCallback(successCount, failureCount, completionLatch), directExecutor());
             });
@@ -249,7 +249,7 @@ public class TestAsyncSemaphore
         Uninterruptibles.awaitUninterruptibly(completionLatch, 1, TimeUnit.MINUTES);
 
         // Make sure they all report failure
-        for (ListenableFuture<?> future : futures) {
+        for (ListenableFuture<Void> future : futures) {
             try {
                 future.get();
                 fail();
@@ -268,7 +268,7 @@ public class TestAsyncSemaphore
     {
         AsyncSemaphore<Object> asyncSemaphore = new AsyncSemaphore<>(1, executor, object -> Futures.immediateFuture(null));
 
-        List<ListenableFuture<?>> futures = new ArrayList<>();
+        List<ListenableFuture<Void>> futures = new ArrayList<>();
         for (int i = 0; i < 1000; i++) {
             futures.add(asyncSemaphore.submit(new Object()));
         }


### PR DESCRIPTION
ListenableFuture<Void> provides a cleaner programming experience for signaling workloads than the commonly used in ListenableFuture<?>. In this PR, we migrate some of the libraries to using ListenableFuture<Void> and provide some useful utilities for converting to it.