### PR TITLE
Switch to MySQL Connector/J 8.x in airlift dbpool

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+215
+- Upgrade to MySQL Connector/J 8.0.22 in dbpool.
+
 214
 - Fix log file rename in launcher script.
 - Remove Executed class from bootstrap module.

--- a/dbpool/src/main/java/io/airlift/dbpool/MySqlDataSource.java
+++ b/dbpool/src/main/java/io/airlift/dbpool/MySqlDataSource.java
@@ -15,7 +15,7 @@
  */
 package io.airlift.dbpool;
 
-import com.mysql.jdbc.jdbc2.optional.MysqlConnectionPoolDataSource;
+import com.mysql.cj.jdbc.MysqlConnectionPoolDataSource;
 import io.airlift.discovery.client.ServiceDescriptor;
 import io.airlift.discovery.client.ServiceSelector;
 

--- a/dbpool/src/main/java/io/airlift/dbpool/MySqlDataSourceConfig.java
+++ b/dbpool/src/main/java/io/airlift/dbpool/MySqlDataSourceConfig.java
@@ -19,7 +19,7 @@ import io.airlift.configuration.Config;
 import io.airlift.configuration.DefunctConfig;
 
 /**
- * see <a href="http://dev.mysql.com/doc/refman/5.0/en/connector-j-reference-configuration-properties.html">http://dev.mysql.com/doc/refman/5.0/en/connector-j-reference-configuration-properties.html</a>
+ * see <a href="https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-configuration-properties.html">https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-configuration-properties.html</a>
  */
 @DefunctConfig({"db.host", "db.port", "db.database", "db.ssl.enabled"})
 public class MySqlDataSourceConfig

--- a/pom.xml
+++ b/pom.xml
@@ -251,7 +251,7 @@
             <dependency>
                 <groupId>mysql</groupId>
                 <artifactId>mysql-connector-java</artifactId>
-                <version>5.1.23</version>
+                <version>8.0.22</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
MySQL Connector/J 8.x allows using the airlift dbpool with both MySQL
5.x and 8.x versions.
