### PR TITLE
Fix ignoring trailing content in JsonCodec

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,9 @@
+247
+
+- Fail decoding with JsonCodec when content is not single JSON value.
+  Previously the codec decoded first JSON value only, ignoring the rest
+  of the payload.
+
 246
 
 - Exclude getter-like record methods from JSON serialization

--- a/json/src/main/java/io/airlift/json/JsonCodec.java
+++ b/json/src/main/java/io/airlift/json/JsonCodec.java
@@ -15,6 +15,7 @@
  */
 package io.airlift.json;
 
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Suppliers;
@@ -31,6 +32,7 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 import static com.fasterxml.jackson.databind.SerializationFeature.INDENT_OUTPUT;
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -130,8 +132,10 @@ public class JsonCodec<T>
     public T fromJson(String json)
             throws IllegalArgumentException
     {
-        try {
-            return mapper.readerFor(javaType).readValue(json);
+        try (JsonParser parser = mapper.createParser(json)) {
+            T value = mapper.readerFor(javaType).readValue(parser);
+            checkArgument(parser.nextToken() == null, "Found characters after the expected end of input");
+            return value;
         }
         catch (IOException e) {
             throw new IllegalArgumentException(format("Invalid JSON string for %s", javaType), e);
@@ -189,8 +193,10 @@ public class JsonCodec<T>
     public T fromJson(byte[] json)
             throws IllegalArgumentException
     {
-        try {
-            return mapper.readerFor(javaType).readValue(json);
+        try (JsonParser parser = mapper.createParser(json)) {
+            T value = mapper.readerFor(javaType).readValue(parser);
+            checkArgument(parser.nextToken() == null, "Found characters after the expected end of input");
+            return value;
         }
         catch (IOException e) {
             throw new IllegalArgumentException(format("Invalid JSON bytes for %s", javaType), e);


### PR DESCRIPTION
Follow-up to https://github.com/trinodb/trino/pull/12907, https://github.com/trinodb/trino/pull/12862 and https://github.com/trinodb/trino/pull/10783