### PR TITLE
Bump actions/setup-java to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,9 @@ jobs:
           - 17
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
+          distribution: 'zulu'
           java-version: ${{ matrix.java-version }}
       - name: Maven Install
         run: mvn install -B -V -DskipTests -Dair.check.skip-all


### PR DESCRIPTION
Fixes two GitHub Actions deprecation warnings:

- `set-output` to be [disabled by 31st May 2023](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) and addressed in actions/setup-java#390
- Node 12 is out of support and [warnings came into effect](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) on Sept 27, 2022, and addressed in actions/setup-java#290

There is a migration guide from V1 to V2 [here](https://github.com/actions/setup-java/blob/main/docs/switching-to-v2.md). Zulu was the previous default, but is now a mandatory parameter.