### PR TITLE
Allow enabling Jetty's case sensitive header cache

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@
 - Support generic list and set injection into configuration classes
 - Update Jetty to 12.0.10
 - Update HdrHistogram to 2.2.2
+- Allow configuring Jetty's header cache case-sensitiveness
 
 248
 

--- a/http-server/src/main/java/io/airlift/http/server/EnableCaseSensitiveHeaderCache.java
+++ b/http-server/src/main/java/io/airlift/http/server/EnableCaseSensitiveHeaderCache.java
@@ -1,6 +1,4 @@
 /*
- * Copyright 2010 Proofpoint, Inc.
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -13,13 +11,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.airlift.http.server.testing;
+package io.airlift.http.server;
 
-public class TestTestingHttpServerWithVirtualThreads
-        extends AbstractTestTestingHttpServer
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@BindingAnnotation
+public @interface EnableCaseSensitiveHeaderCache
 {
-    TestTestingHttpServerWithVirtualThreads()
-    {
-        super(true, false, false);
-    }
 }

--- a/http-server/src/main/java/io/airlift/http/server/HttpServer.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServer.java
@@ -127,6 +127,7 @@ public class HttpServer
             Set<Filter> adminFilters,
             boolean enableVirtualThreads,
             boolean enableLegacyUriCompliance,
+            boolean enableCaseSensitiveHeaderCache,
             ClientCertificate clientCertificate,
             MBeanServer mbeanServer,
             LoginService loginService,
@@ -182,6 +183,9 @@ public class HttpServer
         if (config.getMaxResponseHeaderSize() != null) {
             baseHttpConfiguration.setResponseHeaderSize(toIntExact(config.getMaxResponseHeaderSize().toBytes()));
         }
+
+        // see https://bugs.eclipse.org/bugs/show_bug.cgi?id=414449#c4
+        baseHttpConfiguration.setHeaderCacheCaseSensitive(enableCaseSensitiveHeaderCache);
 
         if (enableLegacyUriCompliance) {
             // allow encoded slashes to occur in URI paths

--- a/http-server/src/main/java/io/airlift/http/server/HttpServerBinder.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServerBinder.java
@@ -41,6 +41,12 @@ public class HttpServerBinder
         return this;
     }
 
+    public HttpServerBinder enableCaseSensitiveHeaderCache()
+    {
+        newOptionalBinder(binder, Key.get(Boolean.class, EnableCaseSensitiveHeaderCache.class)).setBinding().toInstance(true);
+        return this;
+    }
+
     /**
      * @deprecated this will be removed in the near future and is only intended as a stopgap
      */

--- a/http-server/src/main/java/io/airlift/http/server/HttpServerModule.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServerModule.java
@@ -78,6 +78,7 @@ public class HttpServerModule
         newSetBinder(binder, Filter.class, TheAdminServlet.class);
         newSetBinder(binder, HttpResourceBinding.class, TheServlet.class);
         newOptionalBinder(binder, SslContextFactory.Server.class);
+        newOptionalBinder(binder, Key.get(Boolean.class, EnableCaseSensitiveHeaderCache.class)).setDefault().toInstance(false);
 
         newExporter(binder).export(RequestStats.class).withGeneratedName();
 

--- a/http-server/src/main/java/io/airlift/http/server/HttpServerProvider.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServerProvider.java
@@ -58,6 +58,7 @@ public class HttpServerProvider
     private Map<String, String> adminServletInitParameters = ImmutableMap.of();
     private final boolean enableVirtualThreads;
     private final boolean enableLegacyUriCompliance;
+    private final boolean enableCaseSensitiveHeaderCache;
     private MBeanServer mbeanServer;
     private LoginService loginService;
     private final RequestStats stats;
@@ -78,6 +79,7 @@ public class HttpServerProvider
             @TheAdminServlet Set<Filter> adminFilters,
             @EnableVirtualThreads boolean enableVirtualThreads,
             @EnableLegacyUriCompliance boolean enableLegacyUriCompliance,
+            @EnableCaseSensitiveHeaderCache boolean enableCaseSensitiveHeaderCache,
             ClientCertificate clientCertificate,
             RequestStats stats,
             EventClient eventClient,
@@ -106,6 +108,7 @@ public class HttpServerProvider
         this.adminFilters = ImmutableSet.copyOf(adminFilters);
         this.enableVirtualThreads = enableVirtualThreads;
         this.enableLegacyUriCompliance = enableLegacyUriCompliance;
+        this.enableCaseSensitiveHeaderCache = enableCaseSensitiveHeaderCache;
         this.clientCertificate = clientCertificate;
         this.stats = stats;
         this.eventClient = eventClient;
@@ -166,6 +169,7 @@ public class HttpServerProvider
                     adminFilters,
                     enableVirtualThreads,
                     enableLegacyUriCompliance,
+                    enableCaseSensitiveHeaderCache,
                     clientCertificate,
                     mbeanServer,
                     loginService,

--- a/http-server/src/main/java/io/airlift/http/server/testing/TestingHttpServer.java
+++ b/http-server/src/main/java/io/airlift/http/server/testing/TestingHttpServer.java
@@ -18,6 +18,7 @@ package io.airlift.http.server.testing;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import io.airlift.event.client.NullEventClient;
+import io.airlift.http.server.EnableCaseSensitiveHeaderCache;
 import io.airlift.http.server.EnableLegacyUriCompliance;
 import io.airlift.http.server.EnableVirtualThreads;
 import io.airlift.http.server.HttpServer;
@@ -51,7 +52,7 @@ public class TestingHttpServer
             @TheServlet Map<String, String> initParameters)
             throws IOException
     {
-        this(httpServerInfo, nodeInfo, config, servlet, initParameters, false, false);
+        this(httpServerInfo, nodeInfo, config, servlet, initParameters, false, false, false);
     }
 
     public TestingHttpServer(
@@ -61,7 +62,8 @@ public class TestingHttpServer
             @TheServlet Servlet servlet,
             @TheServlet Map<String, String> initParameters,
             boolean enableVirtualThreads,
-            boolean enableLegacyUriCompliance)
+            boolean enableLegacyUriCompliance,
+            boolean enableCaseSensitiveHeaderCache)
             throws IOException
     {
         this(httpServerInfo,
@@ -74,6 +76,7 @@ public class TestingHttpServer
                 ImmutableSet.of(),
                 enableVirtualThreads,
                 enableLegacyUriCompliance,
+                enableCaseSensitiveHeaderCache,
                 ClientCertificate.NONE);
     }
 
@@ -89,6 +92,7 @@ public class TestingHttpServer
             @TheServlet Set<HttpResourceBinding> resources,
             @EnableVirtualThreads boolean enableVirtualThreads,
             @EnableLegacyUriCompliance boolean enableLegacyUriCompliance,
+            @EnableCaseSensitiveHeaderCache boolean enableCaseSensitiveHeaderCache,
             ClientCertificate clientCertificate)
             throws IOException
     {
@@ -105,6 +109,7 @@ public class TestingHttpServer
                 ImmutableSet.of(),
                 enableVirtualThreads,
                 enableLegacyUriCompliance,
+                enableCaseSensitiveHeaderCache,
                 clientCertificate,
                 null,
                 null,

--- a/http-server/src/main/java/io/airlift/http/server/testing/TestingHttpServerModule.java
+++ b/http-server/src/main/java/io/airlift/http/server/testing/TestingHttpServerModule.java
@@ -18,6 +18,7 @@ import com.google.inject.Key;
 import com.google.inject.Scopes;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.airlift.discovery.client.AnnouncementHttpServerInfo;
+import io.airlift.http.server.EnableCaseSensitiveHeaderCache;
 import io.airlift.http.server.EnableLegacyUriCompliance;
 import io.airlift.http.server.EnableVirtualThreads;
 import io.airlift.http.server.HttpServer;
@@ -69,6 +70,7 @@ public class TestingHttpServerModule
         newSetBinder(binder, Filter.class, TheServlet.class);
         newSetBinder(binder, HttpResourceBinding.class, TheServlet.class);
         binder.bind(AnnouncementHttpServerInfo.class).to(LocalAnnouncementHttpServerInfo.class);
+        newOptionalBinder(binder, Key.get(Boolean.class, EnableCaseSensitiveHeaderCache.class)).setDefault().toInstance(false);
 
         newOptionalBinder(binder, HttpsConfig.class);
         install(conditionalModule(HttpServerConfig.class, HttpServerConfig::isHttpsEnabled, moduleBinder -> {

--- a/http-server/src/test/java/io/airlift/http/server/TestHttpServerCipher.java
+++ b/http-server/src/test/java/io/airlift/http/server/TestHttpServerCipher.java
@@ -228,6 +228,7 @@ public class TestHttpServerCipher
                 ImmutableSet.of(),
                 false,
                 false,
+                false,
                 ClientCertificate.NONE,
                 new RequestStats(),
                 new NullEventClient(),

--- a/http-server/src/test/java/io/airlift/http/server/TestHttpServerProvider.java
+++ b/http-server/src/test/java/io/airlift/http/server/TestHttpServerProvider.java
@@ -680,6 +680,7 @@ public class TestHttpServerProvider
                 ImmutableSet.of(),
                 false,
                 false,
+                false,
                 clientCertificate,
                 new RequestStats(),
                 new NullEventClient(),

--- a/http-server/src/test/java/io/airlift/http/server/TestJettyMultipleCerts.java
+++ b/http-server/src/test/java/io/airlift/http/server/TestJettyMultipleCerts.java
@@ -88,6 +88,7 @@ public class TestJettyMultipleCerts
                 ImmutableSet.of(),
                 false,
                 false,
+                false,
                 ClientCertificate.NONE,
                 new RequestStats(),
                 new NullEventClient(),

--- a/http-server/src/test/java/io/airlift/http/server/testing/TestTestingHttpServer.java
+++ b/http-server/src/test/java/io/airlift/http/server/testing/TestTestingHttpServer.java
@@ -20,6 +20,6 @@ public class TestTestingHttpServer
 {
     TestTestingHttpServer()
     {
-        super(false, false);
+        super(false, false, false);
     }
 }

--- a/http-server/src/test/java/io/airlift/http/server/testing/TestTestingHttpServerWithAllEnabled.java
+++ b/http-server/src/test/java/io/airlift/http/server/testing/TestTestingHttpServerWithAllEnabled.java
@@ -5,6 +5,6 @@ public class TestTestingHttpServerWithAllEnabled
 {
     TestTestingHttpServerWithAllEnabled()
     {
-        super(true, true);
+        super(true, true, true);
     }
 }

--- a/http-server/src/test/java/io/airlift/http/server/testing/TestTestingHttpServerWithCaseSensitiveHeaderCache.java
+++ b/http-server/src/test/java/io/airlift/http/server/testing/TestTestingHttpServerWithCaseSensitiveHeaderCache.java
@@ -1,0 +1,10 @@
+package io.airlift.http.server.testing;
+
+public class TestTestingHttpServerWithCaseSensitiveHeaderCache
+        extends AbstractTestTestingHttpServer
+{
+    TestTestingHttpServerWithCaseSensitiveHeaderCache()
+    {
+        super(false, false, true);
+    }
+}

--- a/http-server/src/test/java/io/airlift/http/server/testing/TestTestingHttpServerWithLegacyUriCompliance.java
+++ b/http-server/src/test/java/io/airlift/http/server/testing/TestTestingHttpServerWithLegacyUriCompliance.java
@@ -5,6 +5,6 @@ public class TestTestingHttpServerWithLegacyUriCompliance
 {
     TestTestingHttpServerWithLegacyUriCompliance()
     {
-        super(false, true);
+        super(false, true, false);
     }
 }


### PR DESCRIPTION
See: https://bugs.eclipse.org/bugs/show_bug.cgi?id=414449#c4

Jetty re-writes headers based on a cache. This can result in headers being sent to clients with a cached value that has a different case then what was sent from the remote client. In applications that must validate headers for hash signatures this is a severe problem as the value that was sent by the client is lost.

Add a binding that makes Jetty's header cache case sensitive. This is a documented feature of Jetty.