### PR TITLE
Support request body streaming

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,7 @@
 - Improve request/response metrics accuracy and correctness
 - Update Airbase to 157
 - Remove deprecation notices/annotations from `enableLegacyUriCompliance()`
+- Add support for request body streaming to http client
 
 248
 

--- a/http-client/src/main/java/io/airlift/http/client/BodyGenerator.java
+++ b/http-client/src/main/java/io/airlift/http/client/BodyGenerator.java
@@ -20,7 +20,7 @@ import java.io.OutputStream;
 public interface BodyGenerator
 {
     /**
-     * @deprecated use {@link StaticBodyGenerator}, {@link JsonBodyGenerator}, or {@link FileBodyGenerator}
+     * @deprecated use {@link StaticBodyGenerator}, {@link JsonBodyGenerator}, {@link FileBodyGenerator}, or {@link StreamingBodyGenerator}
      */
     @Deprecated
     void write(OutputStream out)

--- a/http-client/src/main/java/io/airlift/http/client/StreamingBodyGenerator.java
+++ b/http-client/src/main/java/io/airlift/http/client/StreamingBodyGenerator.java
@@ -1,0 +1,35 @@
+package io.airlift.http.client;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import static java.util.Objects.requireNonNull;
+
+public class StreamingBodyGenerator
+        implements BodyGenerator
+{
+    private final InputStream source;
+
+    public static StreamingBodyGenerator streamingBodyGenerator(InputStream source)
+    {
+        return new StreamingBodyGenerator(source);
+    }
+
+    public InputStream source()
+    {
+        return source;
+    }
+
+    private StreamingBodyGenerator(InputStream source)
+    {
+        this.source = requireNonNull(source, "source is null");
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public void write(OutputStream out)
+            throws Exception
+    {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
@@ -13,6 +13,7 @@ import io.airlift.http.client.Request;
 import io.airlift.http.client.RequestStats;
 import io.airlift.http.client.ResponseHandler;
 import io.airlift.http.client.StaticBodyGenerator;
+import io.airlift.http.client.StreamingBodyGenerator;
 import io.airlift.http.client.jetty.HttpClientLogger.RequestInfo;
 import io.airlift.http.client.jetty.HttpClientLogger.ResponseInfo;
 import io.airlift.security.pem.PemReader;
@@ -42,6 +43,7 @@ import org.eclipse.jetty.client.Destination;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.HttpClientTransport;
 import org.eclipse.jetty.client.HttpProxy;
+import org.eclipse.jetty.client.InputStreamRequestContent;
 import org.eclipse.jetty.client.InputStreamResponseListener;
 import org.eclipse.jetty.client.Origin.Address;
 import org.eclipse.jetty.client.PathRequestContent;
@@ -930,6 +932,9 @@ public class JettyHttpClient
             }
             else if (bodyGenerator instanceof FileBodyGenerator generator) {
                 jettyRequest.body(fileContent(generator.getPath()));
+            }
+            else if (bodyGenerator instanceof StreamingBodyGenerator generator) {
+                jettyRequest.body(new InputStreamRequestContent(generator.source()));
             }
             else {
                 jettyRequest.body(new BytesRequestContent(generateBody(bodyGenerator)));

--- a/http-client/src/test/java/io/airlift/http/client/jetty/TestAsyncJettyHttpClient.java
+++ b/http-client/src/test/java/io/airlift/http/client/jetty/TestAsyncJettyHttpClient.java
@@ -52,4 +52,13 @@ public class TestAsyncJettyHttpClient
             return executeAsync(client, request, responseHandler);
         }
     }
+
+    protected void testPutMethodWithStreamingBodyGenerator(boolean largeContent)
+            throws Exception
+    {
+        // don't test with async clients as they buffer responses and the LARGE content is too big
+        if (!largeContent) {
+            super.testPutMethodWithStreamingBodyGenerator(false);
+        }
+    }
 }


### PR DESCRIPTION
Supports streaming the response of one request as the body of another request. i.e. a very simple pipe between two requests/responses. For the Jetty implementation, overrides with a Jetty `InputStreamRequestContent`.