### PR TITLE
Make CpuTimer user time collection optional

### DIFF
--- a/stats/src/main/java/io/airlift/stats/CpuTimer.java
+++ b/stats/src/main/java/io/airlift/stats/CpuTimer.java
@@ -15,8 +15,11 @@ package io.airlift.stats;
 
 import io.airlift.units.Duration;
 
+import javax.annotation.Nullable;
+
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadMXBean;
+import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
@@ -24,6 +27,7 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 public class CpuTimer
 {
     private static final ThreadMXBean THREAD_MX_BEAN = ManagementFactory.getThreadMXBean();
+    private static final Duration ZERO_NANOS = new Duration(0, NANOSECONDS);
 
     private final long wallStartTime;
     private final long cpuStartTime;
@@ -35,9 +39,15 @@ public class CpuTimer
 
     public CpuTimer()
     {
+        this(true);
+    }
+
+    public CpuTimer(boolean collectUserTime)
+    {
         wallStartTime = System.nanoTime();
         cpuStartTime = THREAD_MX_BEAN.getCurrentThreadCpuTime();
-        userStartTime = THREAD_MX_BEAN.getCurrentThreadUserTime();
+        // ThreadMXBean will return -1 if user CPU time collection is not supported
+        userStartTime = collectUserTime ? THREAD_MX_BEAN.getCurrentThreadUserTime() : -1;
 
         intervalWallStart = wallStartTime;
         intervalCpuStart = cpuStartTime;
@@ -48,12 +58,14 @@ public class CpuTimer
     {
         long currentWallTime = System.nanoTime();
         long currentCpuTime = THREAD_MX_BEAN.getCurrentThreadCpuTime();
-        long currentUserTime = THREAD_MX_BEAN.getCurrentThreadUserTime();
+        // ThreadMXBean will return -1 if user CPU time collection is not supported
+        long currentUserTime = intervalUserStart == -1 ? -1 : THREAD_MX_BEAN.getCurrentThreadUserTime();
 
         CpuDuration cpuDuration = new CpuDuration(
                 nanosBetween(intervalWallStart, currentWallTime),
                 nanosBetween(intervalCpuStart, currentCpuTime),
-                nanosBetween(intervalUserStart, currentUserTime));
+                // currentUserTime is -1 when ThreadMXBean does not support user collection or when collectUserTime is false
+                currentUserTime == -1 ? null : nanosBetween(intervalUserStart, currentUserTime));
 
         intervalWallStart = currentWallTime;
         intervalCpuStart = currentCpuTime;
@@ -66,24 +78,28 @@ public class CpuTimer
     {
         long currentWallTime = System.nanoTime();
         long currentCpuTime = THREAD_MX_BEAN.getCurrentThreadCpuTime();
-        long currentUserTime = THREAD_MX_BEAN.getCurrentThreadUserTime();
+        // ThreadMXBean will return -1 if user CPU time collection is not supported
+        long currentUserTime = intervalUserStart == -1 ? -1 : THREAD_MX_BEAN.getCurrentThreadUserTime();
 
         return new CpuDuration(
                 nanosBetween(intervalWallStart, currentWallTime),
                 nanosBetween(intervalCpuStart, currentCpuTime),
-                nanosBetween(intervalUserStart, currentUserTime));
+                // currentUserTime is -1 when ThreadMXBean does not support user collection or when collectUserTime is false
+                currentUserTime == -1 ? null : nanosBetween(intervalUserStart, currentUserTime));
     }
 
     public CpuDuration elapsedTime()
     {
         long currentWallTime = System.nanoTime();
         long currentCpuTime = THREAD_MX_BEAN.getCurrentThreadCpuTime();
-        long currentUserTime = THREAD_MX_BEAN.getCurrentThreadUserTime();
+        // ThreadMXBean will return -1 if user CPU time collection is not supported
+        long currentUserTime = userStartTime == -1 ? -1 : THREAD_MX_BEAN.getCurrentThreadUserTime();
 
         return new CpuDuration(
                 nanosBetween(wallStartTime, currentWallTime),
                 nanosBetween(cpuStartTime, currentCpuTime),
-                nanosBetween(userStartTime, currentUserTime));
+                // currentUserTime is -1 when ThreadMXBean does not support user collection or when collectUserTime is false
+                currentUserTime == -1 ? null : nanosBetween(userStartTime, currentUserTime));
     }
 
     private static Duration nanosBetween(long start, long end)
@@ -95,16 +111,15 @@ public class CpuTimer
     {
         private final Duration wall;
         private final Duration cpu;
+        @Nullable
         private final Duration user;
 
         public CpuDuration()
         {
-            this.wall = new Duration(0, NANOSECONDS);
-            this.cpu = new Duration(0, NANOSECONDS);
-            this.user = new Duration(0, NANOSECONDS);
+            this(ZERO_NANOS, ZERO_NANOS, ZERO_NANOS);
         }
 
-        public CpuDuration(Duration wall, Duration cpu, Duration user)
+        public CpuDuration(Duration wall, Duration cpu, @Nullable Duration user)
         {
             this.wall = wall;
             this.cpu = cpu;
@@ -121,9 +136,24 @@ public class CpuTimer
             return cpu;
         }
 
+        public boolean hasUser()
+        {
+            return user != null;
+        }
+
+        /**
+         * This method will report zero duration when no user time was collected. Check {@link CpuDuration#hasUser()} or use {@link CpuDuration#getUserIfPresent()}
+         * in order distinguish a true zero user CPU time from no value being present.
+         * @return The {@link CpuDuration#user} value if present, otherwise returns a value of zero nanoseconds
+         */
         public Duration getUser()
         {
-            return user;
+            return user == null ? ZERO_NANOS : user;
+        }
+
+        public Optional<Duration> getUserIfPresent()
+        {
+            return Optional.ofNullable(user);
         }
 
         public CpuDuration add(CpuDuration cpuDuration)
@@ -131,7 +161,7 @@ public class CpuTimer
             return new CpuDuration(
                     addDurations(wall, cpuDuration.wall),
                     addDurations(cpu, cpuDuration.cpu),
-                    addDurations(user, cpuDuration.user));
+                    (user == null || cpuDuration.user == null) ? null : addDurations(user, cpuDuration.user));
         }
 
         public CpuDuration subtract(CpuDuration cpuDuration)
@@ -139,7 +169,7 @@ public class CpuTimer
             return new CpuDuration(
                     subtractDurations(wall, cpuDuration.wall),
                     subtractDurations(cpu, cpuDuration.cpu),
-                    subtractDurations(user, cpuDuration.user));
+                    (user == null || cpuDuration.user == null) ? null : subtractDurations(user, cpuDuration.user));
         }
 
         private static Duration addDurations(Duration a, Duration b)

--- a/stats/src/test/java/io/airlift/stats/TestCpuTimer.java
+++ b/stats/src/test/java/io/airlift/stats/TestCpuTimer.java
@@ -1,7 +1,12 @@
 package io.airlift.stats;
 
+import io.airlift.testing.TestingTicker;
 import org.testng.annotations.Test;
 
+import static io.airlift.units.Duration.succinctDuration;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
@@ -37,5 +42,22 @@ public class TestCpuTimer
 
         assertFalse(withUser.subtract(withoutUser).hasUser());
         assertFalse(withoutUser.subtract(withUser).hasUser());
+    }
+
+    @Test
+    public void testNullTicker()
+    {
+        assertThatExceptionOfType(NullPointerException.class)
+                .isThrownBy(() -> new CpuTimer(null, true))
+                .withMessage("ticker is null");
+    }
+
+    @Test
+    public void testCustomTicker()
+    {
+        TestingTicker ticker = new TestingTicker();
+        CpuTimer timer = new CpuTimer(ticker, true);
+        ticker.increment(1, SECONDS);
+        assertEquals(timer.elapsedTime().getWall(), succinctDuration(1, SECONDS));
     }
 }

--- a/stats/src/test/java/io/airlift/stats/TestCpuTimer.java
+++ b/stats/src/test/java/io/airlift/stats/TestCpuTimer.java
@@ -1,0 +1,41 @@
+package io.airlift.stats;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestCpuTimer
+{
+    @Test
+    public void testCpuTimerWithUserTimeEnabled()
+    {
+        CpuTimer timer = new CpuTimer();
+        assertTrue(timer.elapsedTime().hasUser());
+        assertTrue(timer.startNewInterval().hasUser());
+        assertTrue(timer.elapsedIntervalTime().hasUser());
+        assertTrue(timer.elapsedTime().add(new CpuTimer.CpuDuration()).hasUser());
+        assertTrue(timer.elapsedTime().subtract(new CpuTimer.CpuDuration()).hasUser());
+    }
+
+    @Test
+    public void testCpuTimerWithoutUserTimeEnabled()
+    {
+        CpuTimer timer = new CpuTimer(false);
+        assertFalse(timer.elapsedTime().hasUser());
+        assertFalse(timer.startNewInterval().hasUser());
+        assertFalse(timer.elapsedIntervalTime().hasUser());
+
+        CpuTimer.CpuDuration withUser = new CpuTimer.CpuDuration();
+        CpuTimer.CpuDuration withoutUser = timer.elapsedTime();
+
+        assertTrue(withUser.hasUser());
+        assertFalse(withoutUser.hasUser());
+
+        assertFalse(withUser.add(withoutUser).hasUser());
+        assertFalse(withoutUser.add(withUser).hasUser());
+
+        assertFalse(withUser.subtract(withoutUser).hasUser());
+        assertFalse(withoutUser.subtract(withUser).hasUser());
+    }
+}


### PR DESCRIPTION
Adds a constructor overload to `CpuTimer` to disable CPU user time collection. On Linux, user CPU time reporting [requires reading and parsing `/proc/self/task/<thread id>/stat`](https://github.com/openjdk/jdk/blob/df6cf1e41d0fc2dd5f5c094f66c7c8969cf5548d/src/hotspot/os/linux/os_linux.cpp#L5032,L5074) on each call, whereas collecting system and user time combined [has a fast-path](https://github.com/openjdk/jdk/blob/df6cf1e41d0fc2dd5f5c094f66c7c8969cf5548d/src/hotspot/os/linux/os_linux.cpp#L5023,L5029). Collecting user time therefor adds significant overhead if the caller does not care about the breakout of system vs user time.

This change adds handling to detect when `ThreadMXBean` does not support collecting user CPU time and returns `CpuDuration` values that allow the caller to detect when there is no user cpu time value present via `CpuDuration#hasUser()`, although `getUser()` will still return zero nanoseconds to preserve compatibility in that situation.

Also adds support for taking a custom `Ticker` argument to `CpuTimer` if the caller would like to be able to control the wall time collection source.