### PR TITLE
Add openmetrics module to airlift to expose jmx metrics and stats via openmetrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ test-output/
 .pmdruleset.xml
 .pmd
 .flattened-pom.xml
+.attach_pid*

--- a/openmetrics/README.md
+++ b/openmetrics/README.md
@@ -1,0 +1,19 @@
+# OpenMetrics resource for airlift
+
+To use, add the `JmxOpenMetricsModule` to your bootstrap such as:
+
+    Bootstrap app = new Bootstrap(
+            ...
+            new JmxOpenMetricsModule(),
+            ...
+            new MainModule());
+
+See the Sample Server for an example.
+
+Prometheus can be configured to hit the openmetrics endpoint using:
+
+    scrape_configs:
+    - job_name: sample_server
+      static_configs:
+      - targets:
+        - localhost:8080

--- a/openmetrics/pom.xml
+++ b/openmetrics/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>openmetrics</artifactId>
+    <packaging>jar</packaging>
+
+    <parent>
+        <artifactId>airlift</artifactId>
+        <groupId>io.airlift</groupId>
+        <version>224-SNAPSHOT</version>
+    </parent>
+
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>jaxrs</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>stats</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.weakref</groupId>
+            <artifactId>jmxutils</artifactId>
+        </dependency>
+
+        <!-- for testing -->
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/openmetrics/src/main/java/io/airlift/openmetrics/JmxOpenMetricsModule.java
+++ b/openmetrics/src/main/java/io/airlift/openmetrics/JmxOpenMetricsModule.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.openmetrics;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+
+import static io.airlift.configuration.ConfigBinder.configBinder;
+import static io.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
+
+public class JmxOpenMetricsModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        binder.disableCircularProxies();
+
+        configBinder(binder).bindConfig(MetricsConfig.class);
+        jaxrsBinder(binder).bind(MetricsResource.class);
+    }
+}

--- a/openmetrics/src/main/java/io/airlift/openmetrics/MetricsConfig.java
+++ b/openmetrics/src/main/java/io/airlift/openmetrics/MetricsConfig.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.openmetrics;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+
+import java.util.List;
+
+public class MetricsConfig
+{
+    private List<ObjectName> jmxObjectNames = ImmutableList.of();
+
+    public List<ObjectName> getJmxObjectNames()
+    {
+        return jmxObjectNames;
+    }
+
+    @Config("openmetrics.jmx-object-names")
+    @ConfigDescription("JMX object names to include when retrieving all metrics.")
+    public MetricsConfig setJmxObjectNames(List<String> jmxObjectNames)
+    {
+        ImmutableList.Builder objectNames = ImmutableList.builder();
+
+        for (String jmxObjectName : jmxObjectNames) {
+            try {
+                objectNames.add(new ObjectName(jmxObjectName));
+            }
+            catch (MalformedObjectNameException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        this.jmxObjectNames = objectNames.build();
+        return this;
+    }
+}

--- a/openmetrics/src/main/java/io/airlift/openmetrics/MetricsResource.java
+++ b/openmetrics/src/main/java/io/airlift/openmetrics/MetricsResource.java
@@ -1,0 +1,325 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.openmetrics;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.log.Logger;
+import io.airlift.openmetrics.types.Counter;
+import io.airlift.openmetrics.types.Gauge;
+import io.airlift.openmetrics.types.Metric;
+import io.airlift.openmetrics.types.Summary;
+import io.airlift.stats.CounterStat;
+import io.airlift.stats.TimeDistribution;
+import org.weakref.jmx.MBeanExporter;
+import org.weakref.jmx.ManagedClass;
+
+import javax.inject.Inject;
+import javax.management.InstanceNotFoundException;
+import javax.management.IntrospectionException;
+import javax.management.JMException;
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanInfo;
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import javax.management.ReflectionException;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static java.util.Objects.requireNonNull;
+
+@Path("/metrics")
+public class MetricsResource
+{
+    private static final Logger log = Logger.get(MetricsResource.class);
+    private static final String OPENMETRICS_CONTENT_TYPE = "application/openmetrics-text; version=1.0.0; charset=utf-8";
+    private static final String ATTRIBUTE_SEPARATOR = "_ATTRIBUTE_";
+    private static final String TYPE_SEPARATOR = "_TYPE_";
+    private static final String NAME_SEPARATOR = "_NAME_";
+    private static final Pattern METRIC_NAME_PATTERN = Pattern.compile("[[a-zA-Z]][\\w_]*");
+
+    private final MBeanServer mbeanServer;
+    private final MBeanExporter mbeanExporter;
+
+    private final List<ObjectName> allMetricsObjectNames;
+
+    @Inject
+    public MetricsResource(MBeanServer mbeanServer, MBeanExporter mbeanExporter, MetricsConfig metricsConfig)
+    {
+        this.mbeanServer = requireNonNull(mbeanServer, "mbeanServer is null");
+        this.mbeanExporter = requireNonNull(mbeanExporter, "mbeanExporter is null");
+        this.allMetricsObjectNames = metricsConfig.getJmxObjectNames();
+    }
+
+    @GET
+    @Produces(OPENMETRICS_CONTENT_TYPE)
+    public String getMetrics(@QueryParam("name[]") List<String> filter)
+    {
+        StringBuilder body = new StringBuilder();
+        if (filter != null && !filter.isEmpty()) {
+            for (String metricName : filter) {
+                toMetricExposition(metricName).ifPresent(exposition -> body.append(exposition));
+            }
+        }
+        else {
+            body.append(managedMetricExpositions());
+            for (ObjectName metricObjectNames : allMetricsObjectNames) {
+                body.append(jmxMetricExpositions(metricObjectNames));
+            }
+        }
+        body.append("# EOF\n");
+        return body.toString();
+    }
+
+    private Set<ObjectName> objectNamesFromMetricName(String metricName)
+            throws MalformedObjectNameException
+    {
+        int nameStart = metricName.indexOf(NAME_SEPARATOR);
+        int typeStart = metricName.indexOf(TYPE_SEPARATOR);
+        int attributeStart = metricName.indexOf(ATTRIBUTE_SEPARATOR);
+
+        String domain;
+
+        if (nameStart != -1) {
+            domain = metricName.substring(0, nameStart).replace("_", ".");
+        }
+        else if (typeStart != -1) {
+            domain = metricName.substring(0, typeStart).replace("_", ".");
+        }
+        else {
+            domain = metricName.substring(0, attributeStart).replace("_", ".");
+        }
+
+        StringBuilder objectNameBuilder = new StringBuilder(domain).append(":");
+
+        if (nameStart != -1) {
+            objectNameBuilder.append("name=")
+                    .append(metricName, nameStart + NAME_SEPARATOR.length(), typeStart == -1 ? attributeStart : typeStart)
+                    .append(",");
+        }
+        if (typeStart != -1) {
+            objectNameBuilder.append("type=")
+                    .append(metricName.substring(typeStart + TYPE_SEPARATOR.length(), attributeStart).replace("_", "$"))
+                    .append(",");
+        }
+
+        return mbeanServer.queryNames(ObjectName.getInstance(objectNameBuilder.append("*").toString()), null);
+    }
+
+    private String attributeNameFromMetricName(String metricName)
+    {
+        int attributeNameStart = metricName.indexOf(ATTRIBUTE_SEPARATOR);
+        if (attributeNameStart == -1) {
+            throw new RuntimeException("Metric name invalid, no attribute separator %s".formatted(metricName));
+        }
+        return metricName.substring(attributeNameStart + ATTRIBUTE_SEPARATOR.length()).replace("_", ".");
+    }
+
+    private String mBeanNameToMetricName(ObjectName objectName, String attributeName)
+    {
+        if (objectName.getDomain().contains("_")) {
+            log.warn("Unable to expose JMX metric with domain name %s, package names with underscores are unsupported.", objectName.getDomain());
+            throw new RuntimeException("Bad domain name %s".formatted(objectName.getDomain()));
+        }
+
+        StringBuilder metricNameBuilder = new StringBuilder("JMX_")
+                .append(objectName.getDomain().replace(".", "_"));
+
+        if (objectName.getKeyProperty("name") != null) {
+            metricNameBuilder.append(NAME_SEPARATOR)
+                    .append(objectName.getKeyProperty("name"));
+        }
+
+        if (objectName.getKeyProperty("type") != null) {
+            metricNameBuilder.append(TYPE_SEPARATOR)
+                    .append(objectName.getKeyProperty("type").replace("$", "_"));
+        }
+
+        metricNameBuilder.append(ATTRIBUTE_SEPARATOR)
+                .append(attributeName.replace(".", "_"));
+
+        String metricName = metricNameBuilder.toString();
+
+        if (!METRIC_NAME_PATTERN.matcher(metricName).matches()) {
+            log.warn("Calculated metric name has invalid characters %s skipping", metricName);
+        }
+        return metricName;
+    }
+
+    private Optional<String> toMetricExposition(String metricName)
+    {
+        if (metricName.startsWith("JMX_")) {
+            final String jmxMetricName = metricName.substring(4);
+            try {
+                String attributeName = attributeNameFromMetricName(jmxMetricName);
+                return objectNamesFromMetricName(jmxMetricName).stream()
+                        .map(objectName -> getMetric(objectName, attributeName, jmxMetricName, ""))
+                        .flatMap(Optional::stream)
+                        .map(Metric::getMetricExposition)
+                        .findFirst();
+            }
+            catch (MalformedObjectNameException e) {
+                log.warn(e, "Unable to retrieve metric %s.", metricName);
+                return Optional.empty();
+            }
+        }
+        else {
+            Stream<Metric> metricStream = getManagedMetricsStream();
+            return metricStream
+                    .filter(metric -> metric.metricName().equals(metricName))
+                    .findFirst()
+                    .map(Metric::getMetricExposition);
+        }
+    }
+
+    private Optional<Metric> getMetric(ObjectName objectName, String attributeName, String metricName, String description)
+    {
+        try {
+            Object attributeValue = mbeanServer.getAttribute(objectName, attributeName);
+
+            if (attributeValue == null) {
+                return Optional.empty();
+            }
+
+            if (attributeValue instanceof Number) {
+                return Optional.of(Gauge.from(metricName, (Number) attributeValue, description));
+            }
+
+            return Optional.empty();
+        }
+        catch (JMException ex) {
+            log.debug(ex, "Unable to get metric for ObjectName %s and Attribute %s.", objectName.getCanonicalName(), attributeName);
+            return Optional.empty();
+        }
+    }
+
+    private String inferAttributesForObjectName(ObjectName objectName)
+    {
+        StringBuilder expositions = new StringBuilder();
+        try {
+            MBeanInfo mbeanInfo = mbeanServer.getMBeanInfo(objectName);
+            for (MBeanAttributeInfo mBeanAttributeInfo : mbeanInfo.getAttributes()) {
+                String attributeName = mBeanAttributeInfo.getName();
+                String description = mBeanAttributeInfo.getDescription();
+                try {
+                    getMetric(objectName, attributeName, mBeanNameToMetricName(objectName, attributeName), description)
+                            .ifPresent(value -> expositions.append(value.getMetricExposition()));
+                }
+                catch (RuntimeException e) {
+                    log.debug(e, "Unable to get Metric for ObjectName %s and Attribute %s, skipping", objectName.getCanonicalName(), attributeName);
+                }
+            }
+        }
+        catch (InstanceNotFoundException | IntrospectionException | ReflectionException e) {
+            log.debug(e, "Unable to get MBeanInfo for object %s, skipping", objectName.getCanonicalName());
+        }
+        return expositions.toString();
+    }
+
+    private String sanitizeMetricName(String name)
+    {
+        return name.replace(".", "_")
+                .replace("$", "_")
+                .replace(":", "_")
+                .replace("=", "_")
+                .replace(",", "_");
+    }
+
+    private List<Metric> getMetricsRecursively(String prefix, ManagedClass managedClass)
+    {
+        String metricName = sanitizeMetricName(prefix);
+
+        ImmutableList.Builder<Metric> metrics = ImmutableList.builder();
+
+        for (String attributeName : managedClass.getAttributeNames()) {
+            try {
+                String metricAndAttribute = managedClass.isAttributeFlatten(attributeName) ? metricName : metricName + "_" + attributeName;
+                String attributeDescription = managedClass.getAttributeDescription(attributeName);
+
+                ManagedClass child = managedClass.getChildren().get(attributeName);
+                if (child != null) {
+                    // The managed class is directly translatable to an openmetrics type, don't recurse any further
+                    Optional<Metric> metricFromTarget = getMetricFromTarget(child, metricAndAttribute, attributeDescription);
+                    if (metricFromTarget.isPresent()) {
+                        metrics.add(metricFromTarget.get());
+                    }
+                    else {
+                        // Recurse this nested child
+                        metrics.addAll(getMetricsRecursively(metricAndAttribute, child));
+                    }
+                }
+                else {
+                    // Attempt to infer a numeric gauge
+                    Object attributeValue = managedClass.invokeAttribute(attributeName);
+                    if (attributeValue instanceof Number) {
+                        metrics.add(Gauge.from(metricAndAttribute, (Number) attributeValue, attributeDescription));
+                    }
+                }
+            }
+            catch (ReflectiveOperationException e) {
+                log.debug("Unable to invoke getter for managed attribute : " + attributeName);
+            }
+        }
+
+        return metrics.build();
+    }
+
+    private Optional<Metric> getMetricFromTarget(ManagedClass managedClass, String metricName, String description)
+    {
+        if (managedClass.getTargetClass() == CounterStat.class) {
+            return Optional.of(Counter.from(metricName, (CounterStat) managedClass.getTarget(), description));
+        }
+
+        if (managedClass.getTargetClass() == TimeDistribution.class) {
+            return Optional.of(Summary.from(metricName, (TimeDistribution) managedClass.getTarget(), description));
+        }
+        return Optional.empty();
+    }
+
+    private String jmxMetricExpositions(ObjectName initialObjectName)
+    {
+        StringBuilder stringBuilder = new StringBuilder();
+
+        mbeanServer.queryNames(initialObjectName, null).forEach(objectName -> stringBuilder.append(inferAttributesForObjectName(objectName)));
+
+        return stringBuilder.toString();
+    }
+
+    private Stream<Metric> getManagedMetricsStream()
+    {
+        Map<String, ManagedClass> managedClasses = this.mbeanExporter.getManagedClasses();
+
+        return managedClasses.keySet().stream()
+                .map(objectName -> getMetricsRecursively(objectName, managedClasses.get(objectName)))
+                .flatMap(List::stream);
+    }
+
+    private String managedMetricExpositions()
+    {
+        StringBuilder builder = new StringBuilder();
+
+        getManagedMetricsStream().forEach(metric -> builder.append(metric.getMetricExposition()));
+
+        return builder.toString();
+    }
+}

--- a/openmetrics/src/main/java/io/airlift/openmetrics/types/BigCounter.java
+++ b/openmetrics/src/main/java/io/airlift/openmetrics/types/BigCounter.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.openmetrics.types;
+
+import java.math.BigInteger;
+
+import static java.util.Objects.requireNonNull;
+
+public record BigCounter(String metricName, BigInteger value, String help)
+        implements Metric
+{
+    public BigCounter(String metricName, BigInteger value, String help)
+    {
+        this.metricName = requireNonNull(metricName, "metricName is null");
+        this.value = requireNonNull(value, "value is null");
+        this.help = help;
+    }
+
+    @Override
+    public String getMetricExposition()
+    {
+        return Metric.formatSingleValuedMetric(metricName, "counter", help, value.toString());
+    }
+}

--- a/openmetrics/src/main/java/io/airlift/openmetrics/types/Counter.java
+++ b/openmetrics/src/main/java/io/airlift/openmetrics/types/Counter.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.openmetrics.types;
+
+import io.airlift.stats.CounterStat;
+
+import static java.util.Objects.requireNonNull;
+
+public record Counter(String metricName, long value, String help)
+        implements Metric
+{
+    public Counter(String metricName, long value, String help)
+    {
+        this.metricName = requireNonNull(metricName, "metricName is null");
+        this.value = value;
+        this.help = help;
+    }
+
+    public static Counter from(String metricName, CounterStat counterStat, String help)
+    {
+        return new Counter(metricName, counterStat.getTotalCount(), help);
+    }
+
+    @Override
+    public String getMetricExposition()
+    {
+        return Metric.formatSingleValuedMetric(metricName, "counter", help, Long.toString(value));
+    }
+}

--- a/openmetrics/src/main/java/io/airlift/openmetrics/types/Gauge.java
+++ b/openmetrics/src/main/java/io/airlift/openmetrics/types/Gauge.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.openmetrics.types;
+
+import static java.util.Objects.requireNonNull;
+
+public record Gauge(String metricName, double value, String help)
+        implements Metric
+{
+    public Gauge(String metricName, double value, String help)
+    {
+        this.metricName = requireNonNull(metricName, "metricName is null");
+        this.value = value;
+        this.help = help;
+    }
+
+    public static Gauge from(String metricName, Number value, String help)
+    {
+        return new Gauge(metricName, value.doubleValue(), help);
+    }
+
+    @Override
+    public String getMetricExposition()
+    {
+        return Metric.formatSingleValuedMetric(metricName, "gauge", help, Double.toString(value));
+    }
+}

--- a/openmetrics/src/main/java/io/airlift/openmetrics/types/Info.java
+++ b/openmetrics/src/main/java/io/airlift/openmetrics/types/Info.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.openmetrics.types;
+
+import static java.util.Objects.requireNonNull;
+
+public record Info(String metricName, String value, String help) implements Metric
+{
+    public Info(String metricName, String value, String help)
+    {
+        this.metricName = requireNonNull(metricName, "metricName is null");
+        this.value = requireNonNull(value, "value is null");
+        this.help = help;
+    }
+
+    @Override
+    public String getMetricExposition()
+    {
+        return Metric.formatSingleValuedMetric(metricName, "info", help, value);
+    }
+}

--- a/openmetrics/src/main/java/io/airlift/openmetrics/types/Metric.java
+++ b/openmetrics/src/main/java/io/airlift/openmetrics/types/Metric.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.openmetrics.types;
+
+import com.google.common.base.Strings;
+
+public interface Metric
+{
+    String HELP_LINE_FORMAT = "# HELP %s %s\n";
+    String TYPE_LINE_FORMAT = "# TYPE %s %s\n";
+    String VALUE_LINE_FORMAT = "%s %s\n";
+
+    String metricName();
+
+    String getMetricExposition();
+
+    static String formatSingleValuedMetric(String name, String type, String help, String value)
+    {
+        return TYPE_LINE_FORMAT.formatted(name, type) +
+                (Strings.isNullOrEmpty(help) ? "" : HELP_LINE_FORMAT.formatted(name, help)) +
+                VALUE_LINE_FORMAT.formatted(name, value);
+    }
+}

--- a/openmetrics/src/main/java/io/airlift/openmetrics/types/Summary.java
+++ b/openmetrics/src/main/java/io/airlift/openmetrics/types/Summary.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.openmetrics.types;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.stats.TimeDistribution;
+
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+public record Summary(String metricName, Long count, Double sum, Double created, Map<Double, Double> quantiles, String help)
+        implements Metric
+{
+    public static Summary from(String metricName, TimeDistribution timeDistribution, String help)
+    {
+        return new Summary(metricName, (long) timeDistribution.getCount(), timeDistribution.getAvg() * timeDistribution.getCount(), null,
+                ImmutableMap.<Double, Double>builder()
+                        .put(0.5, timeDistribution.getP50())
+                        .put(0.75, timeDistribution.getP75())
+                        .put(0.9, timeDistribution.getP90())
+                        .put(0.95, timeDistribution.getP95())
+                        .put(0.99, timeDistribution.getP99())
+                        .build(), help);
+    }
+
+    public Summary(String metricName, Long count, Double sum, Double created, Map<Double, Double> quantiles, String help)
+    {
+        this.metricName = requireNonNull(metricName, "metricName is null");
+        this.count = count;
+        this.sum = sum;
+        this.created = created;
+        this.quantiles = quantiles;
+        this.help = help;
+    }
+
+    @Override
+    public String getMetricExposition()
+    {
+        StringBuilder stringBuilder = new StringBuilder(TYPE_LINE_FORMAT.formatted(metricName, "summary"));
+
+        if (help != null && !help.isEmpty()) {
+            stringBuilder.append(HELP_LINE_FORMAT.formatted(metricName, help));
+        }
+
+        if (count != null) {
+            stringBuilder.append(VALUE_LINE_FORMAT.formatted(metricName + "_count", count));
+        }
+
+        if (sum != null) {
+            stringBuilder.append(VALUE_LINE_FORMAT.formatted(metricName + "_sum", sum));
+        }
+
+        if (created != null) {
+            stringBuilder.append(VALUE_LINE_FORMAT.formatted(metricName + "_created", created));
+        }
+
+        if (quantiles != null) {
+            for (Map.Entry<Double, Double> quantile : quantiles.entrySet()) {
+                stringBuilder.append(VALUE_LINE_FORMAT.formatted(metricName + "{quantile=\"%s\"}".formatted(quantile.getKey()), quantile.getValue()));
+            }
+        }
+
+        return stringBuilder.toString();
+    }
+}

--- a/openmetrics/src/test/java/io/airlift/openmetrics/TestMetricExpositions.java
+++ b/openmetrics/src/test/java/io/airlift/openmetrics/TestMetricExpositions.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.openmetrics;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.openmetrics.types.BigCounter;
+import io.airlift.openmetrics.types.Counter;
+import io.airlift.openmetrics.types.Gauge;
+import io.airlift.openmetrics.types.Info;
+import io.airlift.openmetrics.types.Summary;
+import org.testng.annotations.Test;
+
+import java.math.BigInteger;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestMetricExpositions
+{
+    @Test
+    public void testCounterExposition()
+    {
+        String expected = """
+                # TYPE metric_name counter
+                # HELP metric_name metric_help
+                metric_name 0
+                """;
+
+        Counter counter = new Counter("metric_name", 0, "metric_help");
+        BigCounter bigCounter = new BigCounter("metric_name", BigInteger.ZERO, "metric_help");
+        assertEquals(counter.getMetricExposition(), bigCounter.getMetricExposition());
+        assertEquals(counter.getMetricExposition(), expected);
+    }
+
+    @Test
+    public void testGaugeExposition()
+    {
+        String expected = """
+                # TYPE metric_name gauge
+                # HELP metric_name metric_help
+                metric_name 0.0
+                """;
+
+        assertEquals(new Gauge("metric_name", 0.0, "metric_help").getMetricExposition(), expected);
+    }
+
+    @Test
+    public void testInfoExposition()
+    {
+        String expected = """
+                # TYPE metric_name info
+                # HELP metric_name metric_help
+                metric_name banana
+                """;
+
+        assertEquals(new Info("metric_name", "banana", "metric_help").getMetricExposition(), expected);
+    }
+
+    @Test
+    public void testSummaryExposition()
+    {
+        String expected = """
+                # TYPE metric_name summary
+                # HELP metric_name metric_help
+                metric_name_count 10
+                metric_name_sum 2.0
+                metric_name_created 3.0
+                metric_name{quantile="0.5"} 0.25
+                """;
+
+        assertEquals(new Summary("metric_name", 10L, 2.0, 3.0, ImmutableMap.of(0.5, 0.25), "metric_help").getMetricExposition(), expected);
+    }
+}

--- a/openmetrics/src/test/java/io/airlift/openmetrics/TestMetricsConfig.java
+++ b/openmetrics/src/test/java/io/airlift/openmetrics/TestMetricsConfig.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.openmetrics;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.configuration.testing.ConfigAssertions;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+public class TestMetricsConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(MetricsConfig.class)
+                .setJmxObjectNames(ImmutableList.of()));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("openmetrics.jmx-object-names", "foo.bar:*,baz.bar:*")
+                .build();
+
+        MetricsConfig expected = new MetricsConfig()
+                .setJmxObjectNames(ImmutableList.of("foo.bar:*", "baz.bar:*"));
+
+        ConfigAssertions.assertFullMapping(properties, expected);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>io.airlift</groupId>
         <artifactId>airbase</artifactId>
-        <version>132</version>
+        <version>133</version>
     </parent>
 
     <inceptionYear>2010</inceptionYear>
@@ -72,6 +72,7 @@
         <module>http-server</module>
         <module>jaxrs</module>
         <module>jaxrs-testing</module>
+        <module>openmetrics</module>
         <module>jmx-http-rpc</module>
         <module>jmx-http</module>
         <module>jmx</module>
@@ -202,6 +203,12 @@
             <dependency>
                 <groupId>io.airlift</groupId>
                 <artifactId>node</artifactId>
+                <version>${dep.airlift.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.airlift</groupId>
+                <artifactId>openmetrics</artifactId>
                 <version>${dep.airlift.version}</version>
             </dependency>
 

--- a/sample-server/pom.xml
+++ b/sample-server/pom.xml
@@ -162,5 +162,9 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>openmetrics</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/sample-server/src/main/java/io/airlift/sample/Main.java
+++ b/sample-server/src/main/java/io/airlift/sample/Main.java
@@ -29,6 +29,7 @@ import io.airlift.json.JsonModule;
 import io.airlift.log.LogJmxModule;
 import io.airlift.log.Logger;
 import io.airlift.node.NodeModule;
+import io.airlift.openmetrics.JmxOpenMetricsModule;
 import io.airlift.tracetoken.TraceTokenModule;
 import org.weakref.jmx.guice.MBeanModule;
 
@@ -50,6 +51,7 @@ public final class Main
                 new JmxModule(),
                 new JmxHttpModule(),
                 new JmxHttpRpcModule(),
+                new JmxOpenMetricsModule(),
                 new LogJmxModule(),
                 new HttpEventModule(),
                 new TraceTokenModule(),

--- a/skeleton-server/pom.xml
+++ b/skeleton-server/pom.xml
@@ -74,6 +74,11 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>openmetrics</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>trace-token</artifactId>
         </dependency>
 

--- a/skeleton-server/src/main/java/io/airlift/skeleton/Main.java
+++ b/skeleton-server/src/main/java/io/airlift/skeleton/Main.java
@@ -29,6 +29,7 @@ import io.airlift.json.JsonModule;
 import io.airlift.log.LogJmxModule;
 import io.airlift.log.Logger;
 import io.airlift.node.NodeModule;
+import io.airlift.openmetrics.JmxOpenMetricsModule;
 import io.airlift.tracetoken.TraceTokenModule;
 import org.weakref.jmx.guice.MBeanModule;
 
@@ -50,6 +51,7 @@ public final class Main
                 new JmxModule(),
                 new JmxHttpModule(),
                 new JmxHttpRpcModule(),
+                new JmxOpenMetricsModule(),
                 new LogJmxModule(),
                 new HttpEventModule(),
                 new TraceTokenModule(),

--- a/stats/src/main/java/io/airlift/stats/CpuTimer.java
+++ b/stats/src/main/java/io/airlift/stats/CpuTimer.java
@@ -163,6 +163,7 @@ public class CpuTimer
         /**
          * This method will report zero duration when no user time was collected. Check {@link CpuDuration#hasUser()} or use {@link CpuDuration#getUserIfPresent()}
          * in order distinguish a true zero user CPU time from no value being present.
+         *
          * @return The {@link CpuDuration#user} value if present, otherwise returns a value of zero nanoseconds
          */
         public Duration getUser()


### PR DESCRIPTION
For reference to the spec see https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md

I started off with just adding explicit types to 2 stats objects, but we can certainly do more in the PR if there are critical ones for Trino.