### PR TITLE
Delay announcement error logging

### DIFF
--- a/discovery/src/main/java/io/airlift/discovery/client/Announcer.java
+++ b/discovery/src/main/java/io/airlift/discovery/client/Announcer.java
@@ -156,8 +156,6 @@ public final class Announcer
 
                 // wait 80% of the suggested delay
                 expectedDelay = new Duration(expectedDelay.toMillis() * 0.8, MILLISECONDS);
-                log.debug("Service announcement succeeded after %s. Next request will happen within %s", Duration.nanosSince(requestStart), expectedDelay);
-
                 scheduleNextAnnouncement(expectedDelay);
             }
 
@@ -165,8 +163,6 @@ public final class Announcer
             public void onFailure(Throwable t)
             {
                 Duration duration = errorBackOff.failed(t);
-                // todo this is a duplicate log message and should be remove after root cause of announcement delay is determined
-                log.error("Service announcement failed after %s. Next request will happen within %s", Duration.nanosSince(requestStart), expectedDelay);
                 scheduleNextAnnouncement(duration);
             }
         }, executor);


### PR DESCRIPTION
Before this change, as Trino starts up, a flurry of exceptions are
logged at the ERROR level as workers try to contact the coordinator.
These errors typically end after a few milliseconds, but they
pollute the logs.  This commit logs these exceptions at the
DEBUG level for the first 500ms after the first request, thereafter
logging at the ERROR level as before.