### PR TITLE
Update jetty to 11.0.17

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+238
+
+- Update Jetty to 11.0.17
+
 237
 
 - Update to OpenTelemetry 1.30.1

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-bom</artifactId>
-                <version>11.0.15</version>
+                <version>11.0.17</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Fixes: https://nvd.nist.gov/vuln/detail/CVE-2023-44487