### PR TITLE
Add public getter for CpuTimer wallStartTime

### DIFF
--- a/stats/src/main/java/io/airlift/stats/CpuTimer.java
+++ b/stats/src/main/java/io/airlift/stats/CpuTimer.java
@@ -63,6 +63,16 @@ public class CpuTimer
         intervalUserStart = userStartTime;
     }
 
+    public long getWallStartTimeNanos()
+    {
+        return wallStartTime;
+    }
+
+    public long getIntervalWallStartNanos()
+    {
+        return intervalWallStart;
+    }
+
     public CpuDuration startNewInterval()
     {
         long currentWallTime = ticker.read();


### PR DESCRIPTION
Allows the caller to access `wallStartTime` and `intervalWallStart` values read from the Ticker which may allow the caller to avoid an additional redundant call to `Ticker#read()` at the point of construction or the initiation of a new interval.

This is an additional follow up item after https://github.com/airlift/airlift/pull/1024 to reduce overheads in Trino `PrioritizedSplitRunner` usage.