### PR TITLE
Bootstrap logging once

### DIFF
--- a/bootstrap/src/test/java/io/airlift/bootstrap/TestBootstrap.java
+++ b/bootstrap/src/test/java/io/airlift/bootstrap/TestBootstrap.java
@@ -25,6 +25,7 @@ import javax.inject.Inject;
 import static io.airlift.testing.Assertions.assertContains;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
 public class TestBootstrap
@@ -114,6 +115,16 @@ public class TestBootstrap
                     assertThat(e).hasStackTraceContaining("Configuration property 'test-required' was not used");
                     assertThat(e).hasStackTraceContaining("An exception was caught and reported. Message: happy user error");
                 });
+    }
+
+    @Test
+    public void testLoggingConfiguredOnce()
+    {
+        java.util.logging.Logger root = java.util.logging.Logger.getLogger("");
+        new Bootstrap().setOptionalConfigurationProperty("log.path", "tcp://0.0.0.0:0").initialize();
+        int configuredHandlerCount = root.getHandlers().length;
+        new Bootstrap().setOptionalConfigurationProperty("log.path", "tcp://0.0.0.0:0").initialize();
+        assertEquals(root.getHandlers().length, configuredHandlerCount);
     }
 
     public static class Instance {}

--- a/log-manager/src/main/java/io/airlift/log/Logging.java
+++ b/log-manager/src/main/java/io/airlift/log/Logging.java
@@ -62,6 +62,9 @@ public class Logging
     @GuardedBy("this")
     private OutputStreamHandler consoleHandler;
 
+    @GuardedBy("this")
+    private boolean configured;
+
     /**
      * Sets up default logging:
      * <p>
@@ -198,8 +201,14 @@ public class Logging
         return levels.build();
     }
 
-    public void configure(LoggingConfiguration config)
+    public synchronized void configure(LoggingConfiguration config)
     {
+        if (configured) {
+            log.warn("Logging already configured; ignoring new configuration.");
+            return;
+        }
+        configured = true;
+
         Map<String, String> logAnnotations = ImmutableMap.of();
         if (config.getLogAnnotationFile() != null) {
             try {


### PR DESCRIPTION
Logging is a singleton that's initialized once, but it may be configured more than once. Doing so used to add a duplicate appender if a log.path configuration is provided. An initial attempt at avoiding duplicate appenders was submitted in #1015.

When initializing subsequent Bootstrap instances, do not re-configure logging.