### PR TITLE
Remove broken uncaught exception handler from Bootstrap

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+230
+
+- Remove broken uncaught exception handler from Bootstrap
+
 229
 
 - Strip trailing whitespace when redirecting standard output streams to log

--- a/bootstrap/src/main/java/io/airlift/bootstrap/Bootstrap.java
+++ b/bootstrap/src/main/java/io/airlift/bootstrap/Bootstrap.java
@@ -161,8 +161,6 @@ public class Bootstrap
             logging = Logging.initialize();
         }
 
-        Thread.currentThread().setUncaughtExceptionHandler((thread, throwable) -> log.error(throwable, "Uncaught exception in thread %s", thread.getName()));
-
         Map<String, String> requiredProperties;
         if (requiredConfigurationProperties == null) {
             // initialize configuration


### PR DESCRIPTION
It was only being set for the current thread. An application that wants this behavior can use `Thread.setDefaultUncaughtExceptionHandler()` which will set it for all threads.