### PR TITLE
Update logback to 1.4.14

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,7 @@
 - Update jersey to 3.1.3
 - Update jaxb to 4.0.4
 - Update airlift units to 1.10
+- Upgrade logback to 1.4.14
 
 239
 

--- a/http-client/src/main/java/io/airlift/http/client/jetty/DefaultHttpClientLogger.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/DefaultHttpClientLogger.java
@@ -163,12 +163,12 @@ class DefaultHttpClientLogger
         private void flush()
         {
             try {
-                lock.lock();
+                streamWriteLock.lock();
                 try {
                     getOutputStream().flush();
                 }
                 finally {
-                    lock.unlock();
+                    streamWriteLock.unlock();
                 }
             }
             catch (IOException e) {

--- a/http-server/src/main/java/io/airlift/http/server/DelimitedRequestLog.java
+++ b/http-server/src/main/java/io/airlift/http/server/DelimitedRequestLog.java
@@ -200,12 +200,12 @@ class DelimitedRequestLog
         private void flush()
         {
             try {
-                lock.lock();
+                streamWriteLock.lock();
                 try {
                     getOutputStream().flush();
                 }
                 finally {
-                    lock.unlock();
+                    streamWriteLock.unlock();
                 }
             }
             catch (IOException e) {

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,7 @@
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
         <dep.jersey.version>3.1.3</dep.jersey.version>
         <dep.jjwt.version>0.12.3</dep.jjwt.version>
+        <dep.logback.version>1.4.14</dep.logback.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
This latest version addresses two CVEs: https://logback.qos.ch/news.html#1.3.14

The `lock` field has been renamed in 1.4.9 (https://github.com/qos-ch/logback/commit/457a64c64edb78e9b5ce18727157fa56f8bf37ab) to address https://jira.qos.ch/projects/LOGBACK/issues/LOGBACK-1754.

I tested this locally with Trino by running the `suite-1` product test suite.