### PR TITLE
Util to bind polymorphic subtypes

### DIFF
--- a/json/pom.xml
+++ b/json/pom.xml
@@ -78,6 +78,12 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/json/src/main/java/io/airlift/json/JsonSubType.java
+++ b/json/src/main/java/io/airlift/json/JsonSubType.java
@@ -1,0 +1,246 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.json;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.TreeNode;
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.AnnotationIntrospector;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.PropertyName;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.cfg.MapperConfig;
+import com.fasterxml.jackson.databind.introspect.AnnotatedClass;
+import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
+import com.fasterxml.jackson.databind.introspect.VirtualAnnotatedMember;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.node.ValueNode;
+import com.fasterxml.jackson.databind.ser.BeanPropertyWriter;
+import com.fasterxml.jackson.databind.ser.impl.AttributePropertyWriter;
+import com.fasterxml.jackson.databind.util.SimpleBeanPropertyDefinition;
+import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static java.util.Objects.requireNonNull;
+
+public class JsonSubType
+{
+    private final Set<Module> modules;
+
+    public static JsonSubType.Builder builder()
+    {
+        return new Builder();
+    }
+
+    public interface SubTypeSubBuilder<B>
+    {
+        default <T extends B> SubTypeSubBuilder<B> add(Class<T> subClass)
+        {
+            return add(subClass, subClass.getSimpleName());
+        }
+
+        <T extends B> SubTypeSubBuilder<B> add(Class<T> subClass, String propertyValue);
+
+        default SubTypeSubBuilder<B> addPermittedSubClasses()
+        {
+            return addPermittedSubClasses(Class::getSimpleName);
+        }
+
+        SubTypeSubBuilder<B> addPermittedSubClasses(Function<Class<?>, String> propertyValueProvider);
+
+        <T> SubTypeSubBuilder<T> forBase(Class<T> baseClass, String propertyName);
+
+        JsonSubType build();
+    }
+
+    public static class Builder
+    {
+        private final ImmutableSet.Builder<Module> modules = ImmutableSet.builder();
+
+        private Builder() {}
+
+        public <B> SubTypeSubBuilder<B> forBase(Class<B> baseClass, String propertyName)
+        {
+            ImmutableMap.Builder<String, Class<?>> subClassBuilder = ImmutableMap.builder();
+
+            Supplier<Map<String, Class<?>>> supplier = Suppliers.memoize(subClassBuilder::build);
+
+            TypeAddingModule module = new TypeAddingModule(propertyName, supplier);
+            module.addDeserializer(baseClass, new Deserializer<>(propertyName, supplier));
+            modules.add(module);
+
+            return new SubTypeSubBuilder<>() {
+                @Override
+                public <T extends B> SubTypeSubBuilder<B> add(Class<T> subClass, String propertyValue)
+                {
+                    subClassBuilder.put(propertyValue, subClass);
+                    return this;
+                }
+
+                @SuppressWarnings("unchecked")
+                @Override
+                public SubTypeSubBuilder<B> addPermittedSubClasses(Function<Class<?>, String> propertyValueProvider)
+                {
+                    Arrays.stream(baseClass.getPermittedSubclasses()).forEach(clazz -> add((Class<? extends B>) clazz, propertyValueProvider.apply(clazz)));
+                    return this;
+                }
+
+                @Override
+                public <T> SubTypeSubBuilder<T> forBase(Class<T> baseClass, String propertyName)
+                {
+                    return Builder.this.forBase(baseClass, propertyName);
+                }
+
+                @Override
+                public JsonSubType build()
+                {
+                    return new JsonSubType(modules.build());
+                }
+            };
+        }
+    }
+
+    public Set<Module> modules()
+    {
+        return modules;
+    }
+
+    private JsonSubType(Set<Module> modules)
+    {
+        this.modules = modules;
+    }
+
+    private static class TypeAddingModule
+            extends SimpleModule
+    {
+        private static final AtomicInteger MODULE_ID_SEQ = new AtomicInteger(1);
+
+        private final String propertyName;
+        private final Supplier<Map<String, Class<?>>> subClassPropertyValues;
+
+        private TypeAddingModule(String propertyName, Supplier<Map<String, Class<?>>> subClassPropertyValues)
+        {
+            super("TypeAddingModule-" + MODULE_ID_SEQ.getAndIncrement(), new Version(1, 0, 0, null, null, null));
+
+            this.propertyName = requireNonNull(propertyName, "propertyName is null");
+            this.subClassPropertyValues = requireNonNull(subClassPropertyValues, "subClassPropertyValues is null");
+        }
+
+        @Override
+        public void setupModule(SetupContext context)
+        {
+            super.setupModule(context);
+
+            Map<Class<?>, String> invertedSubClassMap = subClassPropertyValues.get().entrySet()
+                    .stream()
+                    .collect(toImmutableMap(Map.Entry::getValue, Map.Entry::getKey));
+
+            context.insertAnnotationIntrospector(new TypeAddingIntrospector(propertyName, invertedSubClassMap));
+        }
+    }
+
+    private static class TypeAddingIntrospector
+            extends AnnotationIntrospector
+    {
+        private final String propertyName;
+        private final Map<Class<?>, String> subClassPropertyValues;
+
+        private TypeAddingIntrospector(String propertyName, Map<Class<?>, String> subClassPropertyValues)
+        {
+            this.propertyName = requireNonNull(propertyName, "propertyName is null");
+            this.subClassPropertyValues = ImmutableMap.copyOf(subClassPropertyValues);
+        }
+
+        @Override
+        public void findAndAddVirtualProperties(MapperConfig<?> config, AnnotatedClass ac, List<BeanPropertyWriter> properties)
+        {
+            String propertyValue = subClassPropertyValues.get(ac.getRawType());
+            if (propertyValue == null) {
+                return;
+            }
+
+            // mostly copied from JacksonAnnotationIntrospector._constructVirtualProperty()
+
+            JavaType stringType = config.constructType(String.class);
+
+            AnnotatedMember member = new VirtualAnnotatedMember(ac, ac.getRawType(), propertyName, stringType);
+            SimpleBeanPropertyDefinition propDef = SimpleBeanPropertyDefinition.construct(config, member, PropertyName.construct(propertyName));
+            AttributePropertyWriter propertyWriter = new AttributePropertyWriter(propertyName, propDef, null, stringType)
+            {
+                @Override
+                protected Object value(Object bean, JsonGenerator jgen, SerializerProvider prov)
+                {
+                    return propertyValue;
+                }
+            };
+
+            properties.add(propertyWriter);
+        }
+
+        @Override
+        public Version version()
+        {
+            return Version.unknownVersion();
+        }
+    }
+
+    private static class Deserializer<B>
+            extends JsonDeserializer<B>
+    {
+        private final String propertyName;
+        private final Supplier<Map<String, Class<?>>> subClassPropertyValues;
+
+        public Deserializer(String propertyName, Supplier<Map<String, Class<?>>> subClassPropertyValues)
+        {
+            this.propertyName = requireNonNull(propertyName, "propertyName is null");
+            this.subClassPropertyValues = subClassPropertyValues;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public B deserialize(JsonParser p, DeserializationContext ctxt)
+                throws IOException
+        {
+            TreeNode treeNode = p.readValueAsTree();
+            TreeNode propertyNode = treeNode.get(propertyName);
+
+            String propertyValue = ((propertyNode != null) && propertyNode.isValueNode()) ? ((ValueNode) propertyNode).textValue() : null;
+            if (propertyValue == null) {
+                throw new IllegalArgumentException("JSON expected to have a property named \"%s\". Double check the addBinding() or addPermittedSubClassBindings()".formatted(propertyName));
+            }
+
+            Class<?> subClass = subClassPropertyValues.get().get(propertyValue);
+            if (subClass == null) {
+                throw new IllegalArgumentException("No binding was made for property name \"%s\" and value \"%s\". Double check the addBinding() or addPermittedSubClassBindings().".formatted(propertyName, propertyValue));
+            }
+
+            return (B) p.getCodec().treeToValue(treeNode, subClass);
+        }
+    }
+}

--- a/json/src/main/java/io/airlift/json/JsonSubTypeBinder.java
+++ b/json/src/main/java/io/airlift/json/JsonSubTypeBinder.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.json;
+
+import com.google.inject.Binder;
+import com.google.inject.multibindings.Multibinder;
+
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
+
+public class JsonSubTypeBinder
+{
+    private final Multibinder<JsonSubType> subTypeBinder;
+
+    public static JsonSubTypeBinder jsonSubTypeBinder(Binder binder)
+    {
+        return new JsonSubTypeBinder(binder);
+    }
+
+    public void bindJsonSubType(JsonSubType jsonSubType)
+    {
+        subTypeBinder.addBinding().toInstance(jsonSubType);
+    }
+
+    private JsonSubTypeBinder(Binder binder)
+    {
+        subTypeBinder = newSetBinder(binder, JsonSubType.class);
+    }
+}

--- a/json/src/main/java/io/airlift/json/ObjectMapperProvider.java
+++ b/json/src/main/java/io/airlift/json/ObjectMapperProvider.java
@@ -54,6 +54,8 @@ public class ObjectMapperProvider
     private Map<Class<?>, JsonSerializer<?>> jsonSerializers;
     private Map<Class<?>, JsonDeserializer<?>> jsonDeserializers;
 
+    private final Set<JsonSubType> jsonSubTypes = new HashSet<>();
+
     private final Set<Module> modules = new HashSet<>();
 
     private static final boolean HAS_JAVA_RECORDS = hasJavaRecords();
@@ -144,6 +146,18 @@ public class ObjectMapperProvider
         return this;
     }
 
+    @Inject(optional = true)
+    public void setJsonSubTypes(Set<JsonSubType> jsonSubTypes)
+    {
+        this.jsonSubTypes.addAll(jsonSubTypes);
+    }
+
+    public ObjectMapperProvider withJsonSubTypes(Set<JsonSubType> jsonSubTypes)
+    {
+        setJsonSubTypes(jsonSubTypes);
+        return this;
+    }
+
     @Override
     public ObjectMapper get()
     {
@@ -196,6 +210,10 @@ public class ObjectMapperProvider
                 }
             }
             modules.add(module);
+        }
+
+        for (JsonSubType jsonSubType : jsonSubTypes) {
+            modules.addAll(jsonSubType.modules());
         }
 
         for (Module module : modules) {

--- a/json/src/main/java/io/airlift/json/ObjectMapperProvider.java
+++ b/json/src/main/java/io/airlift/json/ObjectMapperProvider.java
@@ -90,10 +90,22 @@ public class ObjectMapperProvider
         this.jsonSerializers = ImmutableMap.copyOf(jsonSerializers);
     }
 
+    public ObjectMapperProvider withJsonSerializers(Map<Class<?>, JsonSerializer<?>> jsonSerializers)
+    {
+        setJsonSerializers(jsonSerializers);
+        return this;
+    }
+
     @Inject(optional = true)
     public void setJsonDeserializers(Map<Class<?>, JsonDeserializer<?>> jsonDeserializers)
     {
         this.jsonDeserializers = ImmutableMap.copyOf(jsonDeserializers);
+    }
+
+    public ObjectMapperProvider withJsonDeserializers(Map<Class<?>, JsonDeserializer<?>> jsonDeserializers)
+    {
+        setJsonDeserializers(jsonDeserializers);
+        return this;
     }
 
     @Inject(optional = true)
@@ -102,16 +114,34 @@ public class ObjectMapperProvider
         this.keySerializers = keySerializers;
     }
 
+    public ObjectMapperProvider withKeySerializers(@JsonKeySerde Map<Class<?>, JsonSerializer<?>> keySerializers)
+    {
+        setKeySerializers(keySerializers);
+        return this;
+    }
+
     @Inject(optional = true)
     public void setKeyDeserializers(@JsonKeySerde Map<Class<?>, KeyDeserializer> keyDeserializers)
     {
         this.keyDeserializers = keyDeserializers;
     }
 
+    public ObjectMapperProvider withKeyDeserializers(@JsonKeySerde Map<Class<?>, KeyDeserializer> keyDeserializers)
+    {
+        setKeyDeserializers(keyDeserializers);
+        return this;
+    }
+
     @Inject(optional = true)
     public void setModules(Set<Module> modules)
     {
         this.modules.addAll(modules);
+    }
+
+    public ObjectMapperProvider withModules(Set<Module> modules)
+    {
+        setModules(modules);
+        return this;
     }
 
     @Override

--- a/json/src/test/java/io/airlift/json/subtype/Employee.java
+++ b/json/src/test/java/io/airlift/json/subtype/Employee.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.json.subtype;
+
+import java.util.List;
+
+public sealed interface Employee
+{
+    record Programmer(String name)
+            implements Employee {}
+
+    record Manager(String name, List<Employee> reports)
+            implements Employee {}
+}

--- a/json/src/test/java/io/airlift/json/subtype/Part.java
+++ b/json/src/test/java/io/airlift/json/subtype/Part.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.json.subtype;
+
+import java.util.List;
+
+public sealed interface Part
+{
+    record Item(String name)
+            implements Part {}
+
+    record Container(List<Part> parts)
+            implements Part {}
+}

--- a/json/src/test/java/io/airlift/json/subtype/TestJsonSubType.java
+++ b/json/src/test/java/io/airlift/json/subtype/TestJsonSubType.java
@@ -1,0 +1,243 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.json.subtype;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import io.airlift.json.JsonCodec;
+import io.airlift.json.JsonCodecFactory;
+import io.airlift.json.JsonModule;
+import io.airlift.json.JsonSubType;
+import io.airlift.json.ObjectMapperProvider;
+import io.airlift.json.subtype.Employee.Manager;
+import io.airlift.json.subtype.Employee.Programmer;
+import io.airlift.json.subtype.Part.Container;
+import io.airlift.json.subtype.Part.Item;
+import org.testng.annotations.Test;
+
+import static io.airlift.json.JsonSubTypeBinder.jsonSubTypeBinder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.assertThrows;
+
+public class TestJsonSubType
+{
+    private static final Employee programmer1 = new Programmer("Joe");
+    private static final Employee programmer2 = new Programmer("Rachel");
+    private static final Employee programmer3 = new Programmer("Chris");
+    private static final Employee manager1 = new Manager("Jane", ImmutableList.of(programmer1, programmer2));
+    private static final Employee manager2 = new Manager("Horace", ImmutableList.of(programmer3, manager1));
+
+    private static final Part item1 = new Item("one");
+    private static final Part item2 = new Item("two");
+    private static final Part container = new Container(ImmutableList.of(item1, item2));
+
+    @Test
+    public void testAddBinding()
+            throws Exception
+    {
+        JsonSubType jsonSubType = JsonSubType.builder()
+                .forBase(Employee.class, "type")
+                .add(Programmer.class)
+                .add(Manager.class)
+                .build();
+        Injector injector = Guice.createInjector(new JsonModule(), binder -> jsonSubTypeBinder(binder).bindJsonSubType(jsonSubType));
+        ObjectMapper objectMapper = injector.getInstance(ObjectMapper.class);
+
+        internalTest(objectMapper);
+    }
+
+    @Test
+    public void testAddBindingSpecifiedNames()
+            throws Exception
+    {
+        JsonSubType jsonSubType = JsonSubType.builder()
+                .forBase(Employee.class, "specified")
+                .add(Programmer.class, "foo")
+                .add(Manager.class, "bar")
+                .build();
+        Injector injector = Guice.createInjector(new JsonModule(), binder -> jsonSubTypeBinder(binder).bindJsonSubType(jsonSubType));
+        ObjectMapper objectMapper = injector.getInstance(ObjectMapper.class);
+
+        internalTest(objectMapper);
+    }
+
+    @Test
+    public void testAddPermittedSubClassBindings()
+            throws Exception
+    {
+        JsonSubType jsonSubType = JsonSubType.builder()
+                .forBase(Employee.class, "type")
+                .addPermittedSubClasses()
+                .build();
+        Injector injector = Guice.createInjector(new JsonModule(), binder -> jsonSubTypeBinder(binder).bindJsonSubType(jsonSubType));
+        ObjectMapper objectMapper = injector.getInstance(ObjectMapper.class);
+
+        internalTest(objectMapper);
+    }
+
+    @Test
+    public void testAddPermittedSubClassBindingsSpecifiedNames()
+            throws Exception
+    {
+        JsonSubType jsonSubType = JsonSubType.builder()
+                .forBase(Employee.class, "bogus")
+                .addPermittedSubClasses(clazz -> "xxx__" + clazz.getName() + "__XXX")
+                .build();
+        Injector injector = Guice.createInjector(new JsonModule(), binder -> jsonSubTypeBinder(binder).bindJsonSubType(jsonSubType));
+        ObjectMapper objectMapper = injector.getInstance(ObjectMapper.class);
+
+        internalTest(objectMapper);
+    }
+
+    @Test
+    public void testFailsWithoutSubClassBindings()
+    {
+        ObjectMapper objectMapper = new ObjectMapperProvider().get();
+
+        assertThrows(InvalidDefinitionException.class, () -> internalTest(objectMapper));
+    }
+
+    @Test
+    public void testFailsWhenMissingBindings()
+    {
+        JsonSubType jsonSubType = JsonSubType.builder()
+                .forBase(Employee.class, "type")
+                .add(Programmer.class)
+                .build();
+        Injector injector = Guice.createInjector(new JsonModule(), binder -> jsonSubTypeBinder(binder).bindJsonSubType(jsonSubType));
+        ObjectMapper objectMapper = injector.getInstance(ObjectMapper.class);
+
+        assertThrows(IllegalArgumentException.class, () -> internalTest(objectMapper));
+    }
+
+    @Test
+    public void testBuildMultipleTypes()
+            throws Exception
+    {
+        JsonSubType jsonSubType = JsonSubType.builder()
+                .forBase(Employee.class, "type")
+                .addPermittedSubClasses()
+                .forBase(Part.class, "category")
+                .addPermittedSubClasses()
+                .build();
+
+        Injector injector = Guice.createInjector(new JsonModule(), binder -> jsonSubTypeBinder(binder).bindJsonSubType(jsonSubType));
+        ObjectMapper objectMapper = injector.getInstance(ObjectMapper.class);
+
+        internalTest(objectMapper);
+
+        JsonCodecFactory codecFactory = new JsonCodecFactory(() -> objectMapper);
+        JsonCodec<Part> jsonCodec = codecFactory.jsonCodec(Part.class);
+
+        String item1Json = objectMapper.writeValueAsString(item1);
+        String item2Json = objectMapper.writeValueAsString(item2);
+        String containerJson = objectMapper.writeValueAsString(container);
+
+        for (int i = 0; i < 2; ++i) {
+            Part deserializedItem1 = (i == 0) ? objectMapper.readValue(item1Json, Part.class) : jsonCodec.fromJson(item1Json);
+            Part deserializedItem2 = (i == 0) ? objectMapper.readValue(item2Json, Part.class) : jsonCodec.fromJson(item2Json);
+            Part deserializedContainer = (i == 0) ? objectMapper.readValue(containerJson, Part.class) : jsonCodec.fromJson(containerJson);
+
+            assertThat(deserializedItem1).isInstanceOf(Item.class);
+            assertThat(deserializedItem2).isInstanceOf(Item.class);
+            assertThat(deserializedContainer).isInstanceOf(Container.class);
+
+            assertThat(deserializedItem1).isEqualTo(item1);
+            assertThat(deserializedItem2).isEqualTo(item2);
+            assertThat(deserializedContainer).isEqualTo(container);
+        }
+    }
+
+    @Test
+    public void testStandalone()
+            throws Exception
+    {
+        JsonSubType jsonSubType = JsonSubType.builder()
+                .forBase(Employee.class, "type")
+                .add(Programmer.class)
+                .add(Manager.class)
+                .build();
+
+        ObjectMapperProvider objectMapperProvider = new ObjectMapperProvider().withJsonSubTypes(ImmutableSet.of(jsonSubType));
+
+        internalTest(objectMapperProvider.get());
+    }
+
+    @Test
+    public void testExpectedJson()
+            throws Exception
+    {
+        JsonSubType jsonSubType1 = JsonSubType.builder()
+                .forBase(Employee.class, "type")
+                .add(Programmer.class)
+                .add(Manager.class)
+                .build();
+        ObjectMapper objectMapper1 = new ObjectMapperProvider().withJsonSubTypes(ImmutableSet.of(jsonSubType1)).get();
+        String programmer1Json = objectMapper1.writeValueAsString(programmer1);
+        String manager1Json = objectMapper1.writeValueAsString(manager1);
+
+        JsonSubType jsonSubType2 = JsonSubType.builder()
+                .forBase(Employee.class, "category")
+                .add(Programmer.class)
+                .add(Manager.class)
+                .build();
+        ObjectMapper objectMapper2 = new ObjectMapperProvider().withJsonSubTypes(ImmutableSet.of(jsonSubType2)).get();
+        String programmer2Json = objectMapper2.writeValueAsString(programmer1);
+        String manager2Json = objectMapper2.writeValueAsString(manager1);
+
+        assertThat(programmer1Json).isEqualTo("{\"name\":\"Joe\",\"type\":\"Programmer\"}");
+        assertThat(manager1Json).isEqualTo("{\"name\":\"Jane\",\"reports\":[{\"name\":\"Joe\",\"type\":\"Programmer\"},{\"name\":\"Rachel\",\"type\":\"Programmer\"}],\"type\":\"Manager\"}");
+
+        assertThat(programmer2Json).isEqualTo("{\"name\":\"Joe\",\"category\":\"Programmer\"}");
+        assertThat(manager2Json).isEqualTo("{\"name\":\"Jane\",\"reports\":[{\"name\":\"Joe\",\"category\":\"Programmer\"},{\"name\":\"Rachel\",\"category\":\"Programmer\"}],\"category\":\"Manager\"}");
+    }
+
+    private static void internalTest(ObjectMapper objectMapper)
+            throws JsonProcessingException
+    {
+        JsonCodecFactory codecFactory = new JsonCodecFactory(() -> objectMapper);
+        JsonCodec<Employee> jsonCodec = codecFactory.jsonCodec(Employee.class);
+
+        String programmer1Json = objectMapper.writeValueAsString(programmer1);
+        String programmer2Json = objectMapper.writeValueAsString(programmer2);
+        String programmer3Json = objectMapper.writeValueAsString(programmer3);
+        String manager1Json = objectMapper.writeValueAsString(manager1);
+        String manager2Json = objectMapper.writeValueAsString(manager2);
+
+        for (int i = 0; i < 2; ++i) {
+            Employee deserializedProgrammer1 = (i == 0) ? objectMapper.readValue(programmer1Json, Employee.class) : jsonCodec.fromJson(programmer1Json);
+            Employee deserializedProgrammer2 = (i == 0) ? objectMapper.readValue(programmer2Json, Employee.class) : jsonCodec.fromJson(programmer2Json);
+            Employee deserializedProgrammer3 = (i == 0) ? objectMapper.readValue(programmer3Json, Employee.class) : jsonCodec.fromJson(programmer3Json);
+            Employee deserializedManager1 = (i == 0) ? objectMapper.readValue(manager1Json, Employee.class) : jsonCodec.fromJson(manager1Json);
+            Employee deserializedManager2 = (i == 0) ? objectMapper.readValue(manager2Json, Employee.class) : jsonCodec.fromJson(manager2Json);
+
+            assertThat(deserializedProgrammer1).isInstanceOf(Programmer.class);
+            assertThat(deserializedProgrammer2).isInstanceOf(Programmer.class);
+            assertThat(deserializedProgrammer3).isInstanceOf(Programmer.class);
+            assertThat(deserializedManager1).isInstanceOf(Manager.class);
+            assertThat(deserializedManager2).isInstanceOf(Manager.class);
+
+            assertThat(deserializedProgrammer1).isEqualTo(programmer1);
+            assertThat(deserializedProgrammer2).isEqualTo(programmer2);
+            assertThat(deserializedProgrammer3).isEqualTo(programmer3);
+            assertThat(deserializedManager1).isEqualTo(manager1);
+            assertThat(deserializedManager2).isEqualTo(manager2);
+        }
+    }
+}


### PR DESCRIPTION
Proposal for a JSON subtype/polymorphic binder. wdyt?

So-called polymorphic subtypes are cumbersome in Jackson. This binding utility makes it easier by:

- Moving all meta-code into the binder so that no class/record decorations/annotations are needed - de-uglifies these classes
- Automatically adds the type property to the generated JSON
- Automatically generate bindings for sealed classes/hierarchies
- Eliminates potential programmer errors by automating naming and mapping of the type field in Jackson/JSON sub-types