### PR TITLE
Add support for escaping commas when passing list of strings

### DIFF
--- a/configuration/src/main/java/io/airlift/configuration/ConfigurationFactory.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigurationFactory.java
@@ -61,6 +61,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 
 import static com.google.common.base.CaseFormat.LOWER_CAMEL;
 import static com.google.common.base.CaseFormat.UPPER_CAMEL;
@@ -78,7 +79,7 @@ public class ConfigurationFactory
     private static final Validator VALIDATOR;
 
     private static final TypeToken<List<String>> LIST_OF_STRINGS_TYPE_TOKEN = new TypeToken<List<String>>() {};
-    private static final Splitter VALUE_SPLITTER = Splitter.on(",").omitEmptyStrings().trimResults();
+    private static final Splitter VALUE_SPLITTER = Splitter.on(Pattern.compile("(?<!\\\\),")).omitEmptyStrings().trimResults();
 
     static {
         ClassLoader currentClassLoader = Thread.currentThread().getContextClassLoader();
@@ -667,6 +668,7 @@ public class ConfigurationFactory
 
         if (LIST_OF_STRINGS_TYPE_TOKEN.isSubtypeOf(TypeToken.of(type))) {
             return VALUE_SPLITTER.splitToStream(value)
+                    .map((v) -> v.replaceAll("\\\\,", ","))
                     .collect(toImmutableList());
         }
 

--- a/configuration/src/main/java/io/airlift/configuration/ConfigurationLoader.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigurationLoader.java
@@ -17,9 +17,9 @@ package io.airlift.configuration;
 
 import com.google.common.collect.ImmutableSortedMap;
 
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
+import java.io.StringReader;
+import java.nio.file.Path;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
@@ -27,6 +27,9 @@ import java.util.TreeMap;
 
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.Maps.fromProperties;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.Files.readAllLines;
+import static java.util.stream.Collectors.joining;
 
 public final class ConfigurationLoader
 {
@@ -57,9 +60,10 @@ public final class ConfigurationLoader
             throws IOException
     {
         Properties properties = new Properties();
-        try (InputStream inputStream = new FileInputStream(path)) {
-            properties.load(inputStream);
-        }
+        String escapedProperties = readAllLines(Path.of(path), UTF_8).stream()
+                .map(line -> line.replaceAll("\\\\,", "\\\\\\\\,"))
+                .collect(joining("\n"));
+        properties.load(new StringReader(escapedProperties));
 
         return fromProperties(properties).entrySet().stream()
                 .collect(toImmutableMap(Entry::getKey, entry -> entry.getValue().trim()));

--- a/configuration/src/test/java/io/airlift/configuration/TestConfigurationFactory.java
+++ b/configuration/src/test/java/io/airlift/configuration/TestConfigurationFactory.java
@@ -402,6 +402,16 @@ public class TestConfigurationFactory
     }
 
     @Test
+    public void testListOfStringsWithEscapeCharacters()
+    {
+        TestMonitor monitor = new TestMonitor();
+        Injector injector = createInjector(ImmutableMap.of("values", "ala, m\\$a ,ko\\,ta, "), monitor, binder -> configBinder(binder).bindConfig(ListOfStringsClass.class));
+        assertEquals(injector.getInstance(ListOfStringsClass.class).getValues(), ImmutableList.of("ala", "m\\$a", "ko,ta"));
+        monitor.assertNumberOfErrors(0);
+        monitor.assertNumberOfWarnings(0);
+    }
+
+    @Test
     public void testValueOf()
     {
         TestMonitor monitor = new TestMonitor();

--- a/node/src/test/java/io/airlift/node/TestNodeInfo.java
+++ b/node/src/test/java/io/airlift/node/TestNodeInfo.java
@@ -125,7 +125,7 @@ public class TestNodeInfo
         new NodeInfo(ENVIRONMENT, "POOL", null, null, null, null, null, null, null, IP, null);
     }
 
-    @Test(expectedExceptions = UncheckedIOException.class, expectedExceptionsMessageRegExp = "java.io.FileNotFoundException: invalid.file \\(No such file or directory\\)")
+    @Test(expectedExceptions = UncheckedIOException.class, expectedExceptionsMessageRegExp = "java.nio.file.NoSuchFileException: invalid.file")
     public void testInvalidAnnotationFile()
     {
         new NodeInfo(ENVIRONMENT, POOL, "nodeInfo", null, null, null, null, null, null, IP, "invalid.file");

--- a/openmetrics/src/main/java/io/airlift/openmetrics/MetricsConfig.java
+++ b/openmetrics/src/main/java/io/airlift/openmetrics/MetricsConfig.java
@@ -32,7 +32,7 @@ public class MetricsConfig
     }
 
     @Config("openmetrics.jmx-object-names")
-    @ConfigDescription("JMX object names to include when retrieving all metrics.")
+    @ConfigDescription("Comma delimited JMX object names to include when retrieving all metrics. Commas in object names are escaped with a backslash.")
     public MetricsConfig setJmxObjectNames(List<String> jmxObjectNames)
     {
         ImmutableList.Builder<ObjectName> objectNames = ImmutableList.builder();

--- a/openmetrics/src/test/java/io/airlift/openmetrics/TestMetricsConfig.java
+++ b/openmetrics/src/test/java/io/airlift/openmetrics/TestMetricsConfig.java
@@ -33,11 +33,11 @@ public class TestMetricsConfig
     public void testExplicitPropertyMappings()
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
-                .put("openmetrics.jmx-object-names", "foo.bar:*,baz.bar:*")
+                .put("openmetrics.jmx-object-names", "foo.bar:name=baz\\,type=qux,baz.bar:*")
                 .build();
 
         MetricsConfig expected = new MetricsConfig()
-                .setJmxObjectNames(ImmutableList.of("foo.bar:*", "baz.bar:*"));
+                .setJmxObjectNames(ImmutableList.of("foo.bar:name=baz,type=qux", "baz.bar:*"));
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
When passing jmx object names with multiple properties, object names were incorrectly parsed and throws an `MalformedObjectNameException`

```
Caused by: javax.management.MalformedObjectNameException: Domain part must be specified
	at java.management/javax.management.ObjectName.construct(ObjectName.java:467)
	at java.management/javax.management.ObjectName.<init>(ObjectName.java:1405)
	at io.airlift.openmetrics.MetricsConfig.setJmxObjectNames(MetricsConfig.java:42)
	... 31 more
```