### PR TITLE
make https protocol and provider as configuration, fix issue #999

### DIFF
--- a/http-server/src/main/java/io/airlift/http/server/HttpServer.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServer.java
@@ -229,8 +229,10 @@ public class HttpServer
 
             HttpsConfig httpsConfig = maybeHttpsConfig.orElseThrow();
             this.sslContextFactory = Optional.of(this.sslContextFactory.orElseGet(() -> createReloadingSslContextFactory(httpsConfig, clientCertificate, nodeInfo.getEnvironment())));
-            SslConnectionFactory sslConnectionFactory = new SslConnectionFactory(sslContextFactory.get(), "http/1.1");
+            this.sslContextFactory.get().setProtocol(httpsConfig.getHttpsProtocol());
+            this.sslContextFactory.get().setProvider(httpsConfig.getHttpsProvider());
 
+            SslConnectionFactory sslConnectionFactory = new SslConnectionFactory(sslContextFactory.get(), "http/1.1");
             Integer acceptors = config.getHttpsAcceptorThreads();
             Integer selectors = config.getHttpsSelectorThreads();
             httpsConnector = createServerConnector(
@@ -274,7 +276,11 @@ public class HttpServer
 
                 HttpsConfig httpsConfig = maybeHttpsConfig.orElseThrow();
                 this.sslContextFactory = Optional.of(this.sslContextFactory.orElseGet(() -> createReloadingSslContextFactory(httpsConfig, clientCertificate, nodeInfo.getEnvironment())));
+                this.sslContextFactory.get().setProtocol(httpsConfig.getHttpsProtocol());
+                this.sslContextFactory.get().setProvider(httpsConfig.getHttpsProvider());
+
                 SslConnectionFactory sslConnectionFactory = new SslConnectionFactory(sslContextFactory.get(), "http/1.1");
+
                 adminConnector = createServerConnector(
                         httpServerInfo.getAdminChannel(),
                         server,

--- a/http-server/src/main/java/io/airlift/http/server/HttpsConfig.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpsConfig.java
@@ -21,6 +21,9 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 public class HttpsConfig
 {
     private int httpsPort = 8443;
+
+    private String httpsProvider;
+    private String httpsProtocol = "TLS";
     private String keystorePath;
     private String keystorePassword;
     private String keyManagerPassword;
@@ -45,6 +48,30 @@ public class HttpsConfig
     public HttpsConfig setHttpsPort(int httpsPort)
     {
         this.httpsPort = httpsPort;
+        return this;
+    }
+
+    public String getHttpsProvider()
+    {
+        return httpsProvider;
+    }
+
+    @Config("http-server.https.provider")
+    public HttpsConfig setHttpsProvider(String httpsProvider)
+    {
+        this.httpsProvider = httpsProvider;
+        return this;
+    }
+
+    public String getHttpsProtocol()
+    {
+        return httpsProtocol;
+    }
+
+    @Config("http-server.https.protocol")
+    public HttpsConfig setHttpsProtocol(String httpsProtocol)
+    {
+        this.httpsProtocol = httpsProtocol;
         return this;
     }
 


### PR DESCRIPTION
We want to integrate OpenSSL as the provider to accelerate Airlift SSL/TLS performance.

Please refer to this project to get the detail information. https://github.com/heyuanliu-intel/AirliftPerformance

We use Airlift quick start application to do the performance benchmarking, from the results, we can get the 48% performance improvement from OpenSSL as the https provider compared with JDK implementation.

So make https protocol and provider as configuration parameters.