### PR TITLE
Fix setting limits JSON reader limits

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@
 
 - Use pipe as separator for openmetrics object names config
 - Add support for Jetty legacy URI compliance
+- Fix deserializing JSON with large keys
 
 242
 - Update airbase to 151

--- a/json/src/main/java/io/airlift/json/ObjectMapperProvider.java
+++ b/json/src/main/java/io/airlift/json/ObjectMapperProvider.java
@@ -17,6 +17,7 @@ package io.airlift.json;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonFactoryBuilder;
 import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.fasterxml.jackson.core.StreamWriteConstraints;
 import com.fasterxml.jackson.core.Version;
@@ -63,15 +64,18 @@ public class ObjectMapperProvider
     @Inject
     public ObjectMapperProvider()
     {
-        this(new JsonFactory());
+        this(new JsonFactoryBuilder());
     }
 
     public ObjectMapperProvider(JsonFactory jsonFactory)
     {
-        this.jsonFactory = requireNonNull(jsonFactory, "jsonFactory is null");
+        this(new JsonFactoryBuilder(requireNonNull(jsonFactory, "jsonFactory is null")));
+    }
 
+    private ObjectMapperProvider(JsonFactoryBuilder jsonFactoryBuilder)
+    {
         // Disable the length limit, caller will be responsible for validating the input length
-        jsonFactory.setStreamReadConstraints(StreamReadConstraints
+        jsonFactoryBuilder.streamReadConstraints(StreamReadConstraints
                 .builder()
                 .maxStringLength(Integer.MAX_VALUE)
                 .maxNestingDepth(Integer.MAX_VALUE)
@@ -79,10 +83,12 @@ public class ObjectMapperProvider
                 .maxDocumentLength(Long.MAX_VALUE)
                 .build());
 
-        jsonFactory.setStreamWriteConstraints(StreamWriteConstraints
+        jsonFactoryBuilder.streamWriteConstraints(StreamWriteConstraints
                 .builder()
                 .maxNestingDepth(Integer.MAX_VALUE)
                 .build());
+
+        jsonFactory = jsonFactoryBuilder.build();
 
         modules.add(new Jdk8Module());
         modules.add(new JavaTimeModule());

--- a/json/src/test/java/io/airlift/json/TestLimits.java
+++ b/json/src/test/java/io/airlift/json/TestLimits.java
@@ -1,0 +1,67 @@
+package io.airlift.json;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Strings;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestLimits
+{
+    @Test
+    public void testNameLimitDefaultJsonFactory()
+            throws IOException
+    {
+        testNameLengthLimit(new ObjectMapperProvider());
+    }
+
+    @Test
+    public void testNameLimitCustomJsonFactory()
+            throws IOException
+    {
+        JsonFactory myJsonFactory = new JsonFactory();
+        testNameLengthLimit(new ObjectMapperProvider(myJsonFactory));
+    }
+
+    private void testNameLengthLimit(ObjectMapperProvider objectMapperProvider)
+            throws IOException
+    {
+        ObjectMapper objectMapper = objectMapperProvider.get();
+        String longName = Strings.repeat("a", 100000);
+
+        String content = String.format("{ \"%s\" : \"value\" }", longName);
+        JsonNode jsonNode = objectMapper.reader().readTree(content);
+        assertThat(jsonNode.has(longName)).isTrue();
+        assertThat(jsonNode.findValue(longName).asText()).isEqualTo("value");
+    }
+
+    @Test
+    public void testStringLimitDefaultJsonFactory()
+            throws IOException
+    {
+        testNameLengthLimit(new ObjectMapperProvider());
+    }
+
+    @Test
+    public void testStringLimitCustomJsonFactory()
+            throws IOException
+    {
+        JsonFactory myJsonFactory = new JsonFactory();
+        testNameLengthLimit(new ObjectMapperProvider(myJsonFactory));
+    }
+
+    private void testStringLengthLimit(ObjectMapperProvider objectMapperProvider)
+            throws IOException
+    {
+        ObjectMapper objectMapper = objectMapperProvider.get();
+        String longValue = Strings.repeat("a", 100000);
+
+        String content = String.format("{ \"key\" : \"%s\" }", longValue);
+        JsonNode jsonNode = objectMapper.reader().readTree(content);
+        assertThat(jsonNode.findValue("key").asText()).isEqualTo(longValue);
+    }
+}


### PR DESCRIPTION
If limits are set via setStreamReadConstraints on JsonFactory it is not effective for maxStringLength and maxNameLenght.
Those are checked via _rootCharSymbols field of JsonFactory which has a copy of StreamReadConstraints, as of when JsonFactory was created. It is not reset when we call setStreamReadConstraints on JsonFactory.