### PR TITLE
Change content type for openmetrics expositions to prometheus text format

### DIFF
--- a/openmetrics/src/main/java/io/airlift/openmetrics/MetricsResource.java
+++ b/openmetrics/src/main/java/io/airlift/openmetrics/MetricsResource.java
@@ -52,7 +52,7 @@ import static java.util.Objects.requireNonNull;
 public class MetricsResource
 {
     private static final Logger log = Logger.get(MetricsResource.class);
-    private static final String OPENMETRICS_CONTENT_TYPE = "application/openmetrics-text; version=1.0.0; charset=utf-8";
+    private static final String OPENMETRICS_CONTENT_TYPE = "text/plain; version=0.0.4; charset=utf-8";
     private static final String ATTRIBUTE_SEPARATOR = "_ATTRIBUTE_";
     private static final String TYPE_SEPARATOR = "_TYPE_";
     private static final String NAME_SEPARATOR = "_NAME_";


### PR DESCRIPTION
The format produced by this implementation is actually not adhering to the OpenMetrics standard, which causes problems for scrapers that rely on the content-type for deciding how to parse the metrics exposition. The official Prometheus Python client's [parser](https://github.com/prometheus/client_python/blob/master/prometheus_client/openmetrics/parser.py) will raise errors when trying to parse metrics coming out of this implementation. For example, `NaN` values are not allowed in histograms and summaries, and [counters must include a `_total` suffix for the actual sample value](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#counter-1).

The [Prometheus text exposition format](https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format) is much less strict and is therefore a better match for the way the current implementation exposes metrics. Thus, this PR suggests modifying the content type to match the one recommended for that format.

