### PR TITLE
Upgrade jetty version for CVE-2021-34429

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
         <dep.airlift.version>209-SNAPSHOT</dep.airlift.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
-        <dep.jetty.version>9.4.42.v20210604</dep.jetty.version>
+        <dep.jetty.version>9.4.43</dep.jetty.version>
         <dep.jersey.version>2.26</dep.jersey.version>
         <dep.jjwt.version>0.11.2</dep.jjwt.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
         <dep.airlift.version>209-SNAPSHOT</dep.airlift.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
-        <dep.jetty.version>9.4.43</dep.jetty.version>
+        <dep.jetty.version>9.4.43.v20210629</dep.jetty.version>
         <dep.jersey.version>2.26</dep.jersey.version>
         <dep.jjwt.version>0.11.2</dep.jjwt.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
         <dep.airlift.version>209-SNAPSHOT</dep.airlift.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
-        <dep.jetty.version>9.4.43.v20210629</dep.jetty.version>
+        <dep.jetty.version>9.4.44.v20210927</dep.jetty.version>
         <dep.jersey.version>2.26</dep.jersey.version>
         <dep.jjwt.version>0.11.2</dep.jjwt.version>
     </properties>


### PR DESCRIPTION
[CVE-2021-34429](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-34429)