### PR TITLE
Enable legacy URI mode in Jetty and Servlets

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 243
 
 - Use pipe as separator for openmetrics object names config
+- Add support for Jetty legacy URI compliance
 
 242
 - Update airbase to 151

--- a/http-server/src/main/java/io/airlift/http/server/EnableLegacyUriCompliance.java
+++ b/http-server/src/main/java/io/airlift/http/server/EnableLegacyUriCompliance.java
@@ -1,0 +1,13 @@
+package io.airlift.http.server;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@BindingAnnotation
+public @interface EnableLegacyUriCompliance
+{
+}

--- a/http-server/src/main/java/io/airlift/http/server/HttpServer.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServer.java
@@ -102,7 +102,6 @@ public class HttpServer
     private final Server server;
     private final MonitoredQueuedThreadPoolMBean monitoredQueuedThreadPoolMBean;
     private final MonitoredQueuedThreadPoolMBean monitoredAdminQueuedThreadPoolMBean;
-    private final boolean showStackTrace;
     private final DelimitedRequestLog requestLog;
     private ConnectionStats httpConnectionStats;
     private ConnectionStats httpsConnectionStats;
@@ -154,7 +153,8 @@ public class HttpServer
         }
         server = new Server(threadPool);
         this.monitoredQueuedThreadPoolMBean = new MonitoredQueuedThreadPoolMBean(threadPool);
-        showStackTrace = config.isShowStackTrace();
+
+        boolean showStackTrace = config.isShowStackTrace();
 
         this.sslContextFactory = maybeSslContextFactory;
 

--- a/http-server/src/main/java/io/airlift/http/server/HttpServerBinder.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServerBinder.java
@@ -41,6 +41,16 @@ public class HttpServerBinder
         return this;
     }
 
+    /**
+     * @deprecated this will be removed in the near future and is only intended as a stopgap
+     */
+    @Deprecated(forRemoval = true)
+    public HttpServerBinder enableLegacyUriCompliance()
+    {
+        newOptionalBinder(binder, Key.get(Boolean.class, EnableLegacyUriCompliance.class)).setBinding().toInstance(true);
+        return this;
+    }
+
     private HttpResourceBinding bindResource(String baseUri,
             String classPathResourceBase,
             Class<? extends Annotation> annotationType)

--- a/http-server/src/main/java/io/airlift/http/server/HttpServerModule.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServerModule.java
@@ -72,6 +72,8 @@ public class HttpServerModule
         binder.bind(RequestStats.class).in(Scopes.SINGLETON);
         // override with HttpServerBinder.enableVirtualThreads()
         newOptionalBinder(binder, Key.get(Boolean.class, EnableVirtualThreads.class)).setDefault().toInstance(false);
+        // override with HttpServerBinder.enableLegacyUriCompliance()
+        newOptionalBinder(binder, Key.get(Boolean.class, EnableLegacyUriCompliance.class)).setDefault().toInstance(false);
         newSetBinder(binder, Filter.class, TheServlet.class);
         newSetBinder(binder, Filter.class, TheAdminServlet.class);
         newSetBinder(binder, HttpResourceBinding.class, TheServlet.class);

--- a/http-server/src/main/java/io/airlift/http/server/HttpServerProvider.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServerProvider.java
@@ -57,6 +57,7 @@ public class HttpServerProvider
     private Servlet theAdminServlet;
     private Map<String, String> adminServletInitParameters = ImmutableMap.of();
     private final boolean enableVirtualThreads;
+    private final boolean enableLegacyUriCompliance;
     private MBeanServer mbeanServer;
     private LoginService loginService;
     private final RequestStats stats;
@@ -76,6 +77,7 @@ public class HttpServerProvider
             @TheServlet Set<HttpResourceBinding> resources,
             @TheAdminServlet Set<Filter> adminFilters,
             @EnableVirtualThreads boolean enableVirtualThreads,
+            @EnableLegacyUriCompliance boolean enableLegacyUriCompliance,
             ClientCertificate clientCertificate,
             RequestStats stats,
             EventClient eventClient,
@@ -103,6 +105,7 @@ public class HttpServerProvider
         this.resources = ImmutableSet.copyOf(resources);
         this.adminFilters = ImmutableSet.copyOf(adminFilters);
         this.enableVirtualThreads = enableVirtualThreads;
+        this.enableLegacyUriCompliance = enableLegacyUriCompliance;
         this.clientCertificate = clientCertificate;
         this.stats = stats;
         this.eventClient = eventClient;
@@ -162,6 +165,7 @@ public class HttpServerProvider
                     adminServletInitParameters,
                     adminFilters,
                     enableVirtualThreads,
+                    enableLegacyUriCompliance,
                     clientCertificate,
                     mbeanServer,
                     loginService,

--- a/http-server/src/main/java/io/airlift/http/server/testing/TestingHttpServer.java
+++ b/http-server/src/main/java/io/airlift/http/server/testing/TestingHttpServer.java
@@ -18,6 +18,7 @@ package io.airlift.http.server.testing;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import io.airlift.event.client.NullEventClient;
+import io.airlift.http.server.EnableLegacyUriCompliance;
 import io.airlift.http.server.EnableVirtualThreads;
 import io.airlift.http.server.HttpServer;
 import io.airlift.http.server.HttpServerBinder.HttpResourceBinding;
@@ -50,7 +51,7 @@ public class TestingHttpServer
             @TheServlet Map<String, String> initParameters)
             throws IOException
     {
-        this(httpServerInfo, nodeInfo, config, servlet, initParameters, false);
+        this(httpServerInfo, nodeInfo, config, servlet, initParameters, false, false);
     }
 
     public TestingHttpServer(
@@ -59,7 +60,8 @@ public class TestingHttpServer
             HttpServerConfig config,
             @TheServlet Servlet servlet,
             @TheServlet Map<String, String> initParameters,
-            boolean enableVirtualThreads)
+            boolean enableVirtualThreads,
+            boolean enableLegacyUriCompliance)
             throws IOException
     {
         this(httpServerInfo,
@@ -71,6 +73,7 @@ public class TestingHttpServer
                 ImmutableSet.of(),
                 ImmutableSet.of(),
                 enableVirtualThreads,
+                enableLegacyUriCompliance,
                 ClientCertificate.NONE);
     }
 
@@ -85,6 +88,7 @@ public class TestingHttpServer
             @TheServlet Set<Filter> filters,
             @TheServlet Set<HttpResourceBinding> resources,
             @EnableVirtualThreads boolean enableVirtualThreads,
+            @EnableLegacyUriCompliance boolean enableLegacyUriCompliance,
             ClientCertificate clientCertificate)
             throws IOException
     {
@@ -100,6 +104,7 @@ public class TestingHttpServer
                 null,
                 ImmutableSet.of(),
                 enableVirtualThreads,
+                enableLegacyUriCompliance,
                 clientCertificate,
                 null,
                 null,

--- a/http-server/src/main/java/io/airlift/http/server/testing/TestingHttpServerModule.java
+++ b/http-server/src/main/java/io/airlift/http/server/testing/TestingHttpServerModule.java
@@ -18,6 +18,7 @@ import com.google.inject.Key;
 import com.google.inject.Scopes;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.airlift.discovery.client.AnnouncementHttpServerInfo;
+import io.airlift.http.server.EnableLegacyUriCompliance;
 import io.airlift.http.server.EnableVirtualThreads;
 import io.airlift.http.server.HttpServer;
 import io.airlift.http.server.HttpServer.ClientCertificate;
@@ -63,6 +64,8 @@ public class TestingHttpServerModule
         binder.bind(HttpServer.class).to(Key.get(TestingHttpServer.class));
         // override with HttpServerBinder.enableVirtualThreads()
         newOptionalBinder(binder, Key.get(Boolean.class, EnableVirtualThreads.class)).setDefault().toInstance(false);
+        // override with HttpServerBinder.enableLegacyUriCompliance()
+        newOptionalBinder(binder, Key.get(Boolean.class, EnableLegacyUriCompliance.class)).setDefault().toInstance(false);
         newSetBinder(binder, Filter.class, TheServlet.class);
         newSetBinder(binder, HttpResourceBinding.class, TheServlet.class);
         binder.bind(AnnouncementHttpServerInfo.class).to(LocalAnnouncementHttpServerInfo.class);

--- a/http-server/src/test/java/io/airlift/http/server/TestHttpServerCipher.java
+++ b/http-server/src/test/java/io/airlift/http/server/TestHttpServerCipher.java
@@ -227,6 +227,7 @@ public class TestHttpServerCipher
                 ImmutableSet.of(),
                 ImmutableSet.of(),
                 false,
+                false,
                 ClientCertificate.NONE,
                 new RequestStats(),
                 new NullEventClient(),

--- a/http-server/src/test/java/io/airlift/http/server/TestHttpServerProvider.java
+++ b/http-server/src/test/java/io/airlift/http/server/TestHttpServerProvider.java
@@ -679,6 +679,7 @@ public class TestHttpServerProvider
                 ImmutableSet.of(),
                 ImmutableSet.of(),
                 false,
+                false,
                 clientCertificate,
                 new RequestStats(),
                 new NullEventClient(),

--- a/http-server/src/test/java/io/airlift/http/server/TestJettyMultipleCerts.java
+++ b/http-server/src/test/java/io/airlift/http/server/TestJettyMultipleCerts.java
@@ -87,6 +87,7 @@ public class TestJettyMultipleCerts
                 ImmutableSet.of(),
                 ImmutableSet.of(),
                 false,
+                false,
                 ClientCertificate.NONE,
                 new RequestStats(),
                 new NullEventClient(),

--- a/http-server/src/test/java/io/airlift/http/server/testing/AbstractTestTestingHttpServer.java
+++ b/http-server/src/test/java/io/airlift/http/server/testing/AbstractTestTestingHttpServer.java
@@ -75,10 +75,12 @@ import static org.testng.Assert.assertTrue;
 public abstract class AbstractTestTestingHttpServer
 {
     private final boolean enableVirtualThreads;
+    private final boolean enableLegacyUriCompliance;
 
-    AbstractTestTestingHttpServer(boolean enableVirtualThreads)
+    AbstractTestTestingHttpServer(boolean enableVirtualThreads, boolean enableLegacyUriCompliance)
     {
         this.enableVirtualThreads = enableVirtualThreads;
+        this.enableLegacyUriCompliance = enableLegacyUriCompliance;
     }
 
     @BeforeSuite
@@ -94,7 +96,7 @@ public abstract class AbstractTestTestingHttpServer
         skipUnlessJdkHasVirtualThreads();
         DummyServlet servlet = new DummyServlet();
         Map<String, String> params = ImmutableMap.of("sampleInitParameter", "the value");
-        TestingHttpServer server = createTestingHttpServer(enableVirtualThreads, servlet, params);
+        TestingHttpServer server = createTestingHttpServer(enableVirtualThreads, enableLegacyUriCompliance, servlet, params);
 
         try {
             server.start();
@@ -112,7 +114,7 @@ public abstract class AbstractTestTestingHttpServer
     {
         skipUnlessJdkHasVirtualThreads();
         DummyServlet servlet = new DummyServlet();
-        TestingHttpServer server = createTestingHttpServer(enableVirtualThreads, servlet, ImmutableMap.of());
+        TestingHttpServer server = createTestingHttpServer(enableVirtualThreads, enableLegacyUriCompliance, servlet, ImmutableMap.of());
 
         try {
             server.start();
@@ -136,7 +138,7 @@ public abstract class AbstractTestTestingHttpServer
         skipUnlessJdkHasVirtualThreads();
         DummyServlet servlet = new DummyServlet();
         DummyFilter filter = new DummyFilter();
-        TestingHttpServer server = createTestingHttpServerWithFilter(enableVirtualThreads, servlet, ImmutableMap.of(), filter);
+        TestingHttpServer server = createTestingHttpServerWithFilter(enableVirtualThreads, enableLegacyUriCompliance, servlet, ImmutableMap.of(), filter);
 
         try {
             server.start();
@@ -288,22 +290,22 @@ public abstract class AbstractTestTestingHttpServer
         assertEquals(data.getBody().trim(), contents);
     }
 
-    private static TestingHttpServer createTestingHttpServer(boolean enableVirtualThreads, DummyServlet servlet, Map<String, String> params)
+    private static TestingHttpServer createTestingHttpServer(boolean enableVirtualThreads, boolean enableLegacyUriCompliance, DummyServlet servlet, Map<String, String> params)
             throws IOException
     {
         NodeInfo nodeInfo = new NodeInfo("test");
         HttpServerConfig config = new HttpServerConfig().setHttpPort(0);
         HttpServerInfo httpServerInfo = new HttpServerInfo(config, nodeInfo);
-        return new TestingHttpServer(httpServerInfo, nodeInfo, config, servlet, params, enableVirtualThreads);
+        return new TestingHttpServer(httpServerInfo, nodeInfo, config, servlet, params, enableVirtualThreads, enableLegacyUriCompliance);
     }
 
-    private static TestingHttpServer createTestingHttpServerWithFilter(boolean enableVirtualThreads, DummyServlet servlet, Map<String, String> params, DummyFilter filter)
+    private static TestingHttpServer createTestingHttpServerWithFilter(boolean enableVirtualThreads, boolean enableLegacyUriCompliance, DummyServlet servlet, Map<String, String> params, DummyFilter filter)
             throws IOException
     {
         NodeInfo nodeInfo = new NodeInfo("test");
         HttpServerConfig config = new HttpServerConfig().setHttpPort(0);
         HttpServerInfo httpServerInfo = new HttpServerInfo(config, nodeInfo);
-        return new TestingHttpServer(httpServerInfo, nodeInfo, config, Optional.empty(), servlet, params, ImmutableSet.of(filter), ImmutableSet.of(), enableVirtualThreads, ClientCertificate.NONE);
+        return new TestingHttpServer(httpServerInfo, nodeInfo, config, Optional.empty(), servlet, params, ImmutableSet.of(filter), ImmutableSet.of(), enableVirtualThreads, enableLegacyUriCompliance, ClientCertificate.NONE);
     }
 
     static class DummyServlet

--- a/http-server/src/test/java/io/airlift/http/server/testing/TestTestingHttpServer.java
+++ b/http-server/src/test/java/io/airlift/http/server/testing/TestTestingHttpServer.java
@@ -20,6 +20,6 @@ public class TestTestingHttpServer
 {
     TestTestingHttpServer()
     {
-        super(false);
+        super(false, false);
     }
 }

--- a/http-server/src/test/java/io/airlift/http/server/testing/TestTestingHttpServerWithAllEnabled.java
+++ b/http-server/src/test/java/io/airlift/http/server/testing/TestTestingHttpServerWithAllEnabled.java
@@ -1,0 +1,10 @@
+package io.airlift.http.server.testing;
+
+public class TestTestingHttpServerWithAllEnabled
+        extends AbstractTestTestingHttpServer
+{
+    TestTestingHttpServerWithAllEnabled()
+    {
+        super(true, true);
+    }
+}

--- a/http-server/src/test/java/io/airlift/http/server/testing/TestTestingHttpServerWithLegacyUriCompliance.java
+++ b/http-server/src/test/java/io/airlift/http/server/testing/TestTestingHttpServerWithLegacyUriCompliance.java
@@ -1,0 +1,10 @@
+package io.airlift.http.server.testing;
+
+public class TestTestingHttpServerWithLegacyUriCompliance
+        extends AbstractTestTestingHttpServer
+{
+    TestTestingHttpServerWithLegacyUriCompliance()
+    {
+        super(false, true);
+    }
+}

--- a/http-server/src/test/java/io/airlift/http/server/testing/TestTestingHttpServerWithVirtualThreads.java
+++ b/http-server/src/test/java/io/airlift/http/server/testing/TestTestingHttpServerWithVirtualThreads.java
@@ -20,6 +20,6 @@ public class TestTestingHttpServerWithVirtualThreads
 {
     TestTestingHttpServerWithVirtualThreads()
     {
-        super(true);
+        super(true, false);
     }
 }

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -115,6 +115,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>node</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
             <scope>runtime</scope>

--- a/jaxrs/src/test/java/io/airlift/jaxrs/TestLegacyUriMode.java
+++ b/jaxrs/src/test/java/io/airlift/jaxrs/TestLegacyUriMode.java
@@ -1,0 +1,114 @@
+package io.airlift.jaxrs;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.BindingAnnotation;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import io.airlift.bootstrap.Bootstrap;
+import io.airlift.bootstrap.LifeCycleManager;
+import io.airlift.http.client.FullJsonResponseHandler.JsonResponse;
+import io.airlift.http.client.HttpClient;
+import io.airlift.http.client.HttpStatus;
+import io.airlift.http.client.Request;
+import io.airlift.http.server.HttpServerInfo;
+import io.airlift.http.server.testing.TestingHttpServerModule;
+import io.airlift.json.JsonModule;
+import io.airlift.node.testing.TestingNodeModule;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import org.testng.annotations.Test;
+
+import java.lang.annotation.Retention;
+import java.net.URI;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import static io.airlift.http.client.FullJsonResponseHandler.createFullJsonResponseHandler;
+import static io.airlift.http.client.HttpClientBinder.httpClientBinder;
+import static io.airlift.http.client.Request.Builder.prepareGet;
+import static io.airlift.http.server.HttpServerBinder.httpServerBinder;
+import static io.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
+import static io.airlift.json.JsonCodec.listJsonCodec;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.testng.Assert.assertEquals;
+
+public class TestLegacyUriMode
+{
+    @Path("/legacy")
+    public static class MyResource
+    {
+        @GET
+        @Path("test1/{a:.*}/{b:.*}/{c:.*}")
+        public List<String> test1(@PathParam("a") String a, @PathParam("b") String b, @PathParam("c") String c)
+        {
+            return ImmutableList.of("test1", a, b, c);
+        }
+
+        @GET
+        @Path("test2/{a}/{b}/{c}")
+        public List<String> test(@PathParam("a") String a, @PathParam("b") String b, @PathParam("c") String c)
+        {
+            return ImmutableList.of("test2", a, b, c);
+        }
+    }
+
+    @Retention(RUNTIME)
+    @BindingAnnotation
+    public @interface ForTest {}
+
+    @Test
+    public void testLegacyUriModeDisabled()
+    {
+        doTest(false,
+                new Tester("/legacy/test1/one%2ftwo/%2f/three", response -> assertEquals(response.getStatusCode(), HttpStatus.BAD_REQUEST.code())),
+                new Tester("/legacy/test2/one%2ftwo/%2f/three", response -> assertEquals(response.getStatusCode(), HttpStatus.BAD_REQUEST.code())));
+    }
+
+    @Test
+    public void testLegacyUriMode()
+    {
+        doTest(true,
+                new Tester("/legacy/test1/one%2ftwo/%2f/three", response -> assertEquals(response.getValue(), ImmutableList.of("test1", "one/two", "/", "three"))),
+                new Tester("/legacy/test2/one%2ftwo/%2f/three", response -> assertEquals(response.getValue(), ImmutableList.of("test2", "one/two", "/", "three"))));
+    }
+
+    private record Tester(String path, Consumer<JsonResponse<List<String>>> responseConsumer) {}
+
+    private void doTest(boolean legacyUriComplianceEnabled, Tester... testers)
+    {
+        Injector injector = startServer(legacyUriComplianceEnabled);
+        try {
+            HttpClient httpClient = injector.getInstance(Key.get(HttpClient.class, ForTest.class));
+            URI baseuri = injector.getInstance(HttpServerInfo.class).getHttpUri();
+
+            Stream.of(testers).forEach(tester -> {
+                Request request = prepareGet().setUri(baseuri.resolve(tester.path)).build();
+                tester.responseConsumer.accept(httpClient.execute(request, createFullJsonResponseHandler(listJsonCodec(String.class))));
+            });
+        }
+        finally {
+            injector.getInstance(LifeCycleManager.class).stop();
+        }
+    }
+
+    @SuppressWarnings("removal")
+    private Injector startServer(boolean legacyUriComplianceEnabled)
+    {
+        return new Bootstrap(
+                binder -> {
+                    jaxrsBinder(binder).bind(MyResource.class);
+                    httpClientBinder(binder).bindHttpClient("test", ForTest.class);
+                    if (legacyUriComplianceEnabled) {
+                        httpServerBinder(binder).enableLegacyUriCompliance();
+                    }
+                },
+                new TestingNodeModule(),
+                new TestingHttpServerModule(),
+                new JaxrsModule(),
+                new JsonModule())
+                .quiet()
+                .initialize();
+    }
+}


### PR DESCRIPTION
Latest versions of Servlet/Jetty specs disallow encoded slashes in paths. However, there is a legacy mode currently that turns off the compliance validation for this and, thus, allows encoded slashes to work as they have in the past. Enable this legacy mode and add a JAX-RS test to make sure it's passed through.