### PR TITLE
Fix logger BufferedHandler race condition hang on close()

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+221
+
+- Fix hang in logger shutdown.
+
 220
 
 - Change target Java version to 17.

--- a/log-manager/src/main/java/io/airlift/log/BufferedHandler.java
+++ b/log-manager/src/main/java/io/airlift/log/BufferedHandler.java
@@ -124,9 +124,7 @@ class BufferedHandler
 
     private void logging()
     {
-        while (!closed.get() || !queue.isEmpty()) {
-            processQueue();
-        }
+        processQueue();
 
         // logging is closed, so close the current output file
         synchronized (messageOutput) {
@@ -145,7 +143,7 @@ class BufferedHandler
     {
         List<byte[]> batch = new ArrayList<>(MAX_BATCH_COUNT);
         boolean poisonMessageSeen = false;
-        while (!closed.get() || !poisonMessageSeen) {
+        while (!poisonMessageSeen) {
             if (queue.isEmpty()) {
                 try {
                     batch.add(queue.take());


### PR DESCRIPTION
Prior race condition:
1. Thread 1 calls close() on BufferedHandler and blocks on waiting for the logging thread to join.
2. Thread 2 publishes a message after close() has submitted the poison message, but has not yet removed the message from the queue due to the closeure().
3. Logging thread processes the poison message and terminates from the inner loop (inside processQueue()).
4. Logging thread finds that the queue is still not empty and re-enters the processQueue() method.
5. Logging thread will now never complete since it will not get any more poison pills.
6. Thread 1 that calls close() is now hung on join(), and typically this thread is not a daemon thread, so will hang the JVM.