### PR TITLE
NodeConfig errors display regex that's supposed to match

### DIFF
--- a/node/src/main/java/io/airlift/node/NodeConfig.java
+++ b/node/src/main/java/io/airlift/node/NodeConfig.java
@@ -29,8 +29,11 @@ import java.net.InetAddress;
 public class NodeConfig
 {
     public static final String ID_REGEXP = "[A-Za-z0-9][_A-Za-z0-9-]*";
+    public static final String ID_REGEXP_ERROR = "should match " + ID_REGEXP;
     public static final String ENV_REGEXP = "[a-z0-9][_a-z0-9]*";
+    public static final String ENV_REGEXP_ERROR = "should match " + ENV_REGEXP;
     public static final String POOL_REGEXP = "[a-z0-9][_a-z0-9]*";
+    public static final String POOL_REGEXP_ERROR = "should match " + POOL_REGEXP;
 
     private String environment;
     private String pool = "general";
@@ -45,7 +48,7 @@ public class NodeConfig
     private String annotationFile;
 
     @NotNull
-    @Pattern(regexp = ENV_REGEXP, message = "is malformed")
+    @Pattern(regexp = ENV_REGEXP, message = ENV_REGEXP_ERROR)
     public String getEnvironment()
     {
         return environment;
@@ -59,7 +62,7 @@ public class NodeConfig
     }
 
     @NotNull
-    @Pattern(regexp = POOL_REGEXP, message = "is malformed")
+    @Pattern(regexp = POOL_REGEXP, message = POOL_REGEXP_ERROR)
     public String getPool()
     {
         return pool;
@@ -72,7 +75,7 @@ public class NodeConfig
         return this;
     }
 
-    @Pattern(regexp = ID_REGEXP, message = "is malformed")
+    @Pattern(regexp = ID_REGEXP, message = ID_REGEXP_ERROR)
     public String getNodeId()
     {
         return nodeId;

--- a/node/src/main/java/io/airlift/node/NodeInfo.java
+++ b/node/src/main/java/io/airlift/node/NodeInfo.java
@@ -95,14 +95,14 @@ public class NodeInfo
         requireNonNull(environment, "environment is null");
         requireNonNull(pool, "pool is null");
         requireNonNull(internalAddressSource, "internalAddressSource is null");
-        checkArgument(environment.matches(NodeConfig.ENV_REGEXP), "environment '%s' is invalid", environment);
-        checkArgument(pool.matches(NodeConfig.POOL_REGEXP), "pool '%s' is invalid", pool);
+        checkArgument(environment.matches(NodeConfig.ENV_REGEXP), "environment '%s' %s", environment, NodeConfig.ENV_REGEXP_ERROR);
+        checkArgument(pool.matches(NodeConfig.POOL_REGEXP), "pool '%s' %s", pool, NodeConfig.POOL_REGEXP_ERROR);
 
         this.environment = environment;
         this.pool = pool;
 
         if (nodeId != null) {
-            checkArgument(nodeId.matches(NodeConfig.ID_REGEXP), "nodeId '%s' is invalid", nodeId);
+            checkArgument(nodeId.matches(NodeConfig.ID_REGEXP), "nodeId '%s' %s", nodeId, NodeConfig.ID_REGEXP_ERROR);
             this.nodeId = nodeId;
         }
         else {

--- a/node/src/test/java/io/airlift/node/TestNodeConfig.java
+++ b/node/src/test/java/io/airlift/node/TestNodeConfig.java
@@ -94,11 +94,11 @@ public class TestNodeConfig
                 .setEnvironment("test")
                 .setNodeId(UUID.randomUUID().toString()));
 
-        assertFailsValidation(new NodeConfig().setNodeId("abc/123"), "nodeId", "is malformed", Pattern.class);
+        assertFailsValidation(new NodeConfig().setNodeId("abc/123"), "nodeId", "should match [A-Za-z0-9][_A-Za-z0-9-]*", Pattern.class);
 
         assertFailsValidation(new NodeConfig(), "environment", "must not be null", NotNull.class);
-        assertFailsValidation(new NodeConfig().setEnvironment("FOO"), "environment", "is malformed", Pattern.class);
+        assertFailsValidation(new NodeConfig().setEnvironment("FOO"), "environment", "should match [a-z0-9][_a-z0-9]*", Pattern.class);
 
-        assertFailsValidation(new NodeConfig().setPool("FOO"), "pool", "is malformed", Pattern.class);
+        assertFailsValidation(new NodeConfig().setPool("FOO"), "pool", "should match [a-z0-9][_a-z0-9]*", Pattern.class);
     }
 }


### PR DESCRIPTION
Currently node config errors shown when environment, pool or id have quite cryptic message: is malformed. I'd like to make this more readable, so I've added regex pattern that validates field to the message. 