### PR TITLE
Fix HTTP request builder setHeader case sensitivity

### DIFF
--- a/http-client/src/main/java/io/airlift/http/client/Request.java
+++ b/http-client/src/main/java/io/airlift/http/client/Request.java
@@ -15,7 +15,6 @@
  */
 package io.airlift.http.client;
 
-import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.MultimapBuilder;
@@ -39,10 +38,7 @@ public final class Request
     private final Optional<HttpVersion> httpVersion;
     private final URI uri;
     private final String method;
-    private final ListMultimap<String, String> headers = MultimapBuilder
-            .treeKeys(CASE_INSENSITIVE_ORDER)
-            .arrayListValues()
-            .build();
+    private final ListMultimap<String, String> headers = newHeaders();
     private final Optional<Duration> requestTimeout;
     private final Optional<Duration> idleTimeout;
     private final BodyGenerator bodyGenerator;
@@ -196,6 +192,14 @@ public final class Request
                 followRedirects);
     }
 
+    private static ListMultimap<String, String> newHeaders()
+    {
+        return MultimapBuilder
+                .treeKeys(CASE_INSENSITIVE_ORDER)
+                .arrayListValues()
+                .build();
+    }
+
     public static final class Builder
     {
         public static Builder prepareHead()
@@ -248,7 +252,7 @@ public final class Request
 
         private URI uri;
         private String method;
-        private final ListMultimap<String, String> headers = ArrayListMultimap.create();
+        private final ListMultimap<String, String> headers = newHeaders();
         private BodyGenerator bodyGenerator;
         private SpanBuilder spanBuilder;
         private Optional<HttpVersion> version = Optional.empty();

--- a/http-client/src/test/java/io/airlift/http/client/TestRequestBuilder.java
+++ b/http-client/src/test/java/io/airlift/http/client/TestRequestBuilder.java
@@ -23,6 +23,7 @@ import java.net.URI;
 import static io.airlift.http.client.Request.Builder.fromRequest;
 import static io.airlift.http.client.Request.Builder.prepareGet;
 import static io.airlift.http.client.StaticBodyGenerator.createStaticBodyGenerator;
+import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -55,6 +56,47 @@ public class TestRequestBuilder
     {
         Request request = createRequest();
         assertThat(fromRequest(request).build()).isEqualTo(request);
+    }
+
+    @Test
+    public void testAddCaseInsensitive()
+    {
+        Request request = prepareGet()
+                .setUri(URI.create("http://example.com"))
+                .addHeader("my-header", "lower case")
+                .addHeader("My-HeADer", "MixED CAse")
+                .build();
+        assertThat(request.getHeaders().keySet()).hasSize(1);
+        assertThat(request.getHeaders().entries())
+                .containsExactlyInAnyOrder(
+                        entry("my-header", "lower case"),
+                        entry("my-header", "MixED CAse"));
+    }
+
+    @Test
+    public void testSetCaseInsensitive()
+    {
+        Request request = prepareGet()
+                .setUri(URI.create("http://example.com"))
+                .addHeader("my-header", "lower case")
+                .addHeader("My-HeADer", "MixED CAse")
+                // setHeader() should replace the existing headers
+                .setHeader("My-Header", "replaced")
+                .build();
+        assertThat(request.getHeaders().keySet()).hasSize(1);
+        assertThat(request.getHeaders().entries())
+                .containsExactly(entry("My-Header", "replaced"));
+
+        request = prepareGet()
+                .setUri(URI.create("http://example.com"))
+                .addHeader("my-header", "lower case")
+                .addHeader("My-HeADer", "MixED CAse")
+                // setHeader() should replace the existing headers
+                .setHeader("My-HeADEr", "replaced-mixed")
+                .build();
+        assertThat(request.getHeaders().keySet()).hasSize(1);
+        assertThat(request.getHeaders().entries())
+                .containsExactly(entry("My-HeADEr", "replaced-mixed"));
     }
 
     private static Request createRequest()


### PR DESCRIPTION
This fixes a bug in request builder. The `io.airlift.http.client.Request.Builder#setHeader` is supposed to replace existing headers of given name and save the new value. Before this PR, it works only when `setHeader` uses same header name casing as the previously set headers (eg `Cookie` and not `cookie`).