### PR TITLE
Test on JDK 21-ea

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,20 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
-        java-version:
-          - 17
+        include:
+          - java-version: 17
+            java-target: 17
+            experimental: false
+          - java-version: 21-ea
+            java-target: 17
+            experimental: false
+          - java-version: 21-ea
+            java-target: 21
+            experimental: true
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-java@v3
@@ -19,6 +28,6 @@ jobs:
           distribution: 'zulu'
           java-version: ${{ matrix.java-version }}
       - name: Maven Install
-        run: mvn install -B -V -DskipTests -Dair.check.skip-all
+        run: mvn install -B -V -DskipTests -Dair.check.skip-all -Dproject.build.targetJdk=${{ matrix.java-target }}
       - name: Maven Tests
-        run: mvn install -B -P ci
+        run: mvn install -B -P ci -Dproject.build.targetJdk=${{ matrix.java-target }}

--- a/concurrent/src/main/java/io/airlift/concurrent/SetThreadName.java
+++ b/concurrent/src/main/java/io/airlift/concurrent/SetThreadName.java
@@ -26,7 +26,14 @@ public class SetThreadName
     {
         requireNonNull(format, "format is null");
         originalThreadName = Thread.currentThread().getName();
-        Thread.currentThread().setName(String.format(format, args) + "-" + Thread.currentThread().getId());
+        Thread.currentThread().setName(String.format(format, args) + "-" + getThreadId(Thread.currentThread()));
+    }
+
+    @SuppressWarnings("deprecation")
+    public static long getThreadId(Thread thread)
+    {
+        // TODO: thread.threadId() when moved to JDK 21
+        return thread.getId();
     }
 
     @Override

--- a/configuration/src/test/java/io/airlift/configuration/testing/TestConfigAssertions.java
+++ b/configuration/src/test/java/io/airlift/configuration/testing/TestConfigAssertions.java
@@ -503,7 +503,7 @@ public class TestConfigAssertions
                     .setName("Dain")
                     .setEmail("dain@proofpoint.com")
                     .setPhone(null)
-                    .setHomePageUrl(new URL("http://iq80.com")));
+                    .setHomePageUrl(URI.create("http://iq80.com").toURL()));
         }
         catch (AssertionError e) {
             // expected

--- a/jmx-http-rpc/src/main/java/io/airlift/jmx/http/rpc/HttpJmxConnector.java
+++ b/jmx-http-rpc/src/main/java/io/airlift/jmx/http/rpc/HttpJmxConnector.java
@@ -134,6 +134,7 @@ public class HttpJmxConnector
     }
 
     @Override
+    @SuppressWarnings("removal")
     public MBeanServerConnection getMBeanServerConnection(Subject delegationSubject)
     {
         return getMBeanServerConnection();


### PR DESCRIPTION
To ensure forward-compatibility with the new Java LTS.

This adds a new matrix configuration that tests airlift with:

- JDK 17 and 17 as a target
- JDK 21-ea and 17 as a target
- JDK 21-ea and 21 as a target (not required to pass a build)