### PR TITLE
Fix recording exceptions on server spans

### DIFF
--- a/jaxrs/src/main/java/io/airlift/jaxrs/tracing/TracingFilter.java
+++ b/jaxrs/src/main/java/io/airlift/jaxrs/tracing/TracingFilter.java
@@ -115,7 +115,6 @@ public final class TracingFilter
                 span.setAttribute(SemanticAttributes.HTTP_RESPONSE_BODY_SIZE, response.getLength());
             }
         }
-        span.end();
     }
 
     private static String normalizePath(String path)

--- a/jaxrs/src/main/java/io/airlift/jaxrs/tracing/TracingServletFilter.java
+++ b/jaxrs/src/main/java/io/airlift/jaxrs/tracing/TracingServletFilter.java
@@ -36,6 +36,9 @@ public final class TracingServletFilter
             if (request.getAttribute(TracingFilter.REQUEST_SCOPE) instanceof Scope scope) {
                 scope.close();
             }
+            if (request.getAttribute(TracingFilter.REQUEST_SPAN) instanceof Span span) {
+                span.end();
+            }
         }
     }
 }


### PR DESCRIPTION
Looks like we are not recording exceptions for requests that throw

Tested this with sample server and it works fine

![image](https://github.com/airlift/airlift/assets/85896470/28c912e1-cb16-4439-9d05-e9a2743a221c)


