### PR TITLE
Add exponential retries to SocketMessageOutput

### DIFF
--- a/log-manager/src/main/java/io/airlift/log/ExponentialBackOff.java
+++ b/log-manager/src/main/java/io/airlift/log/ExponentialBackOff.java
@@ -1,0 +1,66 @@
+package io.airlift.log;
+
+import io.airlift.units.Duration;
+
+import javax.annotation.concurrent.GuardedBy;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+// This is copied from io.airlift.discovery.client.ExponentialBackOff
+class ExponentialBackOff
+{
+    private final long initialWait;
+    private final long maxWait;
+    private final String serverUpMessage;
+    private final String serverDownMessage;
+    private final Logger log;
+
+    @GuardedBy("this")
+    private boolean serverUp = true;
+
+    @GuardedBy("this")
+    private long currentWaitInMillis = -1;
+
+    public ExponentialBackOff(Duration initialWait, Duration maxWait, String serverUpMessage, String serverDownMessage, Logger log)
+    {
+        this.initialWait = requireNonNull(initialWait, "initialWait is null").toMillis();
+        this.maxWait = requireNonNull(maxWait, "maxWait is null").toMillis();
+        checkArgument(this.initialWait <= this.maxWait, "initialWait %s is less than maxWait %s", initialWait, maxWait);
+
+        this.serverUpMessage = requireNonNull(serverUpMessage, "serverUpMessage is null");
+        this.serverDownMessage = requireNonNull(serverDownMessage, "serverDownMessage is null");
+        this.log = requireNonNull(log, "log is null");
+    }
+
+    public synchronized void success()
+    {
+        if (!serverUp) {
+            serverUp = true;
+            log.info(serverUpMessage);
+        }
+        currentWaitInMillis = -1;
+    }
+
+    public synchronized Duration failed()
+    {
+        if (serverUp) {
+            serverUp = false;
+            log.error(serverDownMessage);
+        }
+
+        if (currentWaitInMillis <= 0) {
+            currentWaitInMillis = initialWait;
+        }
+        else {
+            currentWaitInMillis = Math.min(currentWaitInMillis * 2, maxWait);
+        }
+        return new Duration(currentWaitInMillis, MILLISECONDS);
+    }
+
+    public synchronized void reset()
+    {
+        currentWaitInMillis = -1;
+    }
+}

--- a/log-manager/src/test/java/io/airlift/log/TestRollingFileMessageOutput.java
+++ b/log-manager/src/test/java/io/airlift/log/TestRollingFileMessageOutput.java
@@ -352,6 +352,7 @@ public class TestRollingFileMessageOutput
 
             handler.publish(new LogRecord(Level.SEVERE, "apple"));
             handler.publish(new LogRecord(Level.SEVERE, "banana"));
+            Thread.sleep(100);
 
             handler.close();
 

--- a/log-manager/src/test/java/io/airlift/log/TestSocketHandler.java
+++ b/log-manager/src/test/java/io/airlift/log/TestSocketHandler.java
@@ -36,6 +36,12 @@ public class TestSocketHandler
                     handler.publish(new LogRecord(levels[i], data[i]));
                 }
                 handler.flush();
+                try {
+                    Thread.sleep(500);
+                }
+                catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
                 handler.close();
             });
 
@@ -60,11 +66,23 @@ public class TestSocketHandler
         int unallocatedPort = serverSocket.getLocalPort();
         serverSocket.close();
 
-        BufferedHandler handler = createSocketHandler(HostAndPort.fromParts("localhost", unallocatedPort), TEXT.createFormatter(ImmutableMap.of()), new ErrorManager());
-        handler.publish(new LogRecord(Level.SEVERE, "rutabaga"));
+        final String[] data = {"apple", "banana", "orange"};
+        final Level[] levels = {Level.SEVERE, Level.INFO, Level.WARNING};
+
+        BufferedHandler handler = createSocketHandler(HostAndPort.fromParts("localhost", 5170), TEXT.createFormatter(ImmutableMap.of()), new ErrorManager());
+        for (int i = 0; i < data.length; i++) {
+            handler.publish(new LogRecord(levels[i], data[i]));
+        }
         handler.flush();
+        try {
+            Thread.sleep(10000);
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
         handler.close();
 
-        assertEquals(((SocketMessageOutput) handler.getMessageOutput()).getFailedConnections(), 5);
+        assertEquals(((SocketMessageOutput) handler.getMessageOutput()).getFailedConnections(), 15);
+        assertEquals(handler.getDroppedMessages(), 3);
     }
 }


### PR DESCRIPTION
SocketMessageOutput currently retries messages 5 times before dropping records. This adds exponential backoff between retries and helps in minimizing the dropped log records when the TCP listener is down