### PR TITLE
Add ByteBufferGenerator

### DIFF
--- a/http-client/src/main/java/io/airlift/http/client/ByteBufferBodyGenerator.java
+++ b/http-client/src/main/java/io/airlift/http/client/ByteBufferBodyGenerator.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.http.client;
+
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+
+import static java.util.Objects.requireNonNull;
+
+public class ByteBufferBodyGenerator
+        implements BodyGenerator
+{
+    private final ByteBuffer[] byteBuffers;
+
+    public ByteBufferBodyGenerator(ByteBuffer... byteBuffers)
+    {
+        this.byteBuffers = requireNonNull(byteBuffers, "byteBuffers is null");
+    }
+
+    public ByteBuffer[] getByteBuffers()
+    {
+        return byteBuffers;
+    }
+
+    @Override
+    public void write(OutputStream out)
+    {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.net.HostAndPort;
 import com.google.common.primitives.Ints;
 import io.airlift.http.client.BodyGenerator;
+import io.airlift.http.client.ByteBufferBodyGenerator;
 import io.airlift.http.client.FileBodyGenerator;
 import io.airlift.http.client.HttpClientConfig;
 import io.airlift.http.client.HttpRequestFilter;
@@ -28,6 +29,7 @@ import org.eclipse.jetty.client.api.Destination;
 import org.eclipse.jetty.client.api.Response;
 import org.eclipse.jetty.client.http.HttpClientTransportOverHTTP;
 import org.eclipse.jetty.client.http.HttpConnectionOverHTTP;
+import org.eclipse.jetty.client.util.ByteBufferRequestContent;
 import org.eclipse.jetty.client.util.BytesRequestContent;
 import org.eclipse.jetty.client.util.InputStreamResponseListener;
 import org.eclipse.jetty.client.util.PathRequestContent;
@@ -701,6 +703,9 @@ public class JettyHttpClient
         if (bodyGenerator != null) {
             if (bodyGenerator instanceof StaticBodyGenerator generator) {
                 jettyRequest.body(new BytesRequestContent(generator.getBody()));
+            }
+            else if (bodyGenerator instanceof ByteBufferBodyGenerator generator) {
+                jettyRequest.body(new ByteBufferRequestContent(generator.getByteBuffers()));
             }
             else if (bodyGenerator instanceof FileBodyGenerator generator) {
                 jettyRequest.body(fileContent(generator.getPath()));


### PR DESCRIPTION
Currently `generateBody` will materialize everything and wrap it with `BytesRequestContent`. This is not ideal since it will require extra copy and additional memory. In many cases we can pass an array of ByteBuffers directly. This is useful in the context of buffer service.

Tested with https://github.com/starburstdata/trino-buffer-service/pull/188 and result looks good