### PR TITLE
Exclude non-fields from record serialization

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+246
+
+- Exclude getter-like record methods from JSON serialization
+
 245
 
 - Update bouncycastle to 1.78

--- a/json/src/main/java/io/airlift/json/RecordAutoDetectModule.java
+++ b/json/src/main/java/io/airlift/json/RecordAutoDetectModule.java
@@ -1,11 +1,25 @@
 package io.airlift.json;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.AnnotationIntrospector;
 import com.fasterxml.jackson.databind.introspect.AnnotatedClass;
+import com.fasterxml.jackson.databind.introspect.AnnotatedField;
+import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
+import com.fasterxml.jackson.databind.introspect.AnnotatedMethod;
 import com.fasterxml.jackson.databind.introspect.VisibilityChecker;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Member;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.RecordComponent;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
 public class RecordAutoDetectModule
         extends SimpleModule
@@ -20,12 +34,6 @@ public class RecordAutoDetectModule
     private static class Introspector
             extends AnnotationIntrospector
     {
-        private static final VisibilityChecker.Std RECORD_VISIBILITY_CHECKER = VisibilityChecker.Std.defaultInstance()
-                .withGetterVisibility(JsonAutoDetect.Visibility.PUBLIC_ONLY)
-                .withCreatorVisibility(JsonAutoDetect.Visibility.DEFAULT)
-                .withFieldVisibility(JsonAutoDetect.Visibility.DEFAULT)
-                .withIsGetterVisibility(JsonAutoDetect.Visibility.DEFAULT);
-
         @Override
         public VisibilityChecker<?> findAutoDetectVisibility(AnnotatedClass ac, VisibilityChecker<?> checker)
         {
@@ -34,7 +42,7 @@ public class RecordAutoDetectModule
                 if (overrideAnnotation != null) {
                     return VisibilityChecker.Std.construct(JsonAutoDetect.Value.from(overrideAnnotation));
                 }
-                return RECORD_VISIBILITY_CHECKER;
+                return new RecordVisibilityChecker(ac.getRawType().asSubclass(Record.class));
             }
             return checker;
         }
@@ -43,6 +51,136 @@ public class RecordAutoDetectModule
         public Version version()
         {
             return Version.unknownVersion();
+        }
+    }
+
+    private static class RecordVisibilityChecker
+            implements VisibilityChecker<RecordVisibilityChecker>
+    {
+        private final Set<String> componentNames;
+
+        public RecordVisibilityChecker(Class<? extends Record> recordClass)
+        {
+            componentNames = Stream.of(recordClass.getRecordComponents())
+                    .map(RecordComponent::getName)
+                    .collect(toImmutableSet());
+        }
+
+        @Override
+        public RecordVisibilityChecker with(JsonAutoDetect annotation)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public RecordVisibilityChecker withOverrides(JsonAutoDetect.Value value)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public RecordVisibilityChecker with(JsonAutoDetect.Visibility visibility)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public RecordVisibilityChecker withVisibility(PropertyAccessor propertyAccessor, JsonAutoDetect.Visibility visibility)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public RecordVisibilityChecker withGetterVisibility(JsonAutoDetect.Visibility visibility)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public RecordVisibilityChecker withIsGetterVisibility(JsonAutoDetect.Visibility visibility)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public RecordVisibilityChecker withSetterVisibility(JsonAutoDetect.Visibility visibility)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public RecordVisibilityChecker withCreatorVisibility(JsonAutoDetect.Visibility visibility)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public RecordVisibilityChecker withFieldVisibility(JsonAutoDetect.Visibility visibility)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isGetterVisible(Method method)
+        {
+            if (!Modifier.isPublic(method.getModifiers())) {
+                return false;
+            }
+            return componentNames.contains(method.getName());
+        }
+
+        @Override
+        public boolean isGetterVisible(AnnotatedMethod annotatedMethod)
+        {
+            return isGetterVisible(annotatedMethod.getAnnotated());
+        }
+
+        @Override
+        public boolean isIsGetterVisible(Method method)
+        {
+            return false;
+        }
+
+        @Override
+        public boolean isIsGetterVisible(AnnotatedMethod annotatedMethod)
+        {
+            return false;
+        }
+
+        @Override
+        public boolean isSetterVisible(Method method)
+        {
+            return false;
+        }
+
+        @Override
+        public boolean isSetterVisible(AnnotatedMethod annotatedMethod)
+        {
+            return false;
+        }
+
+        @Override
+        public boolean isCreatorVisible(Member member)
+        {
+            return true;
+        }
+
+        @Override
+        public boolean isCreatorVisible(AnnotatedMember annotatedMember)
+        {
+            return true;
+        }
+
+        @Override
+        public boolean isFieldVisible(Field field)
+        {
+            return false;
+        }
+
+        @Override
+        public boolean isFieldVisible(AnnotatedField field)
+        {
+            return false;
         }
     }
 }

--- a/json/src/test/java/io/airlift/json/TestJsonCodec.java
+++ b/json/src/test/java/io/airlift/json/TestJsonCodec.java
@@ -292,6 +292,16 @@ public class TestJsonCodec
                   "isCool" : true
                 }\
                 """);
+
+        assertEquals(
+                JsonCodec.jsonCodec(LegacyRecordAdditionalGetter.class).toJson(new LegacyRecordAdditionalGetter("my value")),
+                """
+                {
+                  "bar" : "there is no bar field in the record",
+                  "foo" : "not really a foo value",
+                  "safe" : false
+                }\
+                """);
     }
 
     private static <T> void assertSerializationRoundTrip(JsonCodec<T> codec, T object, String expected)
@@ -354,6 +364,30 @@ public class TestJsonCodec
         public boolean getCondition()
         {
             throw new UnsupportedOperationException("this method should not be called during serialization");
+        }
+    }
+
+    @SuppressWarnings("removal")
+    @JsonPropertyOrder(alphabetic = true)
+    @RecordAutoDetectModule.LegacyRecordIntrospection
+    public record LegacyRecordAdditionalGetter(String foo)
+    {
+        // Not the canonical accessor for the foo record component, but takes precedence when serializing to JSON
+        public String getFoo()
+        {
+            return "not really a foo value";
+        }
+
+        // Not a record component, but gets serialized to JSON
+        public String getBar()
+        {
+            return "there is no bar field in the record";
+        }
+
+        // Not a record component, but gets serialized to JSON
+        public boolean isSafe()
+        {
+            return false;
         }
     }
 }

--- a/json/src/test/java/io/airlift/json/TestJsonCodec.java
+++ b/json/src/test/java/io/airlift/json/TestJsonCodec.java
@@ -38,7 +38,6 @@ public class TestJsonCodec
 {
     @Test
     public void testJsonCodec()
-            throws Exception
     {
         JsonCodec<Person> jsonCodec = jsonCodec(Person.class);
 
@@ -51,7 +50,6 @@ public class TestJsonCodec
 
     @Test
     public void testListJsonCodec()
-            throws Exception
     {
         JsonCodec<List<Person>> jsonCodec = listJsonCodec(Person.class);
 
@@ -64,7 +62,6 @@ public class TestJsonCodec
 
     @Test
     public void testListJsonCodecFromJsonCodec()
-            throws Exception
     {
         JsonCodec<List<Person>> jsonCodec = listJsonCodec(jsonCodec(Person.class));
 
@@ -77,7 +74,6 @@ public class TestJsonCodec
 
     @Test
     public void testTypeTokenList()
-            throws Exception
     {
         JsonCodec<List<Person>> jsonCodec = jsonCodec(new TypeToken<List<Person>>() {});
 
@@ -102,7 +98,6 @@ public class TestJsonCodec
 
     @Test
     public void testMapJsonCodec()
-            throws Exception
     {
         JsonCodec<Map<String, Person>> jsonCodec = mapJsonCodec(String.class, Person.class);
 
@@ -115,7 +110,6 @@ public class TestJsonCodec
 
     @Test
     public void testMapJsonCodecFromJsonCodec()
-            throws Exception
     {
         JsonCodec<Map<String, Person>> jsonCodec = mapJsonCodec(String.class, jsonCodec(Person.class));
 
@@ -128,7 +122,6 @@ public class TestJsonCodec
 
     @Test
     public void testTypeLiteralMap()
-            throws Exception
     {
         JsonCodec<Map<String, Person>> jsonCodec = jsonCodec(new TypeToken<Map<String, Person>>() {});
 
@@ -153,7 +146,6 @@ public class TestJsonCodec
 
     @Test
     public void testImmutableJsonCodec()
-            throws Exception
     {
         JsonCodec<ImmutablePerson> jsonCodec = jsonCodec(ImmutablePerson.class);
 
@@ -162,7 +154,6 @@ public class TestJsonCodec
 
     @Test
     public void testAsymmetricJsonCodec()
-            throws Exception
     {
         JsonCodec<ImmutablePerson> jsonCodec = jsonCodec(ImmutablePerson.class);
         ImmutablePerson immutablePerson = jsonCodec.fromJson("{ \"notWritable\": \"foo\" }");
@@ -171,7 +162,6 @@ public class TestJsonCodec
 
     @Test
     public void testImmutableListJsonCodec()
-            throws Exception
     {
         JsonCodec<List<ImmutablePerson>> jsonCodec = listJsonCodec(ImmutablePerson.class);
 
@@ -180,7 +170,6 @@ public class TestJsonCodec
 
     @Test
     public void testImmutableListJsonCodecFromJsonCodec()
-            throws Exception
     {
         JsonCodec<List<ImmutablePerson>> jsonCodec = listJsonCodec(jsonCodec(ImmutablePerson.class));
 
@@ -189,7 +178,6 @@ public class TestJsonCodec
 
     @Test
     public void testImmutableTypeTokenList()
-            throws Exception
     {
         JsonCodec<List<ImmutablePerson>> jsonCodec = jsonCodec(new TypeToken<List<ImmutablePerson>>() {});
 
@@ -198,7 +186,6 @@ public class TestJsonCodec
 
     @Test
     public void testImmutableMapJsonCodec()
-            throws Exception
     {
         JsonCodec<Map<String, ImmutablePerson>> jsonCodec = mapJsonCodec(String.class, ImmutablePerson.class);
 
@@ -207,7 +194,6 @@ public class TestJsonCodec
 
     @Test
     public void testImmutableMapJsonCodecFromJsonCodec()
-            throws Exception
     {
         JsonCodec<Map<String, ImmutablePerson>> jsonCodec = mapJsonCodec(String.class, jsonCodec(ImmutablePerson.class));
 
@@ -216,7 +202,6 @@ public class TestJsonCodec
 
     @Test
     public void testImmutableTypeTokenMap()
-            throws Exception
     {
         JsonCodec<Map<String, ImmutablePerson>> jsonCodec = jsonCodec(new TypeToken<Map<String, ImmutablePerson>>() {});
 


### PR DESCRIPTION
Before the change, a record's getter-like methods would be considered
getters and would be parsed of serialized form. This is undesirable
because

- For record component `foo`, the `foo()` method should be considered
  the accessor. If `getFoo()` exists, it may return something else.
  Using it can lead to correctness problems.
- A method like `getFoo()` may not be accessor to a record component at
  all, it should not be part of serialization.
- The default behavior is different than one for regular classes, so a
  benign refactor from a class to a record changes what gets serialized
  as JSON -- the getter-like non-getters on a class are ignored (do not
  need `@JsonIgnore`) and are included on a record (unless annotated
  with `@JsonIgnore`). This changes serialized form in a hard to notice
  manner, because we ignore those additional properties during
  deserialization.

This commit fixes this. Now only the canonical accessors are considered
a getter in a record.

Alternative solution would be to rely on Jackson built-in record
support. However, it relies on private field access, and we disable
CAN_OVERRIDE_ACCESS_MODIFIERS mapper feature.