### PR TITLE
Add request-scoped jaxrs binding support

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,7 @@
 - Add HTTP protocol version to client traces
 - Improve request/response metrics accuracy and correctness
 - Update Airbase to 157
+- Add request scope bindings to jax-rs
 
 248
 

--- a/jaxrs/src/main/java/io/airlift/jaxrs/AsyncResponseBinder.java
+++ b/jaxrs/src/main/java/io/airlift/jaxrs/AsyncResponseBinder.java
@@ -1,0 +1,110 @@
+package io.airlift.jaxrs;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.units.Duration;
+import jakarta.servlet.AsyncEvent;
+import jakarta.servlet.AsyncListener;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.container.AsyncResponse;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+
+import java.util.Optional;
+import java.util.concurrent.Executor;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static io.airlift.jaxrs.AsyncResponseHandler.bindAsyncResponse;
+import static jakarta.ws.rs.core.Response.status;
+import static java.util.Objects.requireNonNull;
+
+public class AsyncResponseBinder
+{
+    private final HttpServletRequest servletRequest;
+    private boolean cancelOnClientDisconnect = true;
+    private Optional<Duration> timeout = Optional.empty();
+    private Function<Duration, Supplier<Response>> timeoutResponse = AsyncResponseBinder::defaultTimeoutResponse;
+
+    private AsyncResponseBinder(HttpServletRequest servletRequest)
+    {
+        this.servletRequest = requireNonNull(servletRequest, "servletRequest is null");
+    }
+
+    public AsyncResponseBinder cancelOnClientDisconnection(boolean cancelOnClientDisconnection)
+    {
+        this.cancelOnClientDisconnect = cancelOnClientDisconnection;
+        return this;
+    }
+
+    public AsyncResponseBinder withTimeout(Duration timeout)
+    {
+        this.timeout = Optional.of(timeout);
+        return this;
+    }
+
+    public AsyncResponseBinder withTimeoutResponse(Response response)
+    {
+        requireNonNull(response, "response is null");
+        this.timeoutResponse = timeout -> () -> response;
+        return this;
+    }
+
+    public AsyncResponseBinder withTimeoutResponse(Supplier<Response> responseSupplier)
+    {
+        requireNonNull(responseSupplier, "responseSupplier is null");
+        this.timeoutResponse = timeout -> responseSupplier;
+        return this;
+    }
+
+    public void bindTo(AsyncResponse response, ListenableFuture<?> future, Executor httpExecutor)
+    {
+        AsyncResponseHandler<?> asyncResponseHandler = bindAsyncResponse(response, future, httpExecutor);
+        if (cancelOnClientDisconnect) {
+            servletRequest.getAsyncContext().addListener(new AsyncListener()
+            {
+                @Override
+                public void onError(AsyncEvent event)
+                {
+                    // Jetty will signal the client disconnection with the EofException
+                    if (event.getThrowable().getMessage().contains("cancel_stream_error")) {
+                        asyncResponseHandler.clientDisconnected();
+                    }
+                }
+
+                @Override
+                public void onComplete(AsyncEvent event) {}
+
+                @Override
+                public void onTimeout(AsyncEvent event) {}
+
+                @Override
+                public void onStartAsync(AsyncEvent event) {}
+            });
+        }
+        timeout.ifPresent(timeout -> asyncResponseHandler.withTimeout(timeout, timeoutResponse.apply(timeout)));
+    }
+
+    private static Supplier<Response> defaultTimeoutResponse(Duration timeout)
+    {
+        return () -> status(Response.Status.SERVICE_UNAVAILABLE)
+                .entity("Timed out after waiting for " + timeout.convertToMostSuccinctTimeUnit())
+                .build();
+    }
+
+    public static class Factory
+            implements Supplier<AsyncResponseBinder>
+    {
+        private final HttpServletRequest servletRequest;
+
+        private Factory(@Context HttpServletRequest servletRequest)
+        {
+            this.servletRequest = requireNonNull(servletRequest, "servletRequest is null");
+        }
+
+        @Override
+        public AsyncResponseBinder get()
+        {
+            return new AsyncResponseBinder(servletRequest);
+        }
+    }
+}

--- a/jaxrs/src/main/java/io/airlift/jaxrs/JaxrsBinder.java
+++ b/jaxrs/src/main/java/io/airlift/jaxrs/JaxrsBinder.java
@@ -5,11 +5,14 @@ import com.google.inject.Binder;
 import com.google.inject.Key;
 import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.Multibinder;
+import io.airlift.jaxrs.JaxrsModule.JerseyFactoryBinding;
+import org.glassfish.jersey.process.internal.RequestScoped;
 import org.glassfish.jersey.server.wadl.internal.WadlResource;
 import org.glassfish.jersey.server.wadl.processor.OptionsMethodProcessor;
 import org.glassfish.jersey.server.wadl.processor.WadlModelProcessor;
 
 import java.util.Collection;
+import java.util.function.Supplier;
 
 import static com.google.inject.Scopes.SINGLETON;
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
@@ -18,11 +21,14 @@ import static java.util.Objects.requireNonNull;
 public class JaxrsBinder
 {
     private final Multibinder<Object> resourceBinder;
+    private final Multibinder<JerseyFactoryBinding> factoryBinder;
+
     private final Binder binder;
 
     private JaxrsBinder(Binder binder)
     {
         this.binder = requireNonNull(binder, "binder is null").skipSources(getClass());
+        this.factoryBinder = newSetBinder(binder, JerseyFactoryBinding.class);
         this.resourceBinder = newSetBinder(binder, Object.class, JaxrsResource.class).permitDuplicates();
     }
 
@@ -49,6 +55,11 @@ public class JaxrsBinder
         resourceBinder.addBinding().to(targetKey).in(SINGLETON);
     }
 
+    public <T> void bindRequestScoped(Class<T> requestScopeClass, Class<? extends Supplier<T>> scopedFactory)
+    {
+        factoryBinder.addBinding().toInstance(scopedFactoryBinding(requestScopeClass, scopedFactory));
+    }
+
     public void bindInstance(Object instance)
     {
         resourceBinder.addBinding().toInstance(instance);
@@ -57,5 +68,14 @@ public class JaxrsBinder
     public static Collection<Class<?>> getBuiltinResources()
     {
         return ImmutableList.of(WadlResource.class, WadlModelProcessor.class, OptionsMethodProcessor.class);
+    }
+
+    private <T> JerseyFactoryBinding scopedFactoryBinding(Class<T> scopedClazz, Class<? extends Supplier<T>> scopedFactory)
+    {
+        return binder -> binder.bindFactory(scopedFactory)
+                .to(scopedClazz)
+                .proxy(false)
+                .proxyForSameScope(false)
+                .in(RequestScoped.class);
     }
 }

--- a/jaxrs/src/main/java/io/airlift/jaxrs/JaxrsModule.java
+++ b/jaxrs/src/main/java/io/airlift/jaxrs/JaxrsModule.java
@@ -57,6 +57,7 @@ public class JaxrsModule
         jaxrsBinder(binder).bind(SmileMapper.class);
         jaxrsBinder(binder).bind(ParsingExceptionMapper.class);
         jaxrsBinder(binder).bind(FactoryBinder.class);
+        jaxrsBinder(binder).bindRequestScoped(AsyncResponseBinder.class, AsyncResponseBinder.Factory.class);
 
         newSetBinder(binder, Object.class, JaxrsResource.class).permitDuplicates();
 

--- a/jaxrs/src/test/java/io/airlift/jaxrs/TestRequestScopedBinding.java
+++ b/jaxrs/src/test/java/io/airlift/jaxrs/TestRequestScopedBinding.java
@@ -1,0 +1,140 @@
+package io.airlift.jaxrs;
+
+import com.google.inject.BindingAnnotation;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import io.airlift.bootstrap.Bootstrap;
+import io.airlift.bootstrap.LifeCycleManager;
+import io.airlift.http.client.HttpClient;
+import io.airlift.http.client.Request;
+import io.airlift.http.server.HttpServerInfo;
+import io.airlift.http.server.testing.TestingHttpServerModule;
+import io.airlift.json.JsonModule;
+import io.airlift.node.testing.TestingNodeModule;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import org.testng.annotations.Test;
+
+import java.lang.annotation.Retention;
+import java.net.URI;
+import java.util.function.Supplier;
+
+import static io.airlift.http.client.HttpClientBinder.httpClientBinder;
+import static io.airlift.http.client.Request.Builder.prepareGet;
+import static io.airlift.http.client.StringResponseHandler.createStringResponseHandler;
+import static io.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static java.util.Objects.requireNonNull;
+import static org.testng.Assert.assertEquals;
+
+public class TestRequestScopedBinding
+{
+    @Test
+    public void testRequestScopedInjection()
+    {
+        Injector injector = startServer();
+        try {
+            HttpClient httpClient = injector.getInstance(Key.get(HttpClient.class, ForTest.class));
+            URI serverUri = injector.getInstance(HttpServerInfo.class).getHttpUri();
+
+            assertEquals(executeRequest(httpClient, serverUri, "Bob"), "Bob@127.0.0.1");
+            assertEquals(executeRequest(httpClient, serverUri, "Alice"), "Alice@127.0.0.1");
+        }
+        finally {
+            injector.getInstance(LifeCycleManager.class).stop();
+        }
+    }
+
+    private String executeRequest(HttpClient httpClient, URI baseUri, String name)
+    {
+        Request request = prepareGet()
+                .setUri(baseUri.resolve("/hello"))
+                .setHeader("X-Name", name)
+                .build();
+        return httpClient.execute(request, createStringResponseHandler()).getBody();
+    }
+
+    @Path("/hello")
+    public static class MyResource
+    {
+        @GET
+        public String returnRequestScopedInfo(@Context RemoteAddr remoteAddr, @Context HeaderValue headerValue)
+        {
+            return headerValue.getValue() + "@" + remoteAddr.value();
+        }
+    }
+
+    @Retention(RUNTIME)
+    @BindingAnnotation
+    public @interface ForTest {}
+
+    public record RemoteAddr(String value) {}
+
+    // this is not a record in order to test that normal classes work
+    public static class HeaderValue
+    {
+        private final String value;
+
+        public HeaderValue(String value)
+        {
+            this.value = requireNonNull(value, "value is null");
+        }
+
+        public String getValue()
+        {
+            return value;
+        }
+    }
+
+    private Injector startServer()
+    {
+        return new Bootstrap(
+                binder -> {
+                    jaxrsBinder(binder).bind(MyResource.class);
+                    httpClientBinder(binder).bindHttpClient("test", ForTest.class);
+                    jaxrsBinder(binder).bindRequestScoped(RemoteAddr.class, RemoteAddrFactory.class);
+                    jaxrsBinder(binder).bindRequestScoped(HeaderValue.class, HeaderValueFactory.class);
+                },
+                new TestingNodeModule(),
+                new TestingHttpServerModule(),
+                new JaxrsModule(),
+                new JsonModule())
+                .quiet()
+                .initialize();
+    }
+
+    private record RemoteAddrFactory(HttpServletRequest request)
+            implements Supplier<RemoteAddr>
+    {
+        private RemoteAddrFactory(@Context HttpServletRequest request)
+        {
+            this.request = requireNonNull(request, "request is null");
+        }
+
+        @Override
+        public RemoteAddr get()
+        {
+            return new RemoteAddr(request.getRemoteAddr());
+        }
+    }
+
+    private static class HeaderValueFactory
+            implements Supplier<HeaderValue>
+    {
+        private final HttpHeaders headers;
+
+        private HeaderValueFactory(@Context HttpHeaders headers)
+        {
+            this.headers = requireNonNull(headers, "headers is null");
+        }
+
+        @Override
+        public HeaderValue get()
+        {
+            return new HeaderValue(headers.getHeaderString("X-Name"));
+        }
+    }
+}


### PR DESCRIPTION
The second commits matters for HTTP/2 support. As explained in the commit message:

```
Add AsyncResponseBinder that allows to interrupt a Future when client disconnects
from the server. This will not only interrupt work that is no longer necessary
but also makes sure that the AsyncResponse won't be completed with the Response
since it's a pointless thing to do anyway. This is important for HTTP/2 communication
because client explicitly sends a RESET frame that server handles and recycles request/response
objects immediately.
```

This can be used in the Trino following manner:

Instead of:

```
public void getTaskInfo(
            @PathParam("taskId") TaskId taskId,
            @HeaderParam(TRINO_CURRENT_VERSION) Long currentVersion,
            @HeaderParam(TRINO_MAX_WAIT) Duration maxWait,
            @Context UriInfo uriInfo,
            @Suspended AsyncResponse asyncResponse)
```

```
 bindAsyncResponse(asyncResponse, futureTaskInfo, responseExecutor)
      .withTimeout(timeout);
```

following pattern can be used:

```
public void getTaskInfo(
            @PathParam("taskId") TaskId taskId,
            @HeaderParam(TRINO_CURRENT_VERSION) Long currentVersion,
            @HeaderParam(TRINO_MAX_WAIT) Duration maxWait,
            @Context UriInfo uriInfo,
            @Context AsyncResponseBinder asyncResponseBinder,
            @Suspended AsyncResponse asyncResponse)
```


```
asyncResponseBinder
            .withTimeout(timeout)
            .withFuture(futureTaskInfo)
            .withExecutor(responseExecutor)
            .cancelOnClientDisconnection()
            .bindTo(asyncResponse);
```

