### PR TITLE
Add MDC support to logging

### DIFF
--- a/log-manager/src/main/java/io/airlift/log/JsonFormatter.java
+++ b/log-manager/src/main/java/io/airlift/log/JsonFormatter.java
@@ -7,6 +7,7 @@ import com.google.common.collect.ImmutableMap;
 import io.airlift.json.JsonCodec;
 import io.airlift.json.JsonCodecFactory;
 import io.airlift.json.ObjectMapperProvider;
+import io.airlift.log.mdc.MDC;
 import io.opentelemetry.context.Context;
 
 import java.io.IOException;
@@ -40,7 +41,8 @@ public class JsonFormatter
                 record.getMessage(),
                 record.getThrown(),
                 Context.current(),
-                logAnnotations);
+                logAnnotations,
+                MDC.getCopyOfContextMap());
 
         try {
             return toString(jsonRecord);
@@ -55,7 +57,8 @@ public class JsonFormatter
                         outer.getMessage(),
                         outer,
                         Context.current(),
-                        logAnnotations));
+                        logAnnotations,
+                        MDC.getCopyOfContextMap()));
             }
             catch (IllegalArgumentException inner) {
                 inner.addSuppressed(outer);

--- a/log-manager/src/main/java/io/airlift/log/JsonRecord.java
+++ b/log-manager/src/main/java/io/airlift/log/JsonRecord.java
@@ -26,6 +26,7 @@ public class JsonRecord
     private final Throwable throwable;
     private final Optional<SpanContext> spanContext;
     private final Map<String, String> logAnnotations;
+    private final Map<String, String> mdcContext;
 
     @JsonCreator
     public JsonRecord(
@@ -36,7 +37,8 @@ public class JsonRecord
             @JsonProperty("message") String message,
             Throwable throwable,
             Context context,
-            Map<String, String> logAnnotations)
+            Map<String, String> logAnnotations,
+            Map<String, String> mdcContext)
     {
         this.timestamp = requireNonNull(timestamp);
         this.level = requireNonNull(level);
@@ -49,6 +51,7 @@ public class JsonRecord
                 .map(Span::getSpanContext)
                 .filter(SpanContext::isValid);
         this.logAnnotations = (logAnnotations == null || logAnnotations.isEmpty()) ? null : logAnnotations;
+        this.mdcContext = (mdcContext == null || mdcContext.isEmpty()) ? null : mdcContext;
     }
 
     @JsonProperty
@@ -130,6 +133,12 @@ public class JsonRecord
     public Map<String, String> getLogAnnotations()
     {
         return logAnnotations;
+    }
+
+    @JsonProperty("mdc")
+    public Map<String, String> getMdcContext()
+    {
+        return mdcContext;
     }
 
     @Override

--- a/log-manager/src/main/java/io/airlift/log/StaticFormatter.java
+++ b/log-manager/src/main/java/io/airlift/log/StaticFormatter.java
@@ -2,6 +2,7 @@ package io.airlift.log;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
+import io.airlift.log.mdc.MDC;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -83,6 +84,12 @@ class StaticFormatter
         if (!logAnnotations.isEmpty()) {
             stringWriter.append('\t')
                     .append(Joiner.on(",").withKeyValueSeparator("=").join(logAnnotations));
+        }
+
+        Map<String, String> mdcContextMap = MDC.getCopyOfContextMap();
+        if (!mdcContextMap.isEmpty()) {
+            stringWriter.append('\t')
+                    .append(Joiner.on(",").withKeyValueSeparator("=").join(mdcContextMap));
         }
 
         stringWriter.append('\t')

--- a/log-manager/src/main/java/io/airlift/log/mdc/MDC.java
+++ b/log-manager/src/main/java/io/airlift/log/mdc/MDC.java
@@ -1,0 +1,39 @@
+
+package io.airlift.log.mdc;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class MDC
+{
+    static final ThreadLocal<Map<String, String>> contextMap = ThreadLocal.withInitial(HashMap::new);
+
+    private MDC()
+    {
+    }
+
+    public static void put(String key, String val)
+    {
+        contextMap.get().put(key, val);
+    }
+
+    public static String get(String key)
+    {
+        return contextMap.get().get(key);
+    }
+
+    public static void remove(String key)
+    {
+        contextMap.get().remove(key);
+    }
+
+    public static void clear()
+    {
+        contextMap.get().clear();
+    }
+
+    public static Map<String, String> getCopyOfContextMap()
+    {
+        return new HashMap<String, String>(contextMap.get());
+    }
+}


### PR DESCRIPTION
Hello,

With this pull request Airlift will have an MDC like logging functionality.

Adding the following code to a class:

    MDC.put("foo", "bar");
    LOGGER.info("message");

would create the following JSON log:
```
{
  "timestamp": "2023-06-16T15:01:23.048080448Z",
  "level": "INFO",
  "thread": "THREAD123",
  "logger": "com.example.Main",
  "message": "message",
  "mdc": {
    "foo": "bar"
  }
}
```
`

I plan to submit another pull request (PR) but this time in the Trino repository after a successful merge and Trino is updated to the new Airlift version, 
The second PR is needed to ensure that Trino's PluginClassLoader doesn't load the MDC class twice. In that case, the key-value pairs would be added to a different MDC than the one used for logging. To address this issue, it is necessary to include the `io.airlift.log.mdc` package under `PluginManager.SPI_PACKAGES`.