### PR TITLE
Add public method addNanos to TimeStat

### DIFF
--- a/stats/src/main/java/io/airlift/stats/TimeStat.java
+++ b/stats/src/main/java/io/airlift/stats/TimeStat.java
@@ -93,9 +93,12 @@ public class TimeStat
             throws Exception
     {
         long start = ticker.read();
-        T result = callable.call();
-        addNanos(ticker.read() - start);
-        return result;
+        try {
+            return callable.call();
+        }
+        finally {
+            addNanos(ticker.read() - start);
+        }
     }
 
     public BlockTimer time()

--- a/stats/src/test/java/io/airlift/stats/TestTimeStat.java
+++ b/stats/src/test/java/io/airlift/stats/TestTimeStat.java
@@ -144,10 +144,21 @@ public class TestTimeStat
             return null;
         });
 
+        try {
+            stat.time(() -> {
+                ticker.increment(20, TimeUnit.MILLISECONDS);
+                throw new Exception("thrown by time");
+            });
+            fail("Exception should have been thrown");
+        }
+        catch (Exception e) {
+            assertEquals(e.getMessage(), "thrown by time");
+        }
+
         TimeDistribution allTime = stat.getAllTime();
-        assertEquals(allTime.getCount(), 1.0);
+        assertEquals(allTime.getCount(), 2.0);
         assertEquals(allTime.getMin(), 0.010);
-        assertEquals(allTime.getMax(), 0.010);
+        assertEquals(allTime.getMax(), 0.020);
     }
 
     @Test


### PR DESCRIPTION
Supports directly adding a duration in nano seconds to TimeStat which avoids boxing to a Duration value or converting a double value with TimeUnit to nano seconds, since internally values were converted to nano seconds anyway.