### PR TITLE
Support dynamic properties in HTTP announcement 

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@
 - Fail decoding with JsonCodec when content is not single JSON value.
   Previously the codec decoded first JSON value only, ignoring the rest
   of the payload.
+- Support Guice providers in HTTP announcement custom properties.
 - Allow only `@DefunctConfig` class without `@Config` annotation
 - Update airbase to 156
 - Update bouncycastle to 1.78.1

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,7 @@
 247
 
+- Fix failure in DelimitedRequestLogHandler when reporting early
+  request exceptions.
 - Fail decoding with JsonCodec when content is not single JSON value.
   Previously the codec decoded first JSON value only, ignoring the rest
   of the payload.

--- a/discovery/src/main/java/io/airlift/discovery/client/HttpAnnouncement.java
+++ b/discovery/src/main/java/io/airlift/discovery/client/HttpAnnouncement.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.discovery.client;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@BindingAnnotation
+@interface HttpAnnouncement
+{
+    String announcementId();
+}

--- a/discovery/src/main/java/io/airlift/discovery/client/HttpAnnouncementImpl.java
+++ b/discovery/src/main/java/io/airlift/discovery/client/HttpAnnouncementImpl.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.discovery.client;
+
+import java.lang.annotation.Annotation;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+class HttpAnnouncementImpl
+        implements HttpAnnouncement
+{
+    private final String announcementId;
+
+    public HttpAnnouncementImpl(String announcementId)
+    {
+        this.announcementId = requireNonNull(announcementId, "announcementId is null");
+    }
+
+    public String announcementId()
+    {
+        return announcementId;
+    }
+
+    public String toString()
+    {
+        return format("@%s(announcementId=\"%s\")", annotationType().getName(), announcementId.replace("\"", "\\\""));
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (!(o instanceof HttpAnnouncement that)) {
+            return false;
+        }
+        return announcementId.equals(that.announcementId());
+    }
+
+    @Override
+    public int hashCode()
+    {
+        // see Annotation.hashCode()
+        int result = 0;
+        result += ((127 * "announcementId".hashCode()) ^ announcementId.hashCode());
+        return result;
+    }
+
+    public Class<? extends Annotation> annotationType()
+    {
+        return HttpAnnouncement.class;
+    }
+}

--- a/discovery/src/test/java/io/airlift/discovery/client/AbstractTestDiscoveryModule.java
+++ b/discovery/src/test/java/io/airlift/discovery/client/AbstractTestDiscoveryModule.java
@@ -84,7 +84,7 @@ public abstract class AbstractTestDiscoveryModule
                 new ConfigurationModule(new ConfigurationFactory(config)),
                 new JsonModule(),
                 new TestingNodeModule(),
-                new DiscoveryModule(),
+                discoveryModule,
                 binder -> {
                     binder.bind(AnnouncementHttpServerInfo.class).toInstance(httpServerInfo);
                     discoveryBinder(binder).bindHttpAnnouncement("apple");

--- a/discovery/src/test/java/io/airlift/discovery/client/AbstractTestDiscoveryModule.java
+++ b/discovery/src/test/java/io/airlift/discovery/client/AbstractTestDiscoveryModule.java
@@ -48,7 +48,6 @@ public abstract class AbstractTestDiscoveryModule
 
     @Test
     public void testBinding()
-            throws Exception
     {
         Injector injector = Guice.createInjector(
                 new ConfigurationModule(new ConfigurationFactory(ImmutableMap.of("discovery.uri", "fake://server"))),
@@ -67,9 +66,8 @@ public abstract class AbstractTestDiscoveryModule
 
     @Test
     public void testMerging()
-            throws Exception
     {
-        final StaticAnnouncementHttpServerInfoImpl httpServerInfo = new StaticAnnouncementHttpServerInfoImpl(
+        StaticAnnouncementHttpServerInfoImpl httpServerInfo = new StaticAnnouncementHttpServerInfoImpl(
                 URI.create("http://127.0.0.1:4444"),
                 URI.create("http://example.com:4444"),
                 null,

--- a/discovery/src/test/java/io/airlift/discovery/client/TestHttpAnnouncementBinder.java
+++ b/discovery/src/test/java/io/airlift/discovery/client/TestHttpAnnouncementBinder.java
@@ -16,14 +16,17 @@
 package io.airlift.discovery.client;
 
 import com.google.inject.Guice;
+import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.Key;
+import com.google.inject.Provider;
 import com.google.inject.TypeLiteral;
 import io.airlift.discovery.client.testing.TestingDiscoveryModule;
 import org.testng.annotations.Test;
 
 import java.net.URI;
 import java.util.Set;
+import java.util.UUID;
 
 import static com.google.common.collect.MoreCollectors.onlyElement;
 import static io.airlift.discovery.client.DiscoveryBinder.discoveryBinder;
@@ -142,6 +145,38 @@ public class TestHttpAnnouncementBinder
         assertAnnouncement(announcements, announcement);
     }
 
+    @Test
+    public void testHttpAnnouncementWithCustomProvidedProperties()
+    {
+        StaticAnnouncementHttpServerInfoImpl httpServerInfo = new StaticAnnouncementHttpServerInfoImpl(
+                URI.create("http://127.0.0.1:4444"),
+                URI.create("http://example.com:4444"),
+                URI.create("https://127.0.0.1:4444"),
+                URI.create("https://example.com:4444"));
+        String randomValue = UUID.randomUUID().toString();
+
+        Injector injector = Guice.createInjector(
+                new TestingDiscoveryModule(),
+                binder -> {
+                    binder.bind(AnnouncementHttpServerInfo.class).toInstance(httpServerInfo);
+                    discoveryBinder(binder).bindHttpAnnouncement("apple")
+                            .addProperty("instance-property", "my-instance")
+                            .bindPropertyProvider("provided-by-instance", () -> "provided-constant: " + randomValue)
+                            .bindPropertyProvider("provided-by-injected", StringPropertyProvider.class);
+                });
+
+        Set<ServiceAnnouncement> announcements = injector.getInstance(new Key<>() {});
+        assertAnnouncement(announcements, serviceAnnouncement("apple")
+                .addProperty("instance-property", "my-instance")
+                .addProperty("provided-by-instance", "provided-constant: " + randomValue)
+                .addProperty("provided-by-injected", "concatenated: http://127.0.0.1:4444 https://127.0.0.1:4444")
+                .addProperty("http", "http://127.0.0.1:4444")
+                .addProperty("http-external", "http://example.com:4444")
+                .addProperty("https", "https://127.0.0.1:4444")
+                .addProperty("https-external", "https://example.com:4444")
+                .build());
+    }
+
     private void assertAnnouncement(Set<ServiceAnnouncement> actualAnnouncements, ServiceAnnouncement expected)
     {
         assertNotNull(actualAnnouncements);
@@ -149,5 +184,23 @@ public class TestHttpAnnouncementBinder
         ServiceAnnouncement announcement = actualAnnouncements.stream().collect(onlyElement());
         assertEquals(announcement.getType(), expected.getType());
         assertEquals(announcement.getProperties(), expected.getProperties());
+    }
+
+    public static class StringPropertyProvider
+            implements Provider<String>
+    {
+        private final AnnouncementHttpServerInfo httpServerInfo;
+
+        @Inject
+        public StringPropertyProvider(AnnouncementHttpServerInfo httpServerInfo)
+        {
+            this.httpServerInfo = httpServerInfo;
+        }
+
+        @Override
+        public String get()
+        {
+            return "concatenated: %s %s".formatted(httpServerInfo.getHttpUri(), httpServerInfo.getHttpsUri());
+        }
     }
 }

--- a/discovery/src/test/java/io/airlift/discovery/client/TestHttpAnnouncementBinder.java
+++ b/discovery/src/test/java/io/airlift/discovery/client/TestHttpAnnouncementBinder.java
@@ -36,7 +36,7 @@ public class TestHttpAnnouncementBinder
     @Test
     public void testHttpAnnouncement()
     {
-        final StaticAnnouncementHttpServerInfoImpl httpServerInfo = new StaticAnnouncementHttpServerInfoImpl(
+        StaticAnnouncementHttpServerInfoImpl httpServerInfo = new StaticAnnouncementHttpServerInfoImpl(
                 URI.create("http://127.0.0.1:4444"),
                 URI.create("http://example.com:4444"),
                 null,
@@ -54,9 +54,7 @@ public class TestHttpAnnouncementBinder
                 .addProperty("http-external", httpServerInfo.getHttpExternalUri().toASCIIString())
                 .build();
 
-        Set<ServiceAnnouncement> announcements = injector.getInstance(Key.get(new TypeLiteral<Set<ServiceAnnouncement>>()
-        {
-        }));
+        Set<ServiceAnnouncement> announcements = injector.getInstance(Key.get(new TypeLiteral<Set<ServiceAnnouncement>>() {}));
 
         assertAnnouncement(announcements, announcement);
     }
@@ -64,7 +62,7 @@ public class TestHttpAnnouncementBinder
     @Test
     public void testHttpsAnnouncement()
     {
-        final StaticAnnouncementHttpServerInfoImpl httpServerInfo = new StaticAnnouncementHttpServerInfoImpl(
+        StaticAnnouncementHttpServerInfoImpl httpServerInfo = new StaticAnnouncementHttpServerInfoImpl(
                 null,
                 null,
                 URI.create("https://127.0.0.1:4444"),
@@ -82,9 +80,7 @@ public class TestHttpAnnouncementBinder
                 .addProperty("https-external", httpServerInfo.getHttpsExternalUri().toASCIIString())
                 .build();
 
-        Set<ServiceAnnouncement> announcements = injector.getInstance(Key.get(new TypeLiteral<Set<ServiceAnnouncement>>()
-        {
-        }));
+        Set<ServiceAnnouncement> announcements = injector.getInstance(Key.get(new TypeLiteral<Set<ServiceAnnouncement>>() {}));
 
         assertAnnouncement(announcements, announcement);
     }
@@ -92,7 +88,7 @@ public class TestHttpAnnouncementBinder
     @Test
     public void testHttpAnnouncementWithPool()
     {
-        final StaticAnnouncementHttpServerInfoImpl httpServerInfo = new StaticAnnouncementHttpServerInfoImpl(
+        StaticAnnouncementHttpServerInfoImpl httpServerInfo = new StaticAnnouncementHttpServerInfoImpl(
                 URI.create("http://127.0.0.1:4444"),
                 URI.create("http://example.com:4444"),
                 URI.create("https://127.0.0.1:4444"),
@@ -112,9 +108,7 @@ public class TestHttpAnnouncementBinder
                 .addProperty("https-external", httpServerInfo.getHttpsExternalUri().toASCIIString())
                 .build();
 
-        Set<ServiceAnnouncement> announcements = injector.getInstance(Key.get(new TypeLiteral<Set<ServiceAnnouncement>>()
-        {
-        }));
+        Set<ServiceAnnouncement> announcements = injector.getInstance(Key.get(new TypeLiteral<Set<ServiceAnnouncement>>() {}));
 
         assertAnnouncement(announcements, announcement);
     }
@@ -122,7 +116,7 @@ public class TestHttpAnnouncementBinder
     @Test
     public void testHttpAnnouncementWithCustomProperties()
     {
-        final StaticAnnouncementHttpServerInfoImpl httpServerInfo = new StaticAnnouncementHttpServerInfoImpl(
+        StaticAnnouncementHttpServerInfoImpl httpServerInfo = new StaticAnnouncementHttpServerInfoImpl(
                 URI.create("http://127.0.0.1:4444"),
                 URI.create("http://example.com:4444"),
                 URI.create("https://127.0.0.1:4444"),
@@ -143,9 +137,7 @@ public class TestHttpAnnouncementBinder
                 .addProperty("https-external", httpServerInfo.getHttpsExternalUri().toASCIIString())
                 .build();
 
-        Set<ServiceAnnouncement> announcements = injector.getInstance(Key.get(new TypeLiteral<Set<ServiceAnnouncement>>()
-        {
-        }));
+        Set<ServiceAnnouncement> announcements = injector.getInstance(Key.get(new TypeLiteral<Set<ServiceAnnouncement>>() {}));
 
         assertAnnouncement(announcements, announcement);
     }

--- a/discovery/src/test/java/io/airlift/discovery/client/TestHttpAnnouncementImpl.java
+++ b/discovery/src/test/java/io/airlift/discovery/client/TestHttpAnnouncementImpl.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2010 Proofpoint, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.discovery.client;
+
+import org.testng.annotations.Test;
+
+import static io.airlift.testing.EquivalenceTester.equivalenceTester;
+import static org.testng.Assert.assertEquals;
+
+public class TestHttpAnnouncementImpl
+{
+    @HttpAnnouncement(announcementId = "apple")
+    private final HttpAnnouncement appleHttpAnnouncement;
+
+    @HttpAnnouncement(announcementId = "banana")
+    private final HttpAnnouncement bananaHttpAnnouncement;
+
+    @HttpAnnouncement(announcementId = "quot\"ation-and-\\backslash")
+    private final HttpAnnouncement httpAnnouncementWithCharacters;
+
+    public TestHttpAnnouncementImpl()
+    {
+        try {
+            this.appleHttpAnnouncement = getClass().getDeclaredField("appleHttpAnnouncement").getAnnotation(HttpAnnouncement.class);
+            this.bananaHttpAnnouncement = getClass().getDeclaredField("bananaHttpAnnouncement").getAnnotation(HttpAnnouncement.class);
+            this.httpAnnouncementWithCharacters = getClass().getDeclaredField("httpAnnouncementWithCharacters").getAnnotation(HttpAnnouncement.class);
+        }
+        catch (NoSuchFieldException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void testAnnouncementId()
+    {
+        assertEquals(new HttpAnnouncementImpl("type A").announcementId(), "type A");
+    }
+
+    @Test
+    public void testAnnotationType()
+    {
+        assertEquals(new HttpAnnouncementImpl("apple").annotationType(), HttpAnnouncement.class);
+        assertEquals(new HttpAnnouncementImpl("apple").annotationType(), appleHttpAnnouncement.annotationType());
+    }
+
+    @Test
+    public void testEquivalence()
+    {
+        equivalenceTester()
+                .addEquivalentGroup(appleHttpAnnouncement, new HttpAnnouncementImpl("apple"))
+                .addEquivalentGroup(bananaHttpAnnouncement, new HttpAnnouncementImpl("banana"))
+                .check();
+    }
+}


### PR DESCRIPTION
Extend discovery binder's bindHttpAnnouncement's capabilities by
allowing bindings of non-constant properties that require Guice
injection to be calculated.

For https://github.com/trinodb/trino/pull/21744