### PR TITLE
Fix duplicate logging appender when re-configuring logging

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+220
+
+- Fix duplicate logging appender when re-configuring logging.
+
 219
 
 - Report errors thrown from Guice modules during bootstraping together

--- a/log-manager/src/main/java/io/airlift/log/Logging.java
+++ b/log-manager/src/main/java/io/airlift/log/Logging.java
@@ -81,15 +81,22 @@ public class Logging
 
     private Logging()
     {
-        ROOT.setLevel(Level.INFO.toJulLevel());
+        resetConfiguration();
+        log.info("Logging to stderr");
+
+        redirectStdStreams();
+    }
+
+    private void resetConfiguration()
+    {
+        // Reset named loggers, remove their handlers, and reset root to INFO
+        LogManager.getLogManager().reset();
+
         for (Handler handler : ROOT.getHandlers()) {
             ROOT.removeHandler(handler);
         }
 
         enableConsole();
-        log.info("Logging to stderr");
-
-        redirectStdStreams();
     }
 
     private static void redirectStdStreams()
@@ -209,6 +216,8 @@ public class Logging
                 throw new UncheckedIOException(e);
             }
         }
+
+        resetConfiguration();
 
         if (config.getLogPath() != null) {
             if (config.getLogPath().startsWith("tcp://")) {

--- a/log-manager/src/main/java/io/airlift/log/Logging.java
+++ b/log-manager/src/main/java/io/airlift/log/Logging.java
@@ -100,7 +100,7 @@ public class Logging
 
     private synchronized void enableConsole()
     {
-        consoleHandler = new OutputStreamHandler(System.err);
+        consoleHandler = new OutputStreamHandler(stdErr);
         ROOT.addHandler(consoleHandler);
     }
 

--- a/log-manager/src/test/java/io/airlift/log/TestLogging.java
+++ b/log-manager/src/test/java/io/airlift/log/TestLogging.java
@@ -22,9 +22,11 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.logging.LogManager;
 
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
@@ -147,5 +149,19 @@ public class TestLogging
         assertTrue(logger.isDebugEnabled());
         logging.clearLevel("testClearLevel");
         assertFalse(logger.isDebugEnabled());
+    }
+
+    @Test
+    public void testReconfigure()
+    {
+        LoggingConfiguration configuration = new LoggingConfiguration();
+        configuration.setLogPath(new File(tempDir, "reconfigure.log").getPath());
+        Logging logging = Logging.initialize();
+        logging.configure(configuration);
+        java.util.logging.Logger root = java.util.logging.Logger.getLogger("");
+        int configuredHandlerCount = root.getHandlers().length;
+
+        logging.configure(configuration);
+        assertEquals( root.getHandlers().length, configuredHandlerCount);
     }
 }


### PR DESCRIPTION
Logging is a singleton that's initialized once, but it may be configured more than once. Doing so used to add a duplicate appender if a `log.path` configuration is provided. 

Calling `LogManager.reset()` and resetting the root logger's appenders during Logging configuration fixes this duplicate appender problem.