### PR TITLE
Reject X-FORWARDED-* headers if processing is disabled

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,7 @@
 - Update Jetty to 12.0.10
 - Update HdrHistogram to 2.2.2
 - Allow configuring Jetty's header cache case-sensitiveness
+- Reject X-Forwarded-* headers if http-server.process-forwarded is false
 
 248
 

--- a/http-server/src/main/java/io/airlift/http/server/HttpServer.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServer.java
@@ -177,6 +177,9 @@ public class HttpServer
         if (config.isProcessForwarded()) {
             baseHttpConfiguration.addCustomizer(new ForwardedRequestCustomizer());
         }
+        else {
+            baseHttpConfiguration.addCustomizer(new RejectForwardedRequestCustomizer());
+        }
         if (config.getMaxRequestHeaderSize() != null) {
             baseHttpConfiguration.setRequestHeaderSize(toIntExact(config.getMaxRequestHeaderSize().toBytes()));
         }

--- a/http-server/src/main/java/io/airlift/http/server/RejectForwardedRequestCustomizer.java
+++ b/http-server/src/main/java/io/airlift/http/server/RejectForwardedRequestCustomizer.java
@@ -1,0 +1,30 @@
+package io.airlift.http.server;
+
+import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpField;
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.Request;
+
+public class RejectForwardedRequestCustomizer
+        implements HttpConfiguration.Customizer
+{
+    private static final String X_FORWARDED_PREFIX = "x-forwarded-";
+
+    @Override
+    public Request customize(Request request, HttpFields.Mutable responseHeaders)
+    {
+        for (HttpField httpHeader : request.getHeaders()) {
+            if (isForwardingHeader(httpHeader)) {
+                throw new BadMessageException(HttpStatus.NOT_ACCEPTABLE_406, "Server configuration does not allow processing of the %s header".formatted(httpHeader.getName()));
+            }
+        }
+        return request;
+    }
+
+    private static boolean isForwardingHeader(HttpField httpField)
+    {
+        return httpField.getName().regionMatches(true, 0, X_FORWARDED_PREFIX, 0, X_FORWARDED_PREFIX.length());
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/trinodb/trino/issues/6552