### PR TITLE
[log-manager] add retries to TCP log handler

### DIFF
--- a/log-manager/src/main/java/io/airlift/log/ExponentialBackOff.java
+++ b/log-manager/src/main/java/io/airlift/log/ExponentialBackOff.java
@@ -1,0 +1,61 @@
+package io.airlift.log;
+
+import io.airlift.units.Duration;
+
+import javax.annotation.concurrent.GuardedBy;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+// This is copied from io.airlift.discovery.client.ExponentialBackOff
+class ExponentialBackOff
+{
+    private final long initialWait;
+    private final long maxWait;
+    private final String serverUpMessage;
+    private final String serverDownMessage;
+    private final Logger log;
+
+    @GuardedBy("this")
+    private boolean serverUp = true;
+
+    @GuardedBy("this")
+    private long currentWaitInMillis = -1;
+
+    public ExponentialBackOff(Duration initialWait, Duration maxWait, String serverUpMessage, String serverDownMessage, Logger log)
+    {
+        this.initialWait = requireNonNull(initialWait, "initialWait is null").toMillis();
+        this.maxWait = requireNonNull(maxWait, "maxWait is null").toMillis();
+        checkArgument(this.initialWait <= this.maxWait, "initialWait %s is less than maxWait %s", initialWait, maxWait);
+
+        this.serverUpMessage = requireNonNull(serverUpMessage, "serverUpMessage is null");
+        this.serverDownMessage = requireNonNull(serverDownMessage, "serverDownMessage is null");
+        this.log = requireNonNull(log, "log is null");
+    }
+
+    public synchronized void success()
+    {
+        if (!serverUp) {
+            serverUp = true;
+            log.debug(serverUpMessage);
+        }
+        currentWaitInMillis = -1;
+    }
+
+    public synchronized Duration failed()
+    {
+        if (serverUp) {
+            serverUp = false;
+            log.error(serverDownMessage);
+        }
+
+        if (currentWaitInMillis <= 0) {
+            currentWaitInMillis = initialWait;
+        }
+        else {
+            currentWaitInMillis = Math.min(currentWaitInMillis * 2, maxWait);
+        }
+        return new Duration(currentWaitInMillis, MILLISECONDS);
+    }
+}

--- a/log-manager/src/main/java/io/airlift/log/SocketMessageOutput.java
+++ b/log-manager/src/main/java/io/airlift/log/SocketMessageOutput.java
@@ -84,7 +84,7 @@ public class SocketMessageOutput
             throw new IOException("Exception caught connecting via socket to " + socketAddress.getHostName()
                     + " on port " + socketAddress.getPort() + ". "
                     + "There were " + connectionFailures + " failures attempting to write the log message. "
-                    + (connectionFailures == MAX_WRITE_ATTEMPTS_PER_MESSAGE ? "The log message was likely dropped." : "The log message was sent."), lastException);
+                    + (connectionFailures == MAX_WRITE_ATTEMPTS_PER_MESSAGE ? "The log message will be retried." : "The log message was sent."), lastException);
         }
     }
 

--- a/log-manager/src/test/java/io/airlift/log/TestSocketHandler.java
+++ b/log-manager/src/test/java/io/airlift/log/TestSocketHandler.java
@@ -5,11 +5,15 @@ import com.google.common.io.ByteStreams;
 import com.google.common.net.HostAndPort;
 import org.testng.annotations.Test;
 
+import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.logging.ErrorManager;
 import java.util.logging.Level;
@@ -18,6 +22,7 @@ import java.util.logging.LogRecord;
 import static io.airlift.log.Format.TEXT;
 import static io.airlift.log.SocketMessageOutput.createSocketHandler;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 @Test(timeOut = 5 * 60 * 1000)
 public class TestSocketHandler
@@ -52,7 +57,7 @@ public class TestSocketHandler
         }
     }
 
-    @Test
+    @Test(dependsOnMethods = "testSocketLoggingRetries")
     public void testBadListeningSocket()
             throws IOException
     {
@@ -61,10 +66,59 @@ public class TestSocketHandler
         serverSocket.close();
 
         BufferedHandler handler = createSocketHandler(HostAndPort.fromParts("localhost", unallocatedPort), TEXT.createFormatter(ImmutableMap.of()), new ErrorManager());
+
         handler.publish(new LogRecord(Level.SEVERE, "rutabaga"));
         handler.flush();
         handler.close();
 
-        assertEquals(((SocketMessageOutput) handler.getMessageOutput()).getFailedConnections(), 5);
+        assertEquals(handler.getRetryMessages(), 1);
+    }
+
+    @Test
+    public void testSocketLoggingRetries()
+            throws IOException, InterruptedException
+    {
+        final List<String> data = new ArrayList<String>();
+        final List<String> receivedMessages = new ArrayList<String>();
+
+        for (int i = 0; i < 1000; i++) {
+            data.add(UUID.randomUUID().toString());
+        }
+
+        BufferedHandler handler = createSocketHandler(HostAndPort.fromParts("localhost", 5170),
+                TEXT.createFormatter(ImmutableMap.of()), new ErrorManager());
+        for (int i = 0; i < data.size() / 2; i++) {
+            handler.publish(new LogRecord(Level.WARNING, data.get(i)));
+        }
+
+        Thread.sleep(1000);
+
+        try (ServerSocket serverSocket = new ServerSocket(5170)) {
+            Executors.newSingleThreadExecutor().submit(() -> {
+                for (int i = data.size() / 2; i < data.size(); i++) {
+                    handler.publish(new LogRecord(Level.WARNING, data.get(i)));
+                }
+                handler.flush();
+                try {
+                    Thread.sleep(1000);
+                }
+                catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+                handler.close();
+            });
+            try (Socket listeningSocket = serverSocket.accept();
+                    InputStream inputStream = new BufferedInputStream(listeningSocket.getInputStream())) {
+                Thread.sleep(2000);
+                String received = new String(ByteStreams.toByteArray(inputStream), StandardCharsets.UTF_8);
+                String[] lines = received.split("\n");
+                for (String line : lines) {
+                    if (line.length() != 0) {
+                        receivedMessages.add(line.split("\t")[4]);
+                    }
+                }
+            }
+        }
+        assertTrue(receivedMessages.containsAll(data));
     }
 }


### PR DESCRIPTION
This PR adds retry feature to the TCP log handler. It retries transmission of failed log records to the configured TCP listener