### PR TITLE
Add node annotations to openmetrics labels

### DIFF
--- a/openmetrics/pom.xml
+++ b/openmetrics/pom.xml
@@ -42,6 +42,11 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>node</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>stats</artifactId>
         </dependency>
 

--- a/openmetrics/src/main/java/io/airlift/openmetrics/types/BigCounter.java
+++ b/openmetrics/src/main/java/io/airlift/openmetrics/types/BigCounter.java
@@ -14,22 +14,24 @@
 package io.airlift.openmetrics.types;
 
 import java.math.BigInteger;
+import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
 
-public record BigCounter(String metricName, BigInteger value, String help)
+public record BigCounter(String metricName, BigInteger value, Map<String, String> labels, String help)
         implements Metric
 {
-    public BigCounter(String metricName, BigInteger value, String help)
+    public BigCounter(String metricName, BigInteger value, Map<String, String> labels, String help)
     {
         this.metricName = requireNonNull(metricName, "metricName is null");
         this.value = requireNonNull(value, "value is null");
+        this.labels = labels;
         this.help = help;
     }
 
     @Override
     public String getMetricExposition()
     {
-        return Metric.formatSingleValuedMetric(metricName, "counter", help, value.toString());
+        return Metric.formatSingleValuedMetric(metricName, "counter", help, labels, value.toString());
     }
 }

--- a/openmetrics/src/main/java/io/airlift/openmetrics/types/Counter.java
+++ b/openmetrics/src/main/java/io/airlift/openmetrics/types/Counter.java
@@ -15,26 +15,29 @@ package io.airlift.openmetrics.types;
 
 import io.airlift.stats.CounterStat;
 
+import java.util.Map;
+
 import static java.util.Objects.requireNonNull;
 
-public record Counter(String metricName, long value, String help)
+public record Counter(String metricName, long value, Map<String, String> labels, String help)
         implements Metric
 {
-    public Counter(String metricName, long value, String help)
+    public Counter(String metricName, long value, Map<String, String> labels, String help)
     {
         this.metricName = requireNonNull(metricName, "metricName is null");
         this.value = value;
+        this.labels = labels;
         this.help = help;
     }
 
-    public static Counter from(String metricName, CounterStat counterStat, String help)
+    public static Counter from(String metricName, CounterStat counterStat, Map<String, String> labels, String help)
     {
-        return new Counter(metricName, counterStat.getTotalCount(), help);
+        return new Counter(metricName, counterStat.getTotalCount(), labels, help);
     }
 
     @Override
     public String getMetricExposition()
     {
-        return Metric.formatSingleValuedMetric(metricName, "counter", help, Long.toString(value));
+        return Metric.formatSingleValuedMetric(metricName, "counter", help, labels, Long.toString(value));
     }
 }

--- a/openmetrics/src/main/java/io/airlift/openmetrics/types/Gauge.java
+++ b/openmetrics/src/main/java/io/airlift/openmetrics/types/Gauge.java
@@ -13,26 +13,29 @@
  */
 package io.airlift.openmetrics.types;
 
+import java.util.Map;
+
 import static java.util.Objects.requireNonNull;
 
-public record Gauge(String metricName, double value, String help)
+public record Gauge(String metricName, double value, Map<String, String> labels, String help)
         implements Metric
 {
-    public Gauge(String metricName, double value, String help)
+    public Gauge(String metricName, double value, Map<String, String> labels, String help)
     {
         this.metricName = requireNonNull(metricName, "metricName is null");
         this.value = value;
+        this.labels = labels;
         this.help = help;
     }
 
-    public static Gauge from(String metricName, Number value, String help)
+    public static Gauge from(String metricName, Number value, Map<String, String> labels, String help)
     {
-        return new Gauge(metricName, value.doubleValue(), help);
+        return new Gauge(metricName, value.doubleValue(), labels, help);
     }
 
     @Override
     public String getMetricExposition()
     {
-        return Metric.formatSingleValuedMetric(metricName, "gauge", help, Double.toString(value));
+        return Metric.formatSingleValuedMetric(metricName, "gauge", help, labels, Double.toString(value));
     }
 }

--- a/openmetrics/src/main/java/io/airlift/openmetrics/types/Info.java
+++ b/openmetrics/src/main/java/io/airlift/openmetrics/types/Info.java
@@ -13,20 +13,23 @@
  */
 package io.airlift.openmetrics.types;
 
+import java.util.Map;
+
 import static java.util.Objects.requireNonNull;
 
-public record Info(String metricName, String value, String help) implements Metric
+public record Info(String metricName, String value, Map<String, String> labels, String help) implements Metric
 {
-    public Info(String metricName, String value, String help)
+    public Info(String metricName, String value, Map<String, String> labels, String help)
     {
         this.metricName = requireNonNull(metricName, "metricName is null");
         this.value = requireNonNull(value, "value is null");
+        this.labels = labels;
         this.help = help;
     }
 
     @Override
     public String getMetricExposition()
     {
-        return Metric.formatSingleValuedMetric(metricName, "info", help, value);
+        return Metric.formatSingleValuedMetric(metricName, "info", help, labels, value);
     }
 }

--- a/openmetrics/src/main/java/io/airlift/openmetrics/types/Metric.java
+++ b/openmetrics/src/main/java/io/airlift/openmetrics/types/Metric.java
@@ -15,20 +15,36 @@ package io.airlift.openmetrics.types;
 
 import com.google.common.base.Strings;
 
+import java.util.Map;
+import java.util.stream.Collectors;
+
 public interface Metric
 {
     String HELP_LINE_FORMAT = "# HELP %s %s\n";
     String TYPE_LINE_FORMAT = "# TYPE %s %s\n";
+    String NAME_WITH_LABELS_LINE_FORMAT = "%s{%s}";
     String VALUE_LINE_FORMAT = "%s %s\n";
 
     String metricName();
 
     String getMetricExposition();
 
-    static String formatSingleValuedMetric(String name, String type, String help, String value)
+    static String formatSingleValuedMetric(String name, String type, String help, Map<String, String> labels, String value)
     {
         return TYPE_LINE_FORMAT.formatted(name, type) +
-                (Strings.isNullOrEmpty(help) ? "" : HELP_LINE_FORMAT.formatted(name, help)) +
-                VALUE_LINE_FORMAT.formatted(name, value);
+               (Strings.isNullOrEmpty(help) ? "" : HELP_LINE_FORMAT.formatted(name, help)) +
+               VALUE_LINE_FORMAT.formatted(formatNameWithLabels(name, labels), value);
+    }
+
+    static String formatNameWithLabels(String name, Map<String, String> labels)
+    {
+        if (labels.isEmpty()) {
+            return name;
+        }
+        return NAME_WITH_LABELS_LINE_FORMAT.formatted(
+                name,
+                labels.entrySet().stream()
+                        .map(e -> "%s=\"%s\"".formatted(e.getKey(), e.getValue()))
+                        .collect(Collectors.joining(",")));
     }
 }

--- a/openmetrics/src/test/java/io/airlift/openmetrics/TestMetricExpositions.java
+++ b/openmetrics/src/test/java/io/airlift/openmetrics/TestMetricExpositions.java
@@ -36,8 +36,23 @@ public class TestMetricExpositions
                 metric_name 0
                 """;
 
-        Counter counter = new Counter("metric_name", 0, "metric_help");
-        BigCounter bigCounter = new BigCounter("metric_name", BigInteger.ZERO, "metric_help");
+        Counter counter = new Counter("metric_name", 0, ImmutableMap.of(), "metric_help");
+        BigCounter bigCounter = new BigCounter("metric_name", BigInteger.ZERO, ImmutableMap.of(), "metric_help");
+        assertEquals(counter.getMetricExposition(), bigCounter.getMetricExposition());
+        assertEquals(counter.getMetricExposition(), expected);
+    }
+
+    @Test
+    public void testCounterExpositionLabels()
+    {
+        String expected = """
+                # TYPE metric_name counter
+                # HELP metric_name metric_help
+                metric_name{type="cavendish"} 0
+                """;
+
+        Counter counter = new Counter("metric_name", 0, ImmutableMap.of("type", "cavendish"), "metric_help");
+        BigCounter bigCounter = new BigCounter("metric_name", BigInteger.ZERO, ImmutableMap.of("type", "cavendish"), "metric_help");
         assertEquals(counter.getMetricExposition(), bigCounter.getMetricExposition());
         assertEquals(counter.getMetricExposition(), expected);
     }
@@ -51,7 +66,19 @@ public class TestMetricExpositions
                 metric_name 0.0
                 """;
 
-        assertEquals(new Gauge("metric_name", 0.0, "metric_help").getMetricExposition(), expected);
+        assertEquals(new Gauge("metric_name", 0.0, ImmutableMap.of(), "metric_help").getMetricExposition(), expected);
+    }
+
+    @Test
+    public void testGaugeExpositionLabels()
+    {
+        String expected = """
+                # TYPE metric_name gauge
+                # HELP metric_name metric_help
+                metric_name{type="cavendish"} 0.0
+                """;
+
+        assertEquals(new Gauge("metric_name", 0.0, ImmutableMap.of("type", "cavendish"), "metric_help").getMetricExposition(), expected);
     }
 
     @Test
@@ -63,7 +90,19 @@ public class TestMetricExpositions
                 metric_name banana
                 """;
 
-        assertEquals(new Info("metric_name", "banana", "metric_help").getMetricExposition(), expected);
+        assertEquals(new Info("metric_name", "banana", ImmutableMap.of(), "metric_help").getMetricExposition(), expected);
+    }
+
+    @Test
+    public void testInfoExpositionLabels()
+    {
+        String expected = """
+                # TYPE metric_name info
+                # HELP metric_name metric_help
+                metric_name{type="cavendish"} banana
+                """;
+
+        assertEquals(new Info("metric_name", "banana", ImmutableMap.of("type", "cavendish"), "metric_help").getMetricExposition(), expected);
     }
 
     @Test
@@ -78,6 +117,21 @@ public class TestMetricExpositions
                 metric_name{quantile="0.5"} 0.25
                 """;
 
-        assertEquals(new Summary("metric_name", 10L, 2.0, 3.0, ImmutableMap.of(0.5, 0.25), "metric_help").getMetricExposition(), expected);
+        assertEquals(new Summary("metric_name", 10L, 2.0, 3.0, ImmutableMap.of(0.5, 0.25), ImmutableMap.of(), "metric_help").getMetricExposition(), expected);
+    }
+
+    @Test
+    public void testSummaryExpositionLabels()
+    {
+        String expected = """
+                # TYPE metric_name summary
+                # HELP metric_name metric_help
+                metric_name_count{fruit="apple"} 10
+                metric_name_sum{fruit="apple"} 2.0
+                metric_name_created{fruit="apple"} 3.0
+                metric_name{fruit="apple",quantile="0.5"} 0.25
+                """;
+
+        assertEquals(new Summary("metric_name", 10L, 2.0, 3.0, ImmutableMap.of(0.5, 0.25), ImmutableMap.of("fruit", "apple"), "metric_help").getMetricExposition(), expected);
     }
 }


### PR DESCRIPTION
All the properties from `node.annotation-file` will be added as labels to the metrics

Tested this with skeleton server 
```
curl localhost:8080/metrics
# TYPE io_airlift_discovery_client_name_Announcer_Executor_PoolSize gauge
io_airlift_discovery_client_name_Announcer_Executor_PoolSize{fruit="apple",other_fruit="bannana"} 5.0
# TYPE io_airlift_discovery_client_name_Announcer_Executor_MaximumPoolSize gauge
io_airlift_discovery_client_name_Announcer_Executor_MaximumPoolSize{fruit="apple",other_fruit="bannana"} 2.147483647E9
# TYPE io_airlift_discovery_client_name_Announcer_Executor_ActiveCount gauge
io_airlift_discovery_client_name_Announcer_Executor_ActiveCount{fruit="apple",other_fruit="bannana"} 0.0
# TYPE io_airlift_discovery_client_name_Announcer_Executor_CorePoolSize gauge
io_airlift_discovery_client_name_Announcer_Executor_CorePoolSize{fruit="apple",other_fruit="bannana"} 5.0
# TYPE io_airlift_discovery_client_name_Announcer_Executor_CompletedTaskCount gauge
io_airlift_discovery_client_name_Announcer_Executor_CompletedTaskCount{fruit="apple",other_fruit="bannana"} 29.0
```