### PR TITLE
Log when JmxGcMonitor fails to unregister

### DIFF
--- a/stats/src/main/java/io/airlift/stats/JmxGcMonitor.java
+++ b/stats/src/main/java/io/airlift/stats/JmxGcMonitor.java
@@ -95,6 +95,7 @@ public class JmxGcMonitor
                 ManagementFactory.getPlatformMBeanServer().removeNotificationListener(objectName, notificationListener);
             }
             catch (JMException ignored) {
+                log.warn("Failed to unregister GC listener");
             }
         }
     }


### PR DESCRIPTION
This might be useful in tests, where application is started and stopped
many times.