### PR TITLE
Add DynamicSizeBoundQueue

### DIFF
--- a/concurrent/src/main/java/io/airlift/concurrent/DynamicSizeBoundQueue.java
+++ b/concurrent/src/main/java/io/airlift/concurrent/DynamicSizeBoundQueue.java
@@ -1,0 +1,356 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.concurrent;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Ticker;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import com.google.errorprone.annotations.ThreadSafe;
+import jakarta.annotation.Nullable;
+
+import java.util.Optional;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.ToLongFunction;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Verify.verify;
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElseGet;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+/**
+ * Size constrained queue that utilizes a dynamic element size function. To prevent
+ * starvation for adding large elements, the queue will only block new elements if
+ * the total size has already been reached or exceeded. This means in the normal
+ * case, the queue should be no larger than the max size plus the size of one element.
+ * Callers also have the additional option to force insert further elements without
+ * regard for size constraints. In the current implementation, elements are required
+ * to have positive sizes (they cannot have zero size). This implementation is designed
+ * to closely mirror the method signatures of {@link java.util.concurrent.BlockingQueue}.
+ */
+@ThreadSafe
+public class DynamicSizeBoundQueue<T>
+{
+    private final AtomicLong size = new AtomicLong();
+    private final Queue<ElementAndSize<T>> queue = new ConcurrentLinkedQueue<>();
+    private final AtomicReference<SettableFuture<Void>> enqueueFuture = new AtomicReference<>();
+    private final AtomicReference<SettableFuture<Void>> dequeueFuture = new AtomicReference<>();
+
+    private final long maxSize;
+    private final ToLongFunction<T> elementSizeFunction;
+    private final Ticker ticker;
+
+    public DynamicSizeBoundQueue(long maxSize, ToLongFunction<T> elementSizeFunction)
+    {
+        this(maxSize, elementSizeFunction, Ticker.systemTicker());
+    }
+
+    public DynamicSizeBoundQueue(long maxSize, ToLongFunction<T> elementSizeFunction, Ticker ticker)
+    {
+        checkArgument(maxSize > 0, "maxSize must be positive");
+        this.maxSize = maxSize;
+        this.elementSizeFunction = requireNonNull(elementSizeFunction, "elementSizeFunction is null");
+        this.ticker = requireNonNull(ticker, "ticker is null");
+    }
+
+    public long getMaxSize()
+    {
+        return maxSize;
+    }
+
+    /**
+     * Gets the current size of the queue. The size is guaranteed to be no larger than max size plus
+     * the size of one element if {@link DynamicSizeBoundQueue#forcePut(Object)} is not used.
+     */
+    public long getSize()
+    {
+        return size.get();
+    }
+
+    public boolean offer(T element)
+    {
+        long elementSize = elementSizeFunction.applyAsLong(element);
+        return offer(element, elementSize);
+    }
+
+    private boolean offer(T element, long elementSize)
+    {
+        requireNonNull(element, "element is null");
+        checkArgument(elementSize > 0, "element size must be positive");
+        if (!tryAcquireSizeReservation(elementSize)) {
+            return false;
+        }
+        queue.add(new ElementAndSize<>(element, elementSize));
+        notifyIfNecessary(enqueueFuture);
+        return true;
+    }
+
+    private boolean tryAcquireSizeReservation(long elementSize)
+    {
+        // Add the element as long as there is any space available
+        if (size.get() >= maxSize) {
+            return false;
+        }
+
+        long newSize;
+        try {
+            newSize = getAndAddOverflowChecked(size, elementSize);
+        }
+        catch (ArithmeticException e) { // Numeric overflow
+            // While numeric overflow is extremely unlikely given typical numerical sizes,
+            // even the largest possible element of size Long.MAX_VALUE can eventually fit
+            // without numeric overflow as long as the queue can be emptied.
+            return false;
+        }
+
+        if (newSize >= maxSize) {
+            verify(size.addAndGet(-elementSize) >= 0);
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Version of {@link java.util.concurrent.atomic.AtomicLong#getAndAdd} that throws {@link ArithmeticException}
+     * on numeric overflow. This is slightly less efficient than the normal getAndAdd (which often has intrinsic
+     * support). If this ever becomes a performance bottleneck, it is possible to use the original getAndAdd if
+     * the caller can guarantee no risk of numeric overflow.
+     */
+    private static long getAndAddOverflowChecked(AtomicLong atomicLong, long delta)
+    {
+        return atomicLong.getAndAccumulate(delta, Math::addExact);
+    }
+
+    public boolean offer(T element, long timeout, TimeUnit unit)
+            throws InterruptedException
+    {
+        long elementSize = elementSizeFunction.applyAsLong(element);
+        long remainingTimeoutNs = unit.toNanos(timeout);
+        while (!offer(element, elementSize)) {
+            ListenableFuture<Void> future = getOrCreateFuture(dequeueFuture);
+            // Check again in case we already missed the relevant dequeue event
+            if (offer(element, elementSize)) {
+                break;
+            }
+            long startTimeNs = ticker.read();
+            if (remainingTimeoutNs <= 0 || !awaitDequeueFuture(future, remainingTimeoutNs, NANOSECONDS)) {
+                // Timed out
+                return false;
+            }
+            remainingTimeoutNs -= ticker.read() - startTimeNs;
+        }
+        return true;
+    }
+
+    public void put(T element)
+            throws InterruptedException
+    {
+        long elementSize = elementSizeFunction.applyAsLong(element);
+        while (!offer(element, elementSize)) {
+            ListenableFuture<Void> future = getOrCreateFuture(dequeueFuture);
+            // Check again in case we already missed the relevant dequeue event
+            if (offer(element, elementSize)) {
+                break;
+            }
+            awaitDequeueFuture(future);
+        }
+    }
+
+    /**
+     * Enqueue the element if there is space, otherwise returns a ListenableFuture that will complete
+     * when space becomes available for the element. If a future is returned, the element was not inserted.
+     */
+    public Optional<ListenableFuture<Void>> offerWithBackoff(T element)
+    {
+        long elementSize = elementSizeFunction.applyAsLong(element);
+        if (offer(element, elementSize)) {
+            return Optional.empty();
+        }
+        ListenableFuture<Void> future = getOrCreateFuture(dequeueFuture);
+        // Check again in case we already missed the relevant dequeue event
+        if (offer(element, elementSize)) {
+            return Optional.empty();
+        }
+        return Optional.of(Futures.nonCancellationPropagating(future));
+    }
+
+    /**
+     * Insert without regard to the max size (potentially exceeding the max limit). This can throw an
+     * {@link IllegalStateException} if the forced element triggers a numeric overflow, in which case
+     * the element is not inserted.
+     */
+    public void forcePut(T element)
+    {
+        long elementSize = elementSizeFunction.applyAsLong(element);
+        checkArgument(elementSize > 0, "element size must be positive");
+        try {
+            getAndAddOverflowChecked(size, elementSize);
+        }
+        catch (ArithmeticException e) { // Numeric overflow
+            throw new IllegalStateException("Forced element triggered queue size numeric overflow");
+        }
+        queue.add(new ElementAndSize<>(element, elementSize));
+        notifyIfNecessary(enqueueFuture);
+    }
+
+    @Nullable
+    public T poll()
+    {
+        ElementAndSize<T> elementAndSize = queue.poll();
+        if (elementAndSize == null) {
+            return null;
+        }
+
+        verify(size.addAndGet(-elementAndSize.size()) >= 0);
+        notifyIfNecessary(dequeueFuture);
+        return elementAndSize.element();
+    }
+
+    public T poll(long timeout, TimeUnit unit)
+            throws InterruptedException
+    {
+        long remainingTimeoutNs = unit.toNanos(timeout);
+        while (true) {
+            T element = poll();
+            if (element != null) {
+                return element;
+            }
+
+            ListenableFuture<Void> future = getOrCreateFuture(enqueueFuture);
+            // Check again in case we already missed the relevant enqueue event
+            element = poll();
+            if (element != null) {
+                return element;
+            }
+
+            long startTimeNs = ticker.read();
+            if (remainingTimeoutNs <= 0 || !awaitEnqueueFuture(future, remainingTimeoutNs, NANOSECONDS)) {
+                // Timed out
+                return null;
+            }
+            remainingTimeoutNs -= ticker.read() - startTimeNs;
+        }
+    }
+
+    public T take()
+            throws InterruptedException
+    {
+        while (true) {
+            T element = poll();
+            if (element != null) {
+                return element;
+            }
+
+            ListenableFuture<Void> future = getOrCreateFuture(enqueueFuture);
+            // Check again in case we already missed the relevant enqueue event
+            element = poll();
+            if (element != null) {
+                return element;
+            }
+
+            awaitEnqueueFuture(future);
+        }
+    }
+
+    private static ListenableFuture<Void> getOrCreateFuture(AtomicReference<SettableFuture<Void>> reference)
+    {
+        return reference.updateAndGet(current -> requireNonNullElseGet(current, SettableFuture::create));
+    }
+
+    private static void notifyIfNecessary(AtomicReference<SettableFuture<Void>> reference)
+    {
+        SettableFuture<?> future = reference.getAndSet(null);
+        if (future != null) {
+            future.set(null);
+        }
+    }
+
+    @VisibleForTesting
+    void preEnqueueAwaitHook() {}
+
+    @VisibleForTesting
+    void preDequeueAwaitHook() {}
+
+    private void awaitDequeueFuture(Future<?> future)
+            throws InterruptedException
+    {
+        preDequeueAwaitHook();
+        awaitFutureUnchecked(future);
+    }
+
+    private boolean awaitDequeueFuture(Future<?> future, long timeout, TimeUnit timeUnit)
+            throws InterruptedException
+    {
+        preDequeueAwaitHook();
+        return awaitFutureUnchecked(future, timeout, timeUnit);
+    }
+
+    private void awaitEnqueueFuture(Future<?> future)
+            throws InterruptedException
+    {
+        preEnqueueAwaitHook();
+        awaitFutureUnchecked(future);
+    }
+
+    private boolean awaitEnqueueFuture(Future<?> future, long timeout, TimeUnit timeUnit)
+            throws InterruptedException
+    {
+        preEnqueueAwaitHook();
+        return awaitFutureUnchecked(future, timeout, timeUnit);
+    }
+
+    private static void awaitFutureUnchecked(Future<?> future)
+            throws InterruptedException
+    {
+        try {
+            future.get();
+        }
+        catch (ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static boolean awaitFutureUnchecked(Future<?> future, long timeout, TimeUnit timeUnit)
+            throws InterruptedException
+    {
+        try {
+            future.get(timeout, timeUnit);
+            return true;
+        }
+        catch (ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+        catch (TimeoutException e) {
+            return false;
+        }
+    }
+
+    private record ElementAndSize<T>(T element, long size)
+    {
+        private ElementAndSize
+        {
+            requireNonNull(element, "element is null");
+            checkArgument(size > 0, "size must be positive");
+        }
+    }
+}

--- a/concurrent/src/test/java/io/airlift/concurrent/TestDynamicSizeBoundQueue.java
+++ b/concurrent/src/test/java/io/airlift/concurrent/TestDynamicSizeBoundQueue.java
@@ -1,0 +1,591 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.concurrent;
+
+import com.google.common.collect.ConcurrentHashMultiset;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.Uninterruptibles;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
+
+public class TestDynamicSizeBoundQueue
+{
+    private ListeningExecutorService executorService;
+
+    @BeforeMethod
+    public void setUp()
+    {
+        executorService = MoreExecutors.listeningDecorator(Executors.newCachedThreadPool());
+    }
+
+    @AfterMethod
+    public void tearDown()
+    {
+        executorService.shutdownNow();
+    }
+
+    @Test
+    public void testBasicOfferPoll()
+            throws InterruptedException
+    {
+        DynamicSizeBoundQueue<String> queue = new DynamicSizeBoundQueue<>(3, String::length);
+
+        // Empty queue
+        assertThat(queue.getMaxSize()).isEqualTo(3);
+        assertThat(queue.getSize()).isZero();
+        assertThat(queue.poll()).isNull();
+        assertThat(queue.poll(1, TimeUnit.MILLISECONDS))
+                .as("Just use any short poll timeout to test the API")
+                .isNull();
+
+        // Insert a single element of length 1
+        assertThat(queue.offer("a")).isTrue();
+        assertThat(queue.getMaxSize()).isEqualTo(3);
+        assertThat(queue.getSize()).isEqualTo(1);
+        assertThat(queue.poll()).isEqualTo("a");
+        assertThat(queue.poll())
+                .as("No more elements")
+                .isNull();
+        assertThat(queue.getSize()).isZero();
+
+        // Insert 2 elements that fill up the queue exactly to capacity
+        assertThat(queue.offer("a")).isTrue();
+        assertThat(queue.offer("bb")).isTrue();
+        assertThat(queue.offer("c"))
+                .as("Queue already full")
+                .isFalse();
+        assertThat(queue.getMaxSize()).isEqualTo(3);
+        assertThat(queue.getSize()).isEqualTo(3);
+        assertThat(queue.poll()).isEqualTo("a");
+        assertThat(queue.poll()).isEqualTo("bb");
+        assertThat(queue.poll())
+                .as("No more elements")
+                .isNull();
+        assertThat(queue.getSize()).isZero();
+
+        // Overfill queue
+        assertThat(queue.offer("aa")).isTrue();
+        assertThat(queue.offer("bbb")).isTrue();
+        assertThat(queue.offer("c"))
+                .as("Queue already over capacity")
+                .isFalse();
+        assertThat(queue.getMaxSize()).isEqualTo(3);
+        assertThat(queue.getSize()).isEqualTo(5);
+        assertThat(queue.poll()).isEqualTo("aa");
+        assertThat(queue.poll()).isEqualTo("bbb");
+        assertThat(queue.poll())
+                .as("No more elements")
+                .isNull();
+        assertThat(queue.getSize()).isZero();
+    }
+
+    @Test
+    public void testOversizeElement()
+    {
+        DynamicSizeBoundQueue<String> queue = new DynamicSizeBoundQueue<>(3, String::length);
+
+        assertThat(queue.offer("aaaaa"))
+                .as("Queue always allows the insertion of an element as long as any space is available")
+                .isTrue();
+        assertThat(queue.offer("b"))
+                .as("Queue already over capacity")
+                .isFalse();
+        assertThat(queue.getSize()).isEqualTo(5);
+
+        assertThat(queue.poll()).isEqualTo("aaaaa");
+        assertThat(queue.poll())
+                .as("No more elements")
+                .isNull();
+        assertThat(queue.getSize()).isZero();
+    }
+
+    @Test
+    public void testOfferSizeOverflow()
+    {
+        DynamicSizeBoundQueue<Long> queue = new DynamicSizeBoundQueue<>(Long.MAX_VALUE, element -> element);
+
+        assertThat(queue.offer(Long.MAX_VALUE - 1))
+                .isTrue();
+
+        assertThat(queue.offer(2L))
+                .as("Element of size 2 should be rejected due to size numeric overflow")
+                .isFalse();
+        assertThat(queue.getSize())
+                .as("Size should remain unchanged")
+                .isEqualTo(Long.MAX_VALUE - 1);
+
+        assertThat(queue.offer(Long.MAX_VALUE))
+                .as("Element of size Long.MAX_VALUE should be rejected due to size numeric overflow")
+                .isFalse();
+        assertThat(queue.getSize())
+                .as("Size should remain unchanged")
+                .isEqualTo(Long.MAX_VALUE - 1);
+
+        assertThat(queue.offer(1L))
+                .as("Should be able to fill capacity up to Long.MAX_VALUE")
+                .isTrue();
+        assertThat(queue.getSize())
+                .as("Size should be at capacity")
+                .isEqualTo(Long.MAX_VALUE);
+
+        // Empty the queue
+        assertThat(queue.poll())
+                .isEqualTo(Long.MAX_VALUE - 1);
+        assertThat(queue.poll())
+                .isEqualTo(1L);
+
+        assertThat(queue.offer(Long.MAX_VALUE))
+                .as("Element of size Long.MAX_VALUE should be accepted for an empty queue")
+                .isTrue();
+        assertThat(queue.getSize())
+                .isEqualTo(Long.MAX_VALUE);
+    }
+
+    @Test
+    public void testForcePutSizeOverflow()
+    {
+        DynamicSizeBoundQueue<Long> queue = new DynamicSizeBoundQueue<>(Long.MAX_VALUE, element -> element);
+
+        assertThat(queue.offer(Long.MAX_VALUE - 1))
+                .isTrue();
+
+        assertThatThrownBy(() -> queue.forcePut(2L))
+                .as("Element of size 2 should be rejected due to size numeric overflow")
+                .isInstanceOf(IllegalStateException.class);
+        assertThat(queue.getSize())
+                .as("Size should remain unchanged")
+                .isEqualTo(Long.MAX_VALUE - 1);
+    }
+
+    @Test
+    public void testZeroSizeElement()
+    {
+        DynamicSizeBoundQueue<String> queue = new DynamicSizeBoundQueue<>(1, String::length);
+
+        // All forms of insertion should fail if the element size is zero
+        assertThatThrownBy(() -> queue.offer("")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> queue.offer("", 10, TimeUnit.SECONDS)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> queue.offerWithBackoff("")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> queue.put("")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> queue.forcePut("")).isInstanceOf(IllegalArgumentException.class);
+
+        assertThat(queue.getSize()).isZero();
+    }
+
+    @Test
+    public void testNegativeElementSizes()
+    {
+        DynamicSizeBoundQueue<String> queue = new DynamicSizeBoundQueue<>(1, ignored -> -1L);
+
+        // All forms of insertion should fail if the element size is negative
+        assertThatThrownBy(() -> queue.offer("a")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> queue.offer("", 10, TimeUnit.SECONDS)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> queue.offerWithBackoff("a")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> queue.put("a")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> queue.forcePut("a")).isInstanceOf(IllegalArgumentException.class);
+
+        assertThat(queue.getSize()).isZero();
+    }
+
+    @Test
+    public void testUnstableElementSize()
+    {
+        AtomicLong elementSizeToReport = new AtomicLong();
+        DynamicSizeBoundQueue<String> queue = new DynamicSizeBoundQueue<>(3, ignored -> elementSizeToReport.get());
+
+        elementSizeToReport.set(1);
+        assertThat(queue.offer("a")).isTrue();
+        assertThat(queue.getSize()).isEqualTo(1);
+
+        elementSizeToReport.set(100);
+        assertThat(queue.poll()).isEqualTo("a");
+        assertThat(queue.getSize())
+                .as("Even though the element size reported a new value, the original element size is respected")
+                .isZero();
+
+        elementSizeToReport.set(1);
+        assertThat(queue.offer("b")).isTrue();
+        assertThat(queue.getSize()).isEqualTo(1);
+
+        elementSizeToReport.set(10);
+        assertThat(queue.offer("c")).isTrue();
+        assertThat(queue.getSize()).isEqualTo(11);
+
+        elementSizeToReport.set(5);
+        assertThat(queue.poll()).isEqualTo("b");
+        assertThat(queue.getSize())
+                .as("Even though the element size reported a new value, the original element size is respected")
+                .isEqualTo(10);
+
+        elementSizeToReport.set(-1);
+        assertThat(queue.poll()).isEqualTo("c");
+        assertThat(queue.getSize())
+                .as("Even though the element size reported a new negative value, the original element size is respected")
+                .isZero();
+    }
+
+    @Test
+    public void testNullElement()
+    {
+        DynamicSizeBoundQueue<String> queue = new DynamicSizeBoundQueue<>(1, value -> 1);
+        assertThatThrownBy(() -> queue.offer(null))
+                .as("Queue does not permit null elements, even if the element size function does")
+                .isInstanceOf(NullPointerException.class);
+
+        assertThat(queue.getSize())
+                .as("Queue size should not be changed after failing on a null element")
+                .isZero();
+    }
+
+    @Test
+    public void testBlockingOffer()
+            throws ExecutionException, InterruptedException, TimeoutException
+    {
+        CountDownLatch awaitDequeueLatch = new CountDownLatch(1);
+        DynamicSizeBoundQueue<String> queue = new DynamicSizeBoundQueue<>(3, String::length)
+        {
+            @Override
+            void preDequeueAwaitHook()
+            {
+                awaitDequeueLatch.countDown();
+            }
+        };
+
+        assertThat(queue.offer("aaa"))
+                .as("Fill the queue")
+                .isTrue();
+
+        ListenableFuture<Boolean> offerFuture = executorService.submit(() -> queue.offer("b", 10, TimeUnit.SECONDS));
+
+        // Wait for the offering thread to block for space
+        Uninterruptibles.awaitUninterruptibly(awaitDequeueLatch, 10, TimeUnit.SECONDS);
+        assertThat(offerFuture.isDone()).isFalse();
+
+        assertThat(queue.poll())
+                .as("Create space in the queue")
+                .isEqualTo("aaa");
+
+        assertThat(offerFuture.get(10, TimeUnit.SECONDS))
+                .as("Offer should complete quickly once space becomes available")
+                .isTrue();
+        assertThat(queue.poll())
+                .as("Should be able to extract the new element from the queue")
+                .isEqualTo("b");
+    }
+
+    @Test
+    public void testBlockingOfferTimeout()
+            throws ExecutionException, InterruptedException, TimeoutException
+    {
+        DynamicSizeBoundQueue<String> queue = new DynamicSizeBoundQueue<>(3, String::length);
+
+        assertThat(queue.offer("aaa"))
+                .as("Fill the queue")
+                .isTrue();
+
+        ListenableFuture<Boolean> offerFuture = executorService.submit(() -> queue.offer("b", 10, TimeUnit.MILLISECONDS));
+
+        assertThat(offerFuture.get(10, TimeUnit.SECONDS))
+                .as("Offer should timeout")
+                .isFalse();
+        assertThat(queue.getSize())
+                .as("Queue size should remain the same")
+                .isEqualTo(3);
+    }
+
+    @Test
+    public void testPut()
+            throws ExecutionException, InterruptedException, TimeoutException
+    {
+        CountDownLatch awaitDequeueLatch = new CountDownLatch(1);
+        DynamicSizeBoundQueue<String> queue = new DynamicSizeBoundQueue<>(3, String::length)
+        {
+            @Override
+            void preDequeueAwaitHook()
+            {
+                awaitDequeueLatch.countDown();
+            }
+        };
+
+        assertThat(queue.offer("aaa"))
+                .as("Fill the queue")
+                .isTrue();
+
+        ListenableFuture<?> putFuture = executorService.submit(() -> {
+            try {
+                queue.put("b");
+            }
+            catch (InterruptedException e) {
+                fail("Interrupted");
+            }
+        });
+
+        // Wait for the offering thread to block for space
+        Uninterruptibles.awaitUninterruptibly(awaitDequeueLatch, 10, TimeUnit.SECONDS);
+        assertThat(putFuture.isDone()).isFalse();
+
+        assertThat(queue.poll())
+                .as("Create space in the queue")
+                .isEqualTo("aaa");
+
+        // Put should complete quickly once space becomes available
+        putFuture.get(10, TimeUnit.SECONDS);
+        assertThat(queue.poll())
+                .as("Should be able to extract the new element from the queue")
+                .isEqualTo("b");
+    }
+
+    @Test
+    public void testOfferWithBackoff()
+    {
+        DynamicSizeBoundQueue<String> queue = new DynamicSizeBoundQueue<>(3, String::length);
+
+        for (int i = 0; i < 3; i++) {
+            assertThat(queue.offerWithBackoff("a"))
+                    .as("No backoff returned while space exists")
+                    .isEmpty();
+        }
+        assertThat(queue.getSize())
+                .as("Queue is at capacity")
+                .isEqualTo(queue.getMaxSize());
+
+        Optional<ListenableFuture<Void>> backoffResult1 = queue.offerWithBackoff("b");
+        assertThat(backoffResult1)
+                .as("Queue should provide a backoff future when at capacity")
+                .isPresent();
+        assertThat(backoffResult1.get()).isNotDone();
+
+        Optional<ListenableFuture<Void>> backoffResult2 = queue.offerWithBackoff("c");
+        assertThat(backoffResult2)
+                .as("Queue should provide a backoff future when at capacity")
+                .isPresent();
+        assertThat(backoffResult2.get()).isNotDone();
+
+        assertThat(queue.poll())
+                .as("Dequeue an element to make some space")
+                .isEqualTo("a");
+        assertThat(queue.getSize())
+                .as("Space is now available")
+                .isLessThan(queue.getMaxSize());
+
+        // Both backoff futures should complete when any space is made available
+        assertThat(backoffResult1.get()).isDone();
+        assertThat(backoffResult2.get()).isDone();
+    }
+
+    @Test
+    public void testBlockingPoll()
+            throws ExecutionException, InterruptedException, TimeoutException
+    {
+        CountDownLatch awaitEnqueueLatch = new CountDownLatch(1);
+        DynamicSizeBoundQueue<String> queue = new DynamicSizeBoundQueue<>(3, String::length)
+        {
+            @Override
+            void preEnqueueAwaitHook()
+            {
+                awaitEnqueueLatch.countDown();
+            }
+        };
+
+        ListenableFuture<String> pollFuture = executorService.submit(() -> queue.poll(10, TimeUnit.SECONDS));
+
+        // Wait for the polling thread to block for data
+        Uninterruptibles.awaitUninterruptibly(awaitEnqueueLatch, 10, TimeUnit.SECONDS);
+        assertThat(pollFuture.isDone()).isFalse();
+
+        queue.offer("a");
+        assertThat(pollFuture.get(10, TimeUnit.SECONDS))
+                .as("Should be able to extract new element as soon as it is added")
+                .isEqualTo("a");
+    }
+
+    @Test
+    public void testBlockingPollTimeout()
+            throws ExecutionException, InterruptedException, TimeoutException
+    {
+        DynamicSizeBoundQueue<String> queue = new DynamicSizeBoundQueue<>(3, String::length);
+
+        ListenableFuture<String> pollFuture = executorService.submit(() -> queue.poll(10, TimeUnit.MILLISECONDS));
+
+        assertThat(pollFuture.get(10, TimeUnit.SECONDS))
+                .as("Should timeout awaiting a new element")
+                .isNull();
+    }
+
+    @Test
+    public void testTake()
+            throws ExecutionException, InterruptedException, TimeoutException
+    {
+        CountDownLatch awaitEnqueueLatch = new CountDownLatch(1);
+        DynamicSizeBoundQueue<String> queue = new DynamicSizeBoundQueue<>(3, String::length)
+        {
+            @Override
+            void preEnqueueAwaitHook()
+            {
+                awaitEnqueueLatch.countDown();
+            }
+        };
+
+        ListenableFuture<String> takeFuture = executorService.submit(() -> {
+            try {
+                return queue.take();
+            }
+            catch (InterruptedException e) {
+                throw new AssertionError(e);
+            }
+        });
+
+        // Wait for the polling thread to block for a new element
+        Uninterruptibles.awaitUninterruptibly(awaitEnqueueLatch, 10, TimeUnit.SECONDS);
+        assertThat(takeFuture.isDone()).isFalse();
+
+        assertThat(queue.offer("a"))
+                .as("Insert new element")
+                .isTrue();
+
+        assertThat(takeFuture.get(10, TimeUnit.SECONDS))
+                .as("Take should return quickly once a new element becomes available")
+                .isEqualTo("a");
+    }
+
+    @Test
+    public void testConcurrency()
+            throws ExecutionException, InterruptedException, TimeoutException
+    {
+        DynamicSizeBoundQueue<String> queue = new DynamicSizeBoundQueue<>(3, String::length);
+
+        // Concurrent spin loop submissions
+        for (int i = 0; i < 10; i++) {
+            executorService.execute(() -> {
+                int offered = 0;
+                while (offered < 200) {
+                    if (queue.offer("a")) {
+                        offered++;
+                    }
+                }
+            });
+        }
+        int spinLoopSubmissions = 10 * 200;
+
+        // Concurrent blocking offer submissions
+        for (int i = 0; i < 10; i++) {
+            executorService.execute(() -> {
+                try {
+                    int offered = 0;
+                    while (offered < 200) {
+                        if (queue.offer("bb", 100, TimeUnit.MILLISECONDS)) {
+                            offered++;
+                        }
+                    }
+                }
+                catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    fail("Interrupted");
+                }
+            });
+        }
+        int blockingOfferSubmissions = 10 * 200;
+
+        // Concurrent blocking put submissions
+        for (int i = 0; i < 10; i++) {
+            executorService.execute(() -> {
+                for (int j = 0; j < 200; j++) {
+                    try {
+                        queue.put("ccc");
+                    }
+                    catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        fail("Interrupted");
+                    }
+                }
+            });
+        }
+        int blockingPutSubmissions = 10 * 200;
+
+        // Concurrent force put submissions
+        for (int i = 0; i < 10; i++) {
+            executorService.execute(() -> {
+                for (int j = 0; j < 200; j++) {
+                    queue.forcePut("d");
+                }
+            });
+        }
+        int forcePutSubmissions = 10 * 200;
+
+        // Concurrent backoff future submissions
+        for (int i = 0; i < 10; i++) {
+            executorService.execute(() -> {
+                for (int j = 0; j < 200; j++) {
+                    Optional<ListenableFuture<Void>> backoffFuture = queue.offerWithBackoff("ee");
+                    while (backoffFuture.isPresent()) {
+                        Futures.getUnchecked(backoffFuture.get());
+                        backoffFuture = queue.offerWithBackoff("ee");
+                    }
+                }
+            });
+        }
+        int backoffFutureSubmissions = 10 * 200;
+
+        int totalSubmissions = spinLoopSubmissions + blockingOfferSubmissions + blockingPutSubmissions + forcePutSubmissions + backoffFutureSubmissions;
+
+        // Concurrent element pollers
+        List<ListenableFuture<?>> pollFutures = new ArrayList<>();
+        ConcurrentHashMultiset<String> dequeued = ConcurrentHashMultiset.create();
+        for (int i = 0; i < 10; i++) {
+            pollFutures.add(executorService.submit(() -> {
+                try {
+                    while (dequeued.size() < totalSubmissions) {
+                        Optional.ofNullable(queue.poll(1, TimeUnit.MILLISECONDS))
+                                .ifPresent(dequeued::add);
+                    }
+                }
+                catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    fail("Interrupted");
+                }
+            }));
+        }
+
+        // Await polling the expected number of results
+        Futures.allAsList(pollFutures).get(10, TimeUnit.SECONDS);
+
+        assertThat(queue.getSize())
+                .as("Queue should be empty after pulling everything out")
+                .isZero();
+        assertThat(dequeued.size()).isEqualTo(totalSubmissions);
+        assertThat(dequeued.count("a")).isEqualTo(spinLoopSubmissions);
+        assertThat(dequeued.count("bb")).isEqualTo(blockingOfferSubmissions);
+        assertThat(dequeued.count("ccc")).isEqualTo(blockingPutSubmissions);
+        assertThat(dequeued.count("d")).isEqualTo(forcePutSubmissions);
+        assertThat(dequeued.count("ee")).isEqualTo(backoffFutureSubmissions);
+    }
+}


### PR DESCRIPTION
Size constrained queue that utilizes a dynamic element size function. To prevent starvation for adding large elements, the queue will only block new elements if the total size has already been reached or exceeded. This means in the normal case, the queue should be no larger than the max size plus the size of one element. Callers also have the additional option to force insert further elements without regard for size constraints. In the current implementation, elements are required to have positive sizes (they cannot have zero size).