### PR TITLE
Support streaming execution in the HttpClient

### DIFF
--- a/http-client/pom.xml
+++ b/http-client/pom.xml
@@ -96,6 +96,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
@@ -145,6 +150,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
             <scope>runtime</scope>
         </dependency>
 

--- a/http-client/src/main/java/io/airlift/http/client/JsonStreamingResponseHandler.java
+++ b/http-client/src/main/java/io/airlift/http/client/JsonStreamingResponseHandler.java
@@ -1,0 +1,173 @@
+package io.airlift.http.client;
+
+import com.fasterxml.jackson.core.JsonToken;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ListMultimap;
+import com.google.common.primitives.Ints;
+import io.airlift.json.JsonCodec;
+import io.airlift.json.JsonCodecParser;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+import static io.airlift.http.client.JsonResponseHandler.validateResponse;
+import static io.airlift.http.client.ResponseHandlerUtils.propagate;
+import static java.util.Objects.requireNonNull;
+
+public class JsonStreamingResponseHandler<T>
+        implements StreamingResponseHandler<T>
+{
+    private final Set<Integer> successfulResponseCodes;
+    private final JsonCodec<T> codec;
+
+    public static <T> JsonStreamingResponseHandler<T> createJsonStreamingResponse(JsonCodec<T> codec)
+    {
+        return new JsonStreamingResponseHandler<>(codec, 200, 201, 202, 203, 204, 205, 206);
+    }
+
+    public static <T> JsonStreamingResponseHandler<T> createJsonStreamingResponse(JsonCodec<T> codec, int firstSuccessfulResponseCode, int... otherSuccessfulResponseCodes)
+    {
+        return new JsonStreamingResponseHandler<>(codec, firstSuccessfulResponseCode, otherSuccessfulResponseCodes);
+    }
+
+    private JsonStreamingResponseHandler(JsonCodec<T> codec, int firstSuccessfulResponseCode, int... otherSuccessfulResponseCodes)
+    {
+        this.codec = requireNonNull(codec, "codec is null");
+        successfulResponseCodes = ImmutableSet.<Integer>builder().add(firstSuccessfulResponseCode).addAll(Ints.asList(otherSuccessfulResponseCodes)).build();
+    }
+
+    @Override
+    public StreamingResponseIterator<T> handle(Request request, StreamingResponse response)
+    {
+        try {
+            validateResponse(request, response, successfulResponseCodes);
+        }
+        catch (UnexpectedResponseException e) {
+            throw cleanup(request, null, response, e);
+        }
+
+        JsonCodecParser<T> jsonCodecParser = null;
+        try {
+            jsonCodecParser = codec.newParser(response.getInputStream());
+            if (jsonCodecParser.nextToken() != JsonToken.START_ARRAY) {
+                throw new UnexpectedResponseException("Expected JSON array", request, response);
+            }
+            jsonCodecParser.nextToken();
+        }
+        catch (IOException e) {
+            throw cleanup(request, jsonCodecParser, response, new UncheckedIOException(e));
+        }
+
+        return new StreamingIterator<>(request, response, jsonCodecParser);
+    }
+
+    private static RuntimeException cleanup(Request request, JsonCodecParser<?> jsonCodecParser, StreamingResponse response, RuntimeException cause)
+    {
+        if ((jsonCodecParser != null) && !jsonCodecParser.isClosed()) {
+            try {
+                jsonCodecParser.close();
+            }
+            catch (Throwable t) {
+                if (cause == null) {
+                    cause = propagate(request, t);
+                }
+                else {
+                    cause.addSuppressed(propagate(request, t));
+                }
+            }
+        }
+
+        try {
+            response.close();
+        }
+        catch (Throwable t) {
+            if (cause == null) {
+                cause = propagate(request, t);
+            }
+            else {
+                cause.addSuppressed(propagate(request, t));
+            }
+        }
+
+        return cause;
+    }
+
+    private static class StreamingIterator<T>
+            implements StreamingResponseIterator<T>
+    {
+        private final Request request;
+        private final StreamingResponse response;
+        private final JsonCodecParser<T> jsonCodecParser;
+
+        private StreamingIterator(Request request, StreamingResponse response, JsonCodecParser<T> jsonCodecParser)
+        {
+            this.request = request;
+            this.response = requireNonNull(response, "response is null");
+            this.jsonCodecParser = requireNonNull(jsonCodecParser, "parser is null");
+        }
+
+        @Override
+        public int getStatusCode()
+        {
+            return response.getStatusCode();
+        }
+
+        @Override
+        public ListMultimap<HeaderName, String> getHeaders()
+        {
+            return response.getHeaders();
+        }
+
+        @Override
+        public long getBytesRead()
+        {
+            return response.getBytesRead();
+        }
+
+        @Override
+        public InputStream getInputStream()
+                throws IOException
+        {
+            return response.getInputStream();
+        }
+
+        @Override
+        public void close()
+        {
+            RuntimeException exception = cleanup(request, jsonCodecParser, response, null);
+            if (exception != null) {
+                throw exception;
+            }
+        }
+
+        @Override
+        public boolean hasNext()
+        {
+            boolean hasNext = jsonCodecParser.hasCurrentToken() && (jsonCodecParser.currentToken() != JsonToken.END_ARRAY);
+            if (!hasNext) {
+                close();
+            }
+            return hasNext;
+        }
+
+        @Override
+        public T next()
+        {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+
+            try {
+                T value = jsonCodecParser.readValue();
+                jsonCodecParser.nextToken();
+                return value;
+            }
+            catch (IOException e) {
+                throw cleanup(request, jsonCodecParser, response, new UncheckedIOException(e));
+            }
+        }
+    }
+}

--- a/http-client/src/main/java/io/airlift/http/client/StreamingResponse.java
+++ b/http-client/src/main/java/io/airlift/http/client/StreamingResponse.java
@@ -1,0 +1,10 @@
+package io.airlift.http.client;
+
+import java.io.Closeable;
+
+public interface StreamingResponse
+        extends Response, Closeable
+{
+    @Override
+    void close();
+}

--- a/http-client/src/main/java/io/airlift/http/client/StreamingResponseHandler.java
+++ b/http-client/src/main/java/io/airlift/http/client/StreamingResponseHandler.java
@@ -1,0 +1,26 @@
+package io.airlift.http.client;
+
+import static io.airlift.http.client.ResponseHandlerUtils.propagate;
+
+public interface StreamingResponseHandler<T>
+        extends ResponseHandler<StreamingResponseIterator<T>, RuntimeException>
+{
+    @Override
+    default StreamingResponseIterator<T> handleException(Request request, Exception exception)
+            throws RuntimeException
+    {
+        throw propagate(request, exception);
+    }
+
+    @Override
+    default StreamingResponseIterator<T> handle(Request request, Response response)
+            throws RuntimeException
+    {
+        if (response instanceof StreamingResponse streamingResponse) {
+            return handle(request, streamingResponse);
+        }
+        throw new IllegalArgumentException("Response must be a StreamingResponse");
+    }
+
+    StreamingResponseIterator<T> handle(Request request, StreamingResponse response);
+}

--- a/http-client/src/main/java/io/airlift/http/client/StreamingResponseIterator.java
+++ b/http-client/src/main/java/io/airlift/http/client/StreamingResponseIterator.java
@@ -1,0 +1,11 @@
+package io.airlift.http.client;
+
+import java.io.Closeable;
+import java.util.Iterator;
+
+public interface StreamingResponseIterator<T>
+        extends Iterator<T>, Response, Closeable
+{
+    @Override
+    void close();
+}

--- a/http-client/src/main/java/io/airlift/http/client/jetty/JettyStreamingResponse.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/JettyStreamingResponse.java
@@ -1,0 +1,68 @@
+package io.airlift.http.client.jetty;
+
+import com.google.common.collect.ListMultimap;
+import io.airlift.http.client.HeaderName;
+import io.airlift.http.client.Response;
+import io.airlift.http.client.StreamingResponse;
+import io.opentelemetry.api.trace.Span;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static java.util.Objects.requireNonNull;
+
+class JettyStreamingResponse
+        implements StreamingResponse
+{
+    private final Response response;
+    private final Span span;
+    private final Runnable finalizer;
+    private boolean isClosed;
+
+    JettyStreamingResponse(Response response, Span span, Runnable finalizer)
+    {
+        this.response = requireNonNull(response, "response is null");
+        this.span = requireNonNull(span, "span is null");
+        this.finalizer = requireNonNull(finalizer, "finalizer is null");
+    }
+
+    @Override
+    public int getStatusCode()
+    {
+        return response.getStatusCode();
+    }
+
+    @Override
+    public ListMultimap<HeaderName, String> getHeaders()
+    {
+        return response.getHeaders();
+    }
+
+    @Override
+    public long getBytesRead()
+    {
+        return response.getBytesRead();
+    }
+
+    @Override
+    public InputStream getInputStream()
+            throws IOException
+    {
+        return response.getInputStream();
+    }
+
+    @Override
+    public void close()
+    {
+        if (!isClosed) {
+            isClosed = true;
+
+            try {
+                finalizer.run();
+            }
+            finally {
+                span.end();
+            }
+        }
+    }
+}

--- a/http-client/src/test/java/io/airlift/http/client/EchoServlet.java
+++ b/http-client/src/test/java/io/airlift/http/client/EchoServlet.java
@@ -25,8 +25,10 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.net.URI;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -43,6 +45,7 @@ public final class EchoServlet
     private int responseStatusCode = 200;
     private final ListMultimap<String, String> responseHeaders = ArrayListMultimap.create();
     private String responseBody;
+    private Iterator<String> stream;
 
     @Override
     protected void service(HttpServletRequest request, HttpServletResponse response)
@@ -88,6 +91,14 @@ public final class EchoServlet
         if (responseBody != null) {
             response.getOutputStream().write(responseBody.getBytes(UTF_8));
         }
+
+        if (stream != null) {
+            OutputStream outputStream = response.getOutputStream();
+            while (stream.hasNext()) {
+                outputStream.write(stream.next().getBytes(UTF_8));
+                outputStream.flush();
+            }
+        }
     }
 
     public String getRequestMethod()
@@ -128,5 +139,10 @@ public final class EchoServlet
     public void setResponseBody(String responseBody)
     {
         this.responseBody = responseBody;
+    }
+
+    public void setStream(Iterator<String> stream)
+    {
+        this.stream = stream;
     }
 }

--- a/http-client/src/test/java/io/airlift/http/client/jetty/AbstractHttpClientTestHttpProxy.java
+++ b/http-client/src/test/java/io/airlift/http/client/jetty/AbstractHttpClientTestHttpProxy.java
@@ -95,6 +95,27 @@ public abstract class AbstractHttpClientTestHttpProxy
     }
 
     @Override
+    @Test(enabled = false)
+    public void testStreamingJson()
+    {
+        // Streaming is not intended for use with proxies
+    }
+
+    @Override
+    public void testStreamingInvalidJson()
+            throws Exception
+    {
+        // Streaming is not intended for use with proxies
+    }
+
+    @Override
+    @Test(enabled = false)
+    public void testStreamingBlockingJson()
+    {
+        // Streaming is not intended for use with proxies
+    }
+
+    @Override
     public <T, E extends Exception> T executeRequest(Request request, ResponseHandler<T, E> responseHandler)
             throws Exception
     {

--- a/http-client/src/test/java/io/airlift/http/client/jetty/TestAsyncJettyHttpClient.java
+++ b/http-client/src/test/java/io/airlift/http/client/jetty/TestAsyncJettyHttpClient.java
@@ -10,6 +10,7 @@ import io.airlift.http.client.TestingRequestFilter;
 import io.airlift.http.client.TestingStatusListener;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
 
 public class TestAsyncJettyHttpClient
         extends AbstractHttpClientTest
@@ -51,5 +52,26 @@ public class TestAsyncJettyHttpClient
         try (JettyHttpClient client = new JettyHttpClient("test-private", config, ImmutableList.of(new TestingRequestFilter()), ImmutableSet.of(new TestingStatusListener(statusCounts)))) {
             return executeAsync(client, request, responseHandler);
         }
+    }
+
+    @Override
+    @Test(enabled = false)
+    public void testStreamingJson()
+    {
+        // Streaming is not intended for use with async
+    }
+
+    @Override
+    public void testStreamingInvalidJson()
+            throws Exception
+    {
+        // Streaming is not intended for use with async
+    }
+
+    @Override
+    @Test(enabled = false)
+    public void testStreamingBlockingJson()
+    {
+        // Streaming is not intended for use with async
     }
 }

--- a/json/src/main/java/io/airlift/json/JsonCodecParser.java
+++ b/json/src/main/java/io/airlift/json/JsonCodecParser.java
@@ -1,0 +1,96 @@
+package io.airlift.json;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.ObjectReader;
+
+import java.io.IOException;
+
+public class JsonCodecParser<T>
+        implements AutoCloseable
+{
+    private final ObjectReader objectReader;
+    private final JsonParser parser;
+
+    JsonCodecParser(ObjectReader objectReader, JsonParser parser)
+    {
+        this.objectReader = objectReader;
+        this.parser = parser;
+    }
+
+    @Override
+    public void close()
+            throws Exception
+    {
+        parser.close();
+    }
+
+    public boolean isClosed()
+    {
+        return parser.isClosed();
+    }
+
+    public boolean hasCurrentToken()
+    {
+        return parser.hasCurrentToken();
+    }
+
+    public JsonToken currentToken()
+    {
+        return parser.currentToken();
+    }
+
+    public JsonParser skipChildren()
+            throws IOException
+    {
+        return parser.skipChildren();
+    }
+
+    public T readValue()
+            throws IOException
+    {
+        return objectReader.readValue(parser);
+    }
+
+    public JsonToken nextToken()
+            throws IOException
+    {
+        return parser.nextToken();
+    }
+
+    public JsonToken nextValue()
+            throws IOException
+    {
+        return parser.nextValue();
+    }
+
+    public String nextFieldName()
+            throws IOException
+    {
+        return parser.nextFieldName();
+    }
+
+    public String nextTextValue()
+            throws IOException
+    {
+        return parser.nextTextValue();
+    }
+
+    public int nextIntValue(int defaultValue)
+            throws IOException
+    {
+        return parser.nextIntValue(defaultValue);
+    }
+
+    public long nextLongValue(long defaultValue)
+            throws IOException
+    {
+        return parser.nextLongValue(defaultValue);
+    }
+
+    public Boolean nextBooleanValue()
+            throws IOException
+    {
+        return parser.nextBooleanValue();
+    }
+}

--- a/json/src/main/java/io/airlift/json/JsonCodecParser.java
+++ b/json/src/main/java/io/airlift/json/JsonCodecParser.java
@@ -91,6 +91,7 @@ public class JsonCodecParser<T>
     public Boolean nextBooleanValue()
             throws IOException
     {
-        return parser.nextBooleanValue();
+        Boolean b = parser.nextBooleanValue();
+        return (b != null) && b;
     }
 }


### PR DESCRIPTION
Support end-to-end streaming. This is useful for endpoints that return
a large list of entities. Instead of needing to queue that entire list
in memory in both the server and client the entities are streamed.
This has even greater impact when there is a client in the middle:
client -> server A -> server B -> back to client.

The flow is:

- Client sends request to server
- Server begins to stream entities
- Client reads entities one by one

This necessitates giving the client ownership of the internal
input stream.

Additionally, adds JsonStreamingResponse to make it simpler/convenient to stream lists
of JSON entities.
