### PR TITLE
Add support for single-level map of configuration values

### DIFF
--- a/configuration/src/main/java/io/airlift/configuration/ValueType.java
+++ b/configuration/src/main/java/io/airlift/configuration/ValueType.java
@@ -15,21 +15,8 @@
  */
 package io.airlift.configuration;
 
-import com.google.inject.BindingAnnotation;
-
-import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-
-@Documented
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
-@BindingAnnotation
-public @interface Config
+public enum ValueType
 {
-    String value();
-
-    ValueType type() default ValueType.PRIMITIVE;
+    PRIMITIVE,
+    MAP
 }

--- a/configuration/src/test/java/io/airlift/configuration/ConfigMap.java
+++ b/configuration/src/test/java/io/airlift/configuration/ConfigMap.java
@@ -1,0 +1,71 @@
+package io.airlift.configuration;
+
+import java.util.Map;
+
+import static io.airlift.configuration.ValueType.MAP;
+
+public class ConfigMap
+{
+    Map<String, String> mapOption;
+
+    public Map<String, String> getMapOption()
+    {
+        return mapOption;
+    }
+
+    @Config(value = "mapOption", type = MAP)
+    public ConfigMap setMapOption(Map<String, String> mapOption)
+    {
+        this.mapOption = mapOption;
+        return this;
+    }
+
+    Map<String, Integer> mapOptionInteger;
+
+    public Map<String, Integer> getMapOptionInteger()
+    {
+        return mapOptionInteger;
+    }
+
+    String mapSingleOption;
+
+    public String getMapSingleOption()
+    {
+        return mapSingleOption;
+    }
+
+    @Config("mapOption.key1")
+    public ConfigMap setMapSingleOption(String mapSingleOption)
+    {
+        this.mapSingleOption = mapSingleOption;
+        return this;
+    }
+
+    @Config(value = "mapOptionInteger", type = MAP)
+    public ConfigMap setMapOptionInteger(Map<String, Integer> mapOptionInteger)
+    {
+        this.mapOptionInteger = mapOptionInteger;
+        return this;
+    }
+
+    Map<String, EnumOptions> mapOptionEnum;
+
+    public Map<String, EnumOptions> getMapOptionEnum()
+    {
+        return mapOptionEnum;
+    }
+
+    @Config(value = "mapOptionEnum", type = MAP)
+    public ConfigMap setMapOptionEnum(Map<String, EnumOptions> mapOptionEnum)
+    {
+        this.mapOptionEnum = mapOptionEnum;
+        return this;
+    }
+
+    enum EnumOptions
+    {
+        OPTION1,
+        OPTION2,
+        OPTION3
+    }
+}


### PR DESCRIPTION
This adds the ability to pass map of values (key to coerced values as supported already) instead of having to pass the string and parse it according to some format.

Usage:

Properties:
```
config.map.key1 = value1
config.map.key2 = value2
config.map.key3 = value3
```

Config:

```
@Config(value = "config.map", type = MAP)
public ConfigMap setConfigMap(Map<String, String> values)
```

Keys are always String and values are coerced according to the existing logic if type is different than String.