### PR TITLE
Auto detect records for Jackson serialization

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+217
+
+- Auto detect records for Jackson serialization
+
 216
 
 - Remove dbpool module.

--- a/json/src/main/java/io/airlift/json/ObjectMapperProvider.java
+++ b/json/src/main/java/io/airlift/json/ObjectMapperProvider.java
@@ -56,6 +56,8 @@ public class ObjectMapperProvider
 
     private final Set<Module> modules = new HashSet<>();
 
+    private static final boolean HAS_JAVA_RECORDS = hasJavaRecords();
+
     @Inject
     public ObjectMapperProvider()
     {
@@ -70,6 +72,9 @@ public class ObjectMapperProvider
         modules.add(new JavaTimeModule());
         modules.add(new GuavaModule());
         modules.add(new ParameterNamesModule());
+        if (HAS_JAVA_RECORDS) {
+            modules.add(new RecordAutoDetectModule());
+        }
 
         try {
             getClass().getClassLoader().loadClass("org.joda.time.DateTime");
@@ -193,5 +198,16 @@ public class ObjectMapperProvider
     private <T> void addKeySerializer(SimpleModule module, Class<?> type, JsonSerializer<?> keySerializer)
     {
         module.addKeySerializer((Class<? extends T>) type, (JsonSerializer<T>) keySerializer);
+    }
+
+    private static boolean hasJavaRecords()
+    {
+        try {
+            Class.forName("java.lang.Record");
+            return true;
+        }
+        catch (ClassNotFoundException e) {
+            return false;
+        }
     }
 }

--- a/json/src/main/java/io/airlift/json/RecordAutoDetectModule.java
+++ b/json/src/main/java/io/airlift/json/RecordAutoDetectModule.java
@@ -1,0 +1,81 @@
+package io.airlift.json;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.AnnotationIntrospector;
+import com.fasterxml.jackson.databind.introspect.AnnotatedClass;
+import com.fasterxml.jackson.databind.introspect.VisibilityChecker;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.util.Optional;
+
+import static java.lang.invoke.MethodType.methodType;
+
+public class RecordAutoDetectModule
+        extends SimpleModule
+{
+    private static final Optional<MethodHandle> IS_RECORD;
+
+    static {
+        MethodHandle methodHandle;
+        try {
+            //noinspection JavaLangInvokeHandleSignature
+            methodHandle = MethodHandles.lookup()
+                    .findVirtual(Class.class, "isRecord", methodType(boolean.class));
+        }
+        catch (Exception e) {
+            // ignore - assume we're not on Java 14+
+            methodHandle = null;
+        }
+        IS_RECORD = Optional.ofNullable(methodHandle);
+    }
+
+    @Override
+    public void setupModule(SetupContext context)
+    {
+        super.setupModule(context);
+        context.insertAnnotationIntrospector(new Introspector());
+    }
+
+    private static class Introspector
+            extends AnnotationIntrospector
+    {
+        private static final VisibilityChecker.Std RECORD_VISIBILITY_CHECKER = VisibilityChecker.Std.defaultInstance()
+                .withGetterVisibility(JsonAutoDetect.Visibility.PUBLIC_ONLY)
+                .withCreatorVisibility(JsonAutoDetect.Visibility.DEFAULT)
+                .withFieldVisibility(JsonAutoDetect.Visibility.DEFAULT)
+                .withIsGetterVisibility(JsonAutoDetect.Visibility.DEFAULT);
+
+        @Override
+        public VisibilityChecker<?> findAutoDetectVisibility(AnnotatedClass ac, VisibilityChecker<?> checker)
+        {
+            if (IS_RECORD.map(methodHandle -> isRecord(ac, methodHandle)).orElse(false)) {
+                JsonAutoDetect overrideAnnotation = ac.getRawType().getAnnotation(JsonAutoDetect.class);
+                if (overrideAnnotation != null) {
+                    return VisibilityChecker.Std.construct(JsonAutoDetect.Value.from(overrideAnnotation));
+                }
+                return RECORD_VISIBILITY_CHECKER;
+            }
+            return checker;
+        }
+
+        @Override
+        public Version version()
+        {
+            return Version.unknownVersion();
+        }
+    }
+
+    private static boolean isRecord(AnnotatedClass ac, MethodHandle methodHandle)
+    {
+        try {
+            // TODO replace with real call to isRecord() when Airlift is on Java 14+
+            return (boolean) methodHandle.invokeExact(ac.getRawType());
+        }
+        catch (Throwable e) {
+            return false;   // should never get here
+        }
+    }
+}


### PR DESCRIPTION
Currently, record serialization requires annotating records with
`@JsonAutoDetect(getterVisibility = PUBLIC_ONLY)`. This is a nuisance
and can be hard to debug when it's forgotten (Jackson serializes
to an empty object when it's missing).

Add a Jackson module that auto-detects Records and sets
the visibility to match the annotation. Note: Airlift is
currently at Java 11 so record detection is not ideal (though it
mimics what the JDK does). Once Airlift is at Java 17 it can
be updated and a test can be added.

Note: I tested this in Java 17 project independently to verify that it works.
