### PR TITLE
Add HttpStatusListener to http client

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+232
+
+- HTTP client status listener
+
 231
 
 - Restore pre 2.15 Jackson string deserialization length limit

--- a/http-client/src/main/java/io/airlift/http/client/HttpClientModule.java
+++ b/http-client/src/main/java/io/airlift/http/client/HttpClientModule.java
@@ -135,14 +135,19 @@ public class HttpClientModule
         {
             HttpClientConfig config = injector.getInstance(Key.get(HttpClientConfig.class, annotation));
             Optional<String> environment = Optional.ofNullable(nodeInfo).map(NodeInfo::getEnvironment);
-            Optional<SslContextFactory.Client> sslContextFactory = injector.getInstance(Key.get(new TypeLiteral<Optional<SslContextFactory.Client>>() {}));
+            Optional<SslContextFactory.Client> sslContextFactory = injector.getInstance(Key.get(new TypeLiteral<>() {}));
 
             Set<HttpRequestFilter> filters = ImmutableSet.<HttpRequestFilter>builder()
                     .addAll(injector.getInstance(Key.get(new TypeLiteral<Set<HttpRequestFilter>>() {}, GlobalFilter.class)))
                     .addAll(injector.getInstance(Key.get(new TypeLiteral<Set<HttpRequestFilter>>() {}, annotation)))
                     .build();
 
-            return new JettyHttpClient(name, config, ImmutableList.copyOf(filters), openTelemetry, tracer, environment, sslContextFactory);
+            Set<HttpStatusListener> httpStatusListeners = ImmutableSet.<HttpStatusListener>builder()
+                    .addAll(injector.getInstance(Key.get(new TypeLiteral<Set<HttpStatusListener>>() {}, GlobalFilter.class)))
+                    .addAll(injector.getInstance(Key.get(new TypeLiteral<Set<HttpStatusListener>>() {}, annotation)))
+                    .build();
+
+            return new JettyHttpClient(name, config, ImmutableList.copyOf(filters), openTelemetry, tracer, environment, sslContextFactory, httpStatusListeners);
         }
     }
 }

--- a/http-client/src/main/java/io/airlift/http/client/HttpStatusListener.java
+++ b/http-client/src/main/java/io/airlift/http/client/HttpStatusListener.java
@@ -1,0 +1,6 @@
+package io.airlift.http.client;
+
+public interface HttpStatusListener
+{
+    void statusReceived(int statusCode);
+}

--- a/http-client/src/test/java/io/airlift/http/client/AbstractHttpClientTest.java
+++ b/http-client/src/test/java/io/airlift/http/client/AbstractHttpClientTest.java
@@ -1,6 +1,8 @@
 package io.airlift.http.client;
 
+import com.google.common.collect.HashMultiset;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Multiset;
 import io.airlift.http.client.HttpClient.HttpResponseFuture;
 import io.airlift.http.client.StatusResponseHandler.StatusResponse;
 import io.airlift.http.client.StringResponseHandler.StringResponse;
@@ -85,6 +87,7 @@ public abstract class AbstractHttpClientTest
     private String scheme = "http";
     private String host = "127.0.0.1";
     protected String keystore;
+    protected final Multiset<Integer> statusCounts = HashMultiset.create();
 
     protected AbstractHttpClientTest()
     {
@@ -120,6 +123,8 @@ public abstract class AbstractHttpClientTest
         TestingHttpServer server = new TestingHttpServer(Optional.ofNullable(keystore), servlet);
 
         baseURI = new URI(scheme, null, server.getHostAndPort().getHost(), server.getHostAndPort().getPort(), null, null, null);
+
+        statusCounts.clear();
     }
 
     @AfterMethod(alwaysRun = true)
@@ -264,6 +269,7 @@ public abstract class AbstractHttpClientTest
         assertEquals(servlet.getRequestHeaders("foo"), ImmutableList.of("bar"));
         assertEquals(servlet.getRequestHeaders("dupe"), ImmutableList.of("first", "second"));
         assertEquals(servlet.getRequestHeaders("x-custom-filter"), ImmutableList.of("custom value"));
+        assertThat(statusCounts.count(200)).isEqualTo(1);
     }
 
     @Test
@@ -307,6 +313,7 @@ public abstract class AbstractHttpClientTest
         assertEquals(servlet.getRequestHeaders("foo"), ImmutableList.of("bar"));
         assertEquals(servlet.getRequestHeaders("dupe"), ImmutableList.of("first", "second"));
         assertEquals(servlet.getRequestHeaders("x-custom-filter"), ImmutableList.of("custom value"));
+        assertThat(statusCounts.count(200)).isEqualTo(1);
     }
 
     @Test
@@ -389,6 +396,7 @@ public abstract class AbstractHttpClientTest
         assertEquals(servlet.getRequestHeaders("foo"), ImmutableList.of("bar"));
         assertEquals(servlet.getRequestHeaders("dupe"), ImmutableList.of("first", "second"));
         assertEquals(servlet.getRequestHeaders("x-custom-filter"), ImmutableList.of("custom value"));
+        assertThat(statusCounts.count(200)).isEqualTo(1);
     }
 
     @Test
@@ -410,6 +418,7 @@ public abstract class AbstractHttpClientTest
         assertEquals(servlet.getRequestHeaders("foo"), ImmutableList.of("bar"));
         assertEquals(servlet.getRequestHeaders("dupe"), ImmutableList.of("first", "second"));
         assertEquals(servlet.getRequestHeaders("x-custom-filter"), ImmutableList.of("custom value"));
+        assertThat(statusCounts.count(200)).isEqualTo(1);
     }
 
     @Test
@@ -434,6 +443,7 @@ public abstract class AbstractHttpClientTest
         assertEquals(servlet.getRequestHeaders("dupe"), ImmutableList.of("first", "second"));
         assertEquals(servlet.getRequestHeaders("x-custom-filter"), ImmutableList.of("custom value"));
         assertEquals(servlet.getRequestBytes(), body);
+        assertThat(statusCounts.count(200)).isEqualTo(1);
     }
 
     @Test
@@ -460,6 +470,7 @@ public abstract class AbstractHttpClientTest
         assertEquals(servlet.getRequestHeaders("dupe"), ImmutableList.of("first", "second"));
         assertEquals(servlet.getRequestHeaders("x-custom-filter"), ImmutableList.of("custom value"));
         assertEquals(servlet.getRequestBytes(), new byte[] {1, 2, 5});
+        assertThat(statusCounts.count(200)).isEqualTo(1);
     }
 
     @Test
@@ -681,7 +692,6 @@ public abstract class AbstractHttpClientTest
 
     @BeforeClass
     public final void setUp()
-            throws Exception
     {
         executor = Executors.newCachedThreadPool(threadsNamed("test-%s"));
     }

--- a/http-client/src/test/java/io/airlift/http/client/TestingStatusListener.java
+++ b/http-client/src/test/java/io/airlift/http/client/TestingStatusListener.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.http.client;
+
+import com.google.common.collect.Multiset;
+import com.google.inject.Inject;
+
+public class TestingStatusListener
+        implements HttpStatusListener
+{
+    private final Multiset<Integer> statusCounter;
+
+    @Inject
+    public TestingStatusListener(Multiset<Integer> statusCounter)
+    {
+        this.statusCounter = statusCounter;
+    }
+
+    @Override
+    public void statusReceived(int statusCode)
+    {
+        statusCounter.add(statusCode);
+    }
+}

--- a/http-client/src/test/java/io/airlift/http/client/jetty/AbstractHttpClientTestHttpProxy.java
+++ b/http-client/src/test/java/io/airlift/http/client/jetty/AbstractHttpClientTestHttpProxy.java
@@ -14,6 +14,7 @@
 package io.airlift.http.client.jetty;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import io.airlift.http.client.AbstractHttpClientTest;
 import io.airlift.http.client.HttpClientConfig;
 import io.airlift.http.client.Request;
@@ -21,6 +22,7 @@ import io.airlift.http.client.Response;
 import io.airlift.http.client.ResponseHandler;
 import io.airlift.http.client.TestingHttpProxy;
 import io.airlift.http.client.TestingRequestFilter;
+import io.airlift.http.client.TestingStatusListener;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -51,7 +53,7 @@ public abstract class AbstractHttpClientTestHttpProxy
             throws Exception
     {
         testingHttpProxy = new TestingHttpProxy(Optional.ofNullable(keystore));
-        httpClient = new JettyHttpClient("test-shared", createClientConfig(), ImmutableList.of(new TestingRequestFilter()));
+        httpClient = new JettyHttpClient("test-shared", createClientConfig(), ImmutableList.of(new TestingRequestFilter()), ImmutableSet.of(new TestingStatusListener(statusCounts)));
     }
 
     @AfterClass(alwaysRun = true)
@@ -103,7 +105,7 @@ public abstract class AbstractHttpClientTestHttpProxy
     public <T, E extends Exception> T executeRequest(HttpClientConfig config, Request request, ResponseHandler<T, E> responseHandler)
             throws Exception
     {
-        try (JettyHttpClient client = new JettyHttpClient("test-private", config, ImmutableList.of(new TestingRequestFilter()))) {
+        try (JettyHttpClient client = new JettyHttpClient("test-private", config, ImmutableList.of(new TestingRequestFilter()), ImmutableSet.of(new TestingStatusListener(statusCounts)))) {
             return client.execute(request, new ProxyResponseHandler<>(responseHandler));
         }
     }

--- a/http-client/src/test/java/io/airlift/http/client/jetty/TestAsyncJettyHttpClient.java
+++ b/http-client/src/test/java/io/airlift/http/client/jetty/TestAsyncJettyHttpClient.java
@@ -1,11 +1,13 @@
 package io.airlift.http.client.jetty;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import io.airlift.http.client.AbstractHttpClientTest;
 import io.airlift.http.client.HttpClientConfig;
 import io.airlift.http.client.Request;
 import io.airlift.http.client.ResponseHandler;
 import io.airlift.http.client.TestingRequestFilter;
+import io.airlift.http.client.TestingStatusListener;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 
@@ -17,7 +19,7 @@ public class TestAsyncJettyHttpClient
     @BeforeClass
     public void setUpHttpClient()
     {
-        httpClient = new JettyHttpClient("test-shared", createClientConfig(), ImmutableList.of(new TestingRequestFilter()));
+        httpClient = new JettyHttpClient("test-shared", createClientConfig(), ImmutableList.of(new TestingRequestFilter()), ImmutableSet.of(new TestingStatusListener(statusCounts)));
     }
 
     @AfterClass(alwaysRun = true)
@@ -46,7 +48,7 @@ public class TestAsyncJettyHttpClient
     public <T, E extends Exception> T executeRequest(HttpClientConfig config, Request request, ResponseHandler<T, E> responseHandler)
             throws Exception
     {
-        try (JettyHttpClient client = new JettyHttpClient("test-private", config, ImmutableList.of(new TestingRequestFilter()))) {
+        try (JettyHttpClient client = new JettyHttpClient("test-private", config, ImmutableList.of(new TestingRequestFilter()), ImmutableSet.of(new TestingStatusListener(statusCounts)))) {
             return executeAsync(client, request, responseHandler);
         }
     }

--- a/http-client/src/test/java/io/airlift/http/client/jetty/TestJettyHttpClient.java
+++ b/http-client/src/test/java/io/airlift/http/client/jetty/TestJettyHttpClient.java
@@ -1,12 +1,13 @@
 package io.airlift.http.client.jetty;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import io.airlift.http.client.AbstractHttpClientTest;
 import io.airlift.http.client.HttpClientConfig;
-import io.airlift.http.client.HttpRequestFilter;
 import io.airlift.http.client.Request;
 import io.airlift.http.client.ResponseHandler;
 import io.airlift.http.client.TestingRequestFilter;
+import io.airlift.http.client.TestingStatusListener;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 
@@ -18,7 +19,7 @@ public class TestJettyHttpClient
     @BeforeClass
     public void setUpHttpClient()
     {
-        httpClient = new JettyHttpClient("test-shared", createClientConfig(), ImmutableList.of(new TestingRequestFilter()));
+        httpClient = new JettyHttpClient("test-shared", createClientConfig(), ImmutableList.of(new TestingRequestFilter()), ImmutableSet.of(new TestingStatusListener(statusCounts)));
     }
 
     @AfterClass(alwaysRun = true)
@@ -45,7 +46,7 @@ public class TestJettyHttpClient
     public <T, E extends Exception> T executeRequest(HttpClientConfig config, Request request, ResponseHandler<T, E> responseHandler)
             throws Exception
     {
-        try (JettyHttpClient client = new JettyHttpClient("test-private", config, ImmutableList.<HttpRequestFilter>of(new TestingRequestFilter()))) {
+        try (JettyHttpClient client = new JettyHttpClient("test-private", config, ImmutableList.of(new TestingRequestFilter()), ImmutableSet.of(new TestingStatusListener(statusCounts)))) {
             return client.execute(request, responseHandler);
         }
     }

--- a/http-client/src/test/java/io/airlift/http/client/jetty/TestJettyHttpClientSocksProxy.java
+++ b/http-client/src/test/java/io/airlift/http/client/jetty/TestJettyHttpClientSocksProxy.java
@@ -1,12 +1,14 @@
 package io.airlift.http.client.jetty;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import io.airlift.http.client.AbstractHttpClientTest;
 import io.airlift.http.client.HttpClientConfig;
 import io.airlift.http.client.Request;
 import io.airlift.http.client.ResponseHandler;
 import io.airlift.http.client.TestingRequestFilter;
 import io.airlift.http.client.TestingSocksProxy;
+import io.airlift.http.client.TestingStatusListener;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -24,7 +26,7 @@ public class TestJettyHttpClientSocksProxy
             throws IOException
     {
         testingSocksProxy = new TestingSocksProxy().start();
-        httpClient = new JettyHttpClient("test-shared", createClientConfig(), ImmutableList.of(new TestingRequestFilter()));
+        httpClient = new JettyHttpClient("test-shared", createClientConfig(), ImmutableList.of(new TestingRequestFilter()), ImmutableSet.of(new TestingStatusListener(statusCounts)));
     }
 
     @AfterClass(alwaysRun = true)
@@ -54,7 +56,7 @@ public class TestJettyHttpClientSocksProxy
             throws Exception
     {
         config.setSocksProxy(testingSocksProxy.getHostAndPort());
-        try (JettyHttpClient client = new JettyHttpClient("test-private", config, ImmutableList.of(new TestingRequestFilter()))) {
+        try (JettyHttpClient client = new JettyHttpClient("test-private", config, ImmutableList.of(new TestingRequestFilter()), ImmutableSet.of(new TestingStatusListener(statusCounts)))) {
             return client.execute(request, responseHandler);
         }
     }

--- a/http-client/src/test/java/io/airlift/http/client/jetty/TestJettyHttpsClient.java
+++ b/http-client/src/test/java/io/airlift/http/client/jetty/TestJettyHttpsClient.java
@@ -1,11 +1,13 @@
 package io.airlift.http.client.jetty;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import io.airlift.http.client.AbstractHttpClientTest;
 import io.airlift.http.client.HttpClientConfig;
 import io.airlift.http.client.Request;
 import io.airlift.http.client.ResponseHandler;
 import io.airlift.http.client.TestingRequestFilter;
+import io.airlift.http.client.TestingStatusListener;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -30,7 +32,7 @@ public class TestJettyHttpsClient
     @BeforeClass
     public void setUpHttpClient()
     {
-        httpClient = new JettyHttpClient("test-shared", createClientConfig(), ImmutableList.of(new TestingRequestFilter()));
+        httpClient = new JettyHttpClient("test-shared", createClientConfig(), ImmutableList.of(new TestingRequestFilter()), ImmutableSet.of(new TestingStatusListener(statusCounts)));
     }
 
     @AfterClass(alwaysRun = true)
@@ -66,7 +68,7 @@ public class TestJettyHttpsClient
                 .setTrustStorePath(getResource("localhost.truststore").getPath())
                 .setTrustStorePassword("changeit");
 
-        try (JettyHttpClient client = new JettyHttpClient("test-private", config, ImmutableList.of(new TestingRequestFilter()))) {
+        try (JettyHttpClient client = new JettyHttpClient("test-private", config, ImmutableList.of(new TestingRequestFilter()), ImmutableSet.of(new TestingStatusListener(statusCounts)))) {
             return client.execute(request, responseHandler);
         }
     }

--- a/http-client/src/test/java/io/airlift/http/client/jetty/TestJettyHttpsClientPem.java
+++ b/http-client/src/test/java/io/airlift/http/client/jetty/TestJettyHttpsClientPem.java
@@ -1,11 +1,13 @@
 package io.airlift.http.client.jetty;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import io.airlift.http.client.AbstractHttpClientTest;
 import io.airlift.http.client.HttpClientConfig;
 import io.airlift.http.client.Request;
 import io.airlift.http.client.ResponseHandler;
 import io.airlift.http.client.TestingRequestFilter;
+import io.airlift.http.client.TestingStatusListener;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -30,7 +32,7 @@ public class TestJettyHttpsClientPem
     @BeforeClass
     public void setUpHttpClient()
     {
-        httpClient = new JettyHttpClient("test-shared", createClientConfig(), ImmutableList.of(new TestingRequestFilter()));
+        httpClient = new JettyHttpClient("test-shared", createClientConfig(), ImmutableList.of(new TestingRequestFilter()), ImmutableSet.of(new TestingStatusListener(statusCounts)));
     }
 
     @AfterClass(alwaysRun = true)
@@ -63,7 +65,7 @@ public class TestJettyHttpsClientPem
         config.setKeyStorePath(getResource("client.pem").getPath())
                 .setTrustStorePath(getResource("ca.crt").getPath());
 
-        try (JettyHttpClient client = new JettyHttpClient("test-private", config, ImmutableList.of(new TestingRequestFilter()))) {
+        try (JettyHttpClient client = new JettyHttpClient("test-private", config, ImmutableList.of(new TestingRequestFilter()), ImmutableSet.of(new TestingStatusListener(statusCounts)))) {
             return client.execute(request, responseHandler);
         }
     }


### PR DESCRIPTION
An HTTP status listener hooks into Jetty's response listening so that users of this client can listen for the beginning of the response and examine the status before anything else from the request is processed. This type of listener has many uses cases one of which is to short circuit a response that has a status code that indicates the server is busy, no longer available, etc. It also gives users of this client an opportunity to throw an exception so that Jetty removes the connection from its connection pool. There are cases where Jetty's connection pool can get poisoned with bad connections.