### PR TITLE
Report Guice errors while registering configuration classes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+219
+
+- Report errors thrown from Guice modules during bootstraping together with errors from config validator.
+
 218
 
 - Add method add(value, count) to the DistributionStat.

--- a/bootstrap/src/main/java/io/airlift/bootstrap/Bootstrap.java
+++ b/bootstrap/src/main/java/io/airlift/bootstrap/Bootstrap.java
@@ -215,7 +215,7 @@ public class Bootstrap
         }
 
         // Register configuration classes defined in the modules
-        configurationFactory.registerConfigurationClasses(modules);
+        errors.addAll(configurationFactory.registerConfigurationClasses(modules));
 
         // Validate configuration classes
         errors.addAll(configurationFactory.validateRegisteredConfigurationProvider());

--- a/bootstrap/src/test/java/io/airlift/bootstrap/TestConfigurationAwareModule.java
+++ b/bootstrap/src/test/java/io/airlift/bootstrap/TestConfigurationAwareModule.java
@@ -14,7 +14,6 @@
 package io.airlift.bootstrap;
 
 import com.google.inject.Binder;
-import com.google.inject.CreationException;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.Module;
@@ -24,7 +23,6 @@ import io.airlift.configuration.ConfigurationAwareModule;
 import org.testng.annotations.Test;
 
 import static com.google.inject.name.Names.named;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -51,9 +49,9 @@ public class TestConfigurationAwareModule
         Bootstrap bootstrap = new Bootstrap(new BrokenInstallModule())
                 .doNotInitializeLogging();
 
-        assertThatThrownBy(bootstrap::initialize).isInstanceOfSatisfying(CreationException.class, e ->
-                assertThat(e.getErrorMessages()).hasOnlyOneElementSatisfying(m ->
-                        assertThat(m.getMessage()).endsWith("Use super.install() for ConfigurationAwareModule, not binder.install()")));
+        assertThatThrownBy(bootstrap::initialize)
+                .isInstanceOf(ApplicationConfigurationException.class)
+                .hasMessageContaining("Use super.install() for ConfigurationAwareModule, not binder.install()");
     }
 
     @Test


### PR DESCRIPTION
It is valid case that Guice module can throw an exception and
(as a result) do not install some child modules.
If child module were to consume config properties provided in config files,
then Airlift configuration validation will report the errors that
config properties are not used, but will mask the user error which is
root of the problem. This makes understanging what is going on hard.

With this PR both error reported byt Guice module and errors from
configuration validation will be reported.