### PR TITLE
Enhance HTTP/2 support in airlift http-server.

### DIFF
--- a/http-server/pom.xml
+++ b/http-server/pom.xml
@@ -107,6 +107,11 @@
 
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-alpn-server</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-http</artifactId>
         </dependency>
 
@@ -148,6 +153,12 @@
         <dependency>
             <groupId>org.weakref</groupId>
             <artifactId>jmxutils</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-alpn-java-server</artifactId>
+            <scope>runtime</scope>
         </dependency>
 
         <dependency>

--- a/http-server/src/main/java/io/airlift/http/server/HttpServerConfig.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServerConfig.java
@@ -54,6 +54,7 @@ public class HttpServerConfig
     private int httpAcceptQueueSize = 8000;
 
     private boolean httpsEnabled;
+    private boolean http2Enabled;
 
     private String logPath = "var/log/http-request.log";
     private boolean logEnabled = true;
@@ -135,6 +136,18 @@ public class HttpServerConfig
     public HttpServerConfig setHttpsEnabled(boolean httpsEnabled)
     {
         this.httpsEnabled = httpsEnabled;
+        return this;
+    }
+
+    public boolean isHttp2Enabled()
+    {
+        return http2Enabled;
+    }
+
+    @Config("http-server.http2.enabled")
+    public HttpServerConfig setHttp2Enabled(boolean http2Enabled)
+    {
+        this.http2Enabled = http2Enabled;
         return this;
     }
 


### PR DESCRIPTION
This change will allow Trino to use HTTP/2 protocol for internal communication (between coordinator and workers). In addition, if a Trino client is able to support HTTP/2, coordinator will switch to HTTP/2 for communication.