### PR TITLE
Support streaming execution in the HttpClient

### DIFF
--- a/http-client/pom.xml
+++ b/http-client/pom.xml
@@ -96,6 +96,16 @@
         </dependency>
 
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
         </dependency>

--- a/http-client/src/main/java/io/airlift/http/client/CloseableResponse.java
+++ b/http-client/src/main/java/io/airlift/http/client/CloseableResponse.java
@@ -1,0 +1,8 @@
+package io.airlift.http.client;
+
+public interface CloseableResponse
+        extends Response, AutoCloseable
+{
+    @Override
+    void close();
+}

--- a/http-client/src/main/java/io/airlift/http/client/HttpClient.java
+++ b/http-client/src/main/java/io/airlift/http/client/HttpClient.java
@@ -27,6 +27,12 @@ public interface HttpClient
 
     <T, E extends Exception> HttpResponseFuture<T> executeAsync(Request request, ResponseHandler<T, E> responseHandler);
 
+    default CloseableResponse executeStreaming(Request request)
+            throws Exception
+    {
+        throw new UnsupportedOperationException();
+    }
+
     RequestStats getStats();
 
     long getMaxContentLength();

--- a/http-client/src/main/java/io/airlift/http/client/JsonStreamingResponse.java
+++ b/http-client/src/main/java/io/airlift/http/client/JsonStreamingResponse.java
@@ -1,0 +1,200 @@
+package io.airlift.http.client;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.primitives.Ints;
+import io.airlift.json.JsonCodec;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.http.client.JsonResponseHandler.validateResponse;
+import static java.util.Objects.requireNonNull;
+
+public class JsonStreamingResponse<T>
+{
+    private final ObjectReader objectReader;
+    private final Request request;
+    private final ResponseSupplier responseSupplier;
+    private final Set<Integer> successfulResponseCodes;
+    private final ObjectMapper objectMapper;
+    private CloseableResponse response;
+
+    public interface ResponseSupplier
+    {
+        CloseableResponse executeStreaming(Request request)
+                throws Exception;
+    }
+
+    public static <T> JsonStreamingResponse<T> createJsonStreamingResponse(Request request, JsonCodec<T> codec, ResponseSupplier responseSupplier)
+    {
+        return new JsonStreamingResponse<>(request, codec, responseSupplier, 200, 201, 202, 203, 204, 205, 206);
+    }
+
+    public static <T> JsonStreamingResponse<T> createJsonStreamingResponse(Request request, JsonCodec<T> codec, ResponseSupplier responseSupplier, int firstSuccessfulResponseCode, int... otherSuccessfulResponseCodes)
+    {
+        return new JsonStreamingResponse<>(request, codec, responseSupplier, firstSuccessfulResponseCode, otherSuccessfulResponseCodes);
+    }
+
+    public static <T> Iterator<T> startJsonStreamingResponse(Request request, JsonCodec<T> codec, ResponseSupplier responseSupplier)
+    {
+        return createJsonStreamingResponse(request, codec, responseSupplier).start();
+    }
+
+    public static <T> Iterator<T> startJsonStreamingResponse(Request request, JsonCodec<T> codec, ResponseSupplier responseSupplier, int firstSuccessfulResponseCode, int... otherSuccessfulResponseCodes)
+    {
+        return createJsonStreamingResponse(request, codec, responseSupplier, firstSuccessfulResponseCode, otherSuccessfulResponseCodes).start();
+    }
+
+    private JsonStreamingResponse(Request request, JsonCodec<T> codec, ResponseSupplier responseSupplier, int firstSuccessfulResponseCode, int... otherSuccessfulResponseCodes)
+    {
+        this.request = requireNonNull(request, "request is null");
+        this.responseSupplier = requireNonNull(responseSupplier, "responseSupplier is null");
+
+        objectMapper = codec.mapper();
+        JavaType javaType = objectMapper.getTypeFactory().constructType(codec.getType());
+        objectReader = objectMapper.readerFor(javaType);
+
+        successfulResponseCodes = ImmutableSet.<Integer>builder().add(firstSuccessfulResponseCode).addAll(Ints.asList(otherSuccessfulResponseCodes)).build();
+    }
+
+    public interface CloseableIterator<T>
+            extends Iterator<T>, Closeable
+    {
+        @Override
+        void close();
+    }
+
+    public CloseableIterator<T> start()
+    {
+        checkState(response == null, "Already started");
+
+        try {
+            response = responseSupplier.executeStreaming(request);
+        }
+        catch (Exception e) {
+            throw cleanup(null, new RuntimeException("Could not start request: " + request, e));
+        }
+
+        try {
+            validateResponse(request, response, successfulResponseCodes);
+        }
+        catch (UnexpectedResponseException e) {
+            throw cleanup(null, e);
+        }
+
+        JsonParser parser = null;
+        try {
+            parser = objectMapper.createParser(new InputStreamReader(response.getInputStream(), StandardCharsets.UTF_8));
+            if (parser.nextToken() != JsonToken.START_ARRAY) {
+                throw new UnexpectedResponseException("Expected JSON array", request, response);
+            }
+            parser.nextToken();
+        }
+        catch (IOException e) {
+            throw cleanup(parser, new UncheckedIOException(e));
+        }
+
+        return new StreamingIterator(parser);
+    }
+
+    private RuntimeException cleanup(JsonParser parser, RuntimeException cause)
+    {
+        if ((parser != null) && !parser.isClosed()) {
+            try {
+                parser.close();
+            }
+            catch (IOException e) {
+                if (cause != null) {
+                    cause.addSuppressed(e);
+                }
+                else {
+                    cause = new UncheckedIOException(e);
+                }
+            }
+            catch (Throwable t) {
+                if (cause != null) {
+                    cause.addSuppressed(t);
+                }
+                else {
+                    cause = new RuntimeException(t);
+                }
+            }
+        }
+
+        try {
+            if (response != null) {
+                response.close();
+                response = null;
+            }
+        }
+        catch (Exception e) {
+            if (cause != null) {
+                cause.addSuppressed(e);
+            }
+            else {
+                cause = new RuntimeException(e);
+            }
+        }
+
+        return cause;
+    }
+
+    private class StreamingIterator
+            implements CloseableIterator<T>
+    {
+        private final JsonParser parser;
+
+        private StreamingIterator(JsonParser parser)
+        {
+            this.parser = requireNonNull(parser, "parser is null");
+        }
+
+        @Override
+        public void close()
+        {
+            RuntimeException exception = cleanup(parser, null);
+            if (exception != null) {
+                throw exception;
+            }
+        }
+
+        @Override
+        public boolean hasNext()
+        {
+            boolean hasNext = (response != null) && parser.hasCurrentToken() && (parser.currentToken() != JsonToken.END_ARRAY);
+            if (!hasNext) {
+                close();
+            }
+            return hasNext;
+        }
+
+        @Override
+        public T next()
+        {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+
+            try {
+                T value = objectReader.readValue(parser);
+                parser.nextToken();
+                return value;
+            }
+            catch (IOException e) {
+                throw cleanup(parser, new UncheckedIOException(e));
+            }
+        }
+    }
+}

--- a/http-client/src/main/java/io/airlift/http/client/jetty/JettyCloseableResponse.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/JettyCloseableResponse.java
@@ -1,0 +1,66 @@
+package io.airlift.http.client.jetty;
+
+import com.google.common.collect.ListMultimap;
+import io.airlift.http.client.CloseableResponse;
+import io.airlift.http.client.HeaderName;
+import io.opentelemetry.api.trace.Span;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static java.util.Objects.requireNonNull;
+
+class JettyCloseableResponse
+        implements CloseableResponse
+{
+    private final RequestController requestController;
+    private final RequestContext requestContext;
+    private final Span span;
+    private final JettyResponse jettyResponse;
+    private final long responseStart;
+
+    JettyCloseableResponse(RequestController requestController, RequestContext requestContext, Span span, JettyResponse jettyResponse, long responseStart)
+    {
+        this.requestController = requireNonNull(requestController, "requestController is null");
+        this.requestContext = requireNonNull(requestContext, "requestContext is null");
+        this.span = requireNonNull(span, "span is null");
+        this.jettyResponse = requireNonNull(jettyResponse, "jettyResponse is null");
+        this.responseStart = responseStart;
+    }
+
+    @Override
+    public void close()
+    {
+        try {
+            requestController.closeResponse(jettyResponse, requestContext, span, responseStart);
+        }
+        finally {
+            span.end();
+        }
+    }
+
+    @Override
+    public int getStatusCode()
+    {
+        return jettyResponse.getStatusCode();
+    }
+
+    @Override
+    public ListMultimap<HeaderName, String> getHeaders()
+    {
+        return jettyResponse.getHeaders();
+    }
+
+    @Override
+    public long getBytesRead()
+    {
+        return jettyResponse.getBytesRead();
+    }
+
+    @Override
+    public InputStream getInputStream()
+            throws IOException
+    {
+        return jettyResponse.getInputStream();
+    }
+}

--- a/http-client/src/main/java/io/airlift/http/client/jetty/JettyResponseFuture.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/JettyResponseFuture.java
@@ -132,7 +132,7 @@ class JettyResponseFuture<T, E extends Exception>
                 span.setAttribute(SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH, jettyResponse.getBytesRead());
             }
             if (recordRequestComplete) {
-                JettyHttpClient.recordRequestComplete(stats, request, requestSize.getAsLong(), requestStart, jettyResponse, responseStart);
+                RequestController.recordRequestComplete(stats, request, requestSize.getAsLong(), requestStart, jettyResponse, responseStart);
             }
         }
         return value;

--- a/http-client/src/main/java/io/airlift/http/client/jetty/RequestContext.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/RequestContext.java
@@ -1,0 +1,26 @@
+package io.airlift.http.client.jetty;
+
+import io.airlift.http.client.Request;
+import io.airlift.http.client.jetty.HttpClientLogger.RequestInfo;
+import org.eclipse.jetty.client.HttpRequest;
+import org.eclipse.jetty.client.util.InputStreamResponseListener;
+
+import static java.util.Objects.requireNonNull;
+
+record RequestContext(
+        Request request,
+        HttpRequest jettyRequest,
+        InputStreamResponseListener listener,
+        RequestInfo requestInfo,
+        RequestSizeListener requestSize,
+        long requestStart)
+{
+    RequestContext
+    {
+        requireNonNull(request, "request is null");
+        requireNonNull(jettyRequest, "jettyRequest is null");
+        requireNonNull(listener, "listener is null");
+        requireNonNull(requestInfo, "requestInfo is null");
+        requireNonNull(requestSize, "requestSize is null");
+    }
+}

--- a/http-client/src/main/java/io/airlift/http/client/jetty/RequestController.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/RequestController.java
@@ -1,0 +1,221 @@
+package io.airlift.http.client.jetty;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.http.client.BodyGenerator;
+import io.airlift.http.client.ByteBufferBodyGenerator;
+import io.airlift.http.client.FileBodyGenerator;
+import io.airlift.http.client.HttpRequestFilter;
+import io.airlift.http.client.HttpStatusListener;
+import io.airlift.http.client.Request;
+import io.airlift.http.client.StaticBodyGenerator;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.HttpRequest;
+import org.eclipse.jetty.client.api.Response;
+import org.eclipse.jetty.client.util.ByteBufferRequestContent;
+import org.eclipse.jetty.client.util.BytesRequestContent;
+import org.eclipse.jetty.client.util.PathRequestContent;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.TimeoutException;
+
+import static com.google.common.base.Throwables.throwIfUnchecked;
+import static io.airlift.http.client.jetty.AuthorizationPreservingHttpClient.setPreserveAuthorization;
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.eclipse.jetty.client.HttpClient.normalizePort;
+
+class RequestController
+{
+    static final String STATS_KEY = "airlift_stats";
+    private static final AttributeKey<String> CLIENT_NAME = stringKey("airlift.http.client_name");
+
+    private final HttpClient httpClient;
+    private final String name;
+    private final Tracer tracer;
+    private final List<HttpRequestFilter> requestFilters;
+    private final List<HttpStatusListener> httpStatusListeners;
+    private final TextMapPropagator propagator;
+    private final JettyClientDiagnostics clientDiagnostics;
+    private final long requestTimeoutMillis;
+    private final long idleTimeoutMillis;
+    private final boolean logEnabled;
+    private final HttpClientLogger requestLogger;
+
+    RequestController(
+            HttpClient httpClient,
+            String name,
+            Tracer tracer,
+            List<HttpRequestFilter> requestFilters,
+            List<HttpStatusListener> httpStatusListeners,
+            TextMapPropagator propagator,
+            JettyClientDiagnostics clientDiagnostics,
+            HttpClientLogger requestLogger,
+            long requestTimeoutMillis,
+            long idleTimeoutMillis,
+            boolean logEnabled)
+    {
+        this.httpClient = requireNonNull(httpClient, "httpClient is null");
+        this.name = requireNonNull(name, "name is null");
+        this.tracer = requireNonNull(tracer, "tracer is null");
+        this.propagator = requireNonNull(propagator, "propagator is null");
+        this.clientDiagnostics = requireNonNull(clientDiagnostics, "clientDiagnostics is null");
+        this.requestLogger = requireNonNull(requestLogger, "requestLogger is null");
+        this.requestTimeoutMillis = requestTimeoutMillis;
+        this.idleTimeoutMillis = idleTimeoutMillis;
+        this.logEnabled = logEnabled;
+
+        this.requestFilters = ImmutableList.copyOf(requestFilters);
+        this.httpStatusListeners = ImmutableList.copyOf(httpStatusListeners);
+    }
+
+    record PreparedRequest(Request request, Span span)
+    {
+        PreparedRequest
+        {
+            requireNonNull(request, "request is null");
+            requireNonNull(span, "span is null");
+        }
+    }
+
+    PreparedRequest prepareRequest(Request request)
+    {
+        for (HttpRequestFilter requestFilter : requestFilters) {
+            request = requestFilter.filterRequest(request);
+        }
+
+        Span span = startSpan(request);
+        request = injectTracing(request, span);
+
+        return new PreparedRequest(request, span);
+    }
+
+    HttpRequest buildJettyRequest(Request finalRequest)
+    {
+        JettyRequestListener listener = new JettyRequestListener(finalRequest.getUri());
+        HttpRequest jettyRequest = (HttpRequest) httpClient.newRequest(finalRequest.getUri());
+        jettyRequest.onRequestBegin(request -> listener.onRequestBegin());
+        jettyRequest.onRequestSuccess(request -> listener.onRequestEnd());
+        jettyRequest.onResponseBegin(response -> listener.onResponseBegin());
+        jettyRequest.onComplete(result -> listener.onFinish());
+        jettyRequest.onComplete(result -> {
+            if (result.isFailed() && result.getFailure() instanceof TimeoutException) {
+                clientDiagnostics.logDiagnosticsInfo(httpClient);
+            }
+        });
+
+        jettyRequest.attribute(STATS_KEY, listener);
+
+        jettyRequest.method(finalRequest.getMethod());
+
+        jettyRequest.headers(headers -> finalRequest.getHeaders().forEach(headers::add));
+
+        BodyGenerator bodyGenerator = finalRequest.getBodyGenerator();
+        if (bodyGenerator != null) {
+            if (bodyGenerator instanceof StaticBodyGenerator generator) {
+                jettyRequest.body(new BytesRequestContent(generator.getBody()));
+            }
+            else if (bodyGenerator instanceof ByteBufferBodyGenerator generator) {
+                jettyRequest.body(new ByteBufferRequestContent(generator.getByteBuffers()));
+            }
+            else if (bodyGenerator instanceof FileBodyGenerator generator) {
+                jettyRequest.body(fileContent(generator.getPath()));
+            }
+            else {
+                jettyRequest.body(new BytesRequestContent(generateBody(bodyGenerator)));
+            }
+        }
+
+        jettyRequest.followRedirects(finalRequest.isFollowRedirects());
+
+        setPreserveAuthorization(jettyRequest, finalRequest.isPreserveAuthorizationOnRedirect());
+
+        // timeouts
+        jettyRequest.timeout(requestTimeoutMillis, MILLISECONDS);
+        jettyRequest.idleTimeout(idleTimeoutMillis, MILLISECONDS);
+
+        return jettyRequest;
+    }
+
+    void callHttpStatusListeners(Response response)
+    {
+        httpStatusListeners.forEach(listener -> {
+            try {
+                listener.statusReceived(response.getStatus());
+            }
+            catch (Exception e) {
+                response.abort(e);
+            }
+        });
+    }
+
+    void addLoggingListener(HttpRequest jettyRequest, long requestTimestamp)
+    {
+        if (logEnabled) {
+            HttpClientLoggingListener loggingListener = new HttpClientLoggingListener(jettyRequest, requestTimestamp, requestLogger);
+            jettyRequest.listener(loggingListener);
+            jettyRequest.onResponseBegin(loggingListener);
+            jettyRequest.onComplete(loggingListener);
+        }
+    }
+
+    private Span startSpan(Request request)
+    {
+        String method = request.getMethod().toUpperCase(ENGLISH);
+        int port = normalizePort(request.getUri().getScheme(), request.getUri().getPort());
+        return request.getSpanBuilder()
+                .orElseGet(() -> tracer.spanBuilder(name + " " + method))
+                .setSpanKind(SpanKind.CLIENT)
+                .setAttribute(CLIENT_NAME, name)
+                .setAttribute(SemanticAttributes.HTTP_URL, request.getUri().toString())
+                .setAttribute(SemanticAttributes.HTTP_METHOD, method)
+                .setAttribute(SemanticAttributes.NET_PEER_NAME, request.getUri().getHost())
+                .setAttribute(SemanticAttributes.NET_PEER_PORT, (long) port)
+                .startSpan();
+    }
+
+    @SuppressWarnings("DataFlowIssue")
+    private Request injectTracing(Request request, Span span)
+    {
+        Context context = Context.current().with(span);
+        Request.Builder builder = Request.Builder.fromRequest(request);
+        propagator.inject(context, builder, Request.Builder::addHeader);
+        return builder.build();
+    }
+
+    private static PathRequestContent fileContent(Path path)
+    {
+        try {
+            return new PathRequestContent(path);
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    private static byte[] generateBody(BodyGenerator generator)
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try {
+            generator.write(out);
+        }
+        catch (Exception e) {
+            throwIfUnchecked(e);
+            throw new RuntimeException(e);
+        }
+        return out.toByteArray();
+    }
+}

--- a/http-client/src/main/java/io/airlift/http/client/jetty/RequestSizeListener.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/RequestSizeListener.java
@@ -1,0 +1,20 @@
+package io.airlift.http.client.jetty;
+
+import java.nio.ByteBuffer;
+
+class RequestSizeListener
+        implements org.eclipse.jetty.client.api.Request.ContentListener
+{
+    private long bytes;
+
+    @Override
+    public void onContent(org.eclipse.jetty.client.api.Request request, ByteBuffer content)
+    {
+        bytes += content.remaining();
+    }
+
+    public long getBytes()
+    {
+        return bytes;
+    }
+}

--- a/http-client/src/test/java/io/airlift/http/client/EchoServlet.java
+++ b/http-client/src/test/java/io/airlift/http/client/EchoServlet.java
@@ -25,8 +25,10 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.net.URI;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -43,6 +45,7 @@ public final class EchoServlet
     private int responseStatusCode = 200;
     private final ListMultimap<String, String> responseHeaders = ArrayListMultimap.create();
     private String responseBody;
+    private Iterator<String> stream;
 
     @Override
     protected void service(HttpServletRequest request, HttpServletResponse response)
@@ -88,6 +91,14 @@ public final class EchoServlet
         if (responseBody != null) {
             response.getOutputStream().write(responseBody.getBytes(UTF_8));
         }
+
+        if (stream != null) {
+            OutputStream outputStream = response.getOutputStream();
+            while (stream.hasNext()) {
+                outputStream.write(stream.next().getBytes(UTF_8));
+                outputStream.flush();
+            }
+        }
     }
 
     public String getRequestMethod()
@@ -128,5 +139,10 @@ public final class EchoServlet
     public void setResponseBody(String responseBody)
     {
         this.responseBody = responseBody;
+    }
+
+    public void setStream(Iterator<String> stream)
+    {
+        this.stream = stream;
     }
 }

--- a/http-client/src/test/java/io/airlift/http/client/jetty/TestAsyncJettyHttpClient.java
+++ b/http-client/src/test/java/io/airlift/http/client/jetty/TestAsyncJettyHttpClient.java
@@ -3,6 +3,7 @@ package io.airlift.http.client.jetty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.http.client.AbstractHttpClientTest;
+import io.airlift.http.client.CloseableResponse;
 import io.airlift.http.client.HttpClientConfig;
 import io.airlift.http.client.Request;
 import io.airlift.http.client.ResponseHandler;
@@ -51,5 +52,12 @@ public class TestAsyncJettyHttpClient
         try (JettyHttpClient client = new JettyHttpClient("test-private", config, ImmutableList.of(new TestingRequestFilter()), ImmutableSet.of(new TestingStatusListener(statusCounts)))) {
             return executeAsync(client, request, responseHandler);
         }
+    }
+
+    @Override
+    public CloseableResponse executeStreaming(Request request)
+            throws Exception
+    {
+        return httpClient.executeStreaming(request);
     }
 }

--- a/http-client/src/test/java/io/airlift/http/client/jetty/TestJettyHttpClient.java
+++ b/http-client/src/test/java/io/airlift/http/client/jetty/TestJettyHttpClient.java
@@ -3,6 +3,7 @@ package io.airlift.http.client.jetty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.http.client.AbstractHttpClientTest;
+import io.airlift.http.client.CloseableResponse;
 import io.airlift.http.client.HttpClientConfig;
 import io.airlift.http.client.Request;
 import io.airlift.http.client.ResponseHandler;
@@ -49,5 +50,12 @@ public class TestJettyHttpClient
         try (JettyHttpClient client = new JettyHttpClient("test-private", config, ImmutableList.of(new TestingRequestFilter()), ImmutableSet.of(new TestingStatusListener(statusCounts)))) {
             return client.execute(request, responseHandler);
         }
+    }
+
+    @Override
+    public CloseableResponse executeStreaming(Request request)
+            throws Exception
+    {
+        return httpClient.executeStreaming(request);
     }
 }

--- a/http-client/src/test/java/io/airlift/http/client/jetty/TestJettyHttpClientSocksProxy.java
+++ b/http-client/src/test/java/io/airlift/http/client/jetty/TestJettyHttpClientSocksProxy.java
@@ -3,6 +3,7 @@ package io.airlift.http.client.jetty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.http.client.AbstractHttpClientTest;
+import io.airlift.http.client.CloseableResponse;
 import io.airlift.http.client.HttpClientConfig;
 import io.airlift.http.client.Request;
 import io.airlift.http.client.ResponseHandler;
@@ -59,6 +60,13 @@ public class TestJettyHttpClientSocksProxy
         try (JettyHttpClient client = new JettyHttpClient("test-private", config, ImmutableList.of(new TestingRequestFilter()), ImmutableSet.of(new TestingStatusListener(statusCounts)))) {
             return client.execute(request, responseHandler);
         }
+    }
+
+    @Override
+    public CloseableResponse executeStreaming(Request request)
+            throws Exception
+    {
+        return httpClient.executeStreaming(request);
     }
 
     @Override

--- a/http-client/src/test/java/io/airlift/http/client/jetty/TestJettyHttpsClient.java
+++ b/http-client/src/test/java/io/airlift/http/client/jetty/TestJettyHttpsClient.java
@@ -3,6 +3,7 @@ package io.airlift.http.client.jetty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.http.client.AbstractHttpClientTest;
+import io.airlift.http.client.CloseableResponse;
 import io.airlift.http.client.HttpClientConfig;
 import io.airlift.http.client.Request;
 import io.airlift.http.client.ResponseHandler;
@@ -71,6 +72,13 @@ public class TestJettyHttpsClient
         try (JettyHttpClient client = new JettyHttpClient("test-private", config, ImmutableList.of(new TestingRequestFilter()), ImmutableSet.of(new TestingStatusListener(statusCounts)))) {
             return client.execute(request, responseHandler);
         }
+    }
+
+    @Override
+    public CloseableResponse executeStreaming(Request request)
+            throws Exception
+    {
+        return httpClient.executeStreaming(request);
     }
 
     // TLS connections seem to have some conditions that do not respect timeouts

--- a/http-client/src/test/java/io/airlift/http/client/jetty/TestJettyHttpsClientPem.java
+++ b/http-client/src/test/java/io/airlift/http/client/jetty/TestJettyHttpsClientPem.java
@@ -3,6 +3,7 @@ package io.airlift.http.client.jetty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.http.client.AbstractHttpClientTest;
+import io.airlift.http.client.CloseableResponse;
 import io.airlift.http.client.HttpClientConfig;
 import io.airlift.http.client.Request;
 import io.airlift.http.client.ResponseHandler;
@@ -68,6 +69,13 @@ public class TestJettyHttpsClientPem
         try (JettyHttpClient client = new JettyHttpClient("test-private", config, ImmutableList.of(new TestingRequestFilter()), ImmutableSet.of(new TestingStatusListener(statusCounts)))) {
             return client.execute(request, responseHandler);
         }
+    }
+
+    @Override
+    public CloseableResponse executeStreaming(Request request)
+            throws Exception
+    {
+        return httpClient.executeStreaming(request);
     }
 
     // TLS connections seem to have some conditions that do not respect timeouts

--- a/json/src/main/java/io/airlift/json/JsonCodec.java
+++ b/json/src/main/java/io/airlift/json/JsonCodec.java
@@ -215,6 +215,11 @@ public class JsonCodec<T>
         }
     }
 
+    public ObjectMapper mapper()
+    {
+        return mapper;
+    }
+
     @SuppressWarnings("unchecked")
     TypeToken<T> getTypeToken()
     {


### PR DESCRIPTION
Support end-to-end streaming. This is useful for endpoints that return
a large list of entities. Instead of needing to queue that entire list
in memory in both the server and client the entities are streamed.
This has even greater impact when there is a client in the middle:
client -> server A -> server B -> back to client.

The flow is:

- Client sends request to server
- Server begins to stream entities
- Client reads entities one by one

This necessitates giving the client ownership of the internal
input stream.

Additionally, adds JsonStreamingResponse to make it simpler/convenient to stream lists
of JSON entities.
