### PR TITLE
Add testing tracing module for in-memory tracing

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 236
 
 - Do not localize Jakarta validation messages
+- Add TestingTracingModule.
 
 235
 

--- a/tracing/pom.xml
+++ b/tracing/pom.xml
@@ -99,6 +99,18 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>bootstrap</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>

--- a/tracing/src/main/java/io/airlift/tracing/TracingModule.java
+++ b/tracing/src/main/java/io/airlift/tracing/TracingModule.java
@@ -1,15 +1,11 @@
 package io.airlift.tracing;
 
 import com.google.inject.Binder;
-import com.google.inject.Provides;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
-import io.airlift.tracing.SpanSerialization.SpanDeserializer;
-import io.airlift.tracing.SpanSerialization.SpanSerializer;
 import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.api.trace.Tracer;
 
-import static io.airlift.json.JsonBinder.jsonBinder;
+import java.util.Optional;
+
 import static java.util.Objects.requireNonNull;
 
 public class TracingModule
@@ -28,19 +24,12 @@ public class TracingModule
     protected void setup(Binder binder)
     {
         if (buildConfigObject(TracingEnabledConfig.class).isEnabled()) {
-            install(new OpenTelemetryModule(serviceName, serviceVersion));
+            install(new OpenTelemetryModule(serviceName, serviceVersion, Optional.empty()));
         }
         else {
             binder.bind(OpenTelemetry.class).toInstance(OpenTelemetry.noop());
         }
 
-        jsonBinder(binder).addSerializerBinding(Span.class).to(SpanSerializer.class);
-        jsonBinder(binder).addDeserializerBinding(Span.class).to(SpanDeserializer.class);
-    }
-
-    @Provides
-    public Tracer createTracer(OpenTelemetry openTelemetry)
-    {
-        return openTelemetry.getTracer(serviceName);
+        install(new TracingSupportModule(serviceName));
     }
 }

--- a/tracing/src/main/java/io/airlift/tracing/TracingSupportModule.java
+++ b/tracing/src/main/java/io/airlift/tracing/TracingSupportModule.java
@@ -1,0 +1,37 @@
+package io.airlift.tracing;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Provides;
+import io.airlift.tracing.SpanSerialization.SpanDeserializer;
+import io.airlift.tracing.SpanSerialization.SpanSerializer;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+
+import static io.airlift.json.JsonBinder.jsonBinder;
+import static java.util.Objects.requireNonNull;
+
+public class TracingSupportModule
+        implements Module
+{
+    private final String serviceName;
+
+    public TracingSupportModule(String serviceName)
+    {
+        this.serviceName = requireNonNull(serviceName, "serviceName is null");
+    }
+
+    @Override
+    public void configure(Binder binder)
+    {
+        jsonBinder(binder).addSerializerBinding(Span.class).to(SpanSerializer.class);
+        jsonBinder(binder).addDeserializerBinding(Span.class).to(SpanDeserializer.class);
+    }
+
+    @Provides
+    public Tracer createTracer(OpenTelemetry openTelemetry)
+    {
+        return openTelemetry.getTracer(serviceName);
+    }
+}

--- a/tracing/src/main/java/io/airlift/tracing/testing/TestingTracingModule.java
+++ b/tracing/src/main/java/io/airlift/tracing/testing/TestingTracingModule.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.tracing.testing;
+
+import com.google.inject.Binder;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.airlift.tracing.OpenTelemetryModule;
+import io.airlift.tracing.TracingModule;
+import io.airlift.tracing.TracingSupportModule;
+import io.opentelemetry.sdk.trace.SpanProcessor;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class TestingTracingModule
+        extends AbstractConfigurationAwareModule
+{
+    private final String serviceName;
+    private final String serviceVersion;
+    private final Optional<SpanProcessor> spanProcessor;
+
+    public TestingTracingModule(String serviceName, String serviceVersion, Optional<SpanProcessor> spanProcessor)
+    {
+        this.serviceName = requireNonNull(serviceName, "serviceName is null");
+        this.serviceVersion = requireNonNull(serviceVersion, "serviceVersion is null");
+        this.spanProcessor = requireNonNull(spanProcessor, "spanProcessor is null");
+    }
+
+    @Override
+    protected void setup(Binder binder)
+    {
+        if (spanProcessor.isPresent()) {
+            install(new OpenTelemetryModule(serviceName, serviceVersion, spanProcessor));
+            install(new TracingSupportModule(serviceName));
+        }
+        else {
+            install(new TracingModule(serviceName, serviceVersion));
+        }
+    }
+}

--- a/tracing/src/test/java/io/airlift/tracing/testing/TestTestingTracingModule.java
+++ b/tracing/src/test/java/io/airlift/tracing/testing/TestTestingTracingModule.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.tracing.testing;
+
+import com.google.inject.Injector;
+import io.airlift.bootstrap.Bootstrap;
+import io.airlift.json.JsonModule;
+import io.airlift.node.testing.TestingNodeModule;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.collect.MoreCollectors.onlyElement;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestTestingTracingModule
+{
+    @Test
+    public void testInMemorySpanExporter()
+    {
+        InMemorySpanExporter spanExporter = InMemorySpanExporter.create();
+        Bootstrap app = new Bootstrap(
+                new JsonModule(),
+                new TestingNodeModule(),
+                new TestingTracingModule("foo-bar-service-name", "test-version", Optional.of(SimpleSpanProcessor.create(spanExporter))));
+        Injector injector = app
+                .doNotInitializeLogging()
+                .setRequiredConfigurationProperties(Map.of())
+                .initialize();
+        Tracer tracer = injector.getInstance(Tracer.class);
+
+        tracer.spanBuilder("foo-span").startSpan()
+                .setAttribute("foo-attribute", "some-value")
+                .end();
+
+        List<SpanData> recordedSpans = spanExporter.getFinishedSpanItems();
+        assertThat(recordedSpans).as("all recorder spans")
+                .hasSize(1);
+        SpanData recorderSpan = recordedSpans.stream().collect(onlyElement());
+        assertThat(recorderSpan.getName()).as("span name")
+                .isEqualTo("foo-span");
+
+        assertThat(recorderSpan.getAttributes().asMap()).as("span attributes")
+                .isEqualTo(Map.of(AttributeKey.stringKey("foo-attribute"), "some-value"));
+        assertThat(recorderSpan.getResource().getAttributes().get(ResourceAttributes.SERVICE_NAME)).as("span resource service name")
+                .isEqualTo("foo-bar-service-name");
+        assertThat(recorderSpan.getResource().getAttributes().get(ResourceAttributes.SERVICE_VERSION)).as("span resource service version")
+                .isEqualTo("test-version");
+    }
+}


### PR DESCRIPTION
Add `TestingTracingModule` with enhances `TracingModule` with ability to override `SpanProcessor`. This can be used e.g. for in-memory tracing.