### PR TITLE
Add method add(value, count) to the DistributionStat

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+218
+
+- Add method add(value, count) to the DistributionStat.
+
 217
 
 - Auto detect records for Jackson serialization

--- a/stats/src/main/java/io/airlift/stats/DistributionStat.java
+++ b/stats/src/main/java/io/airlift/stats/DistributionStat.java
@@ -31,6 +31,14 @@ public class DistributionStat
         allTime.add(value);
     }
 
+    public void add(long value, long count)
+    {
+        oneMinute.add(value, count);
+        fiveMinutes.add(value, count);
+        fifteenMinutes.add(value, count);
+        allTime.add(value, count);
+    }
+
     @Managed
     @Nested
     public Distribution getOneMinute()


### PR DESCRIPTION
There is no method to add a collected metric with a parameter `count` as there is for `Distribution`. This pull request adds that.  