### PR TITLE
Fix incorrect value reporting in sparse HLL

### DIFF
--- a/stats/src/main/java/io/airlift/stats/cardinality/SparseHll.java
+++ b/stats/src/main/java/io/airlift/stats/cardinality/SparseHll.java
@@ -171,7 +171,7 @@ final class SparseHll
             // if zeros > EXTENDED_BITS_LENGTH - indexBits, it means all those bits were zeros,
             // so look at the entry value, which contains the number of leading 0 *after* EXTENDED_BITS_LENGTH
             int bits = EXTENDED_PREFIX_BITS - indexBitLength;
-            if (zeros > bits) {
+            if (zeros >= bits) {
                 zeros = bits + decodeBucketValue(entry);
             }
 

--- a/stats/src/test/java/io/airlift/stats/cardinality/TestSparseHll.java
+++ b/stats/src/test/java/io/airlift/stats/cardinality/TestSparseHll.java
@@ -31,6 +31,22 @@ public class TestSparseHll
     private static final int SPARSE_HLL_INSTANCE_SIZE = instanceSize(SparseHll.class);
 
     @Test(dataProvider = "bits")
+    public void testNumberOfZeros(int indexBitLength)
+    {
+        for (int i = 0; i < 64 - indexBitLength; i++) {
+            long hash = 1L << i;
+            int expectedValue = Long.numberOfLeadingZeros(hash << indexBitLength) + 1;
+
+            SparseHll sparseHll = new SparseHll(indexBitLength);
+            sparseHll.insertHash(hash);
+            sparseHll.eachBucket((bucket, value) -> {
+                assertEquals(bucket, 0);
+                assertEquals(value, expectedValue);
+            });
+        }
+    }
+
+    @Test(dataProvider = "bits")
     public void testMerge(int prefixBitLength)
             throws Exception
     {


### PR DESCRIPTION
eachBucket() was incorrectly ignoring the slot value when the topmost bit of the slot value is set and every other bit before it in the EXTENDED_BITS_PREFIX is 0 (i.e., when zeros == bits in the affected code)