### PR TITLE
Update byte-buddy from 1.12.6 to 1.12.13

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 218
 
 - Add method add(value, count) to the DistributionStat.
+- Update to Byte Buddy 1.12.13.
 
 217
 

--- a/pom.xml
+++ b/pom.xml
@@ -262,7 +262,7 @@
             <dependency>
                 <groupId>net.bytebuddy</groupId>
                 <artifactId>byte-buddy</artifactId>
-                <version>1.12.6</version>
+                <version>1.12.13</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
The latest byte-buddy version is using the latest version of JNA, 5.12.1. The current one uses 5.8.0. I want to align them in Trino so that I can add a plugin that doesn't use Trino as a parent (so it doesn't inherit dependencies) but uses `trino-main` as a dependency. See https://github.com/trinodb/trino/pull/12929

I ran tests from `trino-main` with this version and all passed.

I also saw that it was quite recently updated in #989 but not to the latest available version. Maybe we could bump it in Tempto too.