### PR TITLE
Sanitize dashes in metric names

### DIFF
--- a/openmetrics/src/main/java/io/airlift/openmetrics/MetricsResource.java
+++ b/openmetrics/src/main/java/io/airlift/openmetrics/MetricsResource.java
@@ -245,7 +245,8 @@ public class MetricsResource
                 .replace("$", "_")
                 .replace(":", "_")
                 .replace("=", "_")
-                .replace(",", "_");
+                .replace(",", "_")
+                .replace("-", "_");
     }
 
     private List<Metric> getMetricsRecursively(String prefix, ManagedClass managedClass)


### PR DESCRIPTION
Metric names cannot contain `-` in prometheus: 
https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels

Notes:
Colons are already sanitized as they are reserved for defining recording rules (ex. pre aggregate some metrics).

Datadog is more permissive:
https://docs.datadoghq.com/developers/guide/what-best-practices-are-recommended-for-naming-metrics-and-tags/