### PR TITLE
HttpStatusListener exceptions need to fail the response

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 234
 
 - Move to Jakarta validation API
+- Fail response if HttpStatusListener throws an exception
 
 233
 

--- a/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
@@ -775,7 +775,14 @@ public class JettyHttpClient
 
     private void callHttpStatusListeners(Response response)
     {
-        httpStatusListeners.forEach(listener -> listener.statusReceived(response.getStatus()));
+        httpStatusListeners.forEach(listener -> {
+            try {
+                listener.statusReceived(response.getStatus());
+            }
+            catch (Exception e) {
+                response.abort(e);
+            }
+        });
     }
 
     private void addLoggingListener(HttpRequest jettyRequest, long requestTimestamp)

--- a/http-client/src/test/java/io/airlift/http/client/AbstractHttpClientTest.java
+++ b/http-client/src/test/java/io/airlift/http/client/AbstractHttpClientTest.java
@@ -794,6 +794,19 @@ public abstract class AbstractHttpClientTest
         executeRequest(request, new ThrowErrorResponseHandler());
     }
 
+    @Test(expectedExceptions = UncheckedIOException.class)
+    public void testHttpStatusListenerException()
+            throws Exception
+    {
+        servlet.setResponseStatusCode(TestingStatusListener.EXCEPTION_STATUS);
+
+        Request request = prepareGet()
+                .setUri(baseURI)
+                .build();
+
+        executeRequest(request, createStatusResponseHandler());
+    }
+
     private void executeExceptionRequest(HttpClientConfig config, Request request)
             throws Exception
     {

--- a/http-client/src/test/java/io/airlift/http/client/TestingStatusListener.java
+++ b/http-client/src/test/java/io/airlift/http/client/TestingStatusListener.java
@@ -18,9 +18,14 @@ package io.airlift.http.client;
 import com.google.common.collect.Multiset;
 import com.google.inject.Inject;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
 public class TestingStatusListener
         implements HttpStatusListener
 {
+    public static final int EXCEPTION_STATUS = 654;
+
     private final Multiset<Integer> statusCounter;
 
     @Inject
@@ -33,5 +38,8 @@ public class TestingStatusListener
     public void statusReceived(int statusCode)
     {
         statusCounter.add(statusCode);
+        if (statusCode == EXCEPTION_STATUS) {
+            throw new UncheckedIOException(new IOException("Fake exception"));
+        }
     }
 }


### PR DESCRIPTION
The most recent version of Jetty ignores exceptions thrown by listeners. This subverts the intent of the recently added HttpStatusListener. Modify the handling of HttpStatusListeners to fail the response if the HttpStatusListener throws an exception.