### PR TITLE
Allow providing a custom ErrorHandler

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,7 @@
 - Update HdrHistogram to 2.1.12
 - Update log4j-to-slf4j to 2.23.1
 - Update bouncycastle to 1.77
+- Allow custom Jetty error handler
 
 243
 

--- a/http-server/src/main/java/io/airlift/http/server/ErrorWriter.java
+++ b/http-server/src/main/java/io/airlift/http/server/ErrorWriter.java
@@ -1,0 +1,27 @@
+package io.airlift.http.server;
+
+import java.io.PrintWriter;
+import java.nio.charset.Charset;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public interface ErrorWriter
+{
+    void writeError(PrintWriter writer, ContentType contentType, Charset charset, ErrorDetails error);
+
+    enum ContentType
+    {
+        JSON,
+        HTML,
+        PLAIN;
+    }
+
+    record ErrorDetails(int responseCode, String message, Optional<Throwable> cause)
+    {
+        public ErrorDetails {
+            requireNonNull(message, "message is null");
+            requireNonNull(cause, "cause is null");
+        }
+    }
+}

--- a/http-server/src/main/java/io/airlift/http/server/ErrorWriterHandler.java
+++ b/http-server/src/main/java/io/airlift/http/server/ErrorWriterHandler.java
@@ -1,0 +1,46 @@
+package io.airlift.http.server;
+
+import io.airlift.http.server.ErrorWriter.ErrorDetails;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.ErrorHandler;
+
+import java.io.PrintWriter;
+import java.io.Writer;
+import java.nio.charset.Charset;
+import java.util.Optional;
+
+import static io.airlift.http.server.ErrorWriter.ContentType.HTML;
+import static io.airlift.http.server.ErrorWriter.ContentType.JSON;
+import static io.airlift.http.server.ErrorWriter.ContentType.PLAIN;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+
+public class ErrorWriterHandler
+        extends ErrorHandler
+{
+    private final ErrorWriter errorWriter;
+
+    public ErrorWriterHandler(ErrorWriter errorWriter)
+    {
+        this.errorWriter = requireNonNull(errorWriter, "errorWriter is null");
+    }
+
+    @Override
+    protected void writeErrorHtml(Request request, Writer writer, Charset charset, int code, String message, Throwable cause, boolean showStacks)
+    {
+        PrintWriter printWriter = (writer instanceof PrintWriter value) ? value : new PrintWriter(writer);
+        errorWriter.writeError(printWriter, HTML, charset, new ErrorDetails(code, message, Optional.ofNullable(cause)));
+    }
+
+    @Override
+    protected void writeErrorPlain(Request request, PrintWriter writer, int code, String message, Throwable cause, boolean showStacks)
+    {
+        errorWriter.writeError(writer, PLAIN, UTF_8, new ErrorDetails(code, message, Optional.ofNullable(cause)));
+    }
+
+    @Override
+    protected void writeErrorJson(Request request, PrintWriter writer, int code, String message, Throwable cause, boolean showStacks)
+    {
+        errorWriter.writeError(writer, JSON, UTF_8, new ErrorDetails(code, message, Optional.ofNullable(cause)));
+    }
+}

--- a/http-server/src/main/java/io/airlift/http/server/HttpServerBinder.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServerBinder.java
@@ -9,6 +9,7 @@ import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.google.inject.Scopes.SINGLETON;
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static java.util.Objects.requireNonNull;
@@ -48,6 +49,18 @@ public class HttpServerBinder
     public HttpServerBinder enableLegacyUriCompliance()
     {
         newOptionalBinder(binder, Key.get(Boolean.class, EnableLegacyUriCompliance.class)).setBinding().toInstance(true);
+        return this;
+    }
+
+    public HttpServerBinder bindErrorWriter(ErrorWriter errorHandler)
+    {
+        newOptionalBinder(binder, ErrorWriter.class).setBinding().toInstance(errorHandler);
+        return this;
+    }
+
+    public HttpServerBinder bindErrorHandler(Class<? extends ErrorWriter> errorWriterClazz)
+    {
+        newOptionalBinder(binder, ErrorWriter.class).setBinding().to(errorWriterClazz).in(SINGLETON);
         return this;
     }
 

--- a/http-server/src/main/java/io/airlift/http/server/HttpServerConfig.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServerConfig.java
@@ -18,6 +18,7 @@ package io.airlift.http.server;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.DefunctConfig;
+import io.airlift.configuration.LegacyConfig;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.airlift.units.MaxDataSize;
@@ -89,6 +90,8 @@ public class HttpServerConfig
     private int adminMaxThreads = 200;
 
     private boolean showStackTrace = true;
+    private boolean showErrorInTitle = true;
+    private boolean showCauses = true;
 
     public boolean isHttpEnabled()
     {
@@ -428,8 +431,9 @@ public class HttpServerConfig
         return showStackTrace;
     }
 
-    @Config("http-server.show-stack-trace")
-    @ConfigDescription("Show the stack trace when generating an error response")
+    @LegacyConfig("http-server.show-stack-trace")
+    @Config("http-server.show-error-stack-trace")
+    @ConfigDescription("Show the stack trace when generating an error page")
     public HttpServerConfig setShowStackTrace(boolean showStackTrace)
     {
         this.showStackTrace = showStackTrace;

--- a/http-server/src/main/java/io/airlift/http/server/HttpServerProvider.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServerProvider.java
@@ -28,6 +28,7 @@ import jakarta.annotation.Nullable;
 import jakarta.servlet.Filter;
 import jakarta.servlet.Servlet;
 import org.eclipse.jetty.security.LoginService;
+import org.eclipse.jetty.server.handler.ErrorHandler;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 
 import javax.management.MBeanServer;
@@ -49,6 +50,7 @@ public class HttpServerProvider
     private final HttpServerInfo httpServerInfo;
     private final NodeInfo nodeInfo;
     private final HttpServerConfig config;
+    private final ErrorHandler errorHandler;
     private final Optional<HttpsConfig> httpsConfig;
     private final Servlet theServlet;
     private final Set<HttpResourceBinding> resources;
@@ -71,6 +73,7 @@ public class HttpServerProvider
     public HttpServerProvider(HttpServerInfo httpServerInfo,
             NodeInfo nodeInfo,
             HttpServerConfig config,
+            ErrorHandler errorHandler,
             Optional<HttpsConfig> httpsConfig,
             @TheServlet Servlet theServlet,
             @TheServlet Set<Filter> filters,
@@ -86,6 +89,7 @@ public class HttpServerProvider
         requireNonNull(httpServerInfo, "httpServerInfo is null");
         requireNonNull(nodeInfo, "nodeInfo is null");
         requireNonNull(config, "config is null");
+        requireNonNull(errorHandler, "errorHandler is null");
         requireNonNull(httpsConfig, "httpsConfig is null");
         requireNonNull(theServlet, "theServlet is null");
         requireNonNull(filters, "filters is null");
@@ -99,6 +103,7 @@ public class HttpServerProvider
         this.httpServerInfo = httpServerInfo;
         this.nodeInfo = nodeInfo;
         this.config = config;
+        this.errorHandler = errorHandler;
         this.httpsConfig = httpsConfig;
         this.theServlet = theServlet;
         this.filters = ImmutableSet.copyOf(filters);
@@ -156,6 +161,7 @@ public class HttpServerProvider
                     httpServerInfo,
                     nodeInfo,
                     config,
+                    errorHandler,
                     httpsConfig,
                     theServlet,
                     servletInitParameters,

--- a/http-server/src/main/java/io/airlift/http/server/testing/TestingHttpServer.java
+++ b/http-server/src/main/java/io/airlift/http/server/testing/TestingHttpServer.java
@@ -38,6 +38,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import static io.airlift.http.server.HttpServerModule.defaultErrorHandler;
+
 public class TestingHttpServer
         extends HttpServer
 {
@@ -95,6 +97,7 @@ public class TestingHttpServer
         super(httpServerInfo,
                 nodeInfo,
                 config.setLogEnabled(false),
+                defaultErrorHandler(config),
                 httpsConfig,
                 servlet,
                 initParameters,

--- a/http-server/src/test/java/io/airlift/http/server/TestHttpServerCipher.java
+++ b/http-server/src/test/java/io/airlift/http/server/TestHttpServerCipher.java
@@ -22,6 +22,7 @@ import jakarta.servlet.http.HttpServlet;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.transport.HttpClientTransportDynamic;
 import org.eclipse.jetty.io.ClientConnector;
+import org.eclipse.jetty.server.handler.ErrorHandler;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -221,6 +222,7 @@ public class TestHttpServerCipher
                 httpServerInfo,
                 nodeInfo,
                 config,
+                new ErrorHandler(),
                 Optional.of(httpsConfig),
                 servlet,
                 ImmutableSet.of(new DummyFilter()),

--- a/http-server/src/test/java/io/airlift/http/server/TestHttpServerConfig.java
+++ b/http-server/src/test/java/io/airlift/http/server/TestHttpServerConfig.java
@@ -102,7 +102,7 @@ public class TestHttpServerConfig
                 .put("http-server.max-request-header-size", "32kB")
                 .put("http-server.max-response-header-size", "57kB")
                 .put("http-server.http2.max-concurrent-streams", "1234")
-                .put("http-server.show-stack-trace", "false")
+                .put("http-server.show-error-stack-trace", "false")
                 .put("http-server.http2.session-receive-window-size", "4MB")
                 .put("http-server.http2.stream-receive-window-size", "4MB")
                 .put("http-server.http2.input-buffer-size", "4MB")

--- a/http-server/src/test/java/io/airlift/http/server/TestJettyMultipleCerts.java
+++ b/http-server/src/test/java/io/airlift/http/server/TestJettyMultipleCerts.java
@@ -28,6 +28,7 @@ import io.airlift.tracetoken.TraceTokenManager;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.server.handler.ErrorHandler;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -81,6 +82,7 @@ public class TestJettyMultipleCerts
                 httpServerInfo,
                 nodeInfo,
                 config,
+                new ErrorHandler(),
                 Optional.of(httpsConfig),
                 servlet,
                 ImmutableSet.of(new DummyFilter()),


### PR DESCRIPTION
This will allow providing a custom Jetty error handler in Trino that always returns a JSON-encoded error message that can be interpreted correctly by internal http clients.

Improves error reporting in cases like: https://github.com/trinodb/trino/issues/18843