### PR TITLE
Skip Object defined methods in configuration classes

### DIFF
--- a/configuration/src/main/java/io/airlift/configuration/ConfigurationMetadata.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigurationMetadata.java
@@ -658,7 +658,7 @@ public class ConfigurationMetadata<T>
         // this returns everything, even if it's declared in a parent
         for (Method method : configClass.getMethods()) {
             // skip methods that are used internally by the vm for implementing covariance, etc
-            if (method.isSynthetic() || method.isBridge() || Modifier.isStatic(method.getModifiers())) {
+            if (method.isSynthetic() || method.isBridge() || Modifier.isStatic(method.getModifiers()) || method.getDeclaringClass().equals(Object.class)) {
                 continue;
             }
 


### PR DESCRIPTION
This skips checking if methods from Object are annotated which causes NoSuchMethodException being thrown multiple times for every object, which forces JVM to construct a stacktrace, which is costly.