### PR TITLE
Make TestingTicker thread safe

### DIFF
--- a/testing/src/main/java/io/airlift/testing/TestingTicker.java
+++ b/testing/src/main/java/io/airlift/testing/TestingTicker.java
@@ -2,14 +2,17 @@ package io.airlift.testing;
 
 import com.google.common.base.Ticker;
 
+import javax.annotation.concurrent.ThreadSafe;
+
 import java.util.concurrent.TimeUnit;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+@ThreadSafe
 public class TestingTicker
         extends Ticker
 {
-    private long time;
+    private volatile long time;
 
     @Override
     public long read()
@@ -17,7 +20,7 @@ public class TestingTicker
         return time;
     }
 
-    public void increment(long delta, TimeUnit unit)
+    public synchronized void increment(long delta, TimeUnit unit)
     {
         checkArgument(delta >= 0, "delta is negative");
         time += unit.toNanos(delta);


### PR DESCRIPTION
This commit makes TestingTicker thread safe.
It is needed if TestingTicker is to be used as a drop-in
replacement for SystemTicker.