### PR TITLE
Avoid empty lines when stdout/stderr redirect to logging

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+229
+
+- Strip trailing whitespace when redirecting standard output streams to log
+
 228
 
 - Exclude Hamcrest from jaxrs-testing

--- a/log-manager/src/main/java/io/airlift/log/LoggingOutputStream.java
+++ b/log-manager/src/main/java/io/airlift/log/LoggingOutputStream.java
@@ -24,13 +24,11 @@ import java.io.IOException;
 class LoggingOutputStream
         extends ByteArrayOutputStream
 {
-    private final String lineSeparator;
     private final Logger logger;
 
     public LoggingOutputStream(Logger logger)
     {
         this.logger = logger;
-        lineSeparator = System.getProperty("line.separator");
     }
 
     /**
@@ -44,7 +42,10 @@ class LoggingOutputStream
         String record = this.toString();
         reset();
 
-        if (record.isEmpty() || record.equals(lineSeparator)) {
+        // Strip trailing new line typically added when this class is used via System.out.println
+        record = record.stripTrailing();
+
+        if (record.isEmpty()) {
             // avoid empty records
             return;
         }

--- a/log-manager/src/test/java/io/airlift/log/TestLoggingOutputStream.java
+++ b/log-manager/src/test/java/io/airlift/log/TestLoggingOutputStream.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.log;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+public class TestLoggingOutputStream
+{
+    @Test(dataProvider = "testStripTrailingNewlineDataProvider")
+    public void testStripTrailingNewline(String printed, String logged)
+    {
+        MockHandler handler = new MockHandler();
+
+        java.util.logging.Logger mockLogger = java.util.logging.Logger.getAnonymousLogger();
+        mockLogger.setUseParentHandlers(false);
+        mockLogger.setLevel(Level.ALL);
+        mockLogger.addHandler(handler);
+
+        PrintStream stream = new PrintStream(new LoggingOutputStream(new Logger(mockLogger)), true);
+        stream.println(printed);
+
+        assertLog(handler.takeRecord(), Level.INFO, logged);
+        assertTrue(handler.isEmpty());
+    }
+
+    @DataProvider
+    public static Object[][] testStripTrailingNewlineDataProvider()
+    {
+        return new Object[][] {
+                {"Greeting from Warsaw!", "Greeting from Warsaw!"},
+                {"many new lines:\n\n", "many new lines:"},
+                {"trailing spaces and tabs \t", "trailing spaces and tabs"},
+                {"intra \t  n \n rn \r\n whitespace", "intra \t  n \n rn \r\n whitespace"},
+        };
+    }
+
+    private void assertLog(LogRecord record, Level level, String message)
+    {
+        assertEquals(record.getLevel(), level);
+        assertEquals(record.getMessage(), message);
+        assertNull(record.getThrown());
+    }
+
+    private static class MockHandler
+            extends Handler
+    {
+        private final List<LogRecord> records = new ArrayList<>();
+
+        private MockHandler()
+        {
+            setLevel(Level.ALL);
+        }
+
+        @Override
+        public void publish(LogRecord record)
+        {
+            records.add(record);
+        }
+
+        @Override
+        public void flush() {}
+
+        @Override
+        public void close() {}
+
+        public LogRecord takeRecord()
+        {
+            assertFalse(records.isEmpty(), "No messages logged");
+            return records.remove(0);
+        }
+
+        public boolean isEmpty()
+        {
+            return records.isEmpty();
+        }
+    }
+}


### PR DESCRIPTION
After `io.airlift.log.Logging#redirectStdStreams`, whenever application printed a line to `System.out` or `System.err`, console handler output two lines. This was because the `System.out.println` prints a newline to the output stream and `LoggingOutputStream` passed it back to logging which added another new line when printing to console.

This commit strips newline in `LoggingOutputStream` so that for a line printed via `System.out.println`, one line gets logged via console handler.