### PR TITLE
Update Jersey to 3.1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <dep.bytebuddy.version>1.14.13</dep.bytebuddy.version>
         <dep.modernizer.version>2.7.0</dep.modernizer.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
-        <dep.jersey.version>3.1.5</dep.jersey.version>
+        <dep.jersey.version>3.1.6</dep.jersey.version>
         <dep.jjwt.version>0.12.5</dep.jjwt.version>
         <dep.jackson.version>2.17.0</dep.jackson.version>
         <dep.jetty.version>12.0.8</dep.jetty.version>


### PR DESCRIPTION
This is first Jersey release that improves compatibility with virtual threads avoiding thread pinning in synchronized blocks