### PR TITLE
Fix failure when system properties modified when loading configuration

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+249
+
+-  Fix failure when system properties modified when loading configuration
+
 248
 
 - Update Jetty to 12.0.9

--- a/configuration/src/main/java/io/airlift/configuration/ConfigurationLoader.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigurationLoader.java
@@ -67,6 +67,9 @@ public final class ConfigurationLoader
 
     public static Map<String, String> getSystemProperties()
     {
-        return fromProperties(System.getProperties());
+        Properties systemProperties = System.getProperties();
+        synchronized (systemProperties) {
+            return fromProperties(systemProperties);
+        }
     }
 }


### PR DESCRIPTION
System properties are global mutable state.  Prevent `ConfigurationLoader` from throwing (`NullPointerException`) when system properties are modified during `getSystemProperties()`.