### PR TITLE
Restore previous string limit for JSON 

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+231
+
+- Restore pre 2.15 Jackson string deserialization length limit
+
 230
 
 - Remove broken uncaught exception handler from Bootstrap

--- a/jmx-http/src/main/java/io/airlift/jmx/JmxHttpModule.java
+++ b/jmx-http/src/main/java/io/airlift/jmx/JmxHttpModule.java
@@ -87,6 +87,7 @@ public class JmxHttpModule
         }
 
         @Override
+        @SuppressWarnings("deprecation")
         public JsonNode getSchema(SerializerProvider provider, Type typeHint)
                 throws JsonMappingException
         {
@@ -148,6 +149,7 @@ public class JmxHttpModule
         }
 
         @Override
+        @SuppressWarnings("deprecation")
         public JsonNode getSchema(SerializerProvider provider, Type typeHint)
         {
             return createSchemaNode("object", true);

--- a/json/src/main/java/io/airlift/json/ObjectMapperProvider.java
+++ b/json/src/main/java/io/airlift/json/ObjectMapperProvider.java
@@ -17,6 +17,7 @@ package io.airlift.json;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonDeserializer;
@@ -68,6 +69,12 @@ public class ObjectMapperProvider
     public ObjectMapperProvider(JsonFactory jsonFactory)
     {
         this.jsonFactory = requireNonNull(jsonFactory, "jsonFactory is null");
+
+        // Disable the length limit, caller will be responsible for validating the input length
+        jsonFactory.setStreamReadConstraints(StreamReadConstraints
+                .builder()
+                .maxStringLength(Integer.MAX_VALUE)
+                .build());
 
         modules.add(new Jdk8Module());
         modules.add(new JavaTimeModule());

--- a/json/src/test/java/io/airlift/json/TestJsonCodec.java
+++ b/json/src/test/java/io/airlift/json/TestJsonCodec.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static com.fasterxml.jackson.core.StreamReadConstraints.DEFAULT_MAX_STRING_LEN;
 import static io.airlift.json.JsonCodec.jsonCodec;
 import static io.airlift.json.JsonCodec.listJsonCodec;
 import static io.airlift.json.JsonCodec.mapJsonCodec;
@@ -232,6 +233,19 @@ public class TestJsonCodec
         assertFalse(jsonCodec.toJsonWithLengthLimit(person, 1000).isPresent());
         assertFalse(jsonCodec.toJsonWithLengthLimit(person, 1035).isPresent());
         assertTrue(jsonCodec.toJsonWithLengthLimit(person, 1036).isPresent());
+    }
+
+    @Test
+    public void testToJsonExceedingDefaultStringLimit()
+    {
+        JsonCodec<ImmutablePerson> jsonCodec = jsonCodec(ImmutablePerson.class);
+        ImmutablePerson person = new ImmutablePerson(Strings.repeat("a", DEFAULT_MAX_STRING_LEN + 1), false);
+
+        String json = jsonCodec.toJson(person);
+        assertEquals(jsonCodec.fromJson(json), person);
+
+        byte[] bytes = jsonCodec.toJsonBytes(person);
+        assertEquals(jsonCodec.fromJson(bytes), person);
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>io.airlift</groupId>
         <artifactId>airbase</artifactId>
-        <version>137</version>
+        <version>139</version>
     </parent>
 
     <inceptionYear>2010</inceptionYear>

--- a/security-jwks/src/main/java/io/airlift/security/jwks/JwkEcPublicKey.java
+++ b/security-jwks/src/main/java/io/airlift/security/jwks/JwkEcPublicKey.java
@@ -57,7 +57,8 @@ public class JwkEcPublicKey
         throw new UnsupportedOperationException();
     }
 
-    protected Object writeReplace() throws ObjectStreamException
+    protected Object writeReplace()
+            throws ObjectStreamException
     {
         throw new UnsupportedOperationException("Java object serialization is not supported");
     }


### PR DESCRIPTION
Prior to the Jackson 2.15 there was no upper bound on the length of the string fields.

In order to increase compatibility with the existing use cases, previous behavior is restored.