### PR TITLE
enableLegacyUriCompliance() should not be deprecated

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,7 @@
 - Add HTTP protocol version to client traces
 - Improve request/response metrics accuracy and correctness
 - Update Airbase to 157
+- Remove deprecation notices/annotations from `enableLegacyUriCompliance()`
 
 248
 

--- a/http-server/src/main/java/io/airlift/http/server/HttpServerBinder.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServerBinder.java
@@ -47,10 +47,6 @@ public class HttpServerBinder
         return this;
     }
 
-    /**
-     * @deprecated this will be removed in the near future and is only intended as a stopgap
-     */
-    @Deprecated(forRemoval = true)
     public HttpServerBinder enableLegacyUriCompliance()
     {
         newOptionalBinder(binder, Key.get(Boolean.class, EnableLegacyUriCompliance.class)).setBinding().toInstance(true);

--- a/http-server/src/test/java/io/airlift/http/server/TestHttpServerModule.java
+++ b/http-server/src/test/java/io/airlift/http/server/TestHttpServerModule.java
@@ -178,7 +178,6 @@ public class TestHttpServerModule
         return ImmutableList.of(true, false).iterator();
     }
 
-    @SuppressWarnings("removal")
     @Test(dataProvider = "enabledDisabled")
     public void testServer(boolean enableLegacyUriCompliance)
             throws Exception

--- a/jaxrs/src/test/java/io/airlift/jaxrs/TestLegacyUriMode.java
+++ b/jaxrs/src/test/java/io/airlift/jaxrs/TestLegacyUriMode.java
@@ -95,7 +95,6 @@ public class TestLegacyUriMode
         }
     }
 
-    @SuppressWarnings("removal")
     private Injector startServer(boolean legacyUriComplianceEnabled)
     {
         return new Bootstrap(


### PR DESCRIPTION
The Jetty team has said that this will be supported in the future

see: https://github.com/airlift/airlift/pull/1127#issuecomment-2003738619