### PR TITLE
New non-blocking buffered handler

### DIFF
--- a/log-manager/pom.xml
+++ b/log-manager/pom.xml
@@ -23,6 +23,11 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>concurrent</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>json</artifactId>
         </dependency>
 

--- a/log-manager/pom.xml
+++ b/log-manager/pom.xml
@@ -98,6 +98,11 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
         </dependency>

--- a/log-manager/src/main/java/io/airlift/log/BufferedHandler.java
+++ b/log-manager/src/main/java/io/airlift/log/BufferedHandler.java
@@ -1,114 +1,407 @@
 package io.airlift.log;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.HashMultiset;
+import com.google.common.collect.ImmutableMultiset;
+import com.google.common.collect.Multiset;
+import com.google.common.util.concurrent.RateLimiter;
 import org.weakref.jmx.Managed;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.time.Duration;
+import java.util.Deque;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.ErrorManager;
 import java.util.logging.Formatter;
 import java.util.logging.Handler;
+import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Comparator.comparing;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.Executors.newSingleThreadExecutor;
 import static java.util.logging.ErrorManager.CLOSE_FAILURE;
 import static java.util.logging.ErrorManager.FLUSH_FAILURE;
 import static java.util.logging.ErrorManager.FORMAT_FAILURE;
+import static java.util.logging.ErrorManager.GENERIC_FAILURE;
 import static java.util.logging.ErrorManager.WRITE_FAILURE;
+import static java.util.stream.Collectors.joining;
 
+@ThreadSafe
 class BufferedHandler
         extends Handler
 {
-    private static final int MAX_BATCH_COUNT = 1024;
-    private static final byte[] POISON_MESSAGE = new byte[0];
+    public interface DropSummaryFormatter
+    {
+        String formatDropSummary(Multiset<String> dropCountBySource);
+    }
+
+    private static final MessageAndSource TERMINAL_MESSAGE = new MessageAndSource(new byte[] {}, "");
+
+    private final ExecutorService bufferDrainExecutor = newSingleThreadExecutor(daemonThreadsNamed("log-buffer-drainer"));
+    private final AtomicBoolean initialized = new AtomicBoolean();
+    private final AtomicBoolean inputClosed = new AtomicBoolean();
+    private final AtomicLong droppedMessages = new AtomicLong();
 
     private final MessageOutput messageOutput;
-    private final Thread thread;
-    private final BlockingQueue<byte[]> queue = new ArrayBlockingQueue<>(MAX_BATCH_COUNT);
-    private final AtomicBoolean closed = new AtomicBoolean();
-    private final AtomicLong droppedMessages = new AtomicLong(0);
+    private final DropSummaryFormatter dropSummaryFormatter;
+    private final RateLimiter errorRetryLimiter;
+    private final Duration maxCloseTime;
+    private final int messageFlushCount;
+
+    // queueDrainLock ensures that queue and dropCountBySource are kept in sync as data is extracted or moved between these structures
+    private final ReentrantLock queueDrainLock = new ReentrantLock();
+    private final Condition recordEnqueued = queueDrainLock.newCondition();
+    private final Deque<MessageAndSource> queue;
+    @GuardedBy("queueDrainLock")
+    private final Multiset<String> dropCountBySource = HashMultiset.create();
+    @GuardedBy("queueDrainLock")
+    private boolean terminalMessageDequeued;
 
     public BufferedHandler(MessageOutput messageOutput, Formatter formatter, ErrorManager errorManager)
     {
-        this.messageOutput = requireNonNull(messageOutput, "messageOutput is null");
-        setErrorManager(requireNonNull(errorManager, "errorManager is null"));
-        setFormatter(requireNonNull(formatter, "formatter is null"));
+        this(
+                messageOutput,
+                formatter,
+                BufferedHandler::defaultFormatDropSummary,
+                errorManager,
+                RateLimiter.create(0.5), // Throttle down to 1 retry every 2 seconds
+                Duration.ofSeconds(10),
+                512,
+                1024);
+    }
 
-        thread = new Thread(this::logging);
-        thread.setName("log-writer");
-        thread.setDaemon(true);
+    public BufferedHandler(
+            MessageOutput messageOutput,
+            Formatter formatter,
+            DropSummaryFormatter dropSummaryFormatter,
+            ErrorManager errorManager,
+            RateLimiter errorRetryLimiter,
+            Duration maxCloseTime,
+            int messageFlushCount,
+            int maxBufferSize)
+    {
+        this.messageOutput = requireNonNull(messageOutput, "messageOutput is null");
+        setFormatter(requireNonNull(formatter, "formatter is null"));
+        this.dropSummaryFormatter = requireNonNull(dropSummaryFormatter, "dropSummaryFormatter is null");
+        setErrorManager(requireNonNull(errorManager, "errorManager is null"));
+        this.errorRetryLimiter = requireNonNull(errorRetryLimiter, "errorRetryLimiter is null");
+        this.maxCloseTime = requireNonNull(maxCloseTime, "maxCloseTime is null");
+        checkArgument(messageFlushCount > 0, "messageFlushCount must be greater than zero");
+        this.messageFlushCount = messageFlushCount;
+        checkArgument(maxBufferSize > 0, "maxBufferSize must be greater than zero");
+        queue = new LinkedBlockingDeque<>(maxBufferSize);
+    }
+
+    private static String defaultFormatDropSummary(Multiset<String> dropCountBySource)
+    {
+        return dropCountBySource.entrySet().stream()
+                .sorted(comparing(Multiset.Entry::getElement))
+                .map(entry -> "%s messages dropped: %s".formatted(entry.getElement(), entry.getCount()))
+                .collect(joining("\n", "Log buffer dropped messages:\n", ""));
+    }
+
+    public void initialize()
+    {
+        if (!initialized.compareAndSet(false, true)) {
+            return;
+        }
+        bufferDrainExecutor.execute(this::bufferDrainLoop);
+    }
+
+    private void bufferDrainLoop()
+    {
+        int flushCounter = 0;
+        while (!Thread.currentThread().isInterrupted()) {
+            try {
+                Multiset<String> dropSnapshot = ImmutableMultiset.of();
+                MessageAndSource message = null;
+                try {
+                    // Extract work to do
+                    queueDrainLock.lock();
+                    try {
+                        while (true) {
+                            if (!dropCountBySource.isEmpty()) {
+                                dropSnapshot = ImmutableMultiset.copyOf(dropCountBySource);
+                                dropCountBySource.clear();
+                            }
+
+                            // Always check if there are any messages (even if we have a drop snapshot to process) to ensure that we
+                            // are processing at least some messages during overload conditions, and not just only printing drop summaries.
+                            // Note: queuePollFirst() will return null and set terminalMessageDequeued when encountering TERMINAL_MESSAGE.
+                            message = queuePollFirst();
+
+                            if (!dropSnapshot.isEmpty() || message != null) {
+                                // Work found
+                                break;
+                            }
+
+                            if (terminalMessageDequeued) {
+                                // No more work and terminal message was already located
+                                return; // Graceful way to exit the drain loop (other than via interruption)
+                            }
+
+                            recordEnqueued.await();
+                        }
+                    }
+                    finally {
+                        queueDrainLock.unlock();
+                    }
+                    // For safety: dropSnapshot and message will be requeued in the finally block if not explicitly unreferenced
+
+                    // Dropped messages occurred before the current, and so drop snapshot need to be written first
+                    if (!dropSnapshot.isEmpty()) {
+                        if (!writeMessageOutputSafe(formatMessageBytes(createDropSummaryRecord(dropSnapshot)))) {
+                            errorRetryLimiter.acquire();
+                            continue;
+                        }
+                        dropSnapshot = ImmutableMultiset.of();
+                        flushCounter++;
+                    }
+
+                    // Then write the message
+                    if (message != null) {
+                        if (!writeMessageOutputSafe(message.logMessage())) {
+                            errorRetryLimiter.acquire();
+                            continue;
+                        }
+                        message = null;
+                        flushCounter++;
+                    }
+
+                    // Flush after some number of messages or if there is nothing more to process at the moment
+                    if (flushCounter >= messageFlushCount || !hasDrainingWork()) {
+                        flushMessageOutputSafe();
+                        flushCounter = 0;
+                    }
+                }
+                finally {
+                    if (message != null || !dropSnapshot.isEmpty()) {
+                        // Return messages that failed
+                        queueDrainLock.lock();
+                        try {
+                            // Return a failed message to the queue, or drop it if at capacity.
+                            if (message != null) {
+                                // If TERMINAL_MESSAGE has been dequeued, the queue is finished and this message must now become part of the drop summary.
+                                // If dropCountBySource is nonempty, then need to drop the current message because subsequent messages have already been dropped (regardless of the current queue size).
+                                // If the queue is full, then also need to drop the current message. NOTE: this must be the last condition checked.
+                                if (terminalMessageDequeued || !dropCountBySource.isEmpty() || !queue.offerFirst(message)) {
+                                    dropCountBySource.add(message.sourceName());
+                                    droppedMessages.incrementAndGet();
+                                }
+                            }
+
+                            // Merge back dropped messages snapshot
+                            dropSnapshot.forEachEntry(dropCountBySource::add);
+                        }
+                        finally {
+                            queueDrainLock.unlock();
+                        }
+                    }
+                }
+            }
+            catch (LogFormatException e) {
+                reportError(null, e, FORMAT_FAILURE);
+            }
+            catch (InterruptedException e) {
+                reportError("Log draining thread interrupted, will exit!", e, GENERIC_FAILURE);
+                Thread.currentThread().interrupt();
+            }
+            catch (Exception e) {
+                reportError("Unexpected buffer drain loop exception", e, GENERIC_FAILURE);
+            }
+        }
+    }
+
+    /**
+     * INVARIANT: Once TERMINAL_MESSAGE has been dequeued, no further records will be dequeued.
+     */
+    @Nullable
+    private MessageAndSource queuePollFirst()
+    {
+        checkState(queueDrainLock.isLocked());
+        if (terminalMessageDequeued) {
+            return null;
+        }
+
+        MessageAndSource message = queue.pollFirst();
+
+        if (message == TERMINAL_MESSAGE) {
+            terminalMessageDequeued = true;
+            return null;
+        }
+
+        return message;
+    }
+
+    private boolean hasDrainingWork()
+    {
+        queueDrainLock.lock();
+        try {
+            return !dropCountBySource.isEmpty() || !queue.isEmpty();
+        }
+        finally {
+            queueDrainLock.unlock();
+        }
+    }
+
+    private LogRecord createDropSummaryRecord(Multiset<String> droppedSnapshot)
+    {
+        try {
+            LogRecord record = new LogRecord(Level.SEVERE, dropSummaryFormatter.formatDropSummary(droppedSnapshot));
+            record.setLoggerName(BufferedHandler.class.getName());
+            return record;
+        }
+        catch (Exception e) {
+            // Wrap exception with the proper classification
+            throw new LogFormatException(e);
+        }
+    }
+
+    private static class LogFormatException
+            extends RuntimeException
+    {
+        public LogFormatException(Throwable cause)
+        {
+            super(cause);
+        }
     }
 
     @Override
     public void publish(LogRecord record)
     {
-        // if closed messages are dropped
-        if (closed.get()) {
-            droppedMessages.getAndIncrement();
-            return;
-        }
-
-        if (!isLoggable(record)) {
-            return;
-        }
-
-        byte[] message;
         try {
-            message = getFormatter().format(record).getBytes(UTF_8);
+            if (!isLoggable(record)) {
+                return;
+            }
+
+            if (inputClosed.get()) {
+                return;
+            }
+
+            // Generate the message on the publishing thread to ensure we get the correct thread name.
+            MessageAndSource message = toMessageAndSource(record);
+
+            // Messages may be inserted after being closed, but they won't be processed if they come after the terminal message
+            queueInsert(message);
         }
-        catch (Exception e) {
-            // catch any exception to assure logging always works
+        catch (LogFormatException e) {
             reportError(null, e, FORMAT_FAILURE);
-            return;
-        }
-
-        try {
-            putUninterruptibly(queue, message);
         }
         catch (Exception e) {
-            // catch any exception to assure logging always works
-            reportError(null, e, WRITE_FAILURE);
+            reportError(null, e, GENERIC_FAILURE);
+        }
+    }
+
+    private MessageAndSource toMessageAndSource(LogRecord record)
+    {
+        return new MessageAndSource(formatMessageBytes(record), determineSourceName(record));
+    }
+
+    private byte[] formatMessageBytes(LogRecord logRecord)
+    {
+        try {
+            return getFormatter().format(logRecord).getBytes(UTF_8);
+        }
+        catch (Exception e) {
+            // Wrap exception with the proper classification
+            throw new LogFormatException(e);
+        }
+    }
+
+    private static String determineSourceName(LogRecord record)
+    {
+        return firstNonNull(record.getLoggerName(), "UNKNOWN");
+    }
+
+    private void queueInsert(MessageAndSource message)
+    {
+        while (!queue.offerLast(message)) {
+            queueDrainLock.lock();
+            try {
+                MessageAndSource toDrop = queuePollFirst();
+                if (toDrop == null) {
+                    if (terminalMessageDequeued) {
+                        return; // Queue already terminated
+                    }
+                    continue;
+                }
+                dropCountBySource.add(toDrop.sourceName());
+                droppedMessages.incrementAndGet();
+            }
+            finally {
+                queueDrainLock.unlock();
+            }
         }
 
-        // if closed while queueing, try to remove the message just to clean up
-        if (closed.get()) {
-            queue.remove(message);
+        // Notify drainer about new message
+        queueDrainLock.lock();
+        try {
+            recordEnqueued.signal();
+        }
+        finally {
+            queueDrainLock.unlock();
         }
     }
 
     @Override
-    public synchronized void flush()
+    public void flush()
     {
-        try {
-            messageOutput.flush();
+        if (inputClosed.get()) {
+            return;
         }
-        catch (Exception e) {
-            reportError(null, e, FLUSH_FAILURE);
-        }
+
+        // This technically does not follow traditional buffer flush semantics, but it is not needed for airlift logging uses
+        flushMessageOutputSafe();
     }
 
     @Override
     public void close()
     {
-        closed.set(true);
+        if (!inputClosed.compareAndSet(false, true)) {
+            return;
+        }
+        queueInsert(TERMINAL_MESSAGE);
 
-        putUninterruptibly(queue, POISON_MESSAGE);
-
-        // wait for logging to finish
         try {
-            thread.join();
+            bufferDrainExecutor.shutdown();
+            if (!bufferDrainExecutor.awaitTermination(maxCloseTime.toMillis(), TimeUnit.MILLISECONDS)) {
+                reportError("Timed out waiting for data flush during close", null, CLOSE_FAILURE);
+            }
         }
         catch (InterruptedException e) {
+            reportError("Interrupted awaiting data flush during close", e, CLOSE_FAILURE);
             Thread.currentThread().interrupt();
         }
+        finally {
+            closeMessageOutputSafe();
+        }
+    }
 
-        queue.clear();
+    @VisibleForTesting
+    boolean isTerminalMessageDequeued()
+    {
+        queueDrainLock.lock();
+        try {
+            return terminalMessageDequeued;
+        }
+        finally {
+            queueDrainLock.unlock();
+        }
     }
 
     @VisibleForTesting
@@ -117,103 +410,50 @@ class BufferedHandler
         return messageOutput;
     }
 
-    protected void start()
-    {
-        thread.start();
-    }
-
-    private void logging()
-    {
-        processQueue();
-
-        // logging is closed, so close the current output file
-        synchronized (messageOutput) {
-            try {
-                messageOutput.close();
-            }
-            catch (IOException e) {
-                reportError("Could not close the MessageOutput", e, CLOSE_FAILURE);
-            }
-        }
-
-        queue.clear();
-    }
-
-    private void processQueue()
-    {
-        List<byte[]> batch = new ArrayList<>(MAX_BATCH_COUNT);
-        boolean poisonMessageSeen = false;
-        while (!poisonMessageSeen) {
-            if (queue.isEmpty()) {
-                try {
-                    batch.add(queue.take());
-                }
-                catch (InterruptedException ignored) {
-                }
-            }
-            else {
-                queue.drainTo(batch, MAX_BATCH_COUNT);
-            }
-
-            int poisonMessageIndex = getPoisonMessageIndex(batch);
-            if (poisonMessageIndex >= 0) {
-                poisonMessageSeen = true;
-                batch = batch.subList(0, poisonMessageIndex);
-            }
-
-            logMessageBatch(batch);
-            batch.clear();
-        }
-    }
-
-    private synchronized void logMessageBatch(List<byte[]> batch)
-    {
-        for (byte[] message : batch) {
-            try {
-                messageOutput.writeMessage(message);
-            }
-            catch (Exception e) {
-                reportError(null, e, WRITE_FAILURE);
-            }
-        }
-        // always flush at the end of a batch, so logs aren't delayed
-        flush();
-    }
-
-    private static <T> void putUninterruptibly(BlockingQueue<T> queue, T element)
-    {
-        boolean interrupted = false;
-        try {
-            while (true) {
-                try {
-                    queue.put(element);
-                    return;
-                }
-                catch (InterruptedException e) {
-                    interrupted = true;
-                }
-            }
-        }
-        finally {
-            if (interrupted) {
-                Thread.currentThread().interrupt();
-            }
-        }
-    }
-
-    private static int getPoisonMessageIndex(List<byte[]> messages)
-    {
-        for (int i = 0; i < messages.size(); i++) {
-            if (messages.get(i) == POISON_MESSAGE) {
-                return i;
-            }
-        }
-        return -1;
-    }
-
     @Managed
     public long getDroppedMessages()
     {
         return droppedMessages.get();
+    }
+
+    private boolean writeMessageOutputSafe(byte[] message)
+    {
+        try {
+            messageOutput.writeMessage(message);
+            return true;
+        }
+        catch (Exception e) {
+            reportError("Could not write to the MessageOutput", e, WRITE_FAILURE);
+            return false;
+        }
+    }
+
+    private void flushMessageOutputSafe()
+    {
+        try {
+            messageOutput.flush();
+        }
+        catch (Exception e) {
+            reportError("Could not flush the MessageOutput", e, FLUSH_FAILURE);
+        }
+    }
+
+    private void closeMessageOutputSafe()
+    {
+        try {
+            messageOutput.close();
+        }
+        catch (Exception e) {
+            reportError("Could not close the MessageOutput", e, CLOSE_FAILURE);
+        }
+    }
+
+    private record MessageAndSource(byte[] logMessage, String sourceName)
+    {
+        private MessageAndSource
+        {
+            requireNonNull(logMessage, "logMessage is null");
+            requireNonNull(sourceName, "sourceName is null");
+        }
     }
 }

--- a/log-manager/src/main/java/io/airlift/log/MessageOutput.java
+++ b/log-manager/src/main/java/io/airlift/log/MessageOutput.java
@@ -1,7 +1,10 @@
 package io.airlift.log;
 
+import javax.annotation.concurrent.ThreadSafe;
+
 import java.io.IOException;
 
+@ThreadSafe
 public interface MessageOutput
 {
     void writeMessage(byte[] message)

--- a/log-manager/src/main/java/io/airlift/log/RollingFileMessageOutput.java
+++ b/log-manager/src/main/java/io/airlift/log/RollingFileMessageOutput.java
@@ -113,7 +113,7 @@ final class RollingFileMessageOutput
     {
         RollingFileMessageOutput output = new RollingFileMessageOutput(filename, maxFileSize, maxTotalSize, compressionType, formatter);
         BufferedHandler handler = new BufferedHandler(output, formatter, errorManager);
-        handler.start();
+        handler.initialize();
         return handler;
     }
 

--- a/log-manager/src/main/java/io/airlift/log/RollingFileMessageOutput.java
+++ b/log-manager/src/main/java/io/airlift/log/RollingFileMessageOutput.java
@@ -103,21 +103,7 @@ final class RollingFileMessageOutput
 
     private final ExecutorService compressionExecutor;
 
-    public static BufferedHandler createRollingFileHandler(
-            String filename,
-            DataSize maxFileSize,
-            DataSize maxTotalSize,
-            CompressionType compressionType,
-            Formatter formatter,
-            ErrorManager errorManager)
-    {
-        RollingFileMessageOutput output = new RollingFileMessageOutput(filename, maxFileSize, maxTotalSize, compressionType, formatter);
-        BufferedHandler handler = new BufferedHandler(output, formatter, errorManager);
-        handler.initialize();
-        return handler;
-    }
-
-    private RollingFileMessageOutput(String filename, DataSize maxFileSize, DataSize maxTotalSize, CompressionType compressionType, Formatter formatter)
+    RollingFileMessageOutput(String filename, DataSize maxFileSize, DataSize maxTotalSize, CompressionType compressionType, Formatter formatter)
     {
         requireNonNull(filename, "filename is null");
         requireNonNull(maxFileSize, "maxFileSize is null");

--- a/log-manager/src/main/java/io/airlift/log/SocketMessageOutput.java
+++ b/log-manager/src/main/java/io/airlift/log/SocketMessageOutput.java
@@ -1,6 +1,5 @@
 package io.airlift.log;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.net.HostAndPort;
 import org.weakref.jmx.Managed;
 
@@ -11,8 +10,6 @@ import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.logging.ErrorManager;
-import java.util.logging.Formatter;
 
 import static java.util.Objects.requireNonNull;
 
@@ -30,19 +27,10 @@ public class SocketMessageOutput
     @GuardedBy("this")
     private OutputStream currentOutputStream;
 
-    @VisibleForTesting
     SocketMessageOutput(HostAndPort hostAndPort)
     {
         requireNonNull(hostAndPort, "hostAndPort is null");
         this.socketAddress = new InetSocketAddress(hostAndPort.getHost(), hostAndPort.getPort());
-    }
-
-    public static BufferedHandler createSocketHandler(HostAndPort hostAndPort, Formatter formatter, ErrorManager errorManager)
-    {
-        SocketMessageOutput output = new SocketMessageOutput(hostAndPort);
-        BufferedHandler handler = new BufferedHandler(output, formatter, errorManager);
-        handler.initialize();
-        return handler;
     }
 
     @Override

--- a/log-manager/src/test/java/io/airlift/log/TestBufferedHandler.java
+++ b/log-manager/src/test/java/io/airlift/log/TestBufferedHandler.java
@@ -1,0 +1,552 @@
+package io.airlift.log;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Predicate;
+import com.google.common.base.Splitter;
+import com.google.common.collect.HashMultiset;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMultiset;
+import com.google.common.collect.Multiset;
+import com.google.common.util.concurrent.RateLimiter;
+import org.testng.annotations.Test;
+
+import javax.annotation.Nullable;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.IntFunction;
+import java.util.logging.ErrorManager;
+import java.util.logging.Formatter;
+import java.util.logging.LogRecord;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.Multisets.filter;
+import static com.google.common.util.concurrent.MoreExecutors.shutdownAndAwaitTermination;
+import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+import static java.util.logging.Level.INFO;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestBufferedHandler
+{
+    @Test
+    public void testIdleFlush()
+            throws Exception
+    {
+        TestingMessageOutput testingMessageOutput = new TestingMessageOutput();
+        BufferedHandler bufferedHandler = new BufferedHandler(
+                testingMessageOutput,
+                testingFormatter(),
+                TestBufferedHandler::serializeMultiset,
+                new ErrorManager(),
+                RateLimiter.create(10),
+                Duration.ofSeconds(5),
+                100,
+                100);
+        bufferedHandler.initialize();
+
+        LogRecord record = logRecord(INFO, "TestLogger", "Test");
+        bufferedHandler.publish(record);
+        testingMessageOutput.awaitFirstFlushAttempt(5, TimeUnit.SECONDS);
+        assertThat(testingMessageOutput.getFlushedMessages())
+                .as("Buffer should flush when idle, even if still less than recordFlushCount")
+                .containsExactly(testingFormatter().format(record));
+
+        bufferedHandler.close();
+    }
+
+    @Test
+    public void testLoggingSequence()
+    {
+        int maxBufferSize = 100;
+
+        TestingMessageOutput testingMessageOutput = new TestingMessageOutput();
+        BufferedHandler bufferedHandler = new BufferedHandler(
+                testingMessageOutput,
+                testingFormatter(),
+                TestBufferedHandler::serializeMultiset,
+                new ErrorManager(),
+                RateLimiter.create(10),
+                Duration.ofSeconds(5),
+                100,
+                maxBufferSize);
+        bufferedHandler.initialize();
+
+        List<LogRecord> logRecords = new ArrayList<>();
+        // Add maxBufferSize - 1 log entries (save one space for the terminal signal)
+        for (int i = 0; i < maxBufferSize - 1; i++) {
+            LogRecord logRecord = logRecord(INFO, "TestLogger", String.valueOf(i));
+            logRecords.add(logRecord);
+            bufferedHandler.publish(logRecord);
+        }
+        bufferedHandler.close();
+
+        assertThat(testingMessageOutput.getFlushedMessages())
+                .as("Every record should be present if the buffer size is not exceeded")
+                .containsExactlyElementsOf(logRecords.stream()
+                        .map(record -> testingFormatter().format(record))
+                        .collect(toImmutableList()));
+    }
+
+    @Test
+    public void testLoggingOverloadSingleThread()
+    {
+        TestingMessageOutput testingMessageOutput = new TestingMessageOutput();
+        BufferedHandler bufferedHandler = new BufferedHandler(
+                testingMessageOutput,
+                testingFormatter(),
+                TestBufferedHandler::serializeMultiset,
+                new ErrorManager(),
+                RateLimiter.create(10),
+                Duration.ofSeconds(5),
+                2,
+                2);
+        bufferedHandler.initialize();
+
+        for (int i = 0; i < 1000; i++) {
+            // None of these calls should block due to lack of buffer space
+            bufferedHandler.publish(logRecord(INFO, "TestLogger", String.valueOf(i)));
+        }
+        bufferedHandler.close();
+
+        assertThat(bufferedHandler.getDroppedMessages())
+                .as("Test control check to make sure that it is dropping some messages")
+                .isGreaterThan(0);
+
+        int actualDropCount = assertLogStreamContents(testingMessageOutput.getFlushedMessages(), "TestLogger", 1000, String::valueOf);
+
+        assertThat(actualDropCount).isEqualTo(bufferedHandler.getDroppedMessages());
+    }
+
+    @Test
+    public void testLoggingOverloadMultiThread()
+    {
+        TestingMessageOutput testingMessageOutput = new TestingMessageOutput();
+        BufferedHandler bufferedHandler = new BufferedHandler(
+                testingMessageOutput,
+                testingFormatter(),
+                TestBufferedHandler::serializeMultiset,
+                new ErrorManager(),
+                RateLimiter.create(10),
+                Duration.ofSeconds(5),
+                2,
+                2);
+        bufferedHandler.initialize();
+
+        ExecutorService executor = Executors.newCachedThreadPool(daemonThreadsNamed("submitter-%s"));
+        executor.execute(() -> {
+            for (int i = 0; i < 1000; i++) {
+                // None of these calls should block due to lack of buffer space
+                bufferedHandler.publish(logRecord(INFO, "A-TestLogger", String.valueOf(i)));
+            }
+        });
+        executor.execute(() -> {
+            for (int i = 0; i < 1000; i++) {
+                // None of these calls should block due to lack of buffer space
+                bufferedHandler.publish(logRecord(INFO, "B-TestLogger", String.valueOf(i)));
+            }
+        });
+
+        assertThat(shutdownAndAwaitTermination(executor, 10, TimeUnit.SECONDS)).isTrue();
+
+        bufferedHandler.close();
+
+        assertThat(bufferedHandler.getDroppedMessages())
+                .as("Test control check to make sure that it is dropping some messages")
+                .isGreaterThan(0);
+
+        int actualDropCount = assertLogStreamContents(testingMessageOutput.getFlushedMessages(), "A-TestLogger", 1000, String::valueOf);
+        actualDropCount += assertLogStreamContents(testingMessageOutput.getFlushedMessages(), "B-TestLogger", 1000, String::valueOf);
+
+        assertThat(actualDropCount).isEqualTo(bufferedHandler.getDroppedMessages());
+    }
+
+    @Test
+    public void testMultiThreadErrorRetry()
+            throws InterruptedException, TimeoutException
+    {
+        TestingMessageOutput testingMessageOutput = new TestingMessageOutput()
+                .setThrowOnWrite(true)
+                .setThrowOnFlush(true);
+        BufferedHandler bufferedHandler = new BufferedHandler(
+                testingMessageOutput,
+                testingFormatter(),
+                TestBufferedHandler::serializeMultiset,
+                new ErrorManager(),
+                RateLimiter.create(10),
+                Duration.ofSeconds(5),
+                50,
+                100);
+        bufferedHandler.initialize();
+
+        ExecutorService executor = Executors.newCachedThreadPool(daemonThreadsNamed("submitter-%s"));
+        executor.execute(() -> {
+            for (int i = 0; i < 1000; i++) {
+                bufferedHandler.publish(logRecord(INFO, "A-TestLogger", String.valueOf(i)));
+            }
+        });
+        executor.execute(() -> {
+            for (int i = 0; i < 1000; i++) {
+                bufferedHandler.publish(logRecord(INFO, "B-TestLogger", String.valueOf(i)));
+            }
+        });
+
+        // Allow the system to recover after it has encountered some errors
+        testingMessageOutput.awaitFirstWriteAttempt(5, TimeUnit.SECONDS);
+        testingMessageOutput.setThrowOnWrite(false);
+        testingMessageOutput.awaitFirstFlushAttempt(5, TimeUnit.SECONDS);
+        testingMessageOutput.setThrowOnFlush(false);
+
+        assertThat(shutdownAndAwaitTermination(executor, 10, TimeUnit.SECONDS)).isTrue();
+
+        bufferedHandler.close();
+
+        int actualDropCount = assertLogStreamContents(testingMessageOutput.getFlushedMessages(), "A-TestLogger", 1000, String::valueOf);
+        actualDropCount += assertLogStreamContents(testingMessageOutput.getFlushedMessages(), "B-TestLogger", 1000, String::valueOf);
+
+        assertThat(actualDropCount).isEqualTo(bufferedHandler.getDroppedMessages());
+    }
+
+    @Test
+    public void testCapacityErrorRetryDuringClose()
+            throws InterruptedException, TimeoutException, ExecutionException
+    {
+        TestingMessageOutput testingMessageOutput = new TestingMessageOutput()
+                .setThrowOnWrite(true);
+        BufferedHandler bufferedHandler = new BufferedHandler(
+                testingMessageOutput,
+                testingFormatter(),
+                TestBufferedHandler::serializeMultiset,
+                new ErrorManager(),
+                RateLimiter.create(10),
+                Duration.ofSeconds(5),
+                10,
+                1);
+
+        // Publish 2 records before initializing the handler (capacity=1) to force the existence of a drop summary at start
+        bufferedHandler.publish(logRecord(INFO, "A-TestLogger", "1"));
+        bufferedHandler.publish(logRecord(INFO, "B-TestLogger", "1"));
+
+        bufferedHandler.initialize();
+
+        ExecutorService executor = Executors.newCachedThreadPool(daemonThreadsNamed("submitter-%s"));
+
+        // Throw in some async spam that races with close() and may or may not be processed
+        Future<?> spamFutureA = executor.submit(() -> {
+            for (int i = 0; i < 100; i++) {
+                bufferedHandler.publish(logRecord(INFO, "Spam-TestLogger", String.valueOf(i)));
+            }
+        });
+        Future<?> spamFutureB = executor.submit(() -> {
+            for (int i = 0; i < 100; i++) {
+                bufferedHandler.publish(logRecord(INFO, "Spam-TestLogger", String.valueOf(i)));
+            }
+        });
+
+        // Submit the close asynchronously
+        Future<?> closeFuture = executor.submit(bufferedHandler::close);
+
+        // Wait for the buffered handler terminal message to be processed, and then for a subsequent write attempt, before allowing writes to proceed
+        while (!bufferedHandler.isTerminalMessageDequeued()) {
+            sleepUninterruptibly(20, TimeUnit.MILLISECONDS);
+        }
+        // Wait for the next 2 write attempts to ensure there was at least one attempt with the terminal message signal established
+        testingMessageOutput.getNextWriteAttemptLatch().await(5, TimeUnit.SECONDS);
+        testingMessageOutput.getNextWriteAttemptLatch().await(5, TimeUnit.SECONDS);
+        testingMessageOutput.setThrowOnWrite(false);
+
+        // Wait for the async futures to complete.
+        spamFutureA.get(5, TimeUnit.SECONDS);
+        spamFutureB.get(5, TimeUnit.SECONDS);
+        closeFuture.get(5, TimeUnit.SECONDS);
+
+        // Assert that both messages submitted before close are present (in spite of the errors and capacity churning)
+        assertLogStreamContents(testingMessageOutput.getFlushedMessages(), "A-TestLogger", 1, String::valueOf);
+        assertLogStreamContents(testingMessageOutput.getFlushedMessages(), "B-TestLogger", 1, String::valueOf);
+    }
+
+    @Test
+    public void testIgnoreWriteAfterClose()
+    {
+        TestingMessageOutput testingMessageOutput = new TestingMessageOutput();
+        BufferedHandler bufferedHandler = new BufferedHandler(
+                testingMessageOutput,
+                testingFormatter(),
+                TestBufferedHandler::serializeMultiset,
+                new ErrorManager(),
+                RateLimiter.create(10),
+                Duration.ofSeconds(5),
+                2,
+                2);
+        bufferedHandler.initialize();
+
+        LogRecord record = logRecord(INFO, "TestLogger", "Test message");
+        bufferedHandler.publish(record);
+
+        bufferedHandler.close();
+
+        bufferedHandler.publish(logRecord(INFO, "TestLogger", "Test message after close"));
+
+        assertThat(bufferedHandler.getDroppedMessages())
+                .as("Messages after close are ignored and not counted as dropped")
+                .isZero();
+
+        assertThat(testingMessageOutput.getFlushedMessages()).containsExactly(testingFormatter().format(record));
+    }
+
+    private static Formatter testingFormatter()
+    {
+        return new Formatter()
+        {
+            @Override
+            public String format(LogRecord record)
+            {
+                return new LogEntry(record.getLoggerName(), record.getMessage()).serialize();
+            }
+        };
+    }
+
+    private static LogRecord logRecord(java.util.logging.Level level, String loggerName, String message)
+    {
+        LogRecord record = new LogRecord(level, message);
+        record.setLoggerName(loggerName);
+        return record;
+    }
+
+    private static int assertLogStreamContents(List<String> actualMessages, String targetLoggerName, int expectedMessageCount, IntFunction<String> indexToExpectedMessage)
+    {
+        int actualDropCount = 0;
+
+        Iterator<EntryOrDropSummary> iterator = deserializeMessages(actualMessages, targetLoggerName::equals).iterator();
+        Multiset<String> currentDropSummary = HashMultiset.create();
+        for (int i = 0; i < expectedMessageCount; i++) {
+            if (currentDropSummary.isEmpty()) {
+                assertThat(iterator)
+                        .as("More entries expected in the result")
+                        .hasNext();
+                EntryOrDropSummary entryOrDropSummary = iterator.next();
+                if (entryOrDropSummary.entry() != null) {
+                    assertThat(entryOrDropSummary.entry().message())
+                            .as("Verify that the message contents match the value sequence")
+                            .isEqualTo(indexToExpectedMessage.apply(i));
+                    continue;
+                }
+                currentDropSummary = HashMultiset.create(entryOrDropSummary.dropSummary());
+            }
+            assertThat(currentDropSummary.remove(targetLoggerName))
+                    .as("Expected to contain this logger name next in sequence")
+                    .isTrue();
+            actualDropCount++;
+        }
+        assertThat(currentDropSummary)
+                .as("Should not have more drop summary entries than total submitted")
+                .isEmpty();
+
+        return actualDropCount;
+    }
+
+    private static <T> Map<T, Integer> toMap(Multiset<T> multiset)
+    {
+        return multiset.entrySet().stream()
+                .collect(toImmutableMap(Multiset.Entry::getElement, Multiset.Entry::getCount));
+    }
+
+    private static String serializeMultiset(Multiset<String> multiset)
+    {
+        return Joiner.on('\n').withKeyValueSeparator('=').join(toMap(multiset));
+    }
+
+    private static Multiset<String> deserializeMultiset(String serializedMultimap)
+    {
+        Map<String, String> split = Splitter.on('\n').withKeyValueSeparator('=').split(serializedMultimap);
+        ImmutableMultiset.Builder<String> builder = ImmutableMultiset.builder();
+        for (Map.Entry<String, String> entry : split.entrySet()) {
+            builder.addCopies(entry.getKey(), Integer.parseInt(entry.getValue()));
+        }
+        return builder.build();
+    }
+
+    private static List<EntryOrDropSummary> deserializeMessages(List<String> messages, Predicate<String> loggerNameFilter)
+    {
+        return messages.stream()
+                .map(logEntryString -> {
+                    LogEntry logEntry = LogEntry.deserialize(logEntryString);
+                    return logEntry.loggerName().equals(BufferedHandler.class.getName())
+                            ? EntryOrDropSummary.forDropSummary(filter(deserializeMultiset(logEntry.message()), loggerNameFilter))
+                            : EntryOrDropSummary.forEntry(logEntry);
+                })
+                .filter(entry -> entry.entry() != null || !entry.dropSummary().isEmpty()) // Filter out empty summaries (due to applied loggerNameFilter)
+                .filter(entry -> entry.dropSummary() != null || loggerNameFilter.apply(entry.entry().loggerName())) // Apply loggerNameFilter to LogEntries
+                .collect(toImmutableList());
+    }
+
+    private record LogEntry(String loggerName, String message)
+    {
+        private LogEntry
+        {
+            requireNonNull(loggerName, "loggerName is null");
+            requireNonNull(message, "message is null");
+        }
+
+        public String serialize()
+        {
+            return Joiner.on(':').join(loggerName, message);
+        }
+
+        public static LogEntry deserialize(String serialized)
+        {
+            List<String> splits = Splitter.on(':').splitToList(serialized);
+            return new LogEntry(splits.get(0), splits.get(1));
+        }
+    }
+
+    private record EntryOrDropSummary(@Nullable LogEntry entry, @Nullable Multiset<String> dropSummary)
+    {
+        private EntryOrDropSummary
+        {
+            checkArgument((entry == null) != (dropSummary == null), "Exactly one of the values must be non-null");
+            dropSummary = dropSummary == null ? null : ImmutableMultiset.copyOf(dropSummary);
+        }
+
+        public static EntryOrDropSummary forEntry(LogEntry entry)
+        {
+            return new EntryOrDropSummary(entry, null);
+        }
+
+        public static EntryOrDropSummary forDropSummary(Multiset<String> dropSummary)
+        {
+            return new EntryOrDropSummary(null, dropSummary);
+        }
+    }
+
+    private static class TestingMessageOutput
+            implements MessageOutput
+    {
+        private final AtomicBoolean closed = new AtomicBoolean();
+        private final Queue<String> writeMessages = new LinkedBlockingQueue<>();
+        private final Queue<String> flushedMessages = new LinkedBlockingQueue<>();
+        private final BlockingQueue<CountDownLatch> nextWriteAttemptLatches = new LinkedBlockingQueue<>();
+        private final CountDownLatch firstWriteAttemptLatch = new CountDownLatch(1);
+        private final CountDownLatch firstFlushAttemptLatch = new CountDownLatch(1);
+        private final AtomicBoolean throwOnWrite = new AtomicBoolean();
+        private final AtomicBoolean throwOnFlush = new AtomicBoolean();
+
+        public TestingMessageOutput setThrowOnWrite(boolean shouldThrow)
+        {
+            throwOnWrite.set(shouldThrow);
+            return this;
+        }
+
+        public TestingMessageOutput setThrowOnFlush(boolean shouldThrow)
+        {
+            throwOnFlush.set(shouldThrow);
+            return this;
+        }
+
+        public CountDownLatch getNextWriteAttemptLatch()
+        {
+            CountDownLatch latch = new CountDownLatch(1);
+            nextWriteAttemptLatches.add(latch);
+            return latch;
+        }
+
+        public void awaitFirstWriteAttempt(long timeout, TimeUnit timeUnit)
+                throws InterruptedException, TimeoutException
+        {
+            if (!firstWriteAttemptLatch.await(timeout, timeUnit)) {
+                throw new TimeoutException();
+            }
+        }
+
+        public void awaitFirstFlushAttempt(long timeout, TimeUnit timeUnit)
+                throws InterruptedException, TimeoutException
+        {
+            if (!firstFlushAttemptLatch.await(timeout, timeUnit)) {
+                throw new TimeoutException();
+            }
+        }
+
+        public List<String> getFlushedMessages()
+        {
+            return ImmutableList.copyOf(flushedMessages);
+        }
+
+        private static void signal(BlockingQueue<CountDownLatch> latches)
+        {
+            List<CountDownLatch> drained = new ArrayList<>();
+            latches.drainTo(drained);
+            drained.forEach(CountDownLatch::countDown);
+        }
+
+        @Override
+        public void writeMessage(byte[] message)
+        {
+            try {
+                checkState(!closed.get(), "Already closed");
+
+                if (throwOnWrite.get()) {
+                    throw new RuntimeException();
+                }
+
+                writeMessages.offer(new String(message, UTF_8));
+            }
+            finally {
+                firstWriteAttemptLatch.countDown();
+                signal(nextWriteAttemptLatches);
+            }
+        }
+
+        @Override
+        public void flush()
+        {
+            try {
+                checkState(!closed.get(), "Already closed");
+
+                if (throwOnFlush.get()) {
+                    throw new RuntimeException();
+                }
+
+                flushInternal();
+            }
+            finally {
+                firstFlushAttemptLatch.countDown();
+            }
+        }
+
+        @Override
+        public void close()
+        {
+            if (!closed.compareAndSet(false, true)) {
+                return;
+            }
+            flushInternal();
+        }
+
+        private void flushInternal()
+        {
+            String message;
+            while ((message = writeMessages.poll()) != null) {
+                flushedMessages.add(message);
+            }
+        }
+    }
+}

--- a/log-manager/src/test/java/io/airlift/log/TestRollingFileMessageOutput.java
+++ b/log-manager/src/test/java/io/airlift/log/TestRollingFileMessageOutput.java
@@ -42,7 +42,6 @@ import static io.airlift.log.Format.TEXT;
 import static io.airlift.log.LogFileName.parseHistoryLogFileName;
 import static io.airlift.log.RollingFileMessageOutput.CompressionType.GZIP;
 import static io.airlift.log.RollingFileMessageOutput.CompressionType.NONE;
-import static io.airlift.log.RollingFileMessageOutput.createRollingFileHandler;
 import static io.airlift.units.DataSize.Unit.BYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -495,6 +494,20 @@ public class TestRollingFileMessageOutput
         {
             return new GZIPInputStream(source.openStream());
         }
+    }
+
+    private static BufferedHandler createRollingFileHandler(
+            String filename,
+            DataSize maxFileSize,
+            DataSize maxTotalSize,
+            RollingFileMessageOutput.CompressionType compressionType,
+            Formatter formatter,
+            ErrorManager errorManager)
+    {
+        RollingFileMessageOutput output = new RollingFileMessageOutput(filename, maxFileSize, maxTotalSize, compressionType, formatter);
+        BufferedHandler handler = new BufferedHandler(output, formatter, errorManager);
+        handler.initialize();
+        return handler;
     }
 
     private static void assertLogDirectory(Path masterFile)


### PR DESCRIPTION
In the previous implementation of BufferedHandler, the log buffer would
cause calling threads to hang if the buffer ever became full. Instead of
hanging the calling threads, we can instead retain a summary of dropped
messages that couldn't fit in the buffer. This dropped summary can then
be emitted once the underlying logging system catches up again.

Note: we need to modify SocketMessageOutput here since previously it
would throw an IOException even if it was successful in it's retries.
Now, it only throws if it fails.