### PR TITLE
Use global OpenTelemetry if tracing is not explicitly enabled

### DIFF
--- a/http-client/src/main/java/io/airlift/http/client/HttpClientModule.java
+++ b/http-client/src/main/java/io/airlift/http/client/HttpClientModule.java
@@ -27,6 +27,7 @@ import com.google.inject.TypeLiteral;
 import io.airlift.configuration.ConfigDefaults;
 import io.airlift.http.client.jetty.JettyHttpClient;
 import io.airlift.node.NodeInfo;
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.TracerProvider;
@@ -98,7 +99,7 @@ public class HttpClientModule
         private final Class<? extends Annotation> annotation;
         private Injector injector;
         private NodeInfo nodeInfo;
-        private OpenTelemetry openTelemetry = OpenTelemetry.noop();
+        private OpenTelemetry openTelemetry = GlobalOpenTelemetry.get();
         private Tracer tracer = TracerProvider.noop().get("noop");
 
         private HttpClientProvider(String name, Class<? extends Annotation> annotation)

--- a/tracing/src/main/java/io/airlift/tracing/TracingModule.java
+++ b/tracing/src/main/java/io/airlift/tracing/TracingModule.java
@@ -5,6 +5,7 @@ import com.google.inject.Provides;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.airlift.tracing.SpanSerialization.SpanDeserializer;
 import io.airlift.tracing.SpanSerialization.SpanSerializer;
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
@@ -31,7 +32,7 @@ public class TracingModule
             install(new OpenTelemetryModule(serviceName, serviceVersion));
         }
         else {
-            binder.bind(OpenTelemetry.class).toInstance(OpenTelemetry.noop());
+            binder.bind(OpenTelemetry.class).toInstance(GlobalOpenTelemetry.get());
         }
 
         jsonBinder(binder).addSerializerBinding(Span.class).to(SpanSerializer.class);


### PR DESCRIPTION
This allows running with the following JVM flags:
```
-javaagent:/otel/opentelemetry-javaagent.jar
-Dotel.exporter.otlp.endpoint=http://host.docker.internal:4317
-Dotel.service.name=load-tests
-Dotel.resource.attributes=env=local
```

instead of these:
```
-Dtracing.enabled=true
-Dtracing.exporter.endpoint=http://host.docker.internal:4317
```

The advantages are:
* enabling more built-in integrations, like getting additional spans from Jetty and JAX-RS
* being able to set the service name and additional attributes

One disadvantage is having to provide the agent jar.

Refs: https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk-extensions/autoconfigure/README.md#opentelemetry-resource