### PR TITLE
Add more @FormatMethod annotation in Logger

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,8 @@
 213
 - Add new methods to Logger which get the message from a Supplier provided by the caller
+- Make Logger methods with no format string parameters interpret the
+  message as a format string, falling back to verbatim message for compatibility
+- Annotate Logger methods with no format string parameters with @FormatMethod
 
 211
 - Fix deadlock in logging error reporting.

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+213
+- Add new methods to Logger which get the message from a Supplier provided by the caller
+
 211
 - Fix deadlock in logging error reporting.
 

--- a/bootstrap/src/main/java/io/airlift/bootstrap/Bootstrap.java
+++ b/bootstrap/src/main/java/io/airlift/bootstrap/Bootstrap.java
@@ -240,16 +240,18 @@ public class Bootstrap
 
         // Log any warnings
         if (!warnings.isEmpty()) {
-            StringBuilder message = new StringBuilder();
-            message.append("Configuration warnings\n");
-            message.append("==========\n\n");
-            message.append("Configuration should be updated:\n\n");
-            for (int index = 0; index < warnings.size(); index++) {
-                message.append(format("%s) %s\n", index + 1, warnings.get(index)));
-            }
-            message.append("\n");
-            message.append("==========");
-            log.warn(message.toString());
+            log.warn(() -> {
+                StringBuilder message = new StringBuilder();
+                message.append("Configuration warnings\n");
+                message.append("==========\n\n");
+                message.append("Configuration should be updated:\n\n");
+                for (int index = 0; index < warnings.size(); index++) {
+                    message.append(format("%s) %s\n", index + 1, warnings.get(index)));
+                }
+                message.append("\n");
+                message.append("==========");
+                return message.toString();
+            });
         }
 
         // system modules

--- a/bootstrap/src/main/java/io/airlift/bootstrap/LoggingWriter.java
+++ b/bootstrap/src/main/java/io/airlift/bootstrap/LoggingWriter.java
@@ -50,7 +50,7 @@ class LoggingWriter
                 if (line == null) {
                     break;
                 }
-                logger.info(line);
+                logger.info("%s", line);
             }
             catch (IOException e) {
                 throw new Error(e); // should never get here

--- a/discovery/pom.xml
+++ b/discovery/pom.xml
@@ -91,6 +91,11 @@
             <optional>true</optional>
         </dependency>
 
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/discovery/src/main/java/io/airlift/discovery/client/ExponentialBackOff.java
+++ b/discovery/src/main/java/io/airlift/discovery/client/ExponentialBackOff.java
@@ -38,7 +38,7 @@ class ExponentialBackOff
     {
         if (!serverUp) {
             serverUp = true;
-            log.info(serverUpMessage);
+            log.info("%s", serverUpMessage);
         }
         currentWaitInMillis = -1;
     }
@@ -47,7 +47,7 @@ class ExponentialBackOff
     {
         if (serverUp) {
             serverUp = false;
-            log.error(t, serverDownMessage);
+            log.error(t, "%s", serverDownMessage);
         }
 
         if (currentWaitInMillis <= 0) {

--- a/discovery/src/main/java/io/airlift/discovery/client/ServiceInventory.java
+++ b/discovery/src/main/java/io/airlift/discovery/client/ServiceInventory.java
@@ -16,6 +16,7 @@
 package io.airlift.discovery.client;
 
 import com.google.common.collect.ImmutableList;
+import com.google.errorprone.annotations.FormatMethod;
 import io.airlift.http.client.HttpClient;
 import io.airlift.http.client.Request.Builder;
 import io.airlift.json.JsonCodec;
@@ -176,6 +177,7 @@ public class ServiceInventory
         }
     }
 
+    @FormatMethod
     private void logServerError(String message, Object... args)
     {
         if (serverUp.compareAndSet(true, false)) {

--- a/http-client/src/main/java/io/airlift/http/client/jetty/JettyClientDiagnostics.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/JettyClientDiagnostics.java
@@ -33,6 +33,6 @@ class JettyClientDiagnostics
             return;
         }
 
-        log.debug(httpClient.dump());
+        log.debug(httpClient::dump);
     }
 }

--- a/log-manager/src/main/java/io/airlift/log/LoggingOutputStream.java
+++ b/log-manager/src/main/java/io/airlift/log/LoggingOutputStream.java
@@ -49,6 +49,6 @@ class LoggingOutputStream
             return;
         }
 
-        logger.info(record);
+        logger.info("%s", record);
     }
 }

--- a/log/src/main/java/io/airlift/log/Logger.java
+++ b/log/src/main/java/io/airlift/log/Logger.java
@@ -18,6 +18,7 @@ package io.airlift.log;
 import com.google.errorprone.annotations.FormatMethod;
 
 import java.util.IllegalFormatException;
+import java.util.function.Supplier;
 
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
@@ -59,6 +60,17 @@ public class Logger
     }
 
     /**
+     * Logs a message, provided by the given supplier, at DEBUG level.
+     *
+     * @param exception an exception associated with the debug message being logged
+     * @param messageSupplier a {@link Supplier} of the pre-formatted message
+     */
+    public void debug(Throwable exception, Supplier<String> messageSupplier)
+    {
+        logger.log(FINE, exception, messageSupplier);
+    }
+
+    /**
      * Logs a message at DEBUG level.
      *
      * @param exception an exception associated with the debug message being logged
@@ -67,6 +79,16 @@ public class Logger
     public void debug(Throwable exception, String message)
     {
         logger.log(FINE, message, exception);
+    }
+
+    /**
+     * Logs a message, provided by the given supplier, at DEBUG level.
+     *
+     * @param messageSupplier a {@link Supplier} of the pre-formatted message
+     */
+    public void debug(Supplier<String> messageSupplier)
+    {
+        debug(null, messageSupplier);
     }
 
     /**
@@ -115,9 +137,17 @@ public class Logger
     @FormatMethod
     public void debug(Throwable exception, String format, Object... args)
     {
-        if (logger.isLoggable(FINE)) {
-            logger.log(FINE, formatMessage(format, "DEBUG", args), exception);
-        }
+        debug(exception, () -> formatMessage(format, "DEBUG", args));
+    }
+
+    /**
+     * Logs a message, provided by the given supplier, at INFO level.
+     *
+     * @param messageSupplier a {@link Supplier} of the pre-formatted message
+     */
+    public void info(Supplier<String> messageSupplier)
+    {
+        logger.log(INFO, messageSupplier);
     }
 
     /**
@@ -146,9 +176,18 @@ public class Logger
     @FormatMethod
     public void info(String format, Object... args)
     {
-        if (logger.isLoggable(INFO)) {
-            logger.log(INFO, formatMessage(format, "INFO", args));
-        }
+        info(() -> formatMessage(format, "INFO", args));
+    }
+
+    /**
+     * Logs a message, provided by the given supplier, at WARN level.
+     *
+     * @param exception an exception associated with the warning being logged
+     * @param messageSupplier a {@link Supplier} of the pre-formatted message
+     */
+    public void warn(Throwable exception, Supplier<String> messageSupplier)
+    {
+        logger.log(WARNING, exception, messageSupplier);
     }
 
     /**
@@ -160,6 +199,16 @@ public class Logger
     public void warn(Throwable exception, String message)
     {
         logger.log(WARNING, message, exception);
+    }
+
+    /**
+     * Logs a message, provided by the given supplier, at WARN level.
+     *
+     * @param messageSupplier a {@link Supplier} of the pre-formatted message
+     */
+    public void warn(Supplier<String> messageSupplier)
+    {
+        warn(null, messageSupplier);
     }
 
     /**
@@ -189,9 +238,7 @@ public class Logger
     @FormatMethod
     public void warn(Throwable exception, String format, Object... args)
     {
-        if (logger.isLoggable(WARNING)) {
-            logger.log(WARNING, formatMessage(format, "WARN", args), exception);
-        }
+        warn(exception, () -> formatMessage(format, "WARN", args));
     }
 
     /**
@@ -214,6 +261,17 @@ public class Logger
     }
 
     /**
+     * Logs a message, provided by the given supplier, at ERROR level.
+     *
+     * @param exception an exception associated with the error being logged
+     * @param messageSupplier a {@link Supplier} of the pre-formatted message
+     */
+    public void error(Throwable exception, Supplier<String> messageSupplier)
+    {
+        logger.log(SEVERE, exception, messageSupplier);
+    }
+
+    /**
      * Logs a message at ERROR level.
      *
      * @param exception an exception associated with the error being logged
@@ -222,6 +280,16 @@ public class Logger
     public void error(Throwable exception, String message)
     {
         logger.log(SEVERE, message, exception);
+    }
+
+    /**
+     * Logs a message, provided by the given supplier, at ERROR level.
+     *
+     * @param messageSupplier a {@link Supplier} of the pre-formatted message
+     */
+    public void error(Supplier<String> messageSupplier)
+    {
+        error(null, messageSupplier);
     }
 
     /**
@@ -251,9 +319,7 @@ public class Logger
     @FormatMethod
     public void error(Throwable exception, String format, Object... args)
     {
-        if (logger.isLoggable(SEVERE)) {
-            logger.log(SEVERE, formatMessage(format, "ERROR", args), exception);
-        }
+        error(exception, () -> formatMessage(format, "ERROR", args));
     }
 
     /**
@@ -268,9 +334,7 @@ public class Logger
      */
     public void error(Throwable exception)
     {
-        if (logger.isLoggable(SEVERE)) {
-            logger.log(SEVERE, exception.getMessage(), exception);
-        }
+        error(exception, exception::getMessage);
     }
 
     /**

--- a/log/src/main/java/io/airlift/log/Logger.java
+++ b/log/src/main/java/io/airlift/log/Logger.java
@@ -32,6 +32,8 @@ public class Logger
 {
     private final java.util.logging.Logger logger;
 
+    private static final Object[] NO_ARGS = {};
+
     Logger(java.util.logging.Logger logger)
     {
         this.logger = requireNonNull(logger, "logger is null");
@@ -74,11 +76,12 @@ public class Logger
      * Logs a message at DEBUG level.
      *
      * @param exception an exception associated with the debug message being logged
-     * @param message a literal message to log
+     * @param format a format string compatible with String.format()
      */
-    public void debug(Throwable exception, String message)
+    @FormatMethod
+    public void debug(Throwable exception, String format)
     {
-        logger.log(FINE, message, exception);
+        debug(exception, () -> formatMessageWithoutParameters(format));
     }
 
     /**
@@ -94,11 +97,12 @@ public class Logger
     /**
      * Logs a message at DEBUG level.
      *
-     * @param message a literal message to log
+     * @param format a format string compatible with String.format()
      */
-    public void debug(String message)
+    @FormatMethod
+    public void debug(String format)
     {
-        logger.log(FINE, message);
+        debug(null, format);
     }
 
     /**
@@ -153,11 +157,12 @@ public class Logger
     /**
      * Logs a message at INFO level.
      *
-     * @param message a literal message to log
+     * @param format a format string compatible with String.format()
      */
-    public void info(String message)
+    @FormatMethod
+    public void info(String format)
     {
-        logger.log(INFO, message);
+        info(() -> formatMessageWithoutParameters(format));
     }
 
     /**
@@ -194,11 +199,12 @@ public class Logger
      * Logs a message at WARN level.
      *
      * @param exception an exception associated with the warning being logged
-     * @param message a literal message to log
+     * @param format a format string compatible with String.format()
      */
-    public void warn(Throwable exception, String message)
+    @FormatMethod
+    public void warn(Throwable exception, String format)
     {
-        logger.log(WARNING, message, exception);
+        warn(exception, () -> formatMessageWithoutParameters(format));
     }
 
     /**
@@ -214,11 +220,12 @@ public class Logger
     /**
      * Logs a message at WARN level.
      *
-     * @param message a literal message to log
+     * @param format a format string compatible with String.format()
      */
-    public void warn(String message)
+    @FormatMethod
+    public void warn(String format)
     {
-        logger.log(WARNING, message);
+        warn(null, format);
     }
 
     /**
@@ -275,11 +282,12 @@ public class Logger
      * Logs a message at ERROR level.
      *
      * @param exception an exception associated with the error being logged
-     * @param message a literal message to log
+     * @param format a format string compatible with String.format()
      */
-    public void error(Throwable exception, String message)
+    @FormatMethod
+    public void error(Throwable exception, String format)
     {
-        logger.log(SEVERE, message, exception);
+        error(exception, () -> formatMessageWithoutParameters(format));
     }
 
     /**
@@ -295,11 +303,12 @@ public class Logger
     /**
      * Logs a message at ERROR level.
      *
-     * @param message a literal message to log
+     * @param format a format string compatible with String.format()
      */
-    public void error(String message)
+    @FormatMethod
+    public void error(String format)
     {
-        logger.severe(message);
+        error(null, format);
     }
 
     /**
@@ -375,6 +384,19 @@ public class Logger
         catch (IllegalFormatException e) {
             logger.log(SEVERE, format("Invalid format string while trying to log: %s '%s' %s", level, format, asList(args)), e);
             message = format("'%s' %s", format, asList(args));
+        }
+        return message;
+    }
+
+    private String formatMessageWithoutParameters(String format)
+    {
+        String message;
+        try {
+            message = format(format, NO_ARGS);
+        }
+        catch (IllegalFormatException e) {
+            // compatibility fallback
+            message = format;
         }
         return message;
     }

--- a/log/src/test/java/io/airlift/log/TestLogger.java
+++ b/log/src/test/java/io/airlift/log/TestLogger.java
@@ -33,6 +33,7 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 @Test(singleThreaded = true)
+@SuppressWarnings("FormatStringAnnotation") // this is the thing we're trying to test
 public class TestLogger
 {
     private MockHandler handler;

--- a/log/src/test/java/io/airlift/log/TestLogger.java
+++ b/log/src/test/java/io/airlift/log/TestLogger.java
@@ -22,6 +22,7 @@ import org.testng.annotations.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
@@ -75,6 +76,23 @@ public class TestLogger
     }
 
     @Test
+    public void testDebugSupplier()
+    {
+        inner.setLevel(Level.FINE);
+
+        // message-only version
+        int token = ThreadLocalRandom.current().nextInt();
+        logger.debug(() -> "hello, " + token);
+        assertLog(Level.FINE, "hello, " + token);
+
+        // throwable with message
+        @SuppressWarnings("ThrowableInstanceNeverThrown")
+        Throwable exception = new Throwable("foo");
+        logger.debug(exception, () -> "got exception: " + exception.getMessage());
+        assertLog(Level.FINE, "got exception: foo", exception);
+    }
+
+    @Test
     public void testDebugFormat()
     {
         inner.setLevel(Level.FINE);
@@ -107,6 +125,17 @@ public class TestLogger
     }
 
     @Test
+    public void testInfoSupplier()
+    {
+        inner.setLevel(Level.INFO);
+
+        int token = ThreadLocalRandom.current().nextInt();
+        logger.info(() -> "hello, " + token);
+
+        assertLog(Level.INFO, "hello, " + token);
+    }
+
+    @Test
     public void testInfoFormat()
     {
         inner.setLevel(Level.INFO);
@@ -122,6 +151,23 @@ public class TestLogger
         logger.info("hello, %%");
 
         assertLog(Level.INFO, "hello, %%");
+    }
+
+    @Test
+    public void testWarnSupplier()
+    {
+        inner.setLevel(Level.WARNING);
+
+        // message-only version
+        int token = ThreadLocalRandom.current().nextInt();
+        logger.warn(() -> "hello, " + token);
+        assertLog(Level.WARNING, "hello, " + token);
+
+        // throwable with message
+        @SuppressWarnings("ThrowableInstanceNeverThrown")
+        Throwable exception = new Throwable("foo");
+        logger.warn(exception, () -> "got exception: " + exception.getMessage());
+        assertLog(Level.WARNING, "got exception: foo", exception);
     }
 
     @Test
@@ -154,6 +200,22 @@ public class TestLogger
         Throwable exception = new Throwable();
         logger.warn(exception, "got exception: %%");
         assertLog(Level.WARNING, "got exception: %%", exception);
+    }
+
+    @Test
+    public void testErrorSupplier()
+    {
+        // message-only version
+        int token = ThreadLocalRandom.current().nextInt();
+        logger.error(() -> "hello, " + token);
+        assertLog(Level.SEVERE, "hello, " + token);
+
+        // throwable with message
+        @SuppressWarnings("ThrowableInstanceNeverThrown")
+        Throwable exception = new Throwable("foo");
+
+        logger.error(exception, () -> "got exception: " + exception.getMessage());
+        assertLog(Level.SEVERE, "got exception: foo", exception);
     }
 
     @Test

--- a/log/src/test/java/io/airlift/log/TestLogger.java
+++ b/log/src/test/java/io/airlift/log/TestLogger.java
@@ -78,9 +78,16 @@ public class TestLogger
     public void testDebugFormat()
     {
         inner.setLevel(Level.FINE);
-        logger.debug("hello, %s", "you");
 
+        // message-only version
+        logger.debug("hello, %s", "you");
         assertLog(Level.FINE, "hello, you");
+
+        // throwable with message
+        @SuppressWarnings("ThrowableInstanceNeverThrown")
+        Throwable exception = new Throwable();
+        logger.debug(exception, "got exception: %s", "foo");
+        assertLog(Level.FINE, "got exception: foo", exception);
     }
 
     @Test

--- a/log/src/test/java/io/airlift/log/TestLogger.java
+++ b/log/src/test/java/io/airlift/log/TestLogger.java
@@ -91,12 +91,37 @@ public class TestLogger
     }
 
     @Test
+    public void testDebugFormatNoArgs()
+    {
+        inner.setLevel(Level.FINE);
+
+        // message-only version
+        logger.debug("hello, %%");
+        assertLog(Level.FINE, "hello, %%");
+
+        // throwable with message
+        @SuppressWarnings("ThrowableInstanceNeverThrown")
+        Throwable exception = new Throwable();
+        logger.debug(exception, "got exception: %%");
+        assertLog(Level.FINE, "got exception: %%", exception);
+    }
+
+    @Test
     public void testInfoFormat()
     {
         inner.setLevel(Level.INFO);
         logger.info("hello, %s", "you");
 
         assertLog(Level.INFO, "hello, you");
+    }
+
+    @Test
+    public void testInfoFormatNoArgs()
+    {
+        inner.setLevel(Level.INFO);
+        logger.info("hello, %%");
+
+        assertLog(Level.INFO, "hello, %%");
     }
 
     @Test
@@ -113,6 +138,22 @@ public class TestLogger
         Throwable exception = new Throwable();
         logger.warn(exception, "got exception: %s", "foo");
         assertLog(Level.WARNING, "got exception: foo", exception);
+    }
+
+    @Test
+    public void testWarnFormatNoArgs()
+    {
+        inner.setLevel(Level.WARNING);
+
+        // message-only version
+        logger.warn("hello, %%");
+        assertLog(Level.WARNING, "hello, %%");
+
+        // throwable with message
+        @SuppressWarnings("ThrowableInstanceNeverThrown")
+        Throwable exception = new Throwable();
+        logger.warn(exception, "got exception: %%");
+        assertLog(Level.WARNING, "got exception: %%", exception);
     }
 
     @Test
@@ -134,6 +175,21 @@ public class TestLogger
         Throwable exception2 = new Throwable("the message");
         logger.error(exception2);
         assertLog(Level.SEVERE, exception2.getMessage(), exception2);
+    }
+
+    @Test
+    public void testErrorFormatNoArgs()
+    {
+        // message-only version
+        logger.error("hello, %%");
+        assertLog(Level.SEVERE, "hello, %%");
+
+        // throwable with message
+        @SuppressWarnings("ThrowableInstanceNeverThrown")
+        Throwable exception = new Throwable();
+
+        logger.error(exception, "got exception: %%");
+        assertLog(Level.SEVERE, "got exception: %%", exception);
     }
 
     @Test

--- a/log/src/test/java/io/airlift/log/TestLogger.java
+++ b/log/src/test/java/io/airlift/log/TestLogger.java
@@ -116,13 +116,37 @@ public class TestLogger
 
         // message-only version
         logger.debug("hello, %%");
-        assertLog(Level.FINE, "hello, %%");
+        assertLog(Level.FINE, "hello, %");
 
         // throwable with message
         @SuppressWarnings("ThrowableInstanceNeverThrown")
         Throwable exception = new Throwable();
         logger.debug(exception, "got exception: %%");
-        assertLog(Level.FINE, "got exception: %%", exception);
+        assertLog(Level.FINE, "got exception: %", exception);
+    }
+
+    @Test
+    public void testDebugFormatNoArgsFallback()
+    {
+        inner.setLevel(Level.FINE);
+
+        // message-only version
+        logger.debug("hello, %!");
+        assertLog(Level.FINE, "hello, %!");
+        logger.debug("hello, %s");
+        assertLog(Level.FINE, "hello, %s");
+        logger.debug("hello, %d");
+        assertLog(Level.FINE, "hello, %d");
+
+        // throwable with message
+        @SuppressWarnings("ThrowableInstanceNeverThrown")
+        Throwable exception = new Throwable();
+        logger.debug(exception, "got exception: %!");
+        assertLog(Level.FINE, "got exception: %!", exception);
+        logger.debug(exception, "got exception: %s");
+        assertLog(Level.FINE, "got exception: %s", exception);
+        logger.debug(exception, "got exception: %d");
+        assertLog(Level.FINE, "got exception: %d", exception);
     }
 
     @Test
@@ -151,7 +175,19 @@ public class TestLogger
         inner.setLevel(Level.INFO);
         logger.info("hello, %%");
 
-        assertLog(Level.INFO, "hello, %%");
+        assertLog(Level.INFO, "hello, %");
+    }
+
+    @Test
+    public void testInfoFormatNoArgsFallback()
+    {
+        inner.setLevel(Level.INFO);
+        logger.info("hello, %!");
+        assertLog(Level.INFO, "hello, %!");
+        logger.info("hello, %s");
+        assertLog(Level.INFO, "hello, %s");
+        logger.info("hello, %d");
+        assertLog(Level.INFO, "hello, %d");
     }
 
     @Test
@@ -194,13 +230,37 @@ public class TestLogger
 
         // message-only version
         logger.warn("hello, %%");
-        assertLog(Level.WARNING, "hello, %%");
+        assertLog(Level.WARNING, "hello, %");
 
         // throwable with message
         @SuppressWarnings("ThrowableInstanceNeverThrown")
         Throwable exception = new Throwable();
         logger.warn(exception, "got exception: %%");
-        assertLog(Level.WARNING, "got exception: %%", exception);
+        assertLog(Level.WARNING, "got exception: %", exception);
+    }
+
+    @Test
+    public void testWarnFormatNoArgsFallback()
+    {
+        inner.setLevel(Level.WARNING);
+
+        // message-only version
+        logger.warn("hello, %!");
+        assertLog(Level.WARNING, "hello, %!");
+        logger.warn("hello, %s");
+        assertLog(Level.WARNING, "hello, %s");
+        logger.warn("hello, %d");
+        assertLog(Level.WARNING, "hello, %d");
+
+        // throwable with message
+        @SuppressWarnings("ThrowableInstanceNeverThrown")
+        Throwable exception = new Throwable();
+        logger.warn(exception, "got exception: %!");
+        assertLog(Level.WARNING, "got exception: %!", exception);
+        logger.warn(exception, "got exception: %s");
+        assertLog(Level.WARNING, "got exception: %s", exception);
+        logger.warn(exception, "got exception: %d");
+        assertLog(Level.WARNING, "got exception: %d", exception);
     }
 
     @Test
@@ -245,14 +305,37 @@ public class TestLogger
     {
         // message-only version
         logger.error("hello, %%");
-        assertLog(Level.SEVERE, "hello, %%");
+        assertLog(Level.SEVERE, "hello, %");
 
         // throwable with message
         @SuppressWarnings("ThrowableInstanceNeverThrown")
         Throwable exception = new Throwable();
 
         logger.error(exception, "got exception: %%");
-        assertLog(Level.SEVERE, "got exception: %%", exception);
+        assertLog(Level.SEVERE, "got exception: %", exception);
+    }
+
+    @Test
+    public void testErrorFormatNoArgsFallback()
+    {
+        // message-only version
+        logger.error("hello, %!");
+        assertLog(Level.SEVERE, "hello, %!");
+        logger.error("hello, %s");
+        assertLog(Level.SEVERE, "hello, %s");
+        logger.error("hello, %d");
+        assertLog(Level.SEVERE, "hello, %d");
+
+        // throwable with message
+        @SuppressWarnings("ThrowableInstanceNeverThrown")
+        Throwable exception = new Throwable();
+
+        logger.error(exception, "got exception: %!");
+        assertLog(Level.SEVERE, "got exception: %!", exception);
+        logger.error(exception, "got exception: %s");
+        assertLog(Level.SEVERE, "got exception: %s", exception);
+        logger.error(exception, "got exception: %d");
+        assertLog(Level.SEVERE, "got exception: %d", exception);
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
 
         <project.build.targetJdk>11</project.build.targetJdk>
         <air.modernizer.java-version>8</air.modernizer.java-version>
+        <dep.errorprone.version>2.10.0</dep.errorprone.version>
 
         <dep.airlift.version>213-SNAPSHOT</dep.airlift.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
@@ -432,4 +433,49 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <profiles>
+        <profile>
+            <id>errorprone-compiler</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <!--suppress MavenModelInspection -->
+                        <configuration combine.children="merge">
+                            <!-- forking required for JDK 16: https://errorprone.info/docs/installation -->
+                            <fork>true</fork>
+                            <compilerArgs>
+                                <arg>-XDcompilePolicy=simple</arg>
+                                <arg>
+                                    -Xplugin:ErrorProne \
+                                    -XepDisableAllChecks \
+                                    -Xep:FormatStringAnnotation:ERROR \
+                                    -XepExcludedPaths:.*/target/generated-(|test-)sources/.*
+                                </arg>
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+                                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+                                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
+                            </compilerArgs>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>com.google.errorprone</groupId>
+                                    <artifactId>error_prone_core</artifactId>
+                                    <version>${dep.errorprone.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
They may not look like format methods, but in fact they are, just without parameters. The reason to treat them this way is that then Error Prone can detect mis-use of these methods, like passing a String concatenation instead of a format string plus arguments.

The caveat is that from now on the message on these methods will be actually treated as format string, so any `%` characters will be interpreted. This will break messages like

```
Frobnicity increased by 10%!
```

which would have to be changed to

```
Frobnicity increased by 10%%!
```

This is a breaking change, but it makes treatment of the messages consistent across all variants of these log methods. For compatibility with existing code, if there is `IllegalFormatException` thrown by `String#format`, we fall back to treating the string as a literal message.

This PR includes dogfooding of this change on Airlift itself. There is a simple Maven profile provided which enables the relevant check (and only that).