### PR TITLE
Update Jackson to 2.17.0

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 243
 
 - Use pipe as separator for openmetrics object names config
+- Update jackson to 2.17.0
 
 242
 - Update airbase to 151

--- a/json/src/test/java/io/airlift/json/TestLimits.java
+++ b/json/src/test/java/io/airlift/json/TestLimits.java
@@ -1,0 +1,67 @@
+package io.airlift.json;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Strings;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestLimits
+{
+    @Test
+    public void testNameLimitDefaultJsonFactory()
+            throws IOException
+    {
+        testNameLengthLimit(new ObjectMapperProvider());
+    }
+
+    @Test
+    public void testNameLimitCustomJsonFactory()
+            throws IOException
+    {
+        JsonFactory myJsonFactory = new JsonFactory();
+        testNameLengthLimit(new ObjectMapperProvider(myJsonFactory));
+    }
+
+    private void testNameLengthLimit(ObjectMapperProvider objectMapperProvider)
+            throws IOException
+    {
+        ObjectMapper objectMapper = objectMapperProvider.get();
+        String longName = Strings.repeat("a", 100000);
+
+        String content = String.format("{ \"%s\" : \"value\" }", longName);
+        JsonNode jsonNode = objectMapper.reader().readTree(content);
+        assertThat(jsonNode.has(longName)).isTrue();
+        assertThat(jsonNode.findValue(longName).asText()).isEqualTo("value");
+    }
+
+    @Test
+    public void testStringLimitDefaultJsonFactory()
+            throws IOException
+    {
+        testNameLengthLimit(new ObjectMapperProvider());
+    }
+
+    @Test
+    public void testStringLimitCustomJsonFactory()
+            throws IOException
+    {
+        JsonFactory myJsonFactory = new JsonFactory();
+        testNameLengthLimit(new ObjectMapperProvider(myJsonFactory));
+    }
+
+    private void testStringLengthLimit(ObjectMapperProvider objectMapperProvider)
+            throws IOException
+    {
+        ObjectMapper objectMapper = objectMapperProvider.get();
+        String longValue = Strings.repeat("a", 100000);
+
+        String content = String.format("{ \"key\" : \"%s\" }", longValue);
+        JsonNode jsonNode = objectMapper.reader().readTree(content);
+        assertThat(jsonNode.findValue("key").asText()).isEqualTo(longValue);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,8 @@
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
         <dep.jersey.version>3.1.5</dep.jersey.version>
         <dep.jjwt.version>0.12.5</dep.jjwt.version>
-        <dep.jackson.version>2.16.1</dep.jackson.version>
+        <!-- remove when updated through Airbase -->
+        <dep.jackson.version>2.17.0</dep.jackson.version>
         <dep.jetty.version>12.0.7</dep.jetty.version>
     </properties>
 


### PR DESCRIPTION
Add a test to ensure that setting limits for JSON is respected when setReadContraints method is used.

https://github.com/FasterXML/jackson-core/issues/1207