### PR TITLE
Rewrite TestNG Assertions to AssertJ

### DIFF
--- a/bootstrap/src/test/java/io/airlift/bootstrap/TestBootstrap.java
+++ b/bootstrap/src/test/java/io/airlift/bootstrap/TestBootstrap.java
@@ -27,8 +27,7 @@ import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.testing.Assertions.assertContains;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 public class TestBootstrap
 {
@@ -118,7 +117,7 @@ public class TestBootstrap
         new Bootstrap().setOptionalConfigurationProperty("log.path", "tcp://0.0.0.0:0").initialize();
         int configuredHandlerCount = root.getHandlers().length;
         new Bootstrap().setOptionalConfigurationProperty("log.path", "tcp://0.0.0.0:0").initialize();
-        assertEquals(root.getHandlers().length, configuredHandlerCount);
+        assertThat(root.getHandlers()).hasSize(configuredHandlerCount);
     }
 
     @SuppressWarnings("AssignmentToStaticFieldFromInstanceMethod")

--- a/bootstrap/src/test/java/io/airlift/bootstrap/TestConfigurationAwareModule.java
+++ b/bootstrap/src/test/java/io/airlift/bootstrap/TestConfigurationAwareModule.java
@@ -23,9 +23,8 @@ import io.airlift.configuration.ConfigurationAwareModule;
 import org.testng.annotations.Test;
 
 import static com.google.inject.name.Names.named;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 
 public class TestConfigurationAwareModule
 {
@@ -38,9 +37,9 @@ public class TestConfigurationAwareModule
                 .setRequiredConfigurationProperty("bar.enabled", "true")
                 .initialize();
 
-        assertEquals(injector.getInstance(Key.get(String.class, named("foo"))), "fooInstance");
-        assertEquals(injector.getInstance(Key.get(String.class, named("bar"))), "barInstance");
-        assertEquals(injector.getInstance(Key.get(String.class, named("abc"))), "abcInstance");
+        assertThat(injector.getInstance(Key.get(String.class, named("foo")))).isEqualTo("fooInstance");
+        assertThat(injector.getInstance(Key.get(String.class, named("bar")))).isEqualTo("barInstance");
+        assertThat(injector.getInstance(Key.get(String.class, named("abc")))).isEqualTo("abcInstance");
     }
 
     @Test
@@ -63,7 +62,7 @@ public class TestConfigurationAwareModule
                     @Override
                     protected void setup(Binder binder)
                     {
-                        assertTrue(buildConfigObject(FooConfig.class).isFoo());
+                        assertThat(buildConfigObject(FooConfig.class).isFoo()).isTrue();
                         binder.bind(String.class).annotatedWith(named("foo")).toInstance("fooInstance");
                     }
                 },
@@ -72,7 +71,7 @@ public class TestConfigurationAwareModule
                     @Override
                     protected void setup(Binder binder)
                     {
-                        assertTrue(buildConfigObject(BarConfig.class).isBar());
+                        assertThat(buildConfigObject(BarConfig.class).isBar()).isTrue();
                         binder.bind(String.class).annotatedWith(named("bar")).toInstance("barInstance");
                     }
                 });
@@ -83,8 +82,8 @@ public class TestConfigurationAwareModule
                 .setRequiredConfigurationProperty("bar.enabled", "true")
                 .initialize();
 
-        assertEquals(injector.getInstance(Key.get(String.class, named("foo"))), "fooInstance");
-        assertEquals(injector.getInstance(Key.get(String.class, named("bar"))), "barInstance");
+        assertThat(injector.getInstance(Key.get(String.class, named("foo")))).isEqualTo("fooInstance");
+        assertThat(injector.getInstance(Key.get(String.class, named("bar")))).isEqualTo("barInstance");
     }
 
     public static class FooModule
@@ -93,7 +92,7 @@ public class TestConfigurationAwareModule
         @Override
         protected void setup(Binder binder)
         {
-            assertTrue(buildConfigObject(FooConfig.class).isFoo());
+            assertThat(buildConfigObject(FooConfig.class).isFoo()).isTrue();
             install(new BarModule());
             binder.bind(String.class).annotatedWith(named("foo")).toInstance("fooInstance");
             binder.install(new AbcModule());
@@ -106,7 +105,7 @@ public class TestConfigurationAwareModule
         @Override
         protected void setup(Binder binder)
         {
-            assertTrue(buildConfigObject(BarConfig.class).isBar());
+            assertThat(buildConfigObject(BarConfig.class).isBar()).isTrue();
             binder.bind(String.class).annotatedWith(named("bar")).toInstance("barInstance");
         }
     }

--- a/bootstrap/src/test/java/io/airlift/bootstrap/TestLifeCycleManager.java
+++ b/bootstrap/src/test/java/io/airlift/bootstrap/TestLifeCycleManager.java
@@ -38,9 +38,8 @@ import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 @Test(singleThreaded = true)
 public class TestLifeCycleManager
@@ -73,7 +72,7 @@ public class TestLifeCycleManager
         LifeCycleManager lifeCycleManager = injector.getInstance(LifeCycleManager.class);
         lifeCycleManager.start();
 
-        assertEquals(stateLog, ImmutableList.of("InstanceThatUsesInstanceThatRequiresStart:OK"));
+        assertThat(stateLog).isEqualTo(ImmutableList.of("InstanceThatUsesInstanceThatRequiresStart:OK"));
     }
 
     @Test
@@ -94,10 +93,10 @@ public class TestLifeCycleManager
 
         LifeCycleManager lifeCycleManager = injector.getInstance(LifeCycleManager.class);
         lifeCycleManager.start();
-        assertEquals(stateLog, ImmutableList.of("postSimpleBaseImpl"));
+        assertThat(stateLog).isEqualTo(ImmutableList.of("postSimpleBaseImpl"));
 
         lifeCycleManager.stop();
-        assertEquals(stateLog, ImmutableList.of("postSimpleBaseImpl", "preSimpleBaseImpl"));
+        assertThat(stateLog).isEqualTo(ImmutableList.of("postSimpleBaseImpl", "preSimpleBaseImpl"));
     }
 
     @Test
@@ -110,11 +109,11 @@ public class TestLifeCycleManager
 
         LifeCycleManager lifeCycleManager = injector.getInstance(LifeCycleManager.class);
         lifeCycleManager.start();
-        assertEquals(stateLog, ImmutableList.of("postSimpleBaseImpl"));
+        assertThat(stateLog).isEqualTo(ImmutableList.of("postSimpleBaseImpl"));
 
         lifeCycleManager.stop();
 
-        assertEquals(stateLog, ImmutableList.of("postSimpleBaseImpl", "preSimpleBaseImpl"));
+        assertThat(stateLog).isEqualTo(ImmutableList.of("postSimpleBaseImpl", "preSimpleBaseImpl"));
     }
 
     @Test
@@ -130,12 +129,12 @@ public class TestLifeCycleManager
         LifeCycleManager lifeCycleManager = injector.getInstance(LifeCycleManager.class);
         lifeCycleManager.start();
         instance.waitForStart();
-        assertEquals(stateLog, ImmutableList.of("Starting"));
+        assertThat(stateLog).isEqualTo(ImmutableList.of("Starting"));
 
         lifeCycleManager.stop();
         instance.waitForEnd();
 
-        assertEquals(stateLog, ImmutableList.of("Starting", "Done"));
+        assertThat(stateLog).isEqualTo(ImmutableList.of("Starting", "Done"));
     }
 
     @Test
@@ -154,10 +153,10 @@ public class TestLifeCycleManager
 
         LifeCycleManager lifeCycleManager = injector.getInstance(LifeCycleManager.class);
         lifeCycleManager.start();
-        assertEquals(stateLog, ImmutableList.of("postDependentInstance"));
+        assertThat(stateLog).isEqualTo(ImmutableList.of("postDependentInstance"));
 
         lifeCycleManager.stop();
-        assertEquals(stateLog, ImmutableList.of("postDependentInstance", "preDependentInstance"));
+        assertThat(stateLog).isEqualTo(ImmutableList.of("postDependentInstance", "preDependentInstance"));
     }
 
     @Test
@@ -187,7 +186,7 @@ public class TestLifeCycleManager
         lifeCycleManager.start();
         lifeCycleManager.stop();
 
-        assertEquals(stateLog, ImmutableList.of("foo"));
+        assertThat(stateLog).isEqualTo(ImmutableList.of("foo"));
     }
 
     @Test
@@ -206,7 +205,7 @@ public class TestLifeCycleManager
         lifeCycleManager.start();
         lifeCycleManager.stop();
 
-        assertEquals(stateLog, ImmutableList.of("postDependentInstance", "preDependentInstance"));
+        assertThat(stateLog).isEqualTo(ImmutableList.of("postDependentInstance", "preDependentInstance"));
     }
 
     @Test
@@ -222,20 +221,23 @@ public class TestLifeCycleManager
 
         LifeCycleManager lifeCycleManager = injector.getInstance(LifeCycleManager.class);
         lifeCycleManager.start();
-        assertEquals(stateLog, ImmutableList.of("postDependentInstance"));
+        assertThat(stateLog).isEqualTo(ImmutableList.of("postDependentInstance"));
         try {
             lifeCycleManager.stopWithoutFailureLogging();
             fail("Expected exception to be thrown");
         }
         catch (LifeCycleStopException e) {
-            assertEquals(e.getSuppressed().length, 2, "Expected two suppressed exceptions");
+            assertThat(e.getSuppressed())
+                    .as("Expected two suppressed exceptions")
+                    .hasSize(2);
             Set<String> suppressedMessages = Arrays.stream(e.getSuppressed())
                     .map(Throwable::getMessage)
                     .collect(Collectors.toSet());
-            assertEquals(ImmutableSet.copyOf(suppressedMessages), ImmutableSet.of("preDestroyExceptionOne", "preDestroyExceptionTwo"));
+            assertThat(ImmutableSet.copyOf(suppressedMessages))
+                    .isEqualTo(ImmutableSet.of("preDestroyExceptionOne", "preDestroyExceptionTwo"));
         }
 
-        assertEquals(ImmutableSet.copyOf(stateLog), ImmutableSet.of(
+        assertThat(ImmutableSet.copyOf(stateLog)).isEqualTo(ImmutableSet.of(
                 "postDependentInstance",
                 "preDestroyExceptionOne",
                 "preDestroyExceptionTwo",
@@ -255,16 +257,18 @@ public class TestLifeCycleManager
 
         LifeCycleManager lifeCycleManager = injector.getInstance(LifeCycleManager.class);
         lifeCycleManager.start();
-        assertEquals(stateLog, ImmutableList.of("postDependentInstance"));
+        assertThat(stateLog).isEqualTo(ImmutableList.of("postDependentInstance"));
         try {
             lifeCycleManager.stop();
             fail("Expected exception to be thrown");
         }
         catch (LifeCycleStopException e) {
-            assertEquals(e.getSuppressed().length, 0, "Suppressed exceptions list should be empty");
+            assertThat(e.getSuppressed())
+                    .as("Suppressed exceptions list should be empty")
+                    .hasSize(0);
         }
 
-        assertEquals(ImmutableSet.copyOf(stateLog), ImmutableSet.of(
+        assertThat(ImmutableSet.copyOf(stateLog)).isEqualTo(ImmutableSet.of(
                 "postDependentInstance",
                 "preDestroyExceptionOne",
                 "preDestroyExceptionTwo",
@@ -275,26 +279,29 @@ public class TestLifeCycleManager
     public void testPostConstructExceptionCallsPreDestroy()
     {
         try {
-            Injector injector = Guice.createInjector(
+            Guice.createInjector(
                     Stage.PRODUCTION,
                     new LifeCycleModule(),
                     binder -> binder.bind(PostConstructExceptionInstance.class).in(Scopes.SINGLETON));
             fail("Expected injector creation to fail with an exception");
         }
         catch (CreationException e) {
-            assertEquals(ImmutableSet.copyOf(stateLog), ImmutableSet.of(
+            assertThat(ImmutableSet.copyOf(stateLog)).isEqualTo(ImmutableSet.of(
                     "postConstructFailure",
                     "preDestroyFailureAfterPostConstructFailureOne",
                     "preDestroyFailureAfterPostConstructFailureTwo"));
-            assertEquals(e.getCause().getClass(), LifeCycleStartException.class, "Expected LifeCycleStartException to be thrown, found: " + e.getCause().getClass());
-            assertEquals(e.getCause().getSuppressed().length, 2, "Expected two suppressed exceptions");
-            assertEquals(
-                    ImmutableSet.copyOf(
-                            Arrays.stream(e.getCause().getSuppressed())
-                                    .map(Throwable::getCause)
-                                    .map(Throwable::getMessage)
-                                    .collect(Collectors.toSet())),
-                    ImmutableSet.of("preDestroyFailureAfterPostConstructFailureOne", "preDestroyFailureAfterPostConstructFailureTwo"));
+            assertThat(e.getCause().getClass())
+                    .as("Expected LifeCycleStartException to be thrown, found: " + e.getCause().getClass())
+                    .isEqualTo(LifeCycleStartException.class);
+            assertThat(e.getCause().getSuppressed())
+                    .as("Expected two suppressed exceptions")
+                    .hasSize(2);
+            assertThat(ImmutableSet.copyOf(
+                    Arrays.stream(e.getCause().getSuppressed())
+                            .map(Throwable::getCause)
+                            .map(Throwable::getMessage)
+                            .collect(Collectors.toSet())))
+                    .isEqualTo(ImmutableSet.of("preDestroyFailureAfterPostConstructFailureOne", "preDestroyFailureAfterPostConstructFailureTwo"));
         }
     }
 
@@ -312,10 +319,10 @@ public class TestLifeCycleManager
 
         LifeCycleManager lifeCycleManager = injector.getInstance(LifeCycleManager.class);
         lifeCycleManager.start();
-        assertEquals(stateLog, ImmutableList.of("makeMe"));
+        assertThat(stateLog).isEqualTo(ImmutableList.of("makeMe"));
 
         lifeCycleManager.stop();
-        assertEquals(stateLog, ImmutableList.of("makeMe", "unmakeMe"));
+        assertThat(stateLog).isEqualTo(ImmutableList.of("makeMe", "unmakeMe"));
     }
 
     @Test
@@ -337,16 +344,15 @@ public class TestLifeCycleManager
         lifeCycleManager.stop();
 
         Set<String> stateLogSet = new HashSet<>(stateLog);
-        assertEquals(stateLogSet,
-                Sets.newHashSet(
-                        "postDependentBoundInstance",
-                        "postDependentInstance",
-                        "postMakeOne",
-                        "postMakeTwo",
-                        "preDestroyTwo",
-                        "preDestroyOne",
-                        "preDependentInstance",
-                        "preDependentBoundInstance"));
+        assertThat(stateLogSet).isEqualTo(Sets.newHashSet(
+                "postDependentBoundInstance",
+                "postDependentInstance",
+                "postMakeOne",
+                "postMakeTwo",
+                "preDestroyTwo",
+                "preDestroyOne",
+                "preDependentInstance",
+                "preDependentBoundInstance"));
     }
 
     @Test
@@ -360,10 +366,12 @@ public class TestLifeCycleManager
         LifeCycleManager lifeCycleManager = injector.getInstance(LifeCycleManager.class);
 
         lifeCycleManager.start();
-        assertEquals(stateLog, ImmutableList.of("postBarProvider", "postBarInstance"));
+        assertThat(stateLog)
+                .isEqualTo(ImmutableList.of("postBarProvider", "postBarInstance"));
 
         lifeCycleManager.stop();
-        assertEquals(stateLog, ImmutableList.of("postBarProvider", "postBarInstance", "preBarInstance", "preBarProvider"));
+        assertThat(stateLog)
+                .isEqualTo(ImmutableList.of("postBarProvider", "postBarInstance", "preBarInstance", "preBarProvider"));
     }
 
     @Test
@@ -388,10 +396,10 @@ public class TestLifeCycleManager
         LifeCycleManager lifeCycleManager = injector.getInstance(LifeCycleManager.class);
 
         lifeCycleManager.start();
-        assertEquals(stateLog, ImmutableList.of("postBarInstance"));
+        assertThat(stateLog).isEqualTo(ImmutableList.of("postBarInstance"));
 
         lifeCycleManager.stop();
-        assertEquals(stateLog, ImmutableList.of("postBarInstance", "preBarInstance"));
+        assertThat(stateLog).isEqualTo(ImmutableList.of("postBarInstance", "preBarInstance"));
     }
 
     @Test
@@ -412,13 +420,13 @@ public class TestLifeCycleManager
                     }
                 });
 
-        assertNull(injector.getInstance(BarInstance.class));
+        assertThat(injector.getInstance(BarInstance.class)).isNull();
 
         LifeCycleManager lifeCycleManager = injector.getInstance(LifeCycleManager.class);
 
         lifeCycleManager.start();
         lifeCycleManager.stop();
 
-        assertNull(injector.getInstance(BarInstance.class));
+        assertThat(injector.getInstance(BarInstance.class)).isNull();
     }
 }

--- a/concurrent/src/test/java/io/airlift/concurrent/TestAsyncSemaphore.java
+++ b/concurrent/src/test/java/io/airlift/concurrent/TestAsyncSemaphore.java
@@ -21,6 +21,7 @@ import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.common.util.concurrent.Uninterruptibles;
 import jakarta.annotation.Nullable;
+import org.assertj.core.api.Fail;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -49,8 +50,7 @@ import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.testing.Assertions.assertLessThanOrEqual;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.fail;
+import static org.assertj.core.api.Fail.fail;
 
 public class TestAsyncSemaphore
 {
@@ -72,7 +72,7 @@ public class TestAsyncSemaphore
         // Wait for completion
         Futures.allAsList(futures).get(1, TimeUnit.MINUTES);
 
-        assertEquals(count.get(), 1000);
+        assertThat(count.get()).isEqualTo(1000);
     }
 
     @Test
@@ -86,7 +86,7 @@ public class TestAsyncSemaphore
 
         List<ListenableFuture<Void>> futures = new ArrayList<>();
         for (int i = 0; i < 1000; i++) {
-            futures.add(asyncSemaphore.submit((Runnable) () -> {
+            futures.add(asyncSemaphore.submit(() -> {
                 count.incrementAndGet();
                 int currentConcurrency = concurrency.incrementAndGet();
                 assertLessThanOrEqual(currentConcurrency, 1);
@@ -98,7 +98,7 @@ public class TestAsyncSemaphore
         // Wait for completion
         Futures.allAsList(futures).get(1, TimeUnit.MINUTES);
 
-        assertEquals(count.get(), 1000);
+        assertThat(count.get()).isEqualTo(1000);
     }
 
     @Test
@@ -124,7 +124,7 @@ public class TestAsyncSemaphore
         // Wait for completion
         Futures.allAsList(futures).get(1, TimeUnit.MINUTES);
 
-        assertEquals(count.get(), 1000);
+        assertThat(count.get()).isEqualTo(1000);
     }
 
     @Test
@@ -141,7 +141,7 @@ public class TestAsyncSemaphore
         for (int i = 0; i < 100; i++) {
             executor.execute(() -> {
                 Uninterruptibles.awaitUninterruptibly(startLatch, 1, TimeUnit.MINUTES);
-                asyncSemaphore.submit((Runnable) () -> {
+                asyncSemaphore.submit(() -> {
                     count.incrementAndGet();
                     int currentConcurrency = concurrency.incrementAndGet();
                     assertLessThanOrEqual(currentConcurrency, 2);
@@ -157,7 +157,7 @@ public class TestAsyncSemaphore
         // Wait for completion
         Uninterruptibles.awaitUninterruptibly(completionLatch, 1, TimeUnit.MINUTES);
 
-        assertEquals(count.get(), 100);
+        assertThat(count.get()).isEqualTo(100);
     }
 
     @Test
@@ -190,8 +190,8 @@ public class TestAsyncSemaphore
             }
         }
 
-        assertEquals(successCount.get(), 0);
-        assertEquals(failureCount.get(), 1000);
+        assertThat(successCount.get()).isEqualTo(0);
+        assertThat(failureCount.get()).isEqualTo(1000);
     }
 
     @Test
@@ -209,7 +209,7 @@ public class TestAsyncSemaphore
         List<ListenableFuture<Void>> futures = new ArrayList<>();
         for (int i = 0; i < 1000; i++) {
             // Should never execute this future
-            ListenableFuture<Void> future = asyncSemaphore.submit(() -> fail(null));
+            ListenableFuture<Void> future = asyncSemaphore.submit(Fail::fail);
             addCallback(future, completionCallback(successCount, failureCount, completionLatch), directExecutor());
             futures.add(future);
         }
@@ -226,8 +226,8 @@ public class TestAsyncSemaphore
             }
         }
 
-        assertEquals(successCount.get(), 0);
-        assertEquals(failureCount.get(), 1000);
+        assertThat(successCount.get()).isEqualTo(0);
+        assertThat(failureCount.get()).isEqualTo(1000);
     }
 
     @Test
@@ -249,7 +249,7 @@ public class TestAsyncSemaphore
             executor.execute(() -> {
                 Uninterruptibles.awaitUninterruptibly(startLatch, 1, TimeUnit.MINUTES);
                 // Should never execute this future
-                ListenableFuture<Void> future = asyncSemaphore.submit(() -> fail(null));
+                ListenableFuture<Void> future = asyncSemaphore.submit(Fail::fail);
                 futures.add(future);
                 addCallback(future, completionCallback(successCount, failureCount, completionLatch), directExecutor());
             });
@@ -270,8 +270,8 @@ public class TestAsyncSemaphore
             }
         }
 
-        assertEquals(successCount.get(), 0);
-        assertEquals(failureCount.get(), 100);
+        assertThat(successCount.get()).isEqualTo(0);
+        assertThat(failureCount.get()).isEqualTo(100);
     }
 
     @Test

--- a/concurrent/src/test/java/io/airlift/concurrent/TestBoundedExecutor.java
+++ b/concurrent/src/test/java/io/airlift/concurrent/TestBoundedExecutor.java
@@ -14,11 +14,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.google.common.util.concurrent.Uninterruptibles.awaitUninterruptibly;
 import static java.util.concurrent.Executors.newCachedThreadPool;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 public class TestBoundedExecutor
 {
@@ -66,7 +64,7 @@ public class TestBoundedExecutor
             });
         }
 
-        assertTrue(awaitUninterruptibly(initializeLatch, 1, TimeUnit.MINUTES)); // Wait for pre-load tasks to initialize
+        assertThat(awaitUninterruptibly(initializeLatch, 1, TimeUnit.MINUTES)).isTrue(); // Wait for pre-load tasks to initialize
         startLatch.countDown(); // Signal go for stage1 threads
 
         // Concurrently submitted tasks
@@ -83,8 +81,8 @@ public class TestBoundedExecutor
             });
         }
 
-        assertTrue(awaitUninterruptibly(completeLatch, 1, TimeUnit.MINUTES)); // Wait for tasks to complete
-        assertEquals(counter.get(), totalTasks);
+        assertThat(awaitUninterruptibly(completeLatch, 1, TimeUnit.MINUTES)).isTrue(); // Wait for tasks to complete
+        assertThat(counter.get()).isEqualTo(totalTasks);
     }
 
     @Test
@@ -160,7 +158,7 @@ public class TestBoundedExecutor
             });
         }
 
-        assertTrue(awaitUninterruptibly(initializeLatch, 1, TimeUnit.MINUTES)); // Wait for pre-load tasks to initialize
+        assertThat(awaitUninterruptibly(initializeLatch, 1, TimeUnit.MINUTES)).isTrue(); // Wait for pre-load tasks to initialize
         startLatch.countDown(); // Signal go for stage1 threads
 
         // Concurrently submitted tasks
@@ -179,8 +177,8 @@ public class TestBoundedExecutor
             });
         }
 
-        assertTrue(awaitUninterruptibly(completeLatch, 1, TimeUnit.MINUTES)); // Wait for tasks to complete
+        assertThat(awaitUninterruptibly(completeLatch, 1, TimeUnit.MINUTES)).isTrue(); // Wait for tasks to complete
 
-        assertFalse(failed.get());
+        assertThat(failed.get()).isFalse();
     }
 }

--- a/concurrent/src/test/java/io/airlift/concurrent/TestExtendedSettableFuture.java
+++ b/concurrent/src/test/java/io/airlift/concurrent/TestExtendedSettableFuture.java
@@ -5,10 +5,8 @@ import org.testng.annotations.Test;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertThrows;
-import static org.testng.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestExtendedSettableFuture
 {
@@ -18,10 +16,10 @@ public class TestExtendedSettableFuture
     {
         ExtendedSettableFuture<String> future = ExtendedSettableFuture.create();
         future.set("abc");
-        assertTrue(future.isDone());
-        assertFalse(future.isCancelled());
-        assertFalse(future.checkWasInterrupted());
-        assertEquals(future.get(), "abc");
+        assertThat(future).isDone();
+        assertThat(future).isNotCancelled();
+        assertThat(future.checkWasInterrupted()).isFalse();
+        assertThat(future.get()).isEqualTo("abc");
     }
 
     @Test
@@ -30,10 +28,11 @@ public class TestExtendedSettableFuture
     {
         ExtendedSettableFuture<String> future = ExtendedSettableFuture.create();
         future.setException(new Exception(""));
-        assertTrue(future.isDone());
-        assertFalse(future.isCancelled());
-        assertFalse(future.checkWasInterrupted());
-        assertThrows(ExecutionException.class, future::get);
+        assertThat(future).isDone();
+        assertThat(future).isNotCancelled();
+        assertThat(future.checkWasInterrupted()).isFalse();
+        assertThatThrownBy(future::get)
+                .isInstanceOf(ExecutionException.class);
     }
 
     @Test
@@ -42,10 +41,11 @@ public class TestExtendedSettableFuture
     {
         ExtendedSettableFuture<String> future = ExtendedSettableFuture.create();
         future.cancel(false);
-        assertTrue(future.isDone());
-        assertTrue(future.isCancelled());
-        assertFalse(future.checkWasInterrupted());
-        assertThrows(CancellationException.class, future::get);
+        assertThat(future).isDone();
+        assertThat(future).isCancelled();
+        assertThat(future.checkWasInterrupted()).isFalse();
+        assertThatThrownBy(future::get)
+                .isInstanceOf(CancellationException.class);
     }
 
     @Test
@@ -54,10 +54,11 @@ public class TestExtendedSettableFuture
     {
         ExtendedSettableFuture<String> future = ExtendedSettableFuture.create();
         future.cancel(true);
-        assertTrue(future.isDone());
-        assertTrue(future.isCancelled());
-        assertTrue(future.checkWasInterrupted());
-        assertThrows(CancellationException.class, future::get);
+        assertThat(future).isDone();
+        assertThat(future).isCancelled();
+        assertThat(future.checkWasInterrupted()).isTrue();
+        assertThatThrownBy(future::get)
+                .isInstanceOf(CancellationException.class);
     }
 
     @Test
@@ -69,14 +70,15 @@ public class TestExtendedSettableFuture
         ExtendedSettableFuture<String> toFuture = ExtendedSettableFuture.create();
         toFuture.setAsync(fromFuture);
         fromFuture.set("abc");
-        assertEquals(toFuture.get(), "abc");
+        assertThat(toFuture.get()).isEqualTo("abc");
 
         // Test exception
         fromFuture = ExtendedSettableFuture.create();
         toFuture = ExtendedSettableFuture.create();
         toFuture.setAsync(fromFuture);
         fromFuture.setException(new RuntimeException());
-        assertThrows(ExecutionException.class, toFuture::get);
+        assertThatThrownBy(toFuture::get)
+                .isInstanceOf(ExecutionException.class);
 
         // Test cancellation without interrupt
         fromFuture = ExtendedSettableFuture.create();
@@ -84,8 +86,8 @@ public class TestExtendedSettableFuture
         toFuture.setAsync(fromFuture);
         toFuture.cancel(false);
         // Parent Future should receive the cancellation
-        assertTrue(fromFuture.isCancelled());
-        assertFalse(fromFuture.checkWasInterrupted());
+        assertThat(fromFuture).isCancelled();
+        assertThat(fromFuture.checkWasInterrupted()).isFalse();
 
         // Test cancellation with interrupt
         fromFuture = ExtendedSettableFuture.create();
@@ -93,7 +95,7 @@ public class TestExtendedSettableFuture
         toFuture.setAsync(fromFuture);
         toFuture.cancel(true);
         // Parent Future should receive the cancellation
-        assertTrue(fromFuture.isCancelled());
-        assertTrue(fromFuture.checkWasInterrupted());
+        assertThat(fromFuture).isCancelled();
+        assertThat(fromFuture.checkWasInterrupted()).isTrue();
     }
 }

--- a/concurrent/src/test/java/io/airlift/concurrent/TestThreadLocalCache.java
+++ b/concurrent/src/test/java/io/airlift/concurrent/TestThreadLocalCache.java
@@ -17,7 +17,7 @@ import org.testng.annotations.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestThreadLocalCache
 {
@@ -32,20 +32,20 @@ public class TestThreadLocalCache
         });
 
         // Load first key
-        assertEquals(cache.get("abc"), "abc0");
-        assertEquals(cache.get("abc"), "abc0");
+        assertThat(cache.get("abc")).isEqualTo("abc0");
+        assertThat(cache.get("abc")).isEqualTo("abc0");
 
         // Load second key
-        assertEquals(cache.get("def"), "def1");
+        assertThat(cache.get("def")).isEqualTo("def1");
 
         // First key should still be there
-        assertEquals(cache.get("abc"), "abc0");
+        assertThat(cache.get("abc")).isEqualTo("abc0");
 
         // Expire first key by exceeding max size
-        assertEquals(cache.get("ghi"), "ghi2");
+        assertThat(cache.get("ghi")).isEqualTo("ghi2");
 
         // First key should now be regenerated
-        assertEquals(cache.get("abc"), "abc3");
+        assertThat(cache.get("abc")).isEqualTo("abc3");
 
         // TODO: add tests for multiple threads
     }

--- a/configuration/src/test/java/io/airlift/configuration/ProblemsTest.java
+++ b/configuration/src/test/java/io/airlift/configuration/ProblemsTest.java
@@ -23,8 +23,8 @@ import java.util.List;
 
 import static io.airlift.testing.Assertions.assertContains;
 import static io.airlift.testing.Assertions.assertContainsAllOf;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class ProblemsTest
 {
@@ -35,10 +35,10 @@ public class ProblemsTest
         problems.addError("message %d", 1);
 
         List<Message> errors = problems.getErrors();
-        assertEquals(errors.size(), 1);
-        assertEquals(errors.get(0).getMessage(), "message 1");
+        assertThat(errors).hasSize(1);
+        assertThat(errors.get(0).getMessage()).isEqualTo("message 1");
 
-        assertEquals(problems.getWarnings().size(), 0, "Found unexpected warnings in problem object");
+        assertThat(problems.getWarnings().size()).as("Found unexpected warnings in problem object").isEqualTo(0);
 
         try {
             problems.throwIfHasErrors();
@@ -57,11 +57,11 @@ public class ProblemsTest
         problems.addError("message %d", 2);
 
         List<Message> errors = problems.getErrors();
-        assertEquals(errors.size(), 2);
-        assertEquals(errors.get(0).getMessage(), "message 1");
-        assertEquals(errors.get(1).getMessage(), "message 2");
+        assertThat(errors).hasSize(2);
+        assertThat(errors.get(0).getMessage()).isEqualTo("message 1");
+        assertThat(errors.get(1).getMessage()).isEqualTo("message 2");
 
-        assertEquals(problems.getWarnings().size(), 0, "Found unexpected warnings in problem object");
+        assertThat(problems.getWarnings().size()).as("Found unexpected warnings in problem object").isEqualTo(0);
 
         try {
             problems.throwIfHasErrors();
@@ -79,10 +79,10 @@ public class ProblemsTest
         problems.addError("message %d", "NaN");
 
         List<Message> errors = problems.getErrors();
-        assertEquals(errors.size(), 1);
+        assertThat(errors).hasSize(1);
         assertContainsAllOf(errors.get(0).getMessage(), "message %d", "NaN", "IllegalFormatConversionException");
 
-        assertEquals(problems.getWarnings().size(), 0, "Found unexpected warnings in problem object");
+        assertThat(problems.getWarnings().size()).as("Found unexpected warnings in problem object").isEqualTo(0);
 
         try {
             problems.throwIfHasErrors();
@@ -99,17 +99,17 @@ public class ProblemsTest
         Problems problems = new Problems();
         problems.addWarning("message %d", 1);
 
-        assertEquals(problems.getErrors().size(), 0, "Found unexpected errors in problem object");
+        assertThat(problems.getErrors().size()).as("Found unexpected errors in problem object").isEqualTo(0);
 
         List<Message> warnings = problems.getWarnings();
-        assertEquals(warnings.size(), 1);
-        assertEquals(warnings.get(0).getMessage(), "message 1");
+        assertThat(warnings).hasSize(1);
+        assertThat(warnings.get(0).getMessage()).isEqualTo("message 1");
 
         try {
             problems.throwIfHasErrors();
         }
         catch (ConfigurationException cause) {
-            fail("Didn't expect problems object to throw", cause);
+            org.assertj.core.api.Assertions.fail("Didn't expect problems object to throw", cause);
         }
     }
 
@@ -120,18 +120,18 @@ public class ProblemsTest
         problems.addWarning("message %d", 1);
         problems.addWarning("message %d", 2);
 
-        assertEquals(problems.getErrors().size(), 0, "Found unexpected errors in problem object");
+        assertThat(problems.getErrors().size()).as("Found unexpected errors in problem object").isEqualTo(0);
 
         List<Message> warnings = problems.getWarnings();
-        assertEquals(warnings.size(), 2);
-        assertEquals(warnings.get(0).getMessage(), "message 1");
-        assertEquals(warnings.get(1).getMessage(), "message 2");
+        assertThat(warnings).hasSize(2);
+        assertThat(warnings.get(0).getMessage()).isEqualTo("message 1");
+        assertThat(warnings.get(1).getMessage()).isEqualTo("message 2");
 
         try {
             problems.throwIfHasErrors();
         }
         catch (ConfigurationException cause) {
-            fail("Didn't expect problems object to throw", cause);
+            org.assertj.core.api.Assertions.fail("Didn't expect problems object to throw", cause);
         }
     }
 
@@ -141,17 +141,17 @@ public class ProblemsTest
         Problems problems = new Problems();
         problems.addWarning("message %d", "NaN");
 
-        assertEquals(problems.getErrors().size(), 0, "Found unexpected errors in problem object");
+        assertThat(problems.getErrors().size()).as("Found unexpected errors in problem object").isEqualTo(0);
 
         List<Message> warnings = problems.getWarnings();
-        assertEquals(warnings.size(), 1);
+        assertThat(warnings).hasSize(1);
         assertContainsAllOf(warnings.get(0).getMessage(), "message %d", "NaN", "IllegalFormatConversionException");
 
         try {
             problems.throwIfHasErrors();
         }
         catch (ConfigurationException cause) {
-            fail("Didn't expect problems object to throw", cause);
+            org.assertj.core.api.Assertions.fail("Didn't expect problems object to throw", cause);
         }
     }
 
@@ -167,15 +167,15 @@ public class ProblemsTest
         problems.addWarning("message w%d", 3);
 
         List<Message> errors = problems.getErrors();
-        assertEquals(errors.size(), 2);
-        assertEquals(errors.get(0).getMessage(), "message e1");
-        assertEquals(errors.get(1).getMessage(), "message e2");
+        assertThat(errors).hasSize(2);
+        assertThat(errors.get(0).getMessage()).isEqualTo("message e1");
+        assertThat(errors.get(1).getMessage()).isEqualTo("message e2");
 
         List<Message> warnings = problems.getWarnings();
-        assertEquals(warnings.size(), 3);
-        assertEquals(warnings.get(0).getMessage(), "message w1");
-        assertEquals(warnings.get(1).getMessage(), "message w2");
-        assertEquals(warnings.get(2).getMessage(), "message w3");
+        assertThat(warnings).hasSize(3);
+        assertThat(warnings.get(0).getMessage()).isEqualTo("message w1");
+        assertThat(warnings.get(1).getMessage()).isEqualTo("message w2");
+        assertThat(warnings.get(2).getMessage()).isEqualTo("message w3");
 
         try {
             problems.throwIfHasErrors();

--- a/configuration/src/test/java/io/airlift/configuration/TestConfig.java
+++ b/configuration/src/test/java/io/airlift/configuration/TestConfig.java
@@ -47,9 +47,10 @@ import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.within;
 
 public class TestConfig
 {
@@ -121,7 +122,7 @@ public class TestConfig
                 new StringOptionDefaults("default string")));
 
         Config1 config = injector.getInstance(Config1.class);
-        assertEquals("default string", config.getStringOption());
+        assertThat("default string").isEqualTo(config.getStringOption());
     }
 
     @Test
@@ -133,7 +134,7 @@ public class TestConfig
                 new StringOptionDefaults("default string")));
 
         Config1 config = injector.getInstance(Key.get(Config1.class, MyAnnotation.class));
-        assertEquals("default string", config.getStringOption());
+        assertThat("default string").isEqualTo(config.getStringOption());
     }
 
     @Test
@@ -145,7 +146,7 @@ public class TestConfig
                 new StringOptionDefaults("default string")));
 
         Config1 config = injector.getInstance(Key.get(Config1.class, named("boo")));
-        assertEquals("default string", config.getStringOption());
+        assertThat("default string").isEqualTo(config.getStringOption());
     }
 
     @Test
@@ -159,7 +160,7 @@ public class TestConfig
                 new StringOptionDefaults("final default string")));
 
         Config1 config = injector.getInstance(Config1.class);
-        assertEquals("final default string", config.getStringOption());
+        assertThat("final default string").isEqualTo(config.getStringOption());
     }
 
     @Test
@@ -176,27 +177,27 @@ public class TestConfig
 
     private static void verifyConfig(Config1 config)
     {
-        assertEquals("a string", config.getStringOption());
-        assertEquals(true, config.getBooleanOption());
-        assertEquals(Boolean.TRUE, config.getBoxedBooleanOption());
-        assertEquals(Byte.MAX_VALUE, config.getByteOption());
-        assertEquals(Byte.valueOf(Byte.MAX_VALUE), config.getBoxedByteOption());
-        assertEquals(Short.MAX_VALUE, config.getShortOption());
-        assertEquals(Short.valueOf(Short.MAX_VALUE), config.getBoxedShortOption());
-        assertEquals(Integer.MAX_VALUE, config.getIntegerOption());
-        assertEquals(Integer.valueOf(Integer.MAX_VALUE), config.getBoxedIntegerOption());
-        assertEquals(Long.MAX_VALUE, config.getLongOption());
-        assertEquals(Long.valueOf(Long.MAX_VALUE), config.getBoxedLongOption());
-        assertEquals(Float.MAX_VALUE, config.getFloatOption(), 0);
-        assertEquals(Float.MAX_VALUE, config.getBoxedFloatOption());
-        assertEquals(Double.MAX_VALUE, config.getDoubleOption(), 0);
-        assertEquals(Double.MAX_VALUE, config.getBoxedDoubleOption());
-        assertEquals(FOO, config.getMyEnumOption());
-        assertEquals(BAR, config.getMyEnumSecondOption());
-        assertEquals(config.getValueClassOption().getValue(), "a value class");
-        assertEquals(config.getMyEnumList(), ImmutableList.of(BAR, FOO));
-        assertEquals(config.getMyEnumSet(), ImmutableSet.of(BAR, FOO));
-        assertEquals(config.getMyIntegerList(), ImmutableList.of(10, 12, 14, 16));
+        assertThat("a string").isEqualTo(config.getStringOption());
+        assertThat(true).isEqualTo(config.getBooleanOption());
+        assertThat(Boolean.TRUE).isEqualTo(config.getBoxedBooleanOption());
+        assertThat(Byte.MAX_VALUE).isEqualTo(config.getByteOption());
+        assertThat(Byte.valueOf(Byte.MAX_VALUE)).isEqualTo(config.getBoxedByteOption());
+        assertThat(Short.MAX_VALUE).isEqualTo(config.getShortOption());
+        assertThat(Short.valueOf(Short.MAX_VALUE)).isEqualTo(config.getBoxedShortOption());
+        assertThat(Integer.MAX_VALUE).isEqualTo(config.getIntegerOption());
+        assertThat(Integer.valueOf(Integer.MAX_VALUE)).isEqualTo(config.getBoxedIntegerOption());
+        assertThat(Long.MAX_VALUE).isEqualTo(config.getLongOption());
+        assertThat(Long.valueOf(Long.MAX_VALUE)).isEqualTo(config.getBoxedLongOption());
+        assertThat(Float.MAX_VALUE).isCloseTo(config.getFloatOption(), within(0f));
+        assertThat(Float.MAX_VALUE).isEqualTo(config.getBoxedFloatOption());
+        assertThat(Double.MAX_VALUE).isCloseTo(config.getDoubleOption(), within(0.));
+        assertThat(Double.MAX_VALUE).isEqualTo(config.getBoxedDoubleOption());
+        assertThat(FOO).isEqualTo(config.getMyEnumOption());
+        assertThat(BAR).isEqualTo(config.getMyEnumSecondOption());
+        assertThat(config.getValueClassOption().getValue()).isEqualTo("a value class");
+        assertThat(config.getMyEnumList()).isEqualTo(ImmutableList.of(BAR, FOO));
+        assertThat(config.getMyEnumSet()).isEqualTo(ImmutableSet.of(BAR, FOO));
+        assertThat(config.getMyIntegerList()).isEqualTo(ImmutableList.of(10, 12, 14, 16));
     }
 
     @Test
@@ -216,13 +217,13 @@ public class TestConfig
     public void testConfigGlobalDefaults()
             throws Exception
     {
-        int globalDefaultValue = 1;
+        byte globalDefaultValue = 1;
         int defaultValue = 2;
         int customValue = 3;
 
         Module module = binder -> {
             configBinder(binder).bindConfigGlobalDefaults(Config1.class, (config -> {
-                config.setByteOption((byte) globalDefaultValue);
+                config.setByteOption(globalDefaultValue);
                 config.setIntegerOption(globalDefaultValue);
                 config.setLongOption(globalDefaultValue);
             }));
@@ -236,9 +237,9 @@ public class TestConfig
         Injector injector = createInjector(ImmutableMap.of("longOption", "" + customValue), module);
 
         Config1 config = injector.getInstance(Key.get(Config1.class, MyAnnotation.class));
-        assertEquals(config.getByteOption(), globalDefaultValue);
-        assertEquals(config.getIntegerOption(), defaultValue);
-        assertEquals(config.getLongOption(), customValue);
+        assertThat(config.getByteOption()).isEqualTo(globalDefaultValue);
+        assertThat(config.getIntegerOption()).isEqualTo(defaultValue);
+        assertThat(config.getLongOption()).isEqualTo(customValue);
     }
 
     @Test
@@ -260,13 +261,11 @@ public class TestConfig
         verifyConfig(injector.getInstance(Config1.class));
         verifyConfig(injector.getInstance(Key.get(Config1.class, MyAnnotation.class)));
 
-        assertEquals(seenBindings.size(), 3);
-        assertEquals(
-                ImmutableSet.copyOf(seenBindings),
-                ImmutableSet.of(
-                        new ConfigurationBinding<>(Key.get(Config1.class), Config1.class, Optional.empty()),
-                        new ConfigurationBinding<>(Key.get(Config1.class, MyAnnotation.class), Config1.class, Optional.empty()),
-                        new ConfigurationBinding<>(Key.get(AnotherConfig.class), AnotherConfig.class, Optional.empty())));
+        assertThat(seenBindings).hasSize(3);
+        assertThat(ImmutableSet.copyOf(seenBindings)).isEqualTo(ImmutableSet.of(
+                new ConfigurationBinding<>(Key.get(Config1.class), Config1.class, Optional.empty()),
+                new ConfigurationBinding<>(Key.get(Config1.class, MyAnnotation.class), Config1.class, Optional.empty()),
+                new ConfigurationBinding<>(Key.get(AnotherConfig.class), AnotherConfig.class, Optional.empty())));
     }
 
     @Test
@@ -299,12 +298,8 @@ public class TestConfig
             }
         };
 
-        assertEquals(
-                createInjector(ImmutableMap.of("value", "a"), module).getInstance(String.class),
-                "used value a");
-        assertEquals(
-                createInjector(ImmutableMap.of("value", "b"), module).getInstance(String.class),
-                "used value b");
+        assertThat(createInjector(ImmutableMap.of("value", "a"), module).getInstance(String.class)).isEqualTo("used value a");
+        assertThat(createInjector(ImmutableMap.of("value", "b"), module).getInstance(String.class)).isEqualTo("used value b");
         assertThatThrownBy(() -> createInjector(ImmutableMap.of("value", "c"), module))
                 .hasStackTraceContaining("Not supported value: C");
     }

--- a/configuration/src/test/java/io/airlift/configuration/TestConfigurationFactory.java
+++ b/configuration/src/test/java/io/airlift/configuration/TestConfigurationFactory.java
@@ -41,13 +41,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertSame;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class TestConfigurationFactory
 {
@@ -75,9 +70,9 @@ public class TestConfigurationFactory
         AnnotatedSetter annotatedSetter = injector.getInstance(AnnotatedSetter.class);
         monitor.assertNumberOfErrors(0);
         monitor.assertNumberOfWarnings(0);
-        assertNotNull(annotatedSetter);
-        assertEquals(annotatedSetter.getStringValue(), "some value");
-        assertTrue(annotatedSetter.isBooleanValue());
+        assertThat(annotatedSetter).isNotNull();
+        assertThat(annotatedSetter.getStringValue()).isEqualTo("some value");
+        assertThat(annotatedSetter.isBooleanValue()).isTrue();
     }
 
     @Test
@@ -91,9 +86,9 @@ public class TestConfigurationFactory
         LegacyConfigPresent legacyConfigPresent = injector.getInstance(LegacyConfigPresent.class);
         monitor.assertNumberOfErrors(0);
         monitor.assertNumberOfWarnings(0);
-        assertNotNull(legacyConfigPresent);
-        assertEquals(legacyConfigPresent.getStringA(), "this is a");
-        assertEquals(legacyConfigPresent.getStringB(), "this is b");
+        assertThat(legacyConfigPresent).isNotNull();
+        assertThat(legacyConfigPresent.getStringA()).isEqualTo("this is a");
+        assertThat(legacyConfigPresent.getStringB()).isEqualTo("this is b");
     }
 
     @Test
@@ -108,9 +103,9 @@ public class TestConfigurationFactory
         monitor.assertNumberOfErrors(0);
         monitor.assertNumberOfWarnings(1);
         monitor.assertMatchingWarningRecorded("Configuration property 'string-value' has been replaced. Use 'string-a' instead.");
-        assertNotNull(legacyConfigPresent);
-        assertEquals(legacyConfigPresent.getStringA(), "this is a");
-        assertEquals(legacyConfigPresent.getStringB(), "this is b");
+        assertThat(legacyConfigPresent).isNotNull();
+        assertThat(legacyConfigPresent.getStringA()).isEqualTo("this is a");
+        assertThat(legacyConfigPresent.getStringB()).isEqualTo("this is b");
     }
 
     @Test
@@ -125,9 +120,9 @@ public class TestConfigurationFactory
         monitor.assertNumberOfErrors(0);
         monitor.assertNumberOfWarnings(1);
         monitor.assertMatchingWarningRecorded("Configuration property 'example.string-value' has been replaced. Use 'example.string-a' instead.");
-        assertNotNull(legacyConfigPresent);
-        assertEquals(legacyConfigPresent.getStringA(), "this is a");
-        assertEquals(legacyConfigPresent.getStringB(), "this is b");
+        assertThat(legacyConfigPresent).isNotNull();
+        assertThat(legacyConfigPresent.getStringA()).isEqualTo("this is a");
+        assertThat(legacyConfigPresent.getStringB()).isEqualTo("this is b");
     }
 
     @Test
@@ -168,9 +163,9 @@ public class TestConfigurationFactory
         DeprecatedConfigPresent deprecatedConfigPresent = injector.getInstance(DeprecatedConfigPresent.class);
         monitor.assertNumberOfErrors(0);
         monitor.assertNumberOfWarnings(0);
-        assertNotNull(deprecatedConfigPresent);
-        assertEquals(deprecatedConfigPresent.getStringA(), "defaultA");
-        assertEquals(deprecatedConfigPresent.getStringB(), "this is b");
+        assertThat(deprecatedConfigPresent).isNotNull();
+        assertThat(deprecatedConfigPresent.getStringA()).isEqualTo("defaultA");
+        assertThat(deprecatedConfigPresent.getStringB()).isEqualTo("this is b");
     }
 
     @Test
@@ -185,9 +180,9 @@ public class TestConfigurationFactory
         monitor.assertNumberOfErrors(0);
         monitor.assertNumberOfWarnings(1);
         monitor.assertMatchingWarningRecorded("Configuration property 'string-a' is deprecated and should not be used");
-        assertNotNull(deprecatedConfigPresent);
-        assertEquals(deprecatedConfigPresent.getStringA(), "this is a");
-        assertEquals(deprecatedConfigPresent.getStringB(), "this is b");
+        assertThat(deprecatedConfigPresent).isNotNull();
+        assertThat(deprecatedConfigPresent.getStringA()).isEqualTo("this is a");
+        assertThat(deprecatedConfigPresent.getStringB()).isEqualTo("this is b");
     }
 
     @Test
@@ -202,9 +197,9 @@ public class TestConfigurationFactory
         monitor.assertNumberOfErrors(0);
         monitor.assertNumberOfWarnings(1);
         monitor.assertMatchingWarningRecorded("Configuration property 'example.string-a' is deprecated and should not be used");
-        assertNotNull(deprecatedConfigPresent);
-        assertEquals(deprecatedConfigPresent.getStringA(), "this is a");
-        assertEquals(deprecatedConfigPresent.getStringB(), "this is b");
+        assertThat(deprecatedConfigPresent).isNotNull();
+        assertThat(deprecatedConfigPresent.getStringA()).isEqualTo("this is a");
+        assertThat(deprecatedConfigPresent.getStringB()).isEqualTo("this is b");
     }
 
     @Test
@@ -242,9 +237,9 @@ public class TestConfigurationFactory
         BeanValidationClass beanValidationClass = injector.getInstance(BeanValidationClass.class);
         monitor.assertNumberOfErrors(0);
         monitor.assertNumberOfWarnings(0);
-        assertNotNull(beanValidationClass);
-        assertEquals(beanValidationClass.getStringValue(), "has a value");
-        assertEquals(beanValidationClass.getIntValue(), 50);
+        assertThat(beanValidationClass).isNotNull();
+        assertThat(beanValidationClass.getStringValue()).isEqualTo("has a value");
+        assertThat(beanValidationClass.getIntValue()).isEqualTo(50);
     }
 
     @Test
@@ -287,7 +282,7 @@ public class TestConfigurationFactory
             Config1 config = requireNonNull(injector.getInstance(Config1.class), "injector.getInstance(Config1.class) is null");
             monitor.assertNumberOfErrors(0);
             monitor.assertNumberOfWarnings(0);
-            assertTrue(config.getBooleanOption());
+            assertThat(config.getBooleanOption()).isTrue();
         }
 
         for (String value : ImmutableList.of("false", "FALSE", "fAlsE")) {
@@ -298,7 +293,7 @@ public class TestConfigurationFactory
             Config1 config = requireNonNull(injector.getInstance(Config1.class), "injector.getInstance(Config1.class) is null");
             monitor.assertNumberOfErrors(0);
             monitor.assertNumberOfWarnings(0);
-            assertFalse(config.getBooleanOption());
+            assertThat(config.getBooleanOption()).isFalse();
         }
     }
 
@@ -327,7 +322,8 @@ public class TestConfigurationFactory
     {
         TestMonitor monitor = new TestMonitor();
         Injector injector = createInjector(ImmutableMap.of("value", "value-good-for-fromString"), monitor, binder -> configBinder(binder).bindConfig(FromStringClass.class));
-        assertSame(injector.getInstance(FromStringClass.class).value, FromStringClass.Value.FROM_STRING_VALUE);
+        assertThat(injector.getInstance(FromStringClass.class).value)
+                .isSameAs(FromStringClass.Value.FROM_STRING_VALUE);
         monitor.assertNumberOfErrors(0);
         monitor.assertNumberOfWarnings(0);
 
@@ -342,7 +338,8 @@ public class TestConfigurationFactory
     {
         TestMonitor monitor = new TestMonitor();
         Injector injector = createInjector(ImmutableMap.of("value", "yes"), monitor, binder -> configBinder(binder).bindConfig(EnumWithFromStringClass.class));
-        assertSame(injector.getInstance(EnumWithFromStringClass.class).value, EnumWithFromStringClass.Value.TRUE);
+        assertThat(injector.getInstance(EnumWithFromStringClass.class).value)
+                .isSameAs(EnumWithFromStringClass.Value.TRUE);
         monitor.assertNumberOfErrors(0);
         monitor.assertNumberOfWarnings(0);
 
@@ -357,7 +354,7 @@ public class TestConfigurationFactory
     {
         TestMonitor monitor = new TestMonitor();
         Injector injector = createInjector(ImmutableMap.of("value", "value"), monitor, binder -> configBinder(binder).bindConfig(EnumClass.class));
-        assertSame(injector.getInstance(EnumClass.class).value, EnumClass.Value.VALUE);
+        assertThat(injector.getInstance(EnumClass.class).value).isSameAs(EnumClass.Value.VALUE);
         monitor.assertNumberOfErrors(0);
         monitor.assertNumberOfWarnings(0);
     }
@@ -367,7 +364,8 @@ public class TestConfigurationFactory
     {
         TestMonitor monitor = new TestMonitor();
         Injector injector = createInjector(ImmutableMap.of("value", "value_with_underscores"), monitor, binder -> configBinder(binder).bindConfig(EnumClass.class));
-        assertSame(injector.getInstance(EnumClass.class).value, EnumClass.Value.VALUE_WITH_UNDERSCORES);
+        assertThat(injector.getInstance(EnumClass.class).value)
+                .isSameAs(EnumClass.Value.VALUE_WITH_UNDERSCORES);
         monitor.assertNumberOfErrors(0);
         monitor.assertNumberOfWarnings(0);
     }
@@ -377,7 +375,8 @@ public class TestConfigurationFactory
     {
         TestMonitor monitor = new TestMonitor();
         Injector injector = createInjector(ImmutableMap.of("value", "value-with-underscores"), monitor, binder -> configBinder(binder).bindConfig(EnumClass.class));
-        assertSame(injector.getInstance(EnumClass.class).value, EnumClass.Value.VALUE_WITH_UNDERSCORES);
+        assertThat(injector.getInstance(EnumClass.class).value)
+                .isSameAs(EnumClass.Value.VALUE_WITH_UNDERSCORES);
         monitor.assertNumberOfErrors(0);
         monitor.assertNumberOfWarnings(0);
     }
@@ -396,7 +395,7 @@ public class TestConfigurationFactory
     {
         TestMonitor monitor = new TestMonitor();
         Injector injector = createInjector(ImmutableMap.of("values", "ala, ma ,kota, "), monitor, binder -> configBinder(binder).bindConfig(ListOfStringsClass.class));
-        assertEquals(injector.getInstance(ListOfStringsClass.class).getValues(), ImmutableList.of("ala", "ma", "kota"));
+        assertThat(injector.getInstance(ListOfStringsClass.class).getValues()).isEqualTo(ImmutableList.of("ala", "ma", "kota"));
         monitor.assertNumberOfErrors(0);
         monitor.assertNumberOfWarnings(0);
     }
@@ -406,7 +405,7 @@ public class TestConfigurationFactory
     {
         TestMonitor monitor = new TestMonitor();
         Injector injector = createInjector(ImmutableMap.of("value", "value-good-for-valueOf"), monitor, binder -> configBinder(binder).bindConfig(ValueOfClass.class));
-        assertSame(injector.getInstance(ValueOfClass.class).value, ValueOfClass.Value.VALUE_OF_VALUE);
+        assertThat(injector.getInstance(ValueOfClass.class).value).isSameAs(ValueOfClass.Value.VALUE_OF_VALUE);
         monitor.assertNumberOfErrors(0);
         monitor.assertNumberOfWarnings(0);
 
@@ -421,7 +420,7 @@ public class TestConfigurationFactory
     {
         TestMonitor monitor = new TestMonitor();
         Injector injector = createInjector(ImmutableMap.of("value", "constructor-value"), monitor, binder -> configBinder(binder).bindConfig(StringConstructorClass.class));
-        assertEquals(injector.getInstance(StringConstructorClass.class).value.string, "constructor-argument: constructor-value");
+        assertThat(injector.getInstance(StringConstructorClass.class).value.string).isEqualTo("constructor-argument: constructor-value");
         monitor.assertNumberOfErrors(0);
         monitor.assertNumberOfWarnings(0);
 
@@ -442,7 +441,7 @@ public class TestConfigurationFactory
         ConfigurationFactory configurationFactory = new ConfigurationFactory(properties, null, new TestMonitor());
         configurationFactory.registerConfigurationClasses(ImmutableList.of(binder -> configBinder(binder).bindConfig(AnnotatedSetter.class)));
         configurationFactory.validateRegisteredConfigurationProvider();
-        assertEquals(configurationFactory.getUsedProperties(), ImmutableSet.of("string-value", "boolean-value"));
+        assertThat(configurationFactory.getUsedProperties()).hasSameElementsAs(ImmutableSet.of("string-value", "boolean-value"));
     }
 
     @Test
@@ -456,7 +455,7 @@ public class TestConfigurationFactory
         configurationFactory.registerConfigurationClasses(ImmutableList.of(binder -> configBinder(binder).bindConfig(AnnotatedSetter.class)));
         List<Message> messages = configurationFactory.validateRegisteredConfigurationProvider();
         assertMessagesMatch(messages, ImmutableList.of(".*Invalid value 'invalid' for type boolean \\(property 'boolean-value'\\).*AnnotatedSetter.*"));
-        assertEquals(configurationFactory.getUsedProperties(), properties.keySet());
+        assertThat(configurationFactory.getUsedProperties()).isEqualTo(properties.keySet());
     }
 
     private static Injector createInjector(Map<String, String> properties, TestMonitor monitor, Module module)
@@ -464,7 +463,7 @@ public class TestConfigurationFactory
         ConfigurationFactory configurationFactory = new ConfigurationFactory(properties, null, monitor);
         configurationFactory.registerConfigurationClasses(ImmutableList.of(module));
         List<Message> messages = configurationFactory.validateRegisteredConfigurationProvider();
-        assertEquals(configurationFactory.getUsedProperties(), properties.keySet());
+        assertThat(configurationFactory.getUsedProperties()).hasSameElementsAs(properties.keySet());
         return Guice.createInjector(new ConfigurationModule(configurationFactory), module, new ValidationErrorModule(messages));
     }
 
@@ -503,7 +502,7 @@ public class TestConfigurationFactory
 
     private static void assertMessagesMatch(Collection<? extends Object> messages, List<String> expectedErrorMessagePatterns)
     {
-        assertEquals(messages.size(), expectedErrorMessagePatterns.size(), "expected error count");
+        assertThat(messages.size()).as("expected error count").isEqualTo(expectedErrorMessagePatterns.size());
 
         List<Pattern> patterns = expectedErrorMessagePatterns.stream()
                 .map(Pattern::compile)
@@ -515,13 +514,13 @@ public class TestConfigurationFactory
             Pattern matchedPattern = null;
             for (Pattern pattern : patterns) {
                 if (pattern.matcher(messageString).matches()) {
-                    assertNull(matchedPattern, format("Error message matches two patterns patterns:\nmessage:\n  %s\npatterns:\n  %s\n  %s", messageString, matchedPattern, pattern));
+                    assertThat(matchedPattern).as(format("Error message matches two patterns patterns:\nmessage:\n  %s\npatterns:\n  %s\n  %s", messageString, matchedPattern, pattern)).isNull();
                     String usedMatch = usedPatterns.put(pattern, messageString);
-                    assertNull(usedMatch, format("Pattern '%s' matches message '%s' and '%s", pattern, messageString, usedMatch));
+                    assertThat(usedMatch).as(format("Pattern '%s' matches message '%s' and '%s", pattern, messageString, usedMatch)).isNull();
                     matchedPattern = pattern;
                 }
             }
-            assertNotNull(matchedPattern, format("Error message did not match any expected patterns:\nmessage:\n  %s\npatterns:\n  %s", messageString, Joiner.on("\n  ").join(patterns)));
+            assertThat(matchedPattern).as(format("Error message did not match any expected patterns:\nmessage:\n  %s\npatterns:\n  %s", messageString, Joiner.on("\n  ").join(patterns))).isNotNull();
         }
     }
 

--- a/configuration/src/test/java/io/airlift/configuration/TestConfigurationInspector.java
+++ b/configuration/src/test/java/io/airlift/configuration/TestConfigurationInspector.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.MoreCollectors.onlyElement;
 import static io.airlift.configuration.ConfigBinder.configBinder;
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestConfigurationInspector
 {
@@ -24,7 +24,7 @@ public class TestConfigurationInspector
                 .stream()
                 .map(ConfigAttribute::getDefaultValue)
                 .collect(toImmutableList());
-        assertEquals(defaultString, ImmutableList.of("----"));
+        assertThat(defaultString).isEqualTo(ImmutableList.of("----"));
     }
 
     @Test
@@ -34,7 +34,7 @@ public class TestConfigurationInspector
                 .stream()
                 .map(ConfigAttribute::getCurrentValue)
                 .collect(toImmutableList());
-        assertEquals(currentString, ImmutableList.of("string"));
+        assertThat(currentString).isEqualTo(ImmutableList.of("string"));
     }
 
     private ConfigRecord<?> getConfigRecord()

--- a/configuration/src/test/java/io/airlift/configuration/TestConfigurationLoader.java
+++ b/configuration/src/test/java/io/airlift/configuration/TestConfigurationLoader.java
@@ -30,7 +30,7 @@ import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static io.airlift.configuration.ConfigurationLoader.loadProperties;
 import static java.nio.file.Files.createTempDirectory;
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestConfigurationLoader
 {
@@ -58,7 +58,7 @@ public class TestConfigurationLoader
 
         Map<String, String> properties = loadProperties();
 
-        assertEquals(properties.get("test"), "foo");
+        assertThat(properties.get("test")).isEqualTo("foo");
 
         System.clearProperty("test");
     }
@@ -72,8 +72,8 @@ public class TestConfigurationLoader
 
         Map<String, String> properties = loadProperties();
 
-        assertEquals(properties.get("test"), "foo");
-        assertEquals(properties.get("config"), file.getAbsolutePath());
+        assertThat(properties.get("test")).isEqualTo("foo");
+        assertThat(properties.get("config")).isEqualTo(file.getAbsolutePath());
 
         System.clearProperty("config");
     }
@@ -92,10 +92,10 @@ public class TestConfigurationLoader
         Map<String, String> properties = loadProperties();
 
         // config files are often human-managed and we need to be permissive, stripping trailing whitespace if any
-        assertEquals(properties.get("trim-whitespace-key1"), "key1-value");
+        assertThat(properties.get("trim-whitespace-key1")).isEqualTo("key1-value");
 
         // trailing whitespace in JVM property value is not so likely to be unintentional, so preserve it
-        assertEquals(properties.get("trim-whitespace-key2"), " \t key2-value \t ");
+        assertThat(properties.get("trim-whitespace-key2")).isEqualTo(" \t key2-value \t ");
 
         System.clearProperty("trim-whitespace-key2");
         System.clearProperty("config");
@@ -114,9 +114,9 @@ public class TestConfigurationLoader
 
         Map<String, String> properties = loadProperties();
 
-        assertEquals(properties.get("config"), file.getAbsolutePath());
-        assertEquals(properties.get("key1"), "overridden");
-        assertEquals(properties.get("key2"), "original");
+        assertThat(properties.get("config")).isEqualTo(file.getAbsolutePath());
+        assertThat(properties.get("key1")).isEqualTo("overridden");
+        assertThat(properties.get("key2")).isEqualTo("original");
 
         System.clearProperty("key1");
         System.clearProperty("config");

--- a/configuration/src/test/java/io/airlift/configuration/TestConfigurationMetadata.java
+++ b/configuration/src/test/java/io/airlift/configuration/TestConfigurationMetadata.java
@@ -28,8 +28,8 @@ import java.util.Map;
 import java.util.Set;
 
 import static io.airlift.testing.EquivalenceTester.equivalenceTester;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class TestConfigurationMetadata
 {
@@ -870,10 +870,10 @@ public class TestConfigurationMetadata
     private void verifyMetaData(ConfigurationMetadata<?> metadata, Class<?> configClass, String description, boolean securitySensitive, boolean hidden, Map<String, Set<String>> attributeProperties)
             throws Exception
     {
-        assertEquals(metadata.getConfigClass(), configClass);
+        assertThat(metadata.getConfigClass()).isEqualTo(configClass);
 
         if (metadata.getConstructor() != null) {
-            assertEquals(metadata.getConstructor(), configClass.getDeclaredConstructor());
+            assertThat(metadata.getConstructor()).isEqualTo(configClass.getDeclaredConstructor());
         }
         else {
             try {
@@ -884,20 +884,20 @@ public class TestConfigurationMetadata
             }
         }
 
-        assertEquals(metadata.getAttributes().size(), attributeProperties.keySet().size());
+        assertThat(metadata.getAttributes()).hasSameSizeAs(attributeProperties.keySet());
 
         for (String name : attributeProperties.keySet()) {
             AttributeMetadata attribute = metadata.getAttributes().get(name);
-            assertEquals(attribute.getConfigClass(), configClass);
+            assertThat(attribute.getConfigClass()).isEqualTo(configClass);
             Set<String> namesToTest = new HashSet<>();
             namesToTest.add(attribute.getInjectionPoint().getProperty());
             for (ConfigurationMetadata.InjectionPointMetaData legacyInjectionPoint : attribute.getLegacyInjectionPoints()) {
                 namesToTest.add(legacyInjectionPoint.getProperty());
             }
-            assertEquals(namesToTest, attributeProperties.get(name));
-            assertEquals(attribute.getDescription(), description);
-            assertEquals(attribute.isSecuritySensitive(), securitySensitive);
-            assertEquals(attribute.isHidden(), hidden);
+            assertThat(namesToTest).isEqualTo(attributeProperties.get(name));
+            assertThat(attribute.getDescription()).isEqualTo(description);
+            assertThat(attribute.isSecuritySensitive()).isEqualTo(securitySensitive);
+            assertThat(attribute.isHidden()).isEqualTo(hidden);
         }
     }
 

--- a/configuration/src/test/java/io/airlift/configuration/TestConfigurationUtils.java
+++ b/configuration/src/test/java/io/airlift/configuration/TestConfigurationUtils.java
@@ -9,7 +9,6 @@ import java.util.Map;
 
 import static io.airlift.configuration.ConfigurationUtils.replaceEnvironmentVariables;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.testng.Assert.assertEquals;
 
 public class TestConfigurationUtils
 {
@@ -59,7 +58,7 @@ public class TestConfigurationUtils
                 .put("no-recursive-replacement", "env-first:${ENV:SECOND}:, env-second:${ENV:FIRST}")
                 .build();
 
-        assertEquals(actual, expected);
+        assertThat(actual).isEqualTo(expected);
 
         assertThat(errors).containsExactly(
                 "Configuration property 'peach' references unset environment variable 'PEACH'",

--- a/configuration/src/test/java/io/airlift/configuration/TestMonitor.java
+++ b/configuration/src/test/java/io/airlift/configuration/TestMonitor.java
@@ -21,8 +21,8 @@ import com.google.inject.spi.Message;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 class TestMonitor
         implements Problems.Monitor
@@ -54,12 +54,12 @@ class TestMonitor
 
     public void assertNumberOfErrors(int expected)
     {
-        assertEquals(errors.size(), expected, String.format("Number of errors is incorrect, actual errors: %s", errorsString()));
+        assertThat(errors.size()).as(String.format("Number of errors is incorrect, actual errors: %s", errorsString())).isEqualTo(expected);
     }
 
     public void assertNumberOfWarnings(int expected)
     {
-        assertEquals(warnings.size(), expected, String.format("Number of warnings is incorrect, actual warnings: %s", warningsString()));
+        assertThat(warnings.size()).as(String.format("Number of warnings is incorrect, actual warnings: %s", warningsString())).isEqualTo(expected);
     }
 
     public void assertMatchingWarningRecorded(String... parts)

--- a/configuration/src/test/java/io/airlift/configuration/testing/TestConfigAssertions.java
+++ b/configuration/src/test/java/io/airlift/configuration/testing/TestConfigAssertions.java
@@ -33,9 +33,8 @@ import java.util.Map;
 import java.util.Objects;
 
 import static io.airlift.testing.Assertions.assertContains;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotSame;
-import static org.testng.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class TestConfigAssertions
 {
@@ -439,23 +438,23 @@ public class TestConfigAssertions
         $$RecordedConfigData<PersonConfig> data = ConfigAssertions.getRecordedConfig(config);
 
         PersonConfig instance = data.getInstance();
-        assertNotSame(instance, config);
+        assertThat(instance).isNotSameAs(config);
 
-        assertEquals(data.getInvokedMethods(), ImmutableSet.of(
+        assertThat(data.getInvokedMethods()).isEqualTo(ImmutableSet.of(
                 PersonConfig.class.getMethod("setName", String.class),
                 PersonConfig.class.getMethod("setEmail", String.class),
                 PersonConfig.class.getMethod("setPhone", String.class),
                 PersonConfig.class.getMethod("setHomePage", URI.class)));
 
-        assertEquals(instance.getName(), "Alice Apple");
-        assertEquals(instance.getEmail(), "alice@example.com");
-        assertEquals(instance.getPhone(), "1-976-alice");
-        assertEquals(instance.getHomePage(), URI.create("http://alice.example.com"));
+        assertThat(instance.getName()).isEqualTo("Alice Apple");
+        assertThat(instance.getEmail()).isEqualTo("alice@example.com");
+        assertThat(instance.getPhone()).isEqualTo("1-976-alice");
+        assertThat(instance.getHomePage()).isEqualTo(URI.create("http://alice.example.com"));
 
-        assertEquals(config.getName(), "Alice Apple");
-        assertEquals(config.getEmail(), "alice@example.com");
-        assertEquals(config.getPhone(), "1-976-alice");
-        assertEquals(config.getHomePage(), URI.create("http://alice.example.com"));
+        assertThat(config.getName()).isEqualTo("Alice Apple");
+        assertThat(config.getEmail()).isEqualTo("alice@example.com");
+        assertThat(config.getPhone()).isEqualTo("1-976-alice");
+        assertThat(config.getHomePage()).isEqualTo(URI.create("http://alice.example.com"));
     }
 
     @Test

--- a/discovery/pom.xml
+++ b/discovery/pom.xml
@@ -105,6 +105,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
             <scope>test</scope>

--- a/discovery/src/test/java/io/airlift/discovery/client/AbstractTestDiscoveryModule.java
+++ b/discovery/src/test/java/io/airlift/discovery/client/AbstractTestDiscoveryModule.java
@@ -33,9 +33,7 @@ import static com.google.common.collect.MoreCollectors.onlyElement;
 import static io.airlift.discovery.client.DiscoveryBinder.discoveryBinder;
 import static io.airlift.discovery.client.ServiceTypes.serviceType;
 import static java.util.Objects.requireNonNull;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class AbstractTestDiscoveryModule
 {
@@ -56,12 +54,12 @@ public abstract class AbstractTestDiscoveryModule
                 discoveryModule);
 
         // should produce a discovery announcement client and a lookup client
-        assertNotNull(injector.getInstance(DiscoveryAnnouncementClient.class));
-        assertNotNull(injector.getInstance(DiscoveryLookupClient.class));
+        assertThat(injector.getInstance(DiscoveryAnnouncementClient.class)).isNotNull();
+        assertThat(injector.getInstance(DiscoveryLookupClient.class)).isNotNull();
         // should produce an Announcer
-        assertNotNull(injector.getInstance(Announcer.class));
+        assertThat(injector.getInstance(Announcer.class)).isNotNull();
         // should produce a ServiceSelectorManager
-        assertNotNull(injector.getInstance(ServiceSelectorManager.class));
+        assertThat(injector.getInstance(ServiceSelectorManager.class)).isNotNull();
     }
 
     @Test
@@ -95,15 +93,15 @@ public abstract class AbstractTestDiscoveryModule
                 });
 
         HttpServiceSelector selector = injector.getInstance(Key.get(HttpServiceSelector.class, serviceType("apple")));
-        assertEquals(selector.selectHttpService().stream().collect(onlyElement()), URI.create("http://127.0.0.1:4444"));
+        assertThat(selector.selectHttpService().stream().collect(onlyElement())).isEqualTo(URI.create("http://127.0.0.1:4444"));
 
         selector = injector.getInstance(Key.get(HttpServiceSelector.class, serviceType("banana")));
-        assertEquals(selector.selectHttpService().stream().collect(onlyElement()), URI.create("http://127.0.0.1:4444"));
+        assertThat(selector.selectHttpService().stream().collect(onlyElement())).isEqualTo(URI.create("http://127.0.0.1:4444"));
 
         selector = injector.getInstance(Key.get(HttpServiceSelector.class, serviceType("carrot")));
-        assertTrue(selector.selectHttpService().isEmpty());
+        assertThat(selector.selectHttpService()).isEmpty();
 
         selector = injector.getInstance(Key.get(HttpServiceSelector.class, serviceType("grape")));
-        assertTrue(selector.selectHttpService().isEmpty());
+        assertThat(selector.selectHttpService()).isEmpty();
     }
 }

--- a/discovery/src/test/java/io/airlift/discovery/client/TestAnnouncement.java
+++ b/discovery/src/test/java/io/airlift/discovery/client/TestAnnouncement.java
@@ -29,8 +29,7 @@ import static io.airlift.json.JsonCodec.jsonCodec;
 import static io.airlift.json.JsonCodec.mapJsonCodec;
 import static io.airlift.testing.EquivalenceTester.equivalenceTester;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestAnnouncement
 {
@@ -55,7 +54,7 @@ public class TestAnnouncement
         List<Map<String, Object>> services = toServices(expected.get("services"));
         services.get(0).put("id", announcement.getServices().stream().collect(onlyElement()).getId().toString());
 
-        assertEquals(actual, expected);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @SuppressWarnings("unchecked")
@@ -67,11 +66,11 @@ public class TestAnnouncement
     @Test
     public void testToString()
     {
-        assertNotNull(new Announcement("environment", "node", "pool", "location", ImmutableSet.of(
+        assertThat(new Announcement("environment", "node", "pool", "location", ImmutableSet.of(
                 serviceAnnouncement("foo")
                         .addProperty("http", "http://localhost:8080")
                         .addProperty("jmx", "jmx://localhost:1234")
-                        .build())));
+                        .build()))).isNotNull();
     }
 
     @Test

--- a/discovery/src/test/java/io/airlift/discovery/client/TestAnnouncer.java
+++ b/discovery/src/test/java/io/airlift/discovery/client/TestAnnouncer.java
@@ -33,9 +33,8 @@ import java.util.concurrent.TimeUnit;
 
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.airlift.discovery.client.ServiceTypes.serviceType;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 @Test(singleThreaded = true)
 public class TestAnnouncer
@@ -151,13 +150,13 @@ public class TestAnnouncer
         Future<ServiceDescriptors> future = discoveryClient.getServices(serviceType.value(), "pool");
         ServiceDescriptors serviceDescriptors = getFutureValue(future, DiscoveryException.class);
 
-        assertEquals(serviceDescriptors.getType(), serviceType.value());
-        assertEquals(serviceDescriptors.getPool(), "pool");
-        assertNotNull(serviceDescriptors.getETag());
-        assertEquals(serviceDescriptors.getMaxAge(), MAX_AGE);
+        assertThat(serviceDescriptors.getType()).isEqualTo(serviceType.value());
+        assertThat(serviceDescriptors.getPool()).isEqualTo("pool");
+        assertThat(serviceDescriptors.getETag()).isNotNull();
+        assertThat(serviceDescriptors.getMaxAge()).isEqualTo(MAX_AGE);
 
         List<ServiceDescriptor> descriptors = serviceDescriptors.getServiceDescriptors();
-        assertEquals(descriptors.size(), serviceAnnouncements.length);
+        assertThat(descriptors).hasSameSizeAs(serviceAnnouncements);
 
         ImmutableMap.Builder<UUID, ServiceDescriptor> builder = ImmutableMap.builder();
         for (ServiceDescriptor descriptor : descriptors) {
@@ -167,12 +166,12 @@ public class TestAnnouncer
 
         for (ServiceAnnouncement serviceAnnouncement : serviceAnnouncements) {
             ServiceDescriptor serviceDescriptor = descriptorMap.get(serviceAnnouncement.getId());
-            assertNotNull(serviceDescriptor, "No descriptor for announcement " + serviceAnnouncement.getId());
-            assertEquals(serviceDescriptor.getType(), serviceType.value());
-            assertEquals(serviceDescriptor.getPool(), "pool");
-            assertEquals(serviceDescriptor.getId(), serviceAnnouncement.getId());
-            assertEquals(serviceDescriptor.getProperties(), serviceAnnouncement.getProperties());
-            assertEquals(serviceDescriptor.getNodeId(), nodeInfo.getNodeId());
+            assertThat(serviceDescriptor).as("No descriptor for announcement " + serviceAnnouncement.getId()).isNotNull();
+            assertThat(serviceDescriptor.getType()).isEqualTo(serviceType.value());
+            assertThat(serviceDescriptor.getPool()).isEqualTo("pool");
+            assertThat(serviceDescriptor.getId()).isEqualTo(serviceAnnouncement.getId());
+            assertThat(serviceDescriptor.getProperties()).isEqualTo(serviceAnnouncement.getProperties());
+            assertThat(serviceDescriptor.getNodeId()).isEqualTo(nodeInfo.getNodeId());
         }
     }
 }

--- a/discovery/src/test/java/io/airlift/discovery/client/TestCachingServiceSelector.java
+++ b/discovery/src/test/java/io/airlift/discovery/client/TestCachingServiceSelector.java
@@ -29,7 +29,7 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.testing.Assertions.assertEqualsIgnoreOrder;
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestCachingServiceSelector
 {
@@ -64,8 +64,8 @@ public class TestCachingServiceSelector
                 new InMemoryDiscoveryClient(nodeInfo),
                 executor);
 
-        assertEquals(serviceSelector.getType(), "type");
-        assertEquals(serviceSelector.getPool(), "pool");
+        assertThat(serviceSelector.getType()).isEqualTo("type");
+        assertThat(serviceSelector.getPool()).isEqualTo("pool");
     }
 
     @Test
@@ -76,7 +76,7 @@ public class TestCachingServiceSelector
                 new InMemoryDiscoveryClient(nodeInfo),
                 executor);
 
-        assertEquals(serviceSelector.selectAllServices(), ImmutableList.of());
+        assertThat(serviceSelector.selectAllServices()).isEqualTo(ImmutableList.of());
     }
 
     @Test
@@ -90,7 +90,7 @@ public class TestCachingServiceSelector
 
         serviceSelector.start();
 
-        assertEquals(serviceSelector.selectAllServices(), ImmutableList.of());
+        assertThat(serviceSelector.selectAllServices()).isEqualTo(ImmutableList.of());
     }
 
     @Test
@@ -107,7 +107,7 @@ public class TestCachingServiceSelector
                 discoveryClient,
                 executor);
 
-        assertEquals(serviceSelector.selectAllServices(), ImmutableList.of());
+        assertThat(serviceSelector.selectAllServices()).isEqualTo(ImmutableList.of());
     }
 
     @Test

--- a/discovery/src/test/java/io/airlift/discovery/client/TestDiscoveryBinder.java
+++ b/discovery/src/test/java/io/airlift/discovery/client/TestDiscoveryBinder.java
@@ -35,8 +35,7 @@ import java.util.Set;
 
 import static io.airlift.discovery.client.DiscoveryBinder.discoveryBinder;
 import static io.airlift.discovery.client.ServiceTypes.serviceType;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestDiscoveryBinder
 {
@@ -49,7 +48,7 @@ public class TestDiscoveryBinder
                 binder -> discoveryBinder(binder).bindServiceAnnouncement(new ServiceAnnouncementProvider().get()));
 
         Set<ServiceAnnouncement> announcements = injector.getInstance(Key.get(new TypeLiteral<Set<ServiceAnnouncement>>() {}));
-        assertEquals(announcements, ImmutableSet.of(ANNOUNCEMENT));
+        assertThat(announcements).isEqualTo(ImmutableSet.of(ANNOUNCEMENT));
     }
 
     @Test
@@ -61,7 +60,7 @@ public class TestDiscoveryBinder
                 binder -> discoveryBinder(binder).bindServiceAnnouncement(ServiceAnnouncementProvider.class));
 
         Set<ServiceAnnouncement> announcements = injector.getInstance(Key.get(new TypeLiteral<Set<ServiceAnnouncement>>() {}));
-        assertEquals(announcements, ImmutableSet.of(ANNOUNCEMENT));
+        assertThat(announcements).isEqualTo(ImmutableSet.of(ANNOUNCEMENT));
     }
 
     @Test
@@ -73,7 +72,7 @@ public class TestDiscoveryBinder
                 binder -> discoveryBinder(binder).bindServiceAnnouncement(new ServiceAnnouncementProvider()));
 
         Set<ServiceAnnouncement> announcements = injector.getInstance(Key.get(new TypeLiteral<Set<ServiceAnnouncement>>() {}));
-        assertEquals(announcements, ImmutableSet.of(ANNOUNCEMENT));
+        assertThat(announcements).isEqualTo(ImmutableSet.of(ANNOUNCEMENT));
     }
 
     @Test
@@ -123,9 +122,9 @@ public class TestDiscoveryBinder
     private void assertCanCreateServiceSelector(Injector injector, String expectedType, String expectedPool)
     {
         ServiceSelector actualServiceSelector = injector.getInstance(Key.get(ServiceSelector.class, serviceType(expectedType)));
-        assertNotNull(actualServiceSelector);
-        assertEquals(actualServiceSelector.getType(), expectedType);
-        assertEquals(actualServiceSelector.getPool(), expectedPool);
+        assertThat(actualServiceSelector).isNotNull();
+        assertThat(actualServiceSelector.getType()).isEqualTo(expectedType);
+        assertThat(actualServiceSelector.getPool()).isEqualTo(expectedPool);
     }
 
     private static class TestModule

--- a/discovery/src/test/java/io/airlift/discovery/client/TestDiscoveryModule.java
+++ b/discovery/src/test/java/io/airlift/discovery/client/TestDiscoveryModule.java
@@ -11,8 +11,7 @@ import org.testng.annotations.Test;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestDiscoveryModule
         extends AbstractTestDiscoveryModule
@@ -37,8 +36,8 @@ public class TestDiscoveryModule
         ExecutorService executor = injector.getInstance(Key.get(ScheduledExecutorService.class, ForDiscoveryClient.class));
         LifeCycleManager lifeCycleManager = injector.getInstance(LifeCycleManager.class);
 
-        assertFalse(executor.isShutdown());
+        assertThat(executor.isShutdown()).isFalse();
         lifeCycleManager.stop();
-        assertTrue(executor.isShutdown());
+        assertThat(executor.isShutdown()).isTrue();
     }
 }

--- a/discovery/src/test/java/io/airlift/discovery/client/TestHttpAnnouncementBinder.java
+++ b/discovery/src/test/java/io/airlift/discovery/client/TestHttpAnnouncementBinder.java
@@ -31,8 +31,7 @@ import java.util.UUID;
 import static com.google.common.collect.MoreCollectors.onlyElement;
 import static io.airlift.discovery.client.DiscoveryBinder.discoveryBinder;
 import static io.airlift.discovery.client.ServiceAnnouncement.serviceAnnouncement;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestHttpAnnouncementBinder
 {
@@ -179,11 +178,11 @@ public class TestHttpAnnouncementBinder
 
     private void assertAnnouncement(Set<ServiceAnnouncement> actualAnnouncements, ServiceAnnouncement expected)
     {
-        assertNotNull(actualAnnouncements);
-        assertEquals(actualAnnouncements.size(), 1);
+        assertThat(actualAnnouncements).isNotNull();
+        assertThat(actualAnnouncements.size()).isEqualTo(1);
         ServiceAnnouncement announcement = actualAnnouncements.stream().collect(onlyElement());
-        assertEquals(announcement.getType(), expected.getType());
-        assertEquals(announcement.getProperties(), expected.getProperties());
+        assertThat(announcement.getType()).isEqualTo(expected.getType());
+        assertThat(announcement.getProperties()).isEqualTo(expected.getProperties());
     }
 
     public static class StringPropertyProvider

--- a/discovery/src/test/java/io/airlift/discovery/client/TestHttpAnnouncementImpl.java
+++ b/discovery/src/test/java/io/airlift/discovery/client/TestHttpAnnouncementImpl.java
@@ -18,7 +18,7 @@ package io.airlift.discovery.client;
 import org.testng.annotations.Test;
 
 import static io.airlift.testing.EquivalenceTester.equivalenceTester;
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestHttpAnnouncementImpl
 {
@@ -46,14 +46,14 @@ public class TestHttpAnnouncementImpl
     @Test
     public void testAnnouncementId()
     {
-        assertEquals(new HttpAnnouncementImpl("type A").announcementId(), "type A");
+        assertThat(new HttpAnnouncementImpl("type A").announcementId()).isEqualTo("type A");
     }
 
     @Test
     public void testAnnotationType()
     {
-        assertEquals(new HttpAnnouncementImpl("apple").annotationType(), HttpAnnouncement.class);
-        assertEquals(new HttpAnnouncementImpl("apple").annotationType(), appleHttpAnnouncement.annotationType());
+        assertThat(new HttpAnnouncementImpl("apple").annotationType()).isEqualTo(HttpAnnouncement.class);
+        assertThat(new HttpAnnouncementImpl("apple").annotationType()).isEqualTo(appleHttpAnnouncement.annotationType());
     }
 
     @Test

--- a/discovery/src/test/java/io/airlift/discovery/client/TestHttpDiscoveryAnnouncementClient.java
+++ b/discovery/src/test/java/io/airlift/discovery/client/TestHttpDiscoveryAnnouncementClient.java
@@ -5,7 +5,7 @@ import org.testng.annotations.Test;
 import java.net.URI;
 
 import static io.airlift.discovery.client.HttpDiscoveryAnnouncementClient.createAnnouncementLocation;
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestHttpDiscoveryAnnouncementClient
 {
@@ -13,11 +13,11 @@ public class TestHttpDiscoveryAnnouncementClient
     public void testCreateAnnouncementLocation()
     {
         URI expected = URI.create("http://example.com:8080/v1/announcement/abc");
-        assertEquals(createAnnouncementLocation(URI.create("http://example.com:8080"), "abc"), expected);
-        assertEquals(createAnnouncementLocation(URI.create("http://example.com:8080/"), "abc"), expected);
+        assertThat(createAnnouncementLocation(URI.create("http://example.com:8080"), "abc")).isEqualTo(expected);
+        assertThat(createAnnouncementLocation(URI.create("http://example.com:8080/"), "abc")).isEqualTo(expected);
 
         expected = URI.create("https://example.com:8080/v1/announcement/abc");
-        assertEquals(createAnnouncementLocation(URI.create("https://example.com:8080"), "abc"), expected);
-        assertEquals(createAnnouncementLocation(URI.create("https://example.com:8080/"), "abc"), expected);
+        assertThat(createAnnouncementLocation(URI.create("https://example.com:8080"), "abc")).isEqualTo(expected);
+        assertThat(createAnnouncementLocation(URI.create("https://example.com:8080/"), "abc")).isEqualTo(expected);
     }
 }

--- a/discovery/src/test/java/io/airlift/discovery/client/TestHttpDiscoveryLookupClient.java
+++ b/discovery/src/test/java/io/airlift/discovery/client/TestHttpDiscoveryLookupClient.java
@@ -6,7 +6,7 @@ import java.net.URI;
 import java.util.Optional;
 
 import static io.airlift.discovery.client.HttpDiscoveryLookupClient.createServiceLocation;
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestHttpDiscoveryLookupClient
 {
@@ -14,15 +14,15 @@ public class TestHttpDiscoveryLookupClient
     public void testCreateServiceLocation()
     {
         URI expected = URI.create("http://example.com:8080/v1/service/abc");
-        assertEquals(createServiceLocation(URI.create("http://example.com:8080"), "abc", Optional.empty()), expected);
-        assertEquals(createServiceLocation(URI.create("http://example.com:8080/"), "abc", Optional.empty()), expected);
+        assertThat(createServiceLocation(URI.create("http://example.com:8080"), "abc", Optional.empty())).isEqualTo(expected);
+        assertThat(createServiceLocation(URI.create("http://example.com:8080/"), "abc", Optional.empty())).isEqualTo(expected);
 
         expected = URI.create("https://example.com:8080/v1/service/abc");
-        assertEquals(createServiceLocation(URI.create("https://example.com:8080"), "abc", Optional.empty()), expected);
-        assertEquals(createServiceLocation(URI.create("https://example.com:8080/"), "abc", Optional.empty()), expected);
+        assertThat(createServiceLocation(URI.create("https://example.com:8080"), "abc", Optional.empty())).isEqualTo(expected);
+        assertThat(createServiceLocation(URI.create("https://example.com:8080/"), "abc", Optional.empty())).isEqualTo(expected);
 
         expected = URI.create("http://example.com:8080/v1/service/abc/xyz");
-        assertEquals(createServiceLocation(URI.create("http://example.com:8080"), "abc", Optional.of("xyz")), expected);
-        assertEquals(createServiceLocation(URI.create("http://example.com:8080/"), "abc", Optional.of("xyz")), expected);
+        assertThat(createServiceLocation(URI.create("http://example.com:8080"), "abc", Optional.of("xyz"))).isEqualTo(expected);
+        assertThat(createServiceLocation(URI.create("http://example.com:8080/"), "abc", Optional.of("xyz"))).isEqualTo(expected);
     }
 }

--- a/discovery/src/test/java/io/airlift/discovery/client/TestHttpServiceSelectorBinder.java
+++ b/discovery/src/test/java/io/airlift/discovery/client/TestHttpServiceSelectorBinder.java
@@ -34,7 +34,7 @@ import static com.google.common.collect.MoreCollectors.onlyElement;
 import static io.airlift.discovery.client.DiscoveryBinder.discoveryBinder;
 import static io.airlift.discovery.client.ServiceAnnouncement.serviceAnnouncement;
 import static io.airlift.discovery.client.ServiceTypes.serviceType;
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestHttpServiceSelectorBinder
 {
@@ -51,7 +51,7 @@ public class TestHttpServiceSelectorBinder
         discoveryClient.announce(ImmutableSet.of(serviceAnnouncement("apple").addProperty("http", "fake://server-http").build()));
 
         HttpServiceSelector selector = injector.getInstance(Key.get(HttpServiceSelector.class, serviceType("apple")));
-        assertEquals(selector.selectHttpService().stream().collect(onlyElement()), URI.create("fake://server-http"));
+        assertThat(selector.selectHttpService().stream().collect(onlyElement())).isEqualTo(URI.create("fake://server-http"));
     }
 
     @Test
@@ -67,10 +67,10 @@ public class TestHttpServiceSelectorBinder
         discoveryClient.announce(ImmutableSet.of(serviceAnnouncement("apple").addProperty("http", "fake://server-http").build()));
 
         HttpServiceSelector selector = injector.getInstance(Key.get(HttpServiceSelector.class, serviceType("apple")));
-        assertEquals(selector.selectHttpService().stream().collect(onlyElement()), URI.create("fake://server-http"));
+        assertThat(selector.selectHttpService().stream().collect(onlyElement())).isEqualTo(URI.create("fake://server-http"));
 
         ServiceSelectorManager manager = injector.getInstance(ServiceSelectorManager.class);
-        assertEquals(manager.getServiceSelectors().size(), 1);
+        assertThat(manager.getServiceSelectors().size()).isEqualTo(1);
         manager.attemptRefresh();
         manager.forceRefresh();
     }
@@ -88,7 +88,7 @@ public class TestHttpServiceSelectorBinder
         discoveryClient.announce(ImmutableSet.of(serviceAnnouncement("apple").addProperty("https", "fake://server-https").build()));
 
         HttpServiceSelector selector = injector.getInstance(Key.get(HttpServiceSelector.class, serviceType("apple")));
-        assertEquals(selector.selectHttpService().stream().collect(onlyElement()), URI.create("fake://server-https"));
+        assertThat(selector.selectHttpService().stream().collect(onlyElement())).isEqualTo(URI.create("fake://server-https"));
     }
 
     @Test
@@ -105,7 +105,7 @@ public class TestHttpServiceSelectorBinder
                 serviceAnnouncement("apple").addProperty("https", "fake://server-https").build()));
 
         HttpServiceSelector selector = injector.getInstance(Key.get(HttpServiceSelector.class, serviceType("apple")));
-        assertEquals(selector.selectHttpService(), ImmutableList.of(URI.create("fake://server-https"), URI.create("fake://server-http")));
+        assertThat(selector.selectHttpService()).isEqualTo(ImmutableList.of(URI.create("fake://server-https"), URI.create("fake://server-http")));
     }
 
     @Test
@@ -121,7 +121,7 @@ public class TestHttpServiceSelectorBinder
         discoveryClient.announce(ImmutableSet.of(serviceAnnouncement("apple").addProperty("foo", "fake://server-https").build()));
 
         HttpServiceSelector selector = injector.getInstance(Key.get(HttpServiceSelector.class, serviceType("apple")));
-        assertEquals(selector.selectHttpService(), ImmutableList.of());
+        assertThat(selector.selectHttpService()).isEqualTo(ImmutableList.of());
     }
 
     @Test
@@ -138,6 +138,6 @@ public class TestHttpServiceSelectorBinder
         discoveryClient.announce(ImmutableSet.of(serviceAnnouncement("apple").addProperty("https", ":::INVALID:::").build()));
 
         HttpServiceSelector selector = injector.getInstance(Key.get(HttpServiceSelector.class, serviceType("apple")));
-        assertEquals(selector.selectHttpService(), ImmutableList.of());
+        assertThat(selector.selectHttpService()).isEqualTo(ImmutableList.of());
     }
 }

--- a/discovery/src/test/java/io/airlift/discovery/client/TestServiceAnnouncement.java
+++ b/discovery/src/test/java/io/airlift/discovery/client/TestServiceAnnouncement.java
@@ -27,8 +27,7 @@ import static io.airlift.json.JsonCodec.jsonCodec;
 import static io.airlift.json.JsonCodec.mapJsonCodec;
 import static io.airlift.testing.EquivalenceTester.equivalenceTester;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestServiceAnnouncement
 {
@@ -52,15 +51,15 @@ public class TestServiceAnnouncement
 
     private void assertAnnouncement(ServiceAnnouncement announcement, String type, Map<String, String> properties)
     {
-        assertNotNull(announcement.getId());
-        assertEquals(announcement.getType(), type);
-        assertEquals(announcement.getProperties(), properties);
+        assertThat(announcement.getId()).isNotNull();
+        assertThat(announcement.getType()).isEqualTo(type);
+        assertThat(announcement.getProperties()).isEqualTo(properties);
     }
 
     @Test
     public void testToString()
     {
-        assertNotNull(serviceAnnouncement("foo").build());
+        assertThat(serviceAnnouncement("foo").build()).isNotNull();
     }
 
     @Test
@@ -79,7 +78,7 @@ public class TestServiceAnnouncement
         // set id in expected
         expected.put("id", serviceAnnouncement.getId().toString());
 
-        assertEquals(actual, expected);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Test

--- a/discovery/src/test/java/io/airlift/discovery/client/TestServiceDescriptor.java
+++ b/discovery/src/test/java/io/airlift/discovery/client/TestServiceDescriptor.java
@@ -30,8 +30,7 @@ import static io.airlift.discovery.client.ServiceDescriptor.serviceDescriptor;
 import static io.airlift.json.JsonCodec.jsonCodec;
 import static io.airlift.testing.EquivalenceTester.equivalenceTester;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestServiceDescriptor
 {
@@ -57,12 +56,12 @@ public class TestServiceDescriptor
     @Test
     public void testToString()
     {
-        assertNotNull(new ServiceDescriptor(UUID.fromString("12345678-1234-1234-1234-123456789012"),
+        assertThat(new ServiceDescriptor(UUID.fromString("12345678-1234-1234-1234-123456789012"),
                 "node",
                 "type",
                 "pool",
                 "location",
-                ServiceState.RUNNING, ImmutableMap.of("a", "apple", "b", "banana")));
+                ServiceState.RUNNING, ImmutableMap.of("a", "apple", "b", "banana"))).isNotNull();
     }
 
     @Test
@@ -143,12 +142,12 @@ public class TestServiceDescriptor
 
     private static void assertDescriptorEquals(ServiceDescriptor expected, ServiceDescriptor actual)
     {
-        assertEquals(actual, expected);
-        assertEquals(actual.getId(), expected.getId());
-        assertEquals(actual.getNodeId(), expected.getNodeId());
-        assertEquals(actual.getType(), expected.getType());
-        assertEquals(actual.getPool(), expected.getPool());
-        assertEquals(actual.getLocation(), expected.getLocation());
-        assertEquals(actual.getProperties(), expected.getProperties());
+        assertThat(actual).isEqualTo(expected);
+        assertThat(actual.getId()).isEqualTo(expected.getId());
+        assertThat(actual.getNodeId()).isEqualTo(expected.getNodeId());
+        assertThat(actual.getType()).isEqualTo(expected.getType());
+        assertThat(actual.getPool()).isEqualTo(expected.getPool());
+        assertThat(actual.getLocation()).isEqualTo(expected.getLocation());
+        assertThat(actual.getProperties()).isEqualTo(expected.getProperties());
     }
 }

--- a/discovery/src/test/java/io/airlift/discovery/client/TestServiceInventory.java
+++ b/discovery/src/test/java/io/airlift/discovery/client/TestServiceInventory.java
@@ -36,7 +36,7 @@ import org.testng.annotations.Test;
 import java.io.IOException;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestServiceInventory
 {
@@ -49,9 +49,9 @@ public class TestServiceInventory
                     JsonCodec.jsonCodec(ServiceDescriptorsRepresentation.class),
                     httpClient);
 
-            assertEquals(Iterables.size(serviceInventory.getServiceDescriptors()), 0);
+            assertThat(Iterables.size(serviceInventory.getServiceDescriptors())).isEqualTo(0);
             serviceInventory.updateServiceInventory();
-            assertEquals(Iterables.size(serviceInventory.getServiceDescriptors()), 0);
+            assertThat(Iterables.size(serviceInventory.getServiceDescriptors())).isEqualTo(0);
         }
     }
 
@@ -68,13 +68,13 @@ public class TestServiceInventory
                     JsonCodec.jsonCodec(ServiceDescriptorsRepresentation.class),
                     httpClient);
 
-            assertEquals(Iterables.size(serviceInventory.getServiceDescriptors()), 2);
-            assertEquals(Iterables.size(serviceInventory.getServiceDescriptors("discovery")), 2);
-            assertEquals(Iterables.size(serviceInventory.getServiceDescriptors("discovery", "general")), 2);
+            assertThat(Iterables.size(serviceInventory.getServiceDescriptors())).isEqualTo(2);
+            assertThat(Iterables.size(serviceInventory.getServiceDescriptors("discovery"))).isEqualTo(2);
+            assertThat(Iterables.size(serviceInventory.getServiceDescriptors("discovery", "general"))).isEqualTo(2);
             serviceInventory.updateServiceInventory();
-            assertEquals(Iterables.size(serviceInventory.getServiceDescriptors()), 2);
-            assertEquals(Iterables.size(serviceInventory.getServiceDescriptors("discovery")), 2);
-            assertEquals(Iterables.size(serviceInventory.getServiceDescriptors("discovery", "general")), 2);
+            assertThat(Iterables.size(serviceInventory.getServiceDescriptors())).isEqualTo(2);
+            assertThat(Iterables.size(serviceInventory.getServiceDescriptors("discovery"))).isEqualTo(2);
+            assertThat(Iterables.size(serviceInventory.getServiceDescriptors("discovery", "general"))).isEqualTo(2);
         }
     }
 
@@ -115,13 +115,13 @@ public class TestServiceInventory
                     JsonCodec.jsonCodec(ServiceDescriptorsRepresentation.class),
                     httpClient);
 
-            assertEquals(Iterables.size(serviceInventory.getServiceDescriptors()), 2);
-            assertEquals(Iterables.size(serviceInventory.getServiceDescriptors("discovery")), 2);
-            assertEquals(Iterables.size(serviceInventory.getServiceDescriptors("discovery", "general")), 2);
+            assertThat(Iterables.size(serviceInventory.getServiceDescriptors())).isEqualTo(2);
+            assertThat(Iterables.size(serviceInventory.getServiceDescriptors("discovery"))).isEqualTo(2);
+            assertThat(Iterables.size(serviceInventory.getServiceDescriptors("discovery", "general"))).isEqualTo(2);
             serviceInventory.updateServiceInventory();
-            assertEquals(Iterables.size(serviceInventory.getServiceDescriptors()), 2);
-            assertEquals(Iterables.size(serviceInventory.getServiceDescriptors("discovery")), 2);
-            assertEquals(Iterables.size(serviceInventory.getServiceDescriptors("discovery", "general")), 2);
+            assertThat(Iterables.size(serviceInventory.getServiceDescriptors())).isEqualTo(2);
+            assertThat(Iterables.size(serviceInventory.getServiceDescriptors("discovery"))).isEqualTo(2);
+            assertThat(Iterables.size(serviceInventory.getServiceDescriptors("discovery", "general"))).isEqualTo(2);
         }
         finally {
             if (server != null) {

--- a/discovery/src/test/java/io/airlift/discovery/client/TestServiceTypes.java
+++ b/discovery/src/test/java/io/airlift/discovery/client/TestServiceTypes.java
@@ -18,7 +18,7 @@ package io.airlift.discovery.client;
 import org.testng.annotations.Test;
 
 import static io.airlift.testing.EquivalenceTester.equivalenceTester;
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestServiceTypes
 {
@@ -46,14 +46,14 @@ public class TestServiceTypes
     @Test
     public void testValue()
     {
-        assertEquals(ServiceTypes.serviceType("type").value(), "type");
+        assertThat(ServiceTypes.serviceType("type").value()).isEqualTo("type");
     }
 
     @Test
     public void testAnnotationType()
     {
-        assertEquals(ServiceTypes.serviceType("apple").annotationType(), ServiceType.class);
-        assertEquals(ServiceTypes.serviceType("apple").annotationType(), appleServiceType.annotationType());
+        assertThat(ServiceTypes.serviceType("apple").annotationType()).isEqualTo(ServiceType.class);
+        assertThat(ServiceTypes.serviceType("apple").annotationType()).isEqualTo(appleServiceType.annotationType());
     }
 
     @Test

--- a/event-http/pom.xml
+++ b/event-http/pom.xml
@@ -83,6 +83,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
             <scope>test</scope>

--- a/event-http/src/test/java/io/airlift/event/client/http/TestHttpEventClient.java
+++ b/event-http/src/test/java/io/airlift/event/client/http/TestHttpEventClient.java
@@ -63,8 +63,7 @@ import static io.airlift.event.client.TestingUtils.getNormalizedJson;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Test(singleThreaded = true)
 public class TestHttpEventClient
@@ -98,8 +97,8 @@ public class TestHttpEventClient
 
         client.post(new FixedDummyEventClass("host", Instant.now(), UUID.randomUUID(), 1, "foo"));
 
-        assertNull(servlet.lastPath);
-        assertNull(servlet.lastBody);
+        assertThat(servlet.lastPath).isNull();
+        assertThat(servlet.lastBody).isNull();
     }
 
     @Test
@@ -110,8 +109,8 @@ public class TestHttpEventClient
 
         client.post(TestingUtils.getEvents()).get();
 
-        assertEquals(servlet.lastPath, "/v2/event");
-        assertEquals(servlet.lastBody, getNormalizedJson("events.json"));
+        assertThat(servlet.lastPath).isEqualTo("/v2/event");
+        assertThat(servlet.lastBody).isEqualTo(getNormalizedJson("events.json"));
     }
 
     @Test
@@ -128,8 +127,8 @@ public class TestHttpEventClient
         for (Future<Void> future : futures) {
             future.get();
         }
-        assertEquals(servlet.lastPath, "/v2/event");
-        assertEquals(servlet.lastBody, getNormalizedJson("events.json"));
+        assertThat(servlet.lastPath).isEqualTo("/v2/event");
+        assertThat(servlet.lastBody).isEqualTo(getNormalizedJson("events.json"));
     }
 
     @BeforeMethod

--- a/event/pom.xml
+++ b/event/pom.xml
@@ -49,6 +49,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/event/src/test/java/io/airlift/event/client/AbstractTestInMemoryEventClient.java
+++ b/event/src/test/java/io/airlift/event/client/AbstractTestInMemoryEventClient.java
@@ -18,7 +18,7 @@ package io.airlift.event.client;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Test(singleThreaded = true)
 public abstract class AbstractTestInMemoryEventClient
@@ -35,7 +35,7 @@ public abstract class AbstractTestInMemoryEventClient
     {
         eventClient.post(event1);
 
-        assertEquals(inMemoryEventClient.getEvents(), ImmutableList.of(event1));
+        assertThat(inMemoryEventClient.getEvents()).isEqualTo(ImmutableList.of(event1));
     }
 
     @Test
@@ -45,8 +45,7 @@ public abstract class AbstractTestInMemoryEventClient
         eventClient.post(event2);
         eventClient.post(event3);
 
-        assertEquals(inMemoryEventClient.getEvents(),
-                ImmutableList.of(event1, event2, event3));
+        assertThat(inMemoryEventClient.getEvents()).isEqualTo(ImmutableList.of(event1, event2, event3));
     }
 
     @Test
@@ -54,8 +53,7 @@ public abstract class AbstractTestInMemoryEventClient
     {
         eventClient.post(event1, event2, event3);
 
-        assertEquals(inMemoryEventClient.getEvents(),
-                ImmutableList.of(event1, event2, event3));
+        assertThat(inMemoryEventClient.getEvents()).isEqualTo(ImmutableList.of(event1, event2, event3));
     }
 
     @Test
@@ -63,8 +61,7 @@ public abstract class AbstractTestInMemoryEventClient
     {
         eventClient.post(ImmutableList.of(event1, event2, event3));
 
-        assertEquals(inMemoryEventClient.getEvents(),
-                ImmutableList.of(event1, event2, event3));
+        assertThat(inMemoryEventClient.getEvents()).isEqualTo(ImmutableList.of(event1, event2, event3));
     }
 
     @Test
@@ -76,7 +73,6 @@ public abstract class AbstractTestInMemoryEventClient
             objectEventPoster.post(event3);
         });
 
-        assertEquals(inMemoryEventClient.getEvents(),
-                ImmutableList.of(event1, event2, event3));
+        assertThat(inMemoryEventClient.getEvents()).isEqualTo(ImmutableList.of(event1, event2, event3));
     }
 }

--- a/event/src/test/java/io/airlift/event/client/AbstractTestMultiEventClient.java
+++ b/event/src/test/java/io/airlift/event/client/AbstractTestMultiEventClient.java
@@ -18,7 +18,7 @@ package io.airlift.event.client;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Test(singleThreaded = true)
 public abstract class AbstractTestMultiEventClient
@@ -36,8 +36,8 @@ public abstract class AbstractTestMultiEventClient
     {
         eventClient.post(event1);
 
-        assertEquals(memoryEventClient1.getEvents(), ImmutableList.of(event1));
-        assertEquals(memoryEventClient2.getEvents(), ImmutableList.of(event1));
+        assertThat(memoryEventClient1.getEvents()).isEqualTo(ImmutableList.of(event1));
+        assertThat(memoryEventClient2.getEvents()).isEqualTo(ImmutableList.of(event1));
     }
 
     @Test
@@ -47,10 +47,8 @@ public abstract class AbstractTestMultiEventClient
         eventClient.post(event2);
         eventClient.post(event3);
 
-        assertEquals(memoryEventClient1.getEvents(),
-                ImmutableList.of(event1, event2, event3));
-        assertEquals(memoryEventClient2.getEvents(),
-                ImmutableList.of(event1, event2, event3));
+        assertThat(memoryEventClient1.getEvents()).isEqualTo(ImmutableList.of(event1, event2, event3));
+        assertThat(memoryEventClient2.getEvents()).isEqualTo(ImmutableList.of(event1, event2, event3));
     }
 
     @Test
@@ -58,10 +56,8 @@ public abstract class AbstractTestMultiEventClient
     {
         eventClient.post(event1, event2, event3);
 
-        assertEquals(memoryEventClient1.getEvents(),
-                ImmutableList.of(event1, event2, event3));
-        assertEquals(memoryEventClient2.getEvents(),
-                ImmutableList.of(event1, event2, event3));
+        assertThat(memoryEventClient1.getEvents()).isEqualTo(ImmutableList.of(event1, event2, event3));
+        assertThat(memoryEventClient2.getEvents()).isEqualTo(ImmutableList.of(event1, event2, event3));
     }
 
     @Test
@@ -69,10 +65,8 @@ public abstract class AbstractTestMultiEventClient
     {
         eventClient.post(ImmutableList.of(event1, event2, event3));
 
-        assertEquals(memoryEventClient1.getEvents(),
-                ImmutableList.of(event1, event2, event3));
-        assertEquals(memoryEventClient2.getEvents(),
-                ImmutableList.of(event1, event2, event3));
+        assertThat(memoryEventClient1.getEvents()).isEqualTo(ImmutableList.of(event1, event2, event3));
+        assertThat(memoryEventClient2.getEvents()).isEqualTo(ImmutableList.of(event1, event2, event3));
     }
 
     @Test
@@ -84,9 +78,7 @@ public abstract class AbstractTestMultiEventClient
             objectEventPoster.post(event3);
         });
 
-        assertEquals(memoryEventClient1.getEvents(),
-                ImmutableList.of(event1, event2, event3));
-        assertEquals(memoryEventClient2.getEvents(),
-                ImmutableList.of(event1, event2, event3));
+        assertThat(memoryEventClient1.getEvents()).isEqualTo(ImmutableList.of(event1, event2, event3));
+        assertThat(memoryEventClient2.getEvents()).isEqualTo(ImmutableList.of(event1, event2, event3));
     }
 }

--- a/event/src/test/java/io/airlift/event/client/TestEventSubmissionFailedException.java
+++ b/event/src/test/java/io/airlift/event/client/TestEventSubmissionFailedException.java
@@ -24,9 +24,7 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.Map;
 
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertSame;
-import static org.testng.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestEventSubmissionFailedException
 {
@@ -41,7 +39,7 @@ public class TestEventSubmissionFailedException
     {
         EventSubmissionFailedException e = new EventSubmissionFailedException("service", "type", Collections.<URI, Exception>emptyMap());
 
-        assertNull(e.getCause());
+        assertThat(e.getCause()).isNull();
     }
 
     @Test
@@ -50,7 +48,7 @@ public class TestEventSubmissionFailedException
         RuntimeException cause = new RuntimeException();
         EventSubmissionFailedException e = new EventSubmissionFailedException("service", "type", ImmutableMap.of(URI.create("/"), cause));
 
-        assertSame(e.getCause(), cause);
+        assertThat(e.getCause()).isSameAs(cause);
     }
 
     @Test
@@ -58,8 +56,8 @@ public class TestEventSubmissionFailedException
     {
         EventSubmissionFailedException e = new EventSubmissionFailedException("serviceX", "typeY", Collections.<URI, Throwable>emptyMap());
 
-        assertTrue(e.getMessage().contains("serviceX"));
-        assertTrue(e.getMessage().contains("typeY"));
+        assertThat(e.getMessage()).contains("serviceX");
+        assertThat(e.getMessage()).contains("typeY");
     }
 
     @Test
@@ -77,6 +75,6 @@ public class TestEventSubmissionFailedException
 
         EventSubmissionFailedException e = new EventSubmissionFailedException("service", "type", causes);
 
-        assertSame(e.getCause(), cause1);
+        assertThat(e.getCause()).isSameAs(cause1);
     }
 }

--- a/event/src/test/java/io/airlift/event/client/TestEventValidation.java
+++ b/event/src/test/java/io/airlift/event/client/TestEventValidation.java
@@ -24,7 +24,7 @@ import static io.airlift.event.client.EventTypeMetadata.getEventTypeMetadata;
 import static io.airlift.event.client.EventTypeMetadata.getEventTypeMetadataNested;
 import static io.airlift.event.client.EventTypeMetadata.getValidEventTypeMetadata;
 import static io.airlift.testing.Assertions.assertContains;
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestEventValidation
 {
@@ -90,15 +90,15 @@ public class TestEventValidation
             }
         }
 
-        assertEquals(getEventTypeMetadataNested(TestEvent.Nested.class).getTypeName(), "NestedCustom");
-        assertEquals(getEventTypeMetadataNested(TestEvent.Nested2.class).getTypeName(), TestEvent.Nested2.class.getSimpleName());
+        assertThat(getEventTypeMetadataNested(TestEvent.Nested.class).getTypeName()).isEqualTo("NestedCustom");
+        assertThat(getEventTypeMetadataNested(TestEvent.Nested2.class).getTypeName()).isEqualTo(TestEvent.Nested2.class.getSimpleName());
     }
 
     private static void assertInvalidEvent(Class<?> eventClass, String errorPart)
     {
         EventTypeMetadata<?> metadata = getEventTypeMetadata(eventClass);
         List<String> errors = metadata.getErrors();
-        assertEquals(errors.size(), 1, "expected exactly one error:\n" + Joiner.on('\n').join(errors));
+        assertThat(errors.size()).as("expected exactly one error:\n" + Joiner.on('\n').join(errors)).isEqualTo(1);
         assertContains(errors.get(0), errorPart);
     }
 }

--- a/event/src/test/java/io/airlift/event/client/TestJsonEventSerializer.java
+++ b/event/src/test/java/io/airlift/event/client/TestJsonEventSerializer.java
@@ -23,7 +23,7 @@ import org.testng.annotations.Test;
 import java.io.ByteArrayOutputStream;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestJsonEventSerializer
 {
@@ -40,6 +40,6 @@ public class TestJsonEventSerializer
         eventSerializer.serialize(event, jsonGenerator);
 
         String json = out.toString(UTF_8.name());
-        assertEquals(json, TestingUtils.getNormalizedJson("event.json"));
+        assertThat(json).isEqualTo(TestingUtils.getNormalizedJson("event.json"));
     }
 }

--- a/event/src/test/java/io/airlift/event/client/TestJsonEventWriter.java
+++ b/event/src/test/java/io/airlift/event/client/TestJsonEventWriter.java
@@ -29,7 +29,7 @@ import static com.google.common.io.ByteStreams.nullOutputStream;
 import static io.airlift.event.client.ChainedCircularEventClass.ChainedPart;
 import static io.airlift.event.client.EventTypeMetadata.getValidEventTypeMetaDataSet;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestJsonEventWriter
 {
@@ -105,7 +105,7 @@ public class TestJsonEventWriter
         eventWriter.writeEvents(events, out);
 
         String json = out.toString(UTF_8.name());
-        assertEquals(json, TestingUtils.getNormalizedJson(resource));
+        assertThat(json).isEqualTo(TestingUtils.getNormalizedJson(resource));
     }
 
     private static <T> EventClient.EventGenerator<T> createEventGenerator(final Iterable<T> events)

--- a/event/src/test/java/io/airlift/event/client/TestTypeParametersUtils.java
+++ b/event/src/test/java/io/airlift/event/client/TestTypeParametersUtils.java
@@ -27,9 +27,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static io.airlift.event.client.TypeParameterUtils.getTypeParameters;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SuppressWarnings({"PublicField", "unused"})
 public class TestTypeParametersUtils
@@ -54,8 +52,8 @@ public class TestTypeParametersUtils
     public void testMap()
             throws Exception
     {
-        assertNull(getParameters("mapNotGeneric"));
-        assertEquals(getParameters("mapSimple"), new Type[] {Key.class, Value.class});
+        assertThat(getParameters("mapNotGeneric")).isNull();
+        assertThat(getParameters("mapSimple")).isEqualTo(new Type[] {Key.class, Value.class});
         assertTwoWildcardTypes(getParameters("mapWildcard"));
         assertTwoWildcardTypes(getParameters("mapExtendsWildcard"));
         assertTwoWildcardTypes(getParameters("mapSuperWildcard"));
@@ -66,7 +64,7 @@ public class TestTypeParametersUtils
             throws Exception
     {
         assertTwoTypeVariables(getParameters("myMapNotGeneric"));
-        assertEquals(getParameters("myMapSimple"), new Type[] {Key.class, Value.class});
+        assertThat(getParameters("myMapSimple")).isEqualTo(new Type[] {Key.class, Value.class});
         assertTwoWildcardTypes(getParameters("myMapWildcard"));
         assertTwoWildcardTypes(getParameters("myMapExtendsWildcard"));
         assertTwoWildcardTypes(getParameters("myMapSuperWildcard"));
@@ -76,12 +74,12 @@ public class TestTypeParametersUtils
     public void testFixedMap()
             throws Exception
     {
-        assertEquals(getParameters("fixedMap"), new Type[] {Key.class, Value.class});
+        assertThat(getParameters("fixedMap")).isEqualTo(new Type[] {Key.class, Value.class});
     }
 
     private static void assertTwoWildcardTypes(Type[] types)
     {
-        assertEquals(types.length, 2);
+        assertThat(types).hasSize(2);
         for (Type type : types) {
             assertInstanceOf(type, WildcardType.class);
         }
@@ -89,7 +87,7 @@ public class TestTypeParametersUtils
 
     private static void assertTwoTypeVariables(Type[] types)
     {
-        assertEquals(types.length, 2);
+        assertThat(types).hasSize(2);
         for (Type type : types) {
             assertInstanceOf(type, TypeVariable.class);
         }
@@ -97,7 +95,9 @@ public class TestTypeParametersUtils
 
     private static void assertInstanceOf(Type type, Class<?> clazz)
     {
-        assertTrue(clazz.isInstance(type), String.format("[%s] is not instance of %s", type, clazz.getSimpleName()));
+        assertThat(type)
+                .as(String.format("[%s] is not instance of %s", type, clazz.getSimpleName()))
+                .isInstanceOf(clazz);
     }
 
     private Type[] getParameters(String fieldName)

--- a/http-client/src/test/java/io/airlift/http/client/AbstractHttpClientTest.java
+++ b/http-client/src/test/java/io/airlift/http/client/AbstractHttpClientTest.java
@@ -72,12 +72,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 @Test(singleThreaded = true)
 public abstract class AbstractHttpClientTest
@@ -159,7 +154,7 @@ public abstract class AbstractHttpClientTest
         for (int i = 0; i < 100_000; i++) {
             try {
                 int statusCode = executeRequest(request, createStatusResponseHandler()).getStatusCode();
-                assertEquals(statusCode, 200);
+                assertThat(statusCode).isEqualTo(200);
             }
             catch (Exception e) {
                 throw new Exception("Error on request " + i, e);
@@ -237,7 +232,7 @@ public abstract class AbstractHttpClientTest
                 .build();
 
         Object expected = new Object();
-        assertEquals(executeRequest(config, request, new DefaultOnExceptionResponseHandler(expected)), expected);
+        assertThat(executeRequest(config, request, new DefaultOnExceptionResponseHandler(expected))).isEqualTo(expected);
     }
 
     @Test(expectedExceptions = {UnknownHostException.class, UnresolvedAddressException.class}, timeOut = 10000)
@@ -283,12 +278,12 @@ public abstract class AbstractHttpClientTest
                 .build();
 
         int statusCode = executeRequest(request, createStatusResponseHandler()).getStatusCode();
-        assertEquals(statusCode, 200);
-        assertEquals(servlet.getRequestMethod(), "DELETE");
-        assertEquals(servlet.getRequestUri(), uri);
-        assertEquals(servlet.getRequestHeaders("foo"), ImmutableList.of("bar"));
-        assertEquals(servlet.getRequestHeaders("dupe"), ImmutableList.of("first", "second"));
-        assertEquals(servlet.getRequestHeaders("x-custom-filter"), ImmutableList.of("custom value"));
+        assertThat(statusCode).isEqualTo(200);
+        assertThat(servlet.getRequestMethod()).isEqualTo("DELETE");
+        assertThat(servlet.getRequestUri()).isEqualTo(uri);
+        assertThat(servlet.getRequestHeaders("foo")).isEqualTo(ImmutableList.of("bar"));
+        assertThat(servlet.getRequestHeaders("dupe")).isEqualTo(ImmutableList.of("first", "second"));
+        assertThat(servlet.getRequestHeaders("x-custom-filter")).isEqualTo(ImmutableList.of("custom value"));
         assertThat(statusCounts.count(200)).isEqualTo(1);
     }
 
@@ -304,8 +299,8 @@ public abstract class AbstractHttpClientTest
                 .build();
 
         StringResponse response = executeRequest(request, createStringResponseHandler());
-        assertEquals(response.getStatusCode(), 500);
-        assertEquals(response.getBody(), "body text");
+        assertThat(response.getStatusCode()).isEqualTo(500);
+        assertThat(response.getBody()).isEqualTo("body text");
     }
 
     @Test
@@ -321,18 +316,18 @@ public abstract class AbstractHttpClientTest
                 .build();
 
         int statusCode = executeRequest(request, createStatusResponseHandler()).getStatusCode();
-        assertEquals(statusCode, 200);
-        assertEquals(servlet.getRequestMethod(), "GET");
+        assertThat(statusCode).isEqualTo(200);
+        assertThat(servlet.getRequestMethod()).isEqualTo("GET");
         if (servlet.getRequestUri().toString().endsWith("=")) {
             // todo jetty client rewrites the uri string for some reason
-            assertEquals(servlet.getRequestUri(), new URI(uri + "="));
+            assertThat(servlet.getRequestUri()).isEqualTo(new URI(uri + "="));
         }
         else {
-            assertEquals(servlet.getRequestUri(), uri);
+            assertThat(servlet.getRequestUri()).isEqualTo(uri);
         }
-        assertEquals(servlet.getRequestHeaders("foo"), ImmutableList.of("bar"));
-        assertEquals(servlet.getRequestHeaders("dupe"), ImmutableList.of("first", "second"));
-        assertEquals(servlet.getRequestHeaders("x-custom-filter"), ImmutableList.of("custom value"));
+        assertThat(servlet.getRequestHeaders("foo")).isEqualTo(ImmutableList.of("bar"));
+        assertThat(servlet.getRequestHeaders("dupe")).isEqualTo(ImmutableList.of("first", "second"));
+        assertThat(servlet.getRequestHeaders("x-custom-filter")).isEqualTo(ImmutableList.of("custom value"));
         assertThat(statusCounts.count(200)).isEqualTo(1);
     }
 
@@ -347,11 +342,11 @@ public abstract class AbstractHttpClientTest
 
         Response response = executeRequest(request, new PassThroughResponseHandler());
 
-        assertNotNull(response.getHeader("date"));
-        assertNotNull(response.getHeader("DATE"));
+        assertThat(response.getHeader("date")).isNotNull();
+        assertThat(response.getHeader("DATE")).isNotNull();
 
-        assertEquals(response.getHeaders("date").size(), 1);
-        assertEquals(response.getHeaders("DATE").size(), 1);
+        assertThat(response.getHeaders("date").size()).isEqualTo(1);
+        assertThat(response.getHeaders("DATE").size()).isEqualTo(1);
     }
 
     @Test
@@ -364,9 +359,9 @@ public abstract class AbstractHttpClientTest
                 .build();
 
         int statusCode = executeRequest(request, createStatusResponseHandler()).getStatusCode();
-        assertEquals(statusCode, 200);
-        assertEquals(servlet.getRequestMethod(), "GET");
-        assertEquals(servlet.getRequestUri(), uri);
+        assertThat(statusCode).isEqualTo(200);
+        assertThat(servlet.getRequestMethod()).isEqualTo("GET");
+        assertThat(servlet.getRequestUri()).isEqualTo(uri);
     }
 
     @Test
@@ -384,16 +379,16 @@ public abstract class AbstractHttpClientTest
         Thread.sleep(1000);
         StatusResponse response3 = executeRequest(request, createStatusResponseHandler());
 
-        assertNotNull(response1.getHeader("remotePort"));
-        assertNotNull(response2.getHeader("remotePort"));
-        assertNotNull(response3.getHeader("remotePort"));
+        assertThat(response1.getHeader("remotePort")).isNotNull();
+        assertThat(response2.getHeader("remotePort")).isNotNull();
+        assertThat(response3.getHeader("remotePort")).isNotNull();
 
         int port1 = Integer.parseInt(response1.getHeader("remotePort"));
         int port2 = Integer.parseInt(response2.getHeader("remotePort"));
         int port3 = Integer.parseInt(response3.getHeader("remotePort"));
 
-        assertEquals(port2, port1);
-        assertEquals(port3, port1);
+        assertThat(port2).isEqualTo(port1);
+        assertThat(port3).isEqualTo(port1);
         assertBetweenInclusive(port1, 1024, 65535);
     }
 
@@ -410,12 +405,12 @@ public abstract class AbstractHttpClientTest
                 .build();
 
         int statusCode = executeRequest(request, createStatusResponseHandler()).getStatusCode();
-        assertEquals(statusCode, 200);
-        assertEquals(servlet.getRequestMethod(), "POST");
-        assertEquals(servlet.getRequestUri(), uri);
-        assertEquals(servlet.getRequestHeaders("foo"), ImmutableList.of("bar"));
-        assertEquals(servlet.getRequestHeaders("dupe"), ImmutableList.of("first", "second"));
-        assertEquals(servlet.getRequestHeaders("x-custom-filter"), ImmutableList.of("custom value"));
+        assertThat(statusCode).isEqualTo(200);
+        assertThat(servlet.getRequestMethod()).isEqualTo("POST");
+        assertThat(servlet.getRequestUri()).isEqualTo(uri);
+        assertThat(servlet.getRequestHeaders("foo")).isEqualTo(ImmutableList.of("bar"));
+        assertThat(servlet.getRequestHeaders("dupe")).isEqualTo(ImmutableList.of("first", "second"));
+        assertThat(servlet.getRequestHeaders("x-custom-filter")).isEqualTo(ImmutableList.of("custom value"));
         assertThat(statusCounts.count(200)).isEqualTo(1);
     }
 
@@ -432,12 +427,12 @@ public abstract class AbstractHttpClientTest
                 .build();
 
         int statusCode = executeRequest(request, createStatusResponseHandler()).getStatusCode();
-        assertEquals(statusCode, 200);
-        assertEquals(servlet.getRequestMethod(), "PUT");
-        assertEquals(servlet.getRequestUri(), uri);
-        assertEquals(servlet.getRequestHeaders("foo"), ImmutableList.of("bar"));
-        assertEquals(servlet.getRequestHeaders("dupe"), ImmutableList.of("first", "second"));
-        assertEquals(servlet.getRequestHeaders("x-custom-filter"), ImmutableList.of("custom value"));
+        assertThat(statusCode).isEqualTo(200);
+        assertThat(servlet.getRequestMethod()).isEqualTo("PUT");
+        assertThat(servlet.getRequestUri()).isEqualTo(uri);
+        assertThat(servlet.getRequestHeaders("foo")).isEqualTo(ImmutableList.of("bar"));
+        assertThat(servlet.getRequestHeaders("dupe")).isEqualTo(ImmutableList.of("first", "second"));
+        assertThat(servlet.getRequestHeaders("x-custom-filter")).isEqualTo(ImmutableList.of("custom value"));
         assertThat(statusCounts.count(200)).isEqualTo(1);
     }
 
@@ -456,13 +451,13 @@ public abstract class AbstractHttpClientTest
                 .build();
 
         int statusCode = executeRequest(request, createStatusResponseHandler()).getStatusCode();
-        assertEquals(statusCode, 200);
-        assertEquals(servlet.getRequestMethod(), "PUT");
-        assertEquals(servlet.getRequestUri(), uri);
-        assertEquals(servlet.getRequestHeaders("foo"), ImmutableList.of("bar"));
-        assertEquals(servlet.getRequestHeaders("dupe"), ImmutableList.of("first", "second"));
-        assertEquals(servlet.getRequestHeaders("x-custom-filter"), ImmutableList.of("custom value"));
-        assertEquals(servlet.getRequestBytes(), body);
+        assertThat(statusCode).isEqualTo(200);
+        assertThat(servlet.getRequestMethod()).isEqualTo("PUT");
+        assertThat(servlet.getRequestUri()).isEqualTo(uri);
+        assertThat(servlet.getRequestHeaders("foo")).isEqualTo(ImmutableList.of("bar"));
+        assertThat(servlet.getRequestHeaders("dupe")).isEqualTo(ImmutableList.of("first", "second"));
+        assertThat(servlet.getRequestHeaders("x-custom-filter")).isEqualTo(ImmutableList.of("custom value"));
+        assertThat(servlet.getRequestBytes()).isEqualTo(body);
         assertThat(statusCounts.count(200)).isEqualTo(1);
     }
 
@@ -483,13 +478,13 @@ public abstract class AbstractHttpClientTest
                 .build();
 
         int statusCode = executeRequest(request, createStatusResponseHandler()).getStatusCode();
-        assertEquals(statusCode, 200);
-        assertEquals(servlet.getRequestMethod(), "PUT");
-        assertEquals(servlet.getRequestUri(), uri);
-        assertEquals(servlet.getRequestHeaders("foo"), ImmutableList.of("bar"));
-        assertEquals(servlet.getRequestHeaders("dupe"), ImmutableList.of("first", "second"));
-        assertEquals(servlet.getRequestHeaders("x-custom-filter"), ImmutableList.of("custom value"));
-        assertEquals(servlet.getRequestBytes(), new byte[] {1, 2, 5});
+        assertThat(statusCode).isEqualTo(200);
+        assertThat(servlet.getRequestMethod()).isEqualTo("PUT");
+        assertThat(servlet.getRequestUri()).isEqualTo(uri);
+        assertThat(servlet.getRequestHeaders("foo")).isEqualTo(ImmutableList.of("bar"));
+        assertThat(servlet.getRequestHeaders("dupe")).isEqualTo(ImmutableList.of("first", "second"));
+        assertThat(servlet.getRequestHeaders("x-custom-filter")).isEqualTo(ImmutableList.of("custom value"));
+        assertThat(servlet.getRequestBytes()).isEqualTo(new byte[] {1, 2, 5});
         assertThat(statusCounts.count(200)).isEqualTo(1);
     }
 
@@ -509,14 +504,14 @@ public abstract class AbstractHttpClientTest
                 .build();
 
         int statusCode = executeRequest(request, createStatusResponseHandler()).getStatusCode();
-        assertEquals(statusCode, 200);
-        assertEquals(servlet.getRequestMethod(), "PUT");
-        assertEquals(servlet.getRequestUri(), uri);
-        assertEquals(servlet.getRequestHeaders(CONTENT_TYPE), ImmutableList.of("x-test"));
-        assertEquals(servlet.getRequestHeaders(CONTENT_LENGTH), ImmutableList.of(String.valueOf(contents.length)));
-        assertEquals(servlet.getRequestBytes(), contents);
+        assertThat(statusCode).isEqualTo(200);
+        assertThat(servlet.getRequestMethod()).isEqualTo("PUT");
+        assertThat(servlet.getRequestUri()).isEqualTo(uri);
+        assertThat(servlet.getRequestHeaders(CONTENT_TYPE)).isEqualTo(ImmutableList.of("x-test"));
+        assertThat(servlet.getRequestHeaders(CONTENT_LENGTH)).isEqualTo(ImmutableList.of(String.valueOf(contents.length)));
+        assertThat(servlet.getRequestBytes()).isEqualTo(contents);
 
-        assertTrue(testFile.delete());
+        assertThat(testFile.delete()).isTrue();
     }
 
     @Test(expectedExceptions = {IOException.class, TimeoutException.class})
@@ -545,8 +540,8 @@ public abstract class AbstractHttpClientTest
                 .build();
 
         StringResponse response = executeRequest(request, createStringResponseHandler());
-        assertEquals(response.getStatusCode(), 200);
-        assertEquals(response.getBody(), "body text");
+        assertThat(response.getStatusCode()).isEqualTo(200);
+        assertThat(response.getBody()).isEqualTo("body text");
     }
 
     @Test
@@ -558,7 +553,7 @@ public abstract class AbstractHttpClientTest
                 .build();
 
         String body = executeRequest(request, createStringResponseHandler()).getBody();
-        assertEquals(body, "");
+        assertThat(body).isEqualTo("");
     }
 
     @Test
@@ -575,8 +570,8 @@ public abstract class AbstractHttpClientTest
 
         StatusResponse response = executeRequest(request, createStatusResponseHandler());
 
-        assertEquals(response.getHeaders("foo"), ImmutableList.of("bar"));
-        assertEquals(response.getHeaders("dupe"), ImmutableList.of("first", "second"));
+        assertThat(response.getHeaders("foo")).isEqualTo(ImmutableList.of("bar"));
+        assertThat(response.getHeaders("dupe")).isEqualTo(ImmutableList.of("first", "second"));
     }
 
     @Test
@@ -589,7 +584,7 @@ public abstract class AbstractHttpClientTest
                 .build();
 
         int statusCode = executeRequest(request, createStatusResponseHandler()).getStatusCode();
-        assertEquals(statusCode, 543);
+        assertThat(statusCode).isEqualTo(543);
     }
 
     @Test
@@ -609,7 +604,7 @@ public abstract class AbstractHttpClientTest
                 .build();
 
         StatusResponse response = executeRequest(request, createStatusResponseHandler());
-        assertEquals(response.getStatusCode(), 200);
+        assertThat(response.getStatusCode()).isEqualTo(200);
         assertThat(servlet.getRequestHeaders("X-Test")).containsExactly("xtest1", "xtest2");
         assertThat(servlet.getRequestHeaders(USER_AGENT)).containsExactly("testagent");
         assertThat(servlet.getRequestHeaders(AUTHORIZATION)).containsExactly(basic, bearer);
@@ -632,8 +627,8 @@ public abstract class AbstractHttpClientTest
                 .build();
 
         StatusResponse response = executeRequest(request, createStatusResponseHandler());
-        assertEquals(response.getStatusCode(), 200);
-        assertEquals(servlet.getRequestUri(), URI.create(baseURI.toASCIIString() + "/redirect"));
+        assertThat(response.getStatusCode()).isEqualTo(200);
+        assertThat(servlet.getRequestUri()).isEqualTo(URI.create(baseURI.toASCIIString() + "/redirect"));
         assertThat(servlet.getRequestHeaders("X-Test")).containsExactly("xtest1", "xtest2");
         assertThat(servlet.getRequestHeaders(USER_AGENT)).containsExactly("testagent");
         assertThat(servlet.getRequestHeaders(AUTHORIZATION)).isEmpty();
@@ -643,8 +638,8 @@ public abstract class AbstractHttpClientTest
                 .build();
 
         response = executeRequest(request, createStatusResponseHandler());
-        assertEquals(response.getStatusCode(), 200);
-        assertEquals(servlet.getRequestUri(), URI.create(baseURI.toASCIIString() + "/redirect"));
+        assertThat(response.getStatusCode()).isEqualTo(200);
+        assertThat(servlet.getRequestUri()).isEqualTo(URI.create(baseURI.toASCIIString() + "/redirect"));
         assertThat(servlet.getRequestHeaders("X-Test")).containsExactly("xtest1", "xtest2");
         assertThat(servlet.getRequestHeaders(USER_AGENT)).containsExactly("testagent");
         assertThat(servlet.getRequestHeaders(AUTHORIZATION)).containsExactly(basic, bearer);
@@ -659,18 +654,18 @@ public abstract class AbstractHttpClientTest
                 .build();
 
         StatusResponse response = executeRequest(request, createStatusResponseHandler());
-        assertEquals(response.getStatusCode(), 200);
-        assertNull(response.getHeader(LOCATION));
-        assertEquals(servlet.getRequestUri(), URI.create(baseURI.toASCIIString() + "/redirect"));
+        assertThat(response.getStatusCode()).isEqualTo(200);
+        assertThat(response.getHeader(LOCATION)).isNull();
+        assertThat(servlet.getRequestUri()).isEqualTo(URI.create(baseURI.toASCIIString() + "/redirect"));
 
         request = Request.Builder.fromRequest(request)
                 .setFollowRedirects(false)
                 .build();
 
         response = executeRequest(request, createStatusResponseHandler());
-        assertEquals(response.getStatusCode(), 302);
-        assertEquals(response.getHeader(LOCATION), "/redirect");
-        assertEquals(servlet.getRequestUri(), request.getUri());
+        assertThat(response.getStatusCode()).isEqualTo(302);
+        assertThat(response.getHeader(LOCATION)).isEqualTo("/redirect");
+        assertThat(servlet.getRequestUri()).isEqualTo(request.getUri());
     }
 
     @Test(expectedExceptions = UnexpectedResponseException.class)
@@ -694,8 +689,8 @@ public abstract class AbstractHttpClientTest
                 .build();
 
         String body = executeRequest(request, createStringResponseHandler()).getBody();
-        assertEquals(body, "");
-        assertFalse(servlet.getRequestHeaders().containsKey(HeaderName.of(ACCEPT_ENCODING)));
+        assertThat(body).isEqualTo("");
+        assertThat(servlet.getRequestHeaders().containsKey(HeaderName.of(ACCEPT_ENCODING))).isFalse();
 
         String json = "{\"fuite\":\"apple\",\"hello\":\"world\"}";
         assertGreaterThanOrEqual(json.length(), GzipHandler.DEFAULT_MIN_GZIP_SIZE);
@@ -704,8 +699,8 @@ public abstract class AbstractHttpClientTest
         servlet.addResponseHeader(CONTENT_TYPE, "application/json");
 
         StringResponse response = executeRequest(request, createStringResponseHandler());
-        assertEquals(response.getHeader(CONTENT_TYPE), "application/json");
-        assertEquals(response.getBody(), json);
+        assertThat(response.getHeader(CONTENT_TYPE)).isEqualTo("application/json");
+        assertThat(response.getBody()).isEqualTo(json);
     }
 
     private ExecutorService executor;

--- a/http-client/src/test/java/io/airlift/http/client/TestBasicAuthRequestFilter.java
+++ b/http-client/src/test/java/io/airlift/http/client/TestBasicAuthRequestFilter.java
@@ -20,8 +20,7 @@ import java.util.function.Predicate;
 
 import static com.google.common.net.HttpHeaders.AUTHORIZATION;
 import static io.airlift.http.client.Request.Builder.prepareGet;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestBasicAuthRequestFilter
 {
@@ -33,10 +32,10 @@ public class TestBasicAuthRequestFilter
         HttpRequestFilter filter = new BasicAuthRequestFilter(predicate, "Aladdin", "open sesame");
 
         Request publicResourceRequest = createTestRequest("/public");
-        assertNull(filter.filterRequest(publicResourceRequest).getHeader(AUTHORIZATION));
+        assertThat(filter.filterRequest(publicResourceRequest).getHeader(AUTHORIZATION)).isNull();
 
         Request privateResourceRequest = createTestRequest("/private");
-        assertEquals(filter.filterRequest(privateResourceRequest).getHeader(AUTHORIZATION), "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
+        assertThat(filter.filterRequest(privateResourceRequest).getHeader(AUTHORIZATION)).isEqualTo("Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
     }
 
     private static Request createTestRequest(String path)

--- a/http-client/src/test/java/io/airlift/http/client/TestCacheControl.java
+++ b/http-client/src/test/java/io/airlift/http/client/TestCacheControl.java
@@ -5,9 +5,7 @@ import org.testng.annotations.Test;
 import java.util.List;
 import java.util.Map;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 // This code was forked from Apache CXF CacheControlHeaderProviderTest
 public class TestCacheControl
@@ -16,30 +14,30 @@ public class TestCacheControl
     public void testFromSimpleString()
     {
         CacheControl c = CacheControl.valueOf("public,must-revalidate");
-        assertFalse(c.isPrivate());
-        assertFalse(c.isNoStore());
-        assertTrue(c.isMustRevalidate());
-        assertFalse(c.isProxyRevalidate());
-        assertFalse(c.isNoCache());
-        assertFalse(c.isNoTransform());
-        assertTrue(c.getNoCacheFields().size() == 0);
-        assertTrue(c.getPrivateFields().size() == 0);
+        assertThat(c.isPrivate()).isFalse();
+        assertThat(c.isNoStore()).isFalse();
+        assertThat(c.isMustRevalidate()).isTrue();
+        assertThat(c.isProxyRevalidate()).isFalse();
+        assertThat(c.isNoCache()).isFalse();
+        assertThat(c.isNoTransform()).isFalse();
+        assertThat(c.getNoCacheFields()).isEmpty();
+        assertThat(c.getPrivateFields()).isEmpty();
     }
 
     @Test
     public void testFromComplexString()
     {
         CacheControl c = CacheControl.valueOf("private=\"foo\",no-cache=\"bar\",no-store,no-transform,must-revalidate,proxy-revalidate,max-age=2,s-maxage=3");
-        assertTrue(c.isPrivate());
-        assertTrue(c.isNoStore());
-        assertTrue(c.isMustRevalidate());
-        assertTrue(c.isProxyRevalidate());
-        assertTrue(c.isNoCache());
-        assertTrue(c.isNoTransform());
-        assertTrue(c.getNoCacheFields().size() == 1);
-        assertTrue(c.getPrivateFields().size() == 1);
-        assertEquals(c.getPrivateFields().get(0), "foo");
-        assertEquals(c.getNoCacheFields().get(0), "bar");
+        assertThat(c.isPrivate()).isTrue();
+        assertThat(c.isNoStore()).isTrue();
+        assertThat(c.isMustRevalidate()).isTrue();
+        assertThat(c.isProxyRevalidate()).isTrue();
+        assertThat(c.isNoCache()).isTrue();
+        assertThat(c.isNoTransform()).isTrue();
+        assertThat(c.getNoCacheFields()).hasSize(1);
+        assertThat(c.getPrivateFields()).hasSize(1);
+        assertThat(c.getPrivateFields().get(0)).isEqualTo("foo");
+        assertThat(c.getNoCacheFields().get(0)).isEqualTo("bar");
     }
 
     @Test
@@ -47,7 +45,7 @@ public class TestCacheControl
     {
         String expected = "private=\"foo\",no-cache=\"bar\",no-store,no-transform,must-revalidate,proxy-revalidate,max-age=2,s-maxage=3";
         String parsed = CacheControl.valueOf(expected).toString();
-        assertEquals(parsed, expected);
+        assertThat(parsed).isEqualTo(expected);
     }
 
     @Test
@@ -55,7 +53,7 @@ public class TestCacheControl
     {
         CacheControl cc = new CacheControl();
         cc.setNoCache(true);
-        assertEquals(cc.toString(), "no-cache,no-transform");
+        assertThat(cc.toString()).isEqualTo("no-cache,no-transform");
     }
 
     @Test
@@ -63,7 +61,7 @@ public class TestCacheControl
     {
         CacheControl cc = new CacheControl();
         cc.setNoCache(false);
-        assertEquals(cc.toString(), "no-transform");
+        assertThat(cc.toString()).isEqualTo("no-transform");
     }
 
     @Test
@@ -73,7 +71,7 @@ public class TestCacheControl
         cc.setPrivate(true);
         cc.getPrivateFields().add("a");
         cc.getPrivateFields().add("b");
-        assertTrue(cc.toString().contains("private=\"a,b\""));
+        assertThat(cc.toString()).contains("private=\"a,b\"");
     }
 
     @Test
@@ -83,7 +81,7 @@ public class TestCacheControl
         cc.setNoCache(true);
         cc.getNoCacheFields().add("c");
         cc.getNoCacheFields().add("d");
-        assertTrue(cc.toString().contains("no-cache=\"c,d\""));
+        assertThat(cc.toString()).contains("no-cache=\"c,d\"");
     }
 
     @Test
@@ -92,27 +90,27 @@ public class TestCacheControl
         String s = "private=\"foo1,foo2\",no-store,no-transform,must-revalidate,proxy-revalidate,max-age=2,s-maxage=3,no-cache=\"bar1,bar2\",ext=1";
         CacheControl cacheControl = CacheControl.valueOf(s);
 
-        assertTrue(cacheControl.isPrivate());
+        assertThat(cacheControl.isPrivate()).isTrue();
         List<String> privateFields = cacheControl.getPrivateFields();
-        assertEquals(privateFields.size(), 2);
-        assertEquals(privateFields.get(0), "foo1");
-        assertEquals(privateFields.get(1), "foo2");
-        assertTrue(cacheControl.isNoCache());
+        assertThat(privateFields.size()).isEqualTo(2);
+        assertThat(privateFields.get(0)).isEqualTo("foo1");
+        assertThat(privateFields.get(1)).isEqualTo("foo2");
+        assertThat(cacheControl.isNoCache()).isTrue();
         List<String> noCacheFields = cacheControl.getNoCacheFields();
-        assertEquals(2, noCacheFields.size());
-        assertEquals(noCacheFields.get(0), "bar1");
-        assertEquals(noCacheFields.get(1), "bar2");
+        assertThat(noCacheFields).hasSize(2);
+        assertThat(noCacheFields.get(0)).isEqualTo("bar1");
+        assertThat(noCacheFields.get(1)).isEqualTo("bar2");
 
-        assertTrue(cacheControl.isNoStore());
-        assertTrue(cacheControl.isNoTransform());
-        assertTrue(cacheControl.isMustRevalidate());
-        assertTrue(cacheControl.isProxyRevalidate());
-        assertEquals(cacheControl.getMaxAge(), 2);
-        assertEquals(cacheControl.getSMaxAge(), 3);
+        assertThat(cacheControl.isNoStore()).isTrue();
+        assertThat(cacheControl.isNoTransform()).isTrue();
+        assertThat(cacheControl.isMustRevalidate()).isTrue();
+        assertThat(cacheControl.isProxyRevalidate()).isTrue();
+        assertThat(cacheControl.getMaxAge()).isEqualTo(2);
+        assertThat(cacheControl.getSMaxAge()).isEqualTo(3);
 
         Map<String, String> cacheExtension = cacheControl.getCacheExtension();
-        assertEquals(cacheExtension.size(), 1);
-        assertEquals(cacheExtension.get("ext"), "1");
+        assertThat(cacheExtension.size()).isEqualTo(1);
+        assertThat(cacheExtension.get("ext")).isEqualTo("1");
     }
 
     @Test
@@ -123,8 +121,10 @@ public class TestCacheControl
         cc.getCacheExtension().put("ext2", "value2");
         cc.getCacheExtension().put("ext3", "value 3");
         String value = cc.toString();
-        assertTrue(value.contains("ext1") && !value.contains("ext1="));
-        assertTrue(value.contains("ext2=value2"));
-        assertTrue(value.contains("ext3=\"value 3\""));
+        assertThat(value)
+                .contains("ext1")
+                .doesNotContain("ext1=");
+        assertThat(value).contains("ext2=value2");
+        assertThat(value).contains("ext3=\"value 3\"");
     }
 }

--- a/http-client/src/test/java/io/airlift/http/client/TestDefaultingJsonResponseHandler.java
+++ b/http-client/src/test/java/io/airlift/http/client/TestDefaultingJsonResponseHandler.java
@@ -11,8 +11,7 @@ import static io.airlift.http.client.DefaultingJsonResponseHandler.createDefault
 import static io.airlift.http.client.HttpStatus.INTERNAL_SERVER_ERROR;
 import static io.airlift.http.client.HttpStatus.OK;
 import static io.airlift.http.client.testing.TestingResponse.mockResponse;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertSame;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestDefaultingJsonResponseHandler
 {
@@ -28,8 +27,8 @@ public class TestDefaultingJsonResponseHandler
         String json = codec.toJson(user);
         User response = handler.handle(null, mockResponse(OK, JSON_UTF_8, json));
 
-        assertEquals(response.getName(), user.getName());
-        assertEquals(response.getAge(), user.getAge());
+        assertThat(response.getName()).isEqualTo(user.getName());
+        assertThat(response.getAge()).isEqualTo(user.getAge());
     }
 
     @Test
@@ -38,7 +37,7 @@ public class TestDefaultingJsonResponseHandler
         String json = "{\"age\": \"foo\"}";
         User response = handler.handle(null, mockResponse(OK, JSON_UTF_8, json));
 
-        assertSame(response, DEFAULT_VALUE);
+        assertThat(response).isSameAs(DEFAULT_VALUE);
     }
 
     @Test
@@ -46,7 +45,7 @@ public class TestDefaultingJsonResponseHandler
     {
         User response = handler.handleException(null, null);
 
-        assertSame(response, DEFAULT_VALUE);
+        assertThat(response).isSameAs(DEFAULT_VALUE);
     }
 
     @Test
@@ -54,7 +53,7 @@ public class TestDefaultingJsonResponseHandler
     {
         User response = handler.handle(null, mockResponse(OK, PLAIN_TEXT_UTF_8, "hello"));
 
-        assertSame(response, DEFAULT_VALUE);
+        assertThat(response).isSameAs(DEFAULT_VALUE);
     }
 
     @Test
@@ -63,7 +62,7 @@ public class TestDefaultingJsonResponseHandler
         String json = "{\"error\": true}";
         User response = handler.handle(null, mockResponse(INTERNAL_SERVER_ERROR, JSON_UTF_8, json));
 
-        assertSame(response, DEFAULT_VALUE);
+        assertThat(response).isSameAs(DEFAULT_VALUE);
     }
 
     public static class User

--- a/http-client/src/test/java/io/airlift/http/client/TestFormDataBodyBuilder.java
+++ b/http-client/src/test/java/io/airlift/http/client/TestFormDataBodyBuilder.java
@@ -3,7 +3,7 @@ package io.airlift.http.client;
 import org.testng.annotations.Test;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestFormDataBodyBuilder
 {
@@ -17,6 +17,6 @@ public class TestFormDataBodyBuilder
                 .addField(":", "colon")
                 .build()
                 .getBody();
-        assertEquals(new String(body, UTF_8), "a=apple&b=banana+split&c=com%2Cma&%3A=colon");
+        assertThat(new String(body, UTF_8)).isEqualTo("a=apple&b=banana+split&c=com%2Cma&%3A=colon");
     }
 }

--- a/http-client/src/test/java/io/airlift/http/client/TestFullJsonResponseHandler.java
+++ b/http-client/src/test/java/io/airlift/http/client/TestFullJsonResponseHandler.java
@@ -16,12 +16,8 @@ import static io.airlift.http.client.HttpStatus.OK;
 import static io.airlift.http.client.testing.TestingResponse.mockResponse;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotSame;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
 public class TestFullJsonResponseHandler
@@ -36,19 +32,19 @@ public class TestFullJsonResponseHandler
         String json = codec.toJson(user);
         JsonResponse<User> response = handler.handle(null, mockResponse(OK, JSON_UTF_8, json));
 
-        assertTrue(response.hasValue());
-        assertEquals(response.getJsonBytes(), json.getBytes(UTF_8));
-        assertEquals(response.getJson(), json);
-        assertEquals(response.getValue().getName(), user.getName());
-        assertEquals(response.getValue().getAge(), user.getAge());
+        assertThat(response.hasValue()).isTrue();
+        assertThat(response.getJsonBytes()).isEqualTo(json.getBytes(UTF_8));
+        assertThat(response.getJson()).isEqualTo(json);
+        assertThat(response.getValue().getName()).isEqualTo(user.getName());
+        assertThat(response.getValue().getAge()).isEqualTo(user.getAge());
 
-        assertNotSame(response.getJson(), response.getJson());
-        assertNotSame(response.getJsonBytes(), response.getJsonBytes());
-        assertNotSame(response.getResponseBytes(), response.getResponseBytes());
-        assertNotSame(response.getResponseBody(), response.getResponseBody());
+        assertThat(response.getJson()).isNotSameAs(response.getJson());
+        assertThat(response.getJsonBytes()).isNotSameAs(response.getJsonBytes());
+        assertThat(response.getResponseBytes()).isNotSameAs(response.getResponseBytes());
+        assertThat(response.getResponseBody()).isNotSameAs(response.getResponseBody());
 
-        assertEquals(response.getResponseBytes(), response.getJsonBytes());
-        assertEquals(response.getResponseBody(), response.getJson());
+        assertThat(response.getResponseBytes()).isEqualTo(response.getJsonBytes());
+        assertThat(response.getResponseBody()).isEqualTo(response.getJson());
     }
 
     @Test
@@ -57,16 +53,16 @@ public class TestFullJsonResponseHandler
         String json = "{\"age\": \"foo\"}";
         JsonResponse<User> response = handler.handle(null, mockResponse(OK, JSON_UTF_8, json));
 
-        assertFalse(response.hasValue());
-        assertEquals(response.getException().getMessage(), format("Unable to create %s from JSON response:\n[%s]", User.class, json));
-        assertTrue(response.getException().getCause() instanceof IllegalArgumentException);
-        assertEquals(response.getException().getCause().getMessage(), "Invalid JSON bytes for [simple type, class io.airlift.http.client.TestFullJsonResponseHandler$User]");
+        assertThat(response.hasValue()).isFalse();
+        assertThat(response.getException().getMessage()).isEqualTo(format("Unable to create %s from JSON response:\n[%s]", User.class, json));
+        assertThat(response.getException()).hasCauseInstanceOf(IllegalArgumentException.class);
+        assertThat(response.getException()).hasStackTraceContaining("Invalid JSON bytes for [simple type, class io.airlift.http.client.TestFullJsonResponseHandler$User]");
 
-        assertEquals(response.getJsonBytes(), json.getBytes(UTF_8));
-        assertEquals(response.getJson(), json);
+        assertThat(response.getJsonBytes()).isEqualTo(json.getBytes(UTF_8));
+        assertThat(response.getJson()).isEqualTo(json);
 
-        assertEquals(response.getResponseBytes(), response.getJsonBytes());
-        assertEquals(response.getResponseBody(), response.getJson());
+        assertThat(response.getResponseBytes()).isEqualTo(response.getJsonBytes());
+        assertThat(response.getResponseBody()).isEqualTo(response.getJson());
     }
 
     @Test
@@ -80,14 +76,14 @@ public class TestFullJsonResponseHandler
             fail("expected exception");
         }
         catch (IllegalStateException e) {
-            assertEquals(e.getMessage(), "Response does not contain a JSON value");
-            assertEquals(e.getCause(), response.getException());
+            assertThat(e.getMessage()).isEqualTo("Response does not contain a JSON value");
+            assertThat(e.getCause()).isEqualTo(response.getException());
 
-            assertEquals(response.getJsonBytes(), json.getBytes(UTF_8));
-            assertEquals(response.getJson(), json);
+            assertThat(response.getJsonBytes()).isEqualTo(json.getBytes(UTF_8));
+            assertThat(response.getJson()).isEqualTo(json);
 
-            assertEquals(response.getResponseBytes(), response.getJsonBytes());
-            assertEquals(response.getResponseBody(), response.getJson());
+            assertThat(response.getResponseBytes()).isEqualTo(response.getJsonBytes());
+            assertThat(response.getResponseBody()).isEqualTo(response.getJson());
         }
     }
 
@@ -96,13 +92,13 @@ public class TestFullJsonResponseHandler
     {
         JsonResponse<User> response = handler.handle(null, mockResponse(OK, PLAIN_TEXT_UTF_8, "hello"));
 
-        assertFalse(response.hasValue());
-        assertNull(response.getException());
-        assertNull(response.getJson());
-        assertNull(response.getJsonBytes());
+        assertThat(response.hasValue()).isFalse();
+        assertThat(response.getException()).isNull();
+        assertThat(response.getJson()).isNull();
+        assertThat(response.getJsonBytes()).isNull();
 
-        assertEquals(response.getResponseBytes(), "hello".getBytes(UTF_8));
-        assertEquals(response.getResponseBody(), "hello");
+        assertThat(response.getResponseBytes()).isEqualTo("hello".getBytes(UTF_8));
+        assertThat(response.getResponseBody()).isEqualTo("hello");
     }
 
     @Test
@@ -111,15 +107,15 @@ public class TestFullJsonResponseHandler
         JsonResponse<User> response = handler.handle(null,
                 new TestingResponse(OK, ImmutableListMultimap.<String, String>of(), "hello".getBytes(UTF_8)));
 
-        assertFalse(response.hasValue());
-        assertNull(response.getException());
-        assertNull(response.getJson());
-        assertNull(response.getJsonBytes());
+        assertThat(response.hasValue()).isFalse();
+        assertThat(response.getException()).isNull();
+        assertThat(response.getJson()).isNull();
+        assertThat(response.getJsonBytes()).isNull();
 
-        assertEquals(response.getResponseBytes(), "hello".getBytes(UTF_8));
-        assertEquals(response.getResponseBody(), "hello");
+        assertThat(response.getResponseBytes()).isEqualTo("hello".getBytes(UTF_8));
+        assertThat(response.getResponseBody()).isEqualTo("hello");
 
-        assertTrue(response.getHeaders().isEmpty());
+        assertThat(response.getHeaders().isEmpty()).isTrue();
     }
 
     @Test
@@ -128,14 +124,14 @@ public class TestFullJsonResponseHandler
         String json = "{\"error\": true}";
         JsonResponse<User> response = handler.handle(null, mockResponse(INTERNAL_SERVER_ERROR, JSON_UTF_8, json));
 
-        assertTrue(response.hasValue());
-        assertEquals(response.getJson(), json);
-        assertEquals(response.getJsonBytes(), json.getBytes(UTF_8));
-        assertNull(response.getValue().getName());
-        assertEquals(response.getValue().getAge(), 0);
+        assertThat(response.hasValue()).isTrue();
+        assertThat(response.getJson()).isEqualTo(json);
+        assertThat(response.getJsonBytes()).isEqualTo(json.getBytes(UTF_8));
+        assertThat(response.getValue().getName()).isNull();
+        assertThat(response.getValue().getAge()).isEqualTo(0);
 
-        assertEquals(response.getResponseBytes(), response.getJsonBytes());
-        assertEquals(response.getResponseBody(), response.getJson());
+        assertThat(response.getResponseBytes()).isEqualTo(response.getJsonBytes());
+        assertThat(response.getResponseBody()).isEqualTo(response.getJson());
     }
 
     public static class User

--- a/http-client/src/test/java/io/airlift/http/client/TestGatheringByteArrayInputStream.java
+++ b/http-client/src/test/java/io/airlift/http/client/TestGatheringByteArrayInputStream.java
@@ -10,7 +10,7 @@ import java.util.Random;
 
 import static java.lang.Math.min;
 import static java.lang.System.arraycopy;
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestGatheringByteArrayInputStream
 {
@@ -34,19 +34,19 @@ public class TestGatheringByteArrayInputStream
             byte[] buffer = new byte[expectedAll.length + 32];
 
             // read the first part
-            assertEquals(in.read(buffer, 0, expectedPartial.length), expectedPartial.length);
+            assertThat(in.read(buffer, 0, expectedPartial.length)).isEqualTo(expectedPartial.length);
 
             // verify the first part
             assertByteArrayEquals(buffer, 0, expectedPartial, 0, expectedPartial.length);
 
             // read the remaining part
-            assertEquals(in.read(buffer, expectedPartial.length, buffer.length - expectedPartial.length), expectedAll.length - expectedPartial.length);
+            assertThat(in.read(buffer, expectedPartial.length, buffer.length - expectedPartial.length)).isEqualTo(expectedAll.length - expectedPartial.length);
 
             // verify the whole string
             assertByteArrayEquals(buffer, 0, expectedAll, 0, expectedAll.length);
 
             // make sure there is no more data
-            assertEquals(-1, in.read(buffer, 0, expectedAll.length));
+            assertThat(-1).isEqualTo(in.read(buffer, 0, expectedAll.length));
         }
     }
 
@@ -67,7 +67,7 @@ public class TestGatheringByteArrayInputStream
                 resultBuffer[i] = (byte) in.read();
             }
             assertByteArrayEquals(resultBuffer, 0, expected, 0, expected.length);
-            assertEquals(in.read(), -1);
+            assertThat(in.read()).isEqualTo(-1);
         }
     }
 
@@ -77,8 +77,8 @@ public class TestGatheringByteArrayInputStream
         byte[] expected = new byte[1];
         expected[0] = -100;
         try (GatheringByteArrayInputStream in = new GatheringByteArrayInputStream(ImmutableList.of(expected), expected.length)) {
-            assertEquals(in.read(), expected[0] & 0x000000ff);
-            assertEquals(in.read(), -1);
+            assertThat(in.read()).isEqualTo(expected[0] & 0x000000ff);
+            assertThat(in.read()).isEqualTo(-1);
         }
     }
 
@@ -99,18 +99,18 @@ public class TestGatheringByteArrayInputStream
             byte[] actual = new byte[length - skipped + 10];
 
             // read the first part
-            assertEquals(in.read(actual, 0, firstPartLength), firstPartLength);
+            assertThat(in.read(actual, 0, firstPartLength)).isEqualTo(firstPartLength);
             assertByteArrayEquals(actual, 0, allDataBytes, 0, firstPartLength);
 
             // skip some bytes
-            assertEquals(in.skip(skipped), skipped);
+            assertThat(in.skip(skipped)).isEqualTo(skipped);
 
             // read the rest part
-            assertEquals(in.read(actual, firstPartLength, restPartLength + 10), restPartLength);
+            assertThat(in.read(actual, firstPartLength, restPartLength + 10)).isEqualTo(restPartLength);
             assertByteArrayEquals(actual, firstPartLength, allDataBytes, firstPartLength + skipped, restPartLength);
 
-            assertEquals(in.skip(10), 0);
-            assertEquals(in.read(), -1);
+            assertThat(in.skip(10)).isEqualTo(0);
+            assertThat(in.read()).isEqualTo(-1);
         }
     }
 
@@ -135,12 +135,12 @@ public class TestGatheringByteArrayInputStream
             copyBytes = 0;
             while (copyBytes < length) {
                 int currentLength = min(length - copyBytes, random.nextInt(1 << 20) + 64);
-                assertEquals(in.read(actual, copyBytes, currentLength), currentLength);
+                assertThat(in.read(actual, copyBytes, currentLength)).isEqualTo(currentLength);
                 assertByteArrayEquals(actual, copyBytes, expected, copyBytes, currentLength);
                 copyBytes += currentLength;
             }
-            assertEquals(in.skip(100), 0);
-            assertEquals(in.read(), -1);
+            assertThat(in.skip(100)).isEqualTo(0);
+            assertThat(in.read()).isEqualTo(-1);
         }
     }
 
@@ -152,7 +152,7 @@ public class TestGatheringByteArrayInputStream
             int length)
     {
         for (int i = 0; i < length; i++) {
-            assertEquals(actual[i + actualStart], expected[i + expectedStart]);
+            assertThat(actual[i + actualStart]).isEqualTo(expected[i + expectedStart]);
         }
     }
 }

--- a/http-client/src/test/java/io/airlift/http/client/TestHeaderName.java
+++ b/http-client/src/test/java/io/airlift/http/client/TestHeaderName.java
@@ -3,7 +3,7 @@ package io.airlift.http.client;
 import org.testng.annotations.Test;
 
 import static io.airlift.testing.EquivalenceTester.equivalenceTester;
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestHeaderName
 {
@@ -19,7 +19,7 @@ public class TestHeaderName
     @Test
     public void testToString()
     {
-        assertEquals(HeaderName.of("FOO").toString(), "FOO");
-        assertEquals(HeaderName.of("foo").toString(), "foo");
+        assertThat(HeaderName.of("FOO").toString()).isEqualTo("FOO");
+        assertThat(HeaderName.of("foo").toString()).isEqualTo("foo");
     }
 }

--- a/http-client/src/test/java/io/airlift/http/client/TestHttpClientBinder.java
+++ b/http-client/src/test/java/io/airlift/http/client/TestHttpClientBinder.java
@@ -38,12 +38,6 @@ import static io.airlift.testing.Assertions.assertInstanceOf;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertNotSame;
-import static org.testng.Assert.assertSame;
-import static org.testng.Assert.assertTrue;
 
 public class TestHttpClientBinder
 {
@@ -59,7 +53,7 @@ public class TestHttpClientBinder
                 .initialize();
 
         JettyHttpClient httpClient = (JettyHttpClient) injector.getInstance(Key.get(HttpClient.class, FooClient.class));
-        assertEquals(httpClient.getRequestTimeoutMillis(), MINUTES.toMillis(33));
+        assertThat(httpClient.getRequestTimeoutMillis()).isEqualTo(MINUTES.toMillis(33));
     }
 
     @Test
@@ -117,15 +111,15 @@ public class TestHttpClientBinder
 
         JettyHttpClient fooClient = (JettyHttpClient) injector.getInstance(Key.get(HttpClient.class, FooClient.class));
         assertFilterCount(fooClient, 3);
-        assertEquals(fooClient.getRequestFilters().get(0), globalFilter1);
-        assertEquals(fooClient.getRequestFilters().get(1), globalFilter2);
-        assertEquals(fooClient.getRequestFilters().get(2), filter1);
+        assertThat(fooClient.getRequestFilters().get(0)).isEqualTo(globalFilter1);
+        assertThat(fooClient.getRequestFilters().get(1)).isEqualTo(globalFilter2);
+        assertThat(fooClient.getRequestFilters().get(2)).isEqualTo(filter1);
 
         JettyHttpClient barClient = (JettyHttpClient) injector.getInstance(Key.get(HttpClient.class, BarClient.class));
         assertFilterCount(barClient, 3);
-        assertEquals(barClient.getRequestFilters().get(0), globalFilter1);
-        assertEquals(barClient.getRequestFilters().get(1), globalFilter2);
-        assertEquals(barClient.getRequestFilters().get(2), filter2);
+        assertThat(barClient.getRequestFilters().get(0)).isEqualTo(globalFilter1);
+        assertThat(barClient.getRequestFilters().get(1)).isEqualTo(globalFilter2);
+        assertThat(barClient.getRequestFilters().get(2)).isEqualTo(filter2);
     }
 
     @Test
@@ -189,7 +183,7 @@ public class TestHttpClientBinder
                 .quiet()
                 .initialize();
 
-        assertNotNull(injector.getInstance(Key.get(HttpClient.class, FooClient.class)));
+        assertThat(injector.getInstance(Key.get(HttpClient.class, FooClient.class))).isNotNull();
     }
 
     @Test
@@ -203,9 +197,9 @@ public class TestHttpClientBinder
                 .initialize();
 
         HttpClient client = injector.getInstance(Key.get(HttpClient.class, FooClient.class));
-        assertSame(injector.getInstance(Key.get(HttpClient.class, FooAlias1.class)), client);
-        assertSame(injector.getInstance(Key.get(HttpClient.class, FooAlias2.class)), client);
-        assertSame(injector.getInstance(Key.get(HttpClient.class, FooAlias3.class)), client);
+        assertThat(injector.getInstance(Key.get(HttpClient.class, FooAlias1.class))).isSameAs(client);
+        assertThat(injector.getInstance(Key.get(HttpClient.class, FooAlias2.class))).isSameAs(client);
+        assertThat(injector.getInstance(Key.get(HttpClient.class, FooAlias3.class))).isSameAs(client);
     }
 
     @Test
@@ -219,8 +213,8 @@ public class TestHttpClientBinder
                 .initialize();
 
         HttpClient client = injector.getInstance(Key.get(HttpClient.class, FooClient.class));
-        assertSame(injector.getInstance(Key.get(HttpClient.class, FooAlias1.class)), client);
-        assertSame(injector.getInstance(Key.get(HttpClient.class, FooAlias2.class)), client);
+        assertThat(injector.getInstance(Key.get(HttpClient.class, FooAlias1.class))).isSameAs(client);
+        assertThat(injector.getInstance(Key.get(HttpClient.class, FooAlias2.class))).isSameAs(client);
     }
 
     @Test
@@ -236,7 +230,7 @@ public class TestHttpClientBinder
 
         HttpClient fooClient = injector.getInstance(Key.get(HttpClient.class, FooClient.class));
         HttpClient barClient = injector.getInstance(Key.get(HttpClient.class, BarClient.class));
-        assertNotSame(fooClient, barClient);
+        assertThat(fooClient).isNotSameAs(barClient);
     }
 
     @Test
@@ -253,20 +247,20 @@ public class TestHttpClientBinder
         HttpClient fooClient = injector.getInstance(Key.get(HttpClient.class, FooClient.class));
         HttpClient barClient = injector.getInstance(Key.get(HttpClient.class, BarClient.class));
 
-        assertFalse(fooClient.isClosed());
-        assertFalse(barClient.isClosed());
+        assertThat(fooClient.isClosed()).isFalse();
+        assertThat(barClient.isClosed()).isFalse();
 
         injector.getInstance(LifeCycleManager.class).stop();
 
-        assertTrue(fooClient.isClosed());
-        assertTrue(barClient.isClosed());
+        assertThat(fooClient.isClosed()).isTrue();
+        assertThat(barClient.isClosed()).isTrue();
     }
 
     private static void assertFilterCount(HttpClient httpClient, int filterCount)
     {
-        assertNotNull(httpClient);
+        assertThat(httpClient).isNotNull();
         assertInstanceOf(httpClient, JettyHttpClient.class);
-        assertEquals(((JettyHttpClient) httpClient).getRequestFilters().size(), filterCount);
+        assertThat(((JettyHttpClient) httpClient).getRequestFilters().size()).isEqualTo(filterCount);
     }
 
     private static void assertStatusListenerCount(HttpClient httpClient, int statusListenerCount)

--- a/http-client/src/test/java/io/airlift/http/client/TestHttpUriBuilder.java
+++ b/http-client/src/test/java/io/airlift/http/client/TestHttpUriBuilder.java
@@ -7,8 +7,8 @@ import java.net.URI;
 
 import static io.airlift.http.client.HttpUriBuilder.uriBuilder;
 import static io.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.testng.Assert.assertEquals;
 
 public class TestHttpUriBuilder
 {
@@ -16,7 +16,7 @@ public class TestHttpUriBuilder
     public void testCreateFromUri()
     {
         URI original = URI.create("http://www.example.com:8081/a%20/%C3%A5?k=1&k=2&%C3%A5=3");
-        assertEquals(uriBuilderFrom(original).build(), original);
+        assertThat(uriBuilderFrom(original).build()).isEqualTo(original);
     }
 
     @Test
@@ -27,7 +27,7 @@ public class TestHttpUriBuilder
                 .host("www.example.com")
                 .build();
 
-        assertEquals(uri.toASCIIString(), "http://www.example.com");
+        assertThat(uri.toASCIIString()).isEqualTo("http://www.example.com");
     }
 
     @Test
@@ -39,7 +39,7 @@ public class TestHttpUriBuilder
                 .replacePath("/a/b/c")
                 .build();
 
-        assertEquals(uri.toASCIIString(), "http://www.example.com/a/b/c");
+        assertThat(uri.toASCIIString()).isEqualTo("http://www.example.com/a/b/c");
     }
 
     @Test
@@ -51,7 +51,7 @@ public class TestHttpUriBuilder
                 .replacePath("a/b/c")
                 .build();
 
-        assertEquals(uri.toASCIIString(), "http://www.example.com/a/b/c");
+        assertThat(uri.toASCIIString()).isEqualTo("http://www.example.com/a/b/c");
     }
 
     @Test
@@ -63,7 +63,7 @@ public class TestHttpUriBuilder
                 .appendPath("/a/b/c")
                 .build();
 
-        assertEquals(uri.toASCIIString(), "http://www.example.com/a/b/c");
+        assertThat(uri.toASCIIString()).isEqualTo("http://www.example.com/a/b/c");
     }
 
     @Test
@@ -75,7 +75,7 @@ public class TestHttpUriBuilder
                 .appendPath("a/b/c")
                 .build();
 
-        assertEquals(uri.toASCIIString(), "http://www.example.com/a/b/c");
+        assertThat(uri.toASCIIString()).isEqualTo("http://www.example.com/a/b/c");
     }
 
     @Test
@@ -88,7 +88,7 @@ public class TestHttpUriBuilder
                 .appendPath("/x/y/z")
                 .build();
 
-        assertEquals(uri.toASCIIString(), "http://www.example.com/a/b/c/x/y/z");
+        assertThat(uri.toASCIIString()).isEqualTo("http://www.example.com/a/b/c/x/y/z");
     }
 
     @Test
@@ -101,7 +101,7 @@ public class TestHttpUriBuilder
                 .appendPath("x/y/z")
                 .build();
 
-        assertEquals(uri.toASCIIString(), "http://www.example.com/a/b/c/x/y/z");
+        assertThat(uri.toASCIIString()).isEqualTo("http://www.example.com/a/b/c/x/y/z");
     }
 
     @Test
@@ -114,7 +114,7 @@ public class TestHttpUriBuilder
                 .appendPath("/x/y/z")
                 .build();
 
-        assertEquals(uri.toASCIIString(), "http://www.example.com/a/b/c/x/y/z");
+        assertThat(uri.toASCIIString()).isEqualTo("http://www.example.com/a/b/c/x/y/z");
     }
 
     @Test
@@ -126,7 +126,7 @@ public class TestHttpUriBuilder
                 .appendPath("/a/b/c/")
                 .build();
 
-        assertEquals(uri.toASCIIString(), "http://www.example.com/a/b/c/");
+        assertThat(uri.toASCIIString()).isEqualTo("http://www.example.com/a/b/c/");
     }
 
     @Test
@@ -140,7 +140,7 @@ public class TestHttpUriBuilder
                 .replaceParameter("k", "1")
                 .build();
 
-        assertEquals(uri.toASCIIString(), "http://www.example.com:8081/a/b/c?k=1");
+        assertThat(uri.toASCIIString()).isEqualTo("http://www.example.com:8081/a/b/c?k=1");
     }
 
     @Test
@@ -156,7 +156,7 @@ public class TestHttpUriBuilder
                 .addParameter("k2", "3")
                 .build();
 
-        assertEquals(uri.toASCIIString(), "http://www.example.com/?k1=1&k1=2&k1=0&k2=3");
+        assertThat(uri.toASCIIString()).isEqualTo("http://www.example.com/?k1=1&k1=2&k1=0&k2=3");
     }
 
     @Test
@@ -169,7 +169,7 @@ public class TestHttpUriBuilder
                 .addParameter("k1", "1", "2", "0")
                 .build();
 
-        assertEquals(uri.toASCIIString(), "http://www.example.com/?k1=1&k1=2&k1=0");
+        assertThat(uri.toASCIIString()).isEqualTo("http://www.example.com/?k1=1&k1=2&k1=0");
     }
 
     @Test
@@ -181,7 +181,7 @@ public class TestHttpUriBuilder
                 .addParameter("pretty")
                 .build();
 
-        assertEquals(uri.toASCIIString(), "http://www.example.com/?pretty");
+        assertThat(uri.toASCIIString()).isEqualTo("http://www.example.com/?pretty");
     }
 
     @Test
@@ -194,7 +194,7 @@ public class TestHttpUriBuilder
                 .addParameter("pretty")
                 .build();
 
-        assertEquals(uri.toASCIIString(), "http://www.example.com/?pretty&pretty");
+        assertThat(uri.toASCIIString()).isEqualTo("http://www.example.com/?pretty&pretty");
     }
 
     @Test
@@ -208,7 +208,7 @@ public class TestHttpUriBuilder
                 .addParameter("pretty")
                 .build();
 
-        assertEquals(uri.toASCIIString(), "http://www.example.com/?pretty&pretty=true&pretty");
+        assertThat(uri.toASCIIString()).isEqualTo("http://www.example.com/?pretty&pretty=true&pretty");
     }
 
     @Test
@@ -218,7 +218,7 @@ public class TestHttpUriBuilder
                 .replaceParameter("k1", "4")
                 .build();
 
-        assertEquals(uri.toASCIIString(), "http://www.example.com:8081/?k2=3&k1=4");
+        assertThat(uri.toASCIIString()).isEqualTo("http://www.example.com:8081/?k2=3&k1=4");
     }
 
     @Test
@@ -228,7 +228,7 @@ public class TestHttpUriBuilder
                 .replaceParameter("k1", "a", "b", "c")
                 .build();
 
-        assertEquals(uri.toASCIIString(), "http://www.example.com/?k2=3&k1=a&k1=b&k1=c");
+        assertThat(uri.toASCIIString()).isEqualTo("http://www.example.com/?k2=3&k1=a&k1=b&k1=c");
     }
 
     @Test
@@ -238,7 +238,7 @@ public class TestHttpUriBuilder
                 .port(801)
                 .build();
 
-        assertEquals(uri.toASCIIString(), "http://www.example.com:801/");
+        assertThat(uri.toASCIIString()).isEqualTo("http://www.example.com:801/");
     }
 
     @Test
@@ -248,19 +248,19 @@ public class TestHttpUriBuilder
                 .defaultPort()
                 .build();
 
-        assertEquals(uri.toASCIIString(), "http://www.example.com");
+        assertThat(uri.toASCIIString()).isEqualTo("http://www.example.com");
 
         uri = uriBuilderFrom(URI.create("http://www.example.com:8081"))
                 .port(80)
                 .build();
 
-        assertEquals(uri.toASCIIString(), "http://www.example.com");
+        assertThat(uri.toASCIIString()).isEqualTo("http://www.example.com");
 
         uri = uriBuilderFrom(URI.create("https://www.example.com:8081"))
                 .port(443)
                 .build();
 
-        assertEquals(uri.toASCIIString(), "https://www.example.com");
+        assertThat(uri.toASCIIString()).isEqualTo("https://www.example.com");
     }
 
     @Test
@@ -273,7 +273,7 @@ public class TestHttpUriBuilder
                 .replacePath("/a/b")
                 .build();
 
-        assertEquals(uri.toASCIIString(), "http://[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:8081/a/b");
+        assertThat(uri.toASCIIString()).isEqualTo("http://[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:8081/a/b");
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "host starts with a bracket")
@@ -286,7 +286,7 @@ public class TestHttpUriBuilder
                 .replacePath("/a/b")
                 .build();
 
-        assertEquals(uri.toASCIIString(), "http://[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:8081/a/b");
+        assertThat(uri.toASCIIString()).isEqualTo("http://[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:8081/a/b");
     }
 
     @Test
@@ -298,7 +298,7 @@ public class TestHttpUriBuilder
                 .hostAndPort(HostAndPort.fromParts("example.com", 8081))
                 .build();
 
-        assertEquals(uri.toASCIIString(), "http://example.com:8081");
+        assertThat(uri.toASCIIString()).isEqualTo("http://example.com:8081");
     }
 
     @Test
@@ -310,7 +310,7 @@ public class TestHttpUriBuilder
                 .hostAndPort(HostAndPort.fromString("example.com"))
                 .build();
 
-        assertEquals(uri.toASCIIString(), "http://example.com");
+        assertThat(uri.toASCIIString()).isEqualTo("http://example.com");
     }
 
     @Test
@@ -322,7 +322,7 @@ public class TestHttpUriBuilder
                 .hostAndPort(HostAndPort.fromParts("[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]", 8081))
                 .build();
 
-        assertEquals(uri.toASCIIString(), "http://[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:8081");
+        assertThat(uri.toASCIIString()).isEqualTo("http://[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:8081");
     }
 
     @Test
@@ -334,7 +334,7 @@ public class TestHttpUriBuilder
                 .hostAndPort(HostAndPort.fromParts("FEDC:BA98:7654:3210:FEDC:BA98:7654:3210", 8081))
                 .build();
 
-        assertEquals(uri.toASCIIString(), "http://[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:8081");
+        assertThat(uri.toASCIIString()).isEqualTo("http://[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:8081");
     }
 
     @Test
@@ -346,7 +346,7 @@ public class TestHttpUriBuilder
                 .hostAndPort(HostAndPort.fromString("FEDC:BA98:7654:3210:FEDC:BA98:7654:3210"))
                 .build();
 
-        assertEquals(uri.toASCIIString(), "http://[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]");
+        assertThat(uri.toASCIIString()).isEqualTo("http://[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]");
     }
 
     @Test
@@ -358,7 +358,7 @@ public class TestHttpUriBuilder
                 .replacePath("/`#%^{}|[]<>?áéíóú")
                 .build();
 
-        assertEquals(uri.toASCIIString(), "http://www.example.com/%60%23%25%5E%7B%7D%7C%5B%5D%3C%3E%3F%C3%A1%C3%A9%C3%AD%C3%B3%C3%BA");
+        assertThat(uri.toASCIIString()).isEqualTo("http://www.example.com/%60%23%25%5E%7B%7D%7C%5B%5D%3C%3E%3F%C3%A1%C3%A9%C3%AD%C3%B3%C3%BA");
     }
 
     @Test
@@ -395,7 +395,7 @@ public class TestHttpUriBuilder
                 .addParameter("a", "1")
                 .build();
 
-        assertEquals(uri.toASCIIString(), "http://www.example.com/?a=1");
+        assertThat(uri.toASCIIString()).isEqualTo("http://www.example.com/?a=1");
     }
 
     @Test
@@ -407,7 +407,7 @@ public class TestHttpUriBuilder
                 .replaceParameter("a", "&")
                 .build();
 
-        assertEquals(uri.toASCIIString(), "http://www.example.com/?a=%26");
+        assertThat(uri.toASCIIString()).isEqualTo("http://www.example.com/?a=%26");
     }
 
     @Test

--- a/http-client/src/test/java/io/airlift/http/client/TestJsonResponseHandler.java
+++ b/http-client/src/test/java/io/airlift/http/client/TestJsonResponseHandler.java
@@ -14,8 +14,7 @@ import static io.airlift.http.client.TestFullJsonResponseHandler.User;
 import static io.airlift.http.client.testing.TestingResponse.mockResponse;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestJsonResponseHandler
 {
@@ -28,8 +27,8 @@ public class TestJsonResponseHandler
         User user = new User("Joe", 25);
         User response = handler.handle(null, mockResponse(OK, JSON_UTF_8, codec.toJson(user)));
 
-        assertEquals(response.getName(), user.getName());
-        assertEquals(response.getAge(), user.getAge());
+        assertThat(response.getName()).isEqualTo(user.getName());
+        assertThat(response.getAge()).isEqualTo(user.getAge());
     }
 
     @Test
@@ -40,9 +39,9 @@ public class TestJsonResponseHandler
             handler.handle(null, mockResponse(OK, JSON_UTF_8, json));
         }
         catch (IllegalArgumentException e) {
-            assertEquals(e.getMessage(), format("Unable to create %s from JSON response:\n[%s]", User.class, json));
-            assertTrue(e.getCause() instanceof IllegalArgumentException);
-            assertEquals(e.getCause().getMessage(), "Invalid JSON bytes for [simple type, class io.airlift.http.client.TestFullJsonResponseHandler$User]");
+            assertThat(e.getMessage()).isEqualTo(format("Unable to create %s from JSON response:\n[%s]", User.class, json));
+            assertThat(e).hasCauseInstanceOf(IllegalArgumentException.class);
+            assertThat(e).hasStackTraceContaining("Invalid JSON bytes for [simple type, class io.airlift.http.client.TestFullJsonResponseHandler$User]");
         }
     }
 

--- a/http-client/src/test/java/io/airlift/http/client/TestRequestBuilder.java
+++ b/http-client/src/test/java/io/airlift/http/client/TestRequestBuilder.java
@@ -23,8 +23,7 @@ import java.net.URI;
 import static io.airlift.http.client.Request.Builder.fromRequest;
 import static io.airlift.http.client.Request.Builder.prepareGet;
 import static io.airlift.http.client.StaticBodyGenerator.createStaticBodyGenerator;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestRequestBuilder
 {
@@ -34,12 +33,12 @@ public class TestRequestBuilder
     public void testRequestBuilder()
     {
         Request request = createRequest();
-        assertEquals(request.getMethod(), "GET");
-        assertEquals(request.getBodyGenerator(), NULL_BODY_GENERATOR);
-        assertEquals(request.getUri(), URI.create("http://example.com"));
-        assertEquals(request.getHeaders(), ImmutableListMultimap.of(
+        assertThat(request.getMethod()).isEqualTo("GET");
+        assertThat(request.getBodyGenerator()).isEqualTo(NULL_BODY_GENERATOR);
+        assertThat(request.getUri()).isEqualTo(URI.create("http://example.com"));
+        assertThat(request.getHeaders()).isEqualTo(ImmutableListMultimap.of(
                 "newheader", "withvalue", "anotherheader", "anothervalue"));
-        assertFalse(request.isFollowRedirects());
+        assertThat(request.isFollowRedirects()).isFalse();
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Cannot make requests to HTTP port 0")
@@ -53,7 +52,7 @@ public class TestRequestBuilder
     public void testBuilderFromRequest()
     {
         Request request = createRequest();
-        assertEquals(fromRequest(request).build(), request);
+        assertThat(fromRequest(request).build()).isEqualTo(request);
     }
 
     private static Request createRequest()

--- a/http-client/src/test/java/io/airlift/http/client/TestTraceTokenRequestFilter.java
+++ b/http-client/src/test/java/io/airlift/http/client/TestTraceTokenRequestFilter.java
@@ -23,9 +23,7 @@ import java.net.URI;
 
 import static io.airlift.http.client.Request.Builder.prepareGet;
 import static io.airlift.http.client.TraceTokenRequestFilter.TRACETOKEN_HEADER;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotSame;
-import static org.testng.Assert.assertSame;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestTraceTokenRequestFilter
 {
@@ -39,11 +37,11 @@ public class TestTraceTokenRequestFilter
 
         Request filtered = filter.filterRequest(original);
 
-        assertNotSame(filter, original);
-        assertEquals(filtered.getUri(), original.getUri());
-        assertEquals(original.getHeaders().size(), 0);
-        assertEquals(filtered.getHeaders().size(), 1);
-        assertEquals(filtered.getHeaders().get(TRACETOKEN_HEADER), ImmutableList.of("testBasic"));
+        assertThat(filtered).isNotSameAs(original);
+        assertThat(filtered.getUri()).isEqualTo(original.getUri());
+        assertThat(original.getHeaders().size()).isEqualTo(0);
+        assertThat(filtered.getHeaders().size()).isEqualTo(1);
+        assertThat(filtered.getHeaders().get(TRACETOKEN_HEADER)).isEqualTo(ImmutableList.of("testBasic"));
     }
 
     @Test
@@ -55,6 +53,6 @@ public class TestTraceTokenRequestFilter
 
         Request request = filter.filterRequest(original);
 
-        assertSame(request, original);
+        assertThat(request).isSameAs(original);
     }
 }

--- a/http-client/src/test/java/io/airlift/http/client/jetty/TestHttpClientLogger.java
+++ b/http-client/src/test/java/io/airlift/http/client/jetty/TestHttpClientLogger.java
@@ -62,8 +62,6 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.jetty.http.HttpVersion.HTTP_1_1;
 import static org.eclipse.jetty.http.HttpVersion.HTTP_2;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotEquals;
 
 @Test(singleThreaded = true)
 public class TestHttpClientLogger
@@ -127,19 +125,19 @@ public class TestHttpClientLogger
 
         String actual = Files.asCharSource(file, UTF_8).read();
         String[] columns = actual.trim().split("\\t");
-        assertEquals(columns[0], ISO_FORMATTER.format(Instant.ofEpochMilli(requestTimestamp)));
-        assertEquals(columns[1], HTTP_2.toString());
-        assertEquals(columns[2], method);
-        assertEquals(columns[3], uri.toString());
-        assertEquals(columns[4], Integer.toString(status));
-        assertEquals(columns[5], Long.toString(responseSize));
-        assertEquals(columns[6], Long.toString(NANOSECONDS.toMillis(requestTotalTime)));
-        assertEquals(columns[7], Long.toString(NANOSECONDS.toMillis(queueTime)));
-        assertEquals(columns[8], Long.toString(NANOSECONDS.toMillis(requestEnd - requestBegin)));
-        assertEquals(columns[9], Long.toString(NANOSECONDS.toMillis(responseBegin - requestEnd)));
-        assertEquals(columns[10], Long.toString(NANOSECONDS.toMillis(responseComplete - responseBegin)));
-        assertEquals(columns[11], Long.toString(responseInfo.getResponseTimestampMillis() - requestTimestamp));
-        assertEquals(columns[12], "test-token");
+        assertThat(columns[0]).isEqualTo(ISO_FORMATTER.format(Instant.ofEpochMilli(requestTimestamp)));
+        assertThat(columns[1]).isEqualTo(HTTP_2.toString());
+        assertThat(columns[2]).isEqualTo(method);
+        assertThat(columns[3]).isEqualTo(uri.toString());
+        assertThat(columns[4]).isEqualTo(Integer.toString(status));
+        assertThat(columns[5]).isEqualTo(Long.toString(responseSize));
+        assertThat(columns[6]).isEqualTo(Long.toString(NANOSECONDS.toMillis(requestTotalTime)));
+        assertThat(columns[7]).isEqualTo(Long.toString(NANOSECONDS.toMillis(queueTime)));
+        assertThat(columns[8]).isEqualTo(Long.toString(NANOSECONDS.toMillis(requestEnd - requestBegin)));
+        assertThat(columns[9]).isEqualTo(Long.toString(NANOSECONDS.toMillis(responseBegin - requestEnd)));
+        assertThat(columns[10]).isEqualTo(Long.toString(NANOSECONDS.toMillis(responseComplete - responseBegin)));
+        assertThat(columns[11]).isEqualTo(Long.toString(responseInfo.getResponseTimestampMillis() - requestTimestamp));
+        assertThat(columns[12]).isEqualTo("test-token");
     }
 
     @Test
@@ -169,19 +167,19 @@ public class TestHttpClientLogger
 
         String actual = Files.asCharSource(file, UTF_8).read();
         String[] columns = actual.trim().split("\\t");
-        assertEquals(columns[0], ISO_FORMATTER.format(Instant.ofEpochMilli(requestTimestamp)));
-        assertEquals(columns[1], HTTP_1_1.toString());
-        assertEquals(columns[2], method);
-        assertEquals(columns[3], uri.toString());
-        assertEquals(columns[4], getFailureReason(responseInfo).get());
-        assertEquals(columns[5], Integer.toString(NO_RESPONSE));
-        assertNotEquals(columns[6], Long.toString(0));
-        assertEquals(columns[7], Long.toString(0));
-        assertEquals(columns[8], Long.toString(0));
-        assertEquals(columns[9], Long.toString(0));
-        assertEquals(columns[10], Long.toString(0));
-        assertEquals(columns[11], Long.toString(responseInfo.getResponseTimestampMillis() - requestTimestamp));
-        assertEquals(columns[12], "test-token");
+        assertThat(columns[0]).isEqualTo(ISO_FORMATTER.format(Instant.ofEpochMilli(requestTimestamp)));
+        assertThat(columns[1]).isEqualTo(HTTP_1_1.toString());
+        assertThat(columns[2]).isEqualTo(method);
+        assertThat(columns[3]).isEqualTo(uri.toString());
+        assertThat(columns[4]).isEqualTo(getFailureReason(responseInfo).get());
+        assertThat(columns[5]).isEqualTo(Integer.toString(NO_RESPONSE));
+        assertThat(columns[6]).isNotEqualTo(Long.toString(0));
+        assertThat(columns[7]).isEqualTo(Long.toString(0));
+        assertThat(columns[8]).isEqualTo(Long.toString(0));
+        assertThat(columns[9]).isEqualTo(Long.toString(0));
+        assertThat(columns[10]).isEqualTo(Long.toString(0));
+        assertThat(columns[11]).isEqualTo(Long.toString(responseInfo.getResponseTimestampMillis() - requestTimestamp));
+        assertThat(columns[12]).isEqualTo("test-token");
     }
 
     @Test

--- a/http-client/src/test/java/io/airlift/http/client/testing/TestTestingHttpClient.java
+++ b/http-client/src/test/java/io/airlift/http/client/testing/TestTestingHttpClient.java
@@ -11,8 +11,8 @@ import java.util.concurrent.ExecutionException;
 
 import static io.airlift.http.client.Request.Builder.prepareGet;
 import static io.airlift.testing.Assertions.assertInstanceOf;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class TestTestingHttpClient
 {
@@ -37,7 +37,7 @@ public class TestTestingHttpClient
         catch (ExecutionException e) {
             Throwable cause = e.getCause();
             assertInstanceOf(cause, CapturedException.class);
-            assertEquals(cause.getCause(), expectedException);
+            assertThat(cause.getCause()).isEqualTo(expectedException);
         }
     }
 }

--- a/http-server/src/test/java/io/airlift/http/server/TestDelimitedRequestLog.java
+++ b/http-server/src/test/java/io/airlift/http/server/TestDelimitedRequestLog.java
@@ -44,12 +44,12 @@ import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.jetty.http.HttpVersion.HTTP_2;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
-import static org.testng.Assert.assertEquals;
 
 @Test(singleThreaded = true)
 public class TestDelimitedRequestLog
@@ -104,13 +104,13 @@ public class TestDelimitedRequestLog
             logger.stop();
 
             List<Object> events = eventClient.getEvents();
-            assertEquals(events.size(), 3);
+            assertThat(events.size()).isEqualTo(3);
             // first two events should have the token set from the header
             for (int i = 0; i < 2; i++) {
-                assertEquals(((HttpRequestEvent) events.get(i)).traceToken(), token);
+                assertThat(((HttpRequestEvent) events.get(i)).traceToken()).isEqualTo(token);
             }
             // last event should have the token set by the tokenManager
-            assertEquals(((HttpRequestEvent) events.get(2)).traceToken(), tokenManager.getCurrentRequestToken());
+            assertThat(((HttpRequestEvent) events.get(2)).traceToken()).isEqualTo(tokenManager.getCurrentRequestToken());
         }
     }
 
@@ -176,28 +176,28 @@ public class TestDelimitedRequestLog
             logger.stop();
 
             List<Object> events = eventClient.getEvents();
-            assertEquals(events.size(), 1);
+            assertThat(events.size()).isEqualTo(1);
             HttpRequestEvent event = (HttpRequestEvent) events.get(0);
 
-            assertEquals(event.timeStamp().toEpochMilli(), timings.requestStarted().toEpochMilli());
-            assertEquals(event.clientAddress(), ip);
-            assertEquals(event.protocol(), protocol);
-            assertEquals(event.method(), method);
-            assertEquals(event.requestUri(), uri.toString());
-            assertEquals(event.user(), user);
-            assertEquals(event.agent(), agent);
-            assertEquals(event.referrer(), referrer);
-            assertEquals(event.requestSize(), requestSize);
-            assertEquals(event.requestContentType(), requestContentType);
-            assertEquals(event.responseSize(), responseSize);
-            assertEquals(event.responseCode(), responseCode);
-            assertEquals(event.responseContentType(), responseContentType);
-            assertEquals(event.timeToFirstByte(), timeToFirstByte);
-            assertEquals(event.timeToLastByte(), timeToLastByte);
-            assertEquals(event.traceToken(), tokenManager.getCurrentRequestToken());
-            assertEquals(event.timeToHandle(), timeToHandle);
-            assertEquals(event.timeFromFirstToLastContent(), event.timeToLastByte() - event.timeToFirstByte());
-            assertEquals(event.responseContentInterarrivalStats(), responseContentInterarrivalStats);
+            assertThat(event.timeStamp().toEpochMilli()).isEqualTo(timings.requestStarted().toEpochMilli());
+            assertThat(event.clientAddress()).isEqualTo(ip);
+            assertThat(event.protocol()).isEqualTo(protocol);
+            assertThat(event.method()).isEqualTo(method);
+            assertThat(event.requestUri()).isEqualTo(uri.toString());
+            assertThat(event.user()).isEqualTo(user);
+            assertThat(event.agent()).isEqualTo(agent);
+            assertThat(event.referrer()).isEqualTo(referrer);
+            assertThat(event.requestSize()).isEqualTo(requestSize);
+            assertThat(event.requestContentType()).isEqualTo(requestContentType);
+            assertThat(event.responseSize()).isEqualTo(responseSize);
+            assertThat(event.responseCode()).isEqualTo(responseCode);
+            assertThat(event.responseContentType()).isEqualTo(responseContentType);
+            assertThat(event.timeToFirstByte()).isEqualTo(timeToFirstByte);
+            assertThat(event.timeToLastByte()).isEqualTo(timeToLastByte);
+            assertThat(event.traceToken()).isEqualTo(tokenManager.getCurrentRequestToken());
+            assertThat(event.timeToHandle()).isEqualTo(timeToHandle);
+            assertThat(event.timeFromFirstToLastContent()).isEqualTo(event.timeToLastByte() - event.timeToFirstByte());
+            assertThat(event.responseContentInterarrivalStats()).isEqualTo(responseContentInterarrivalStats);
 
             String actual = asCharSource(file, UTF_8).read();
             String expected = String.format("%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
@@ -218,7 +218,7 @@ public class TestDelimitedRequestLog
                     firstToLastContentTimeInMillis,
                     format("%.2f, %.2f, %.2f, %d", stats.getMin(), stats.getAverage(), stats.getMax(), stats.getCount()));
 
-            assertEquals(actual, expected);
+            assertThat(actual).isEqualTo(expected);
         }
     }
 
@@ -239,10 +239,10 @@ public class TestDelimitedRequestLog
             logger.stop();
 
             List<Object> events = eventClient.getEvents();
-            assertEquals(events.size(), 1);
+            assertThat(events.size()).isEqualTo(1);
             HttpRequestEvent event = (HttpRequestEvent) events.get(0);
 
-            assertEquals(event.protocol(), protocol);
+            assertThat(event.protocol()).isEqualTo(protocol);
         }
     }
 
@@ -263,10 +263,10 @@ public class TestDelimitedRequestLog
             logger.stop();
 
             List<Object> events = eventClient.getEvents();
-            assertEquals(events.size(), 1);
+            assertThat(events.size()).isEqualTo(1);
             HttpRequestEvent event = (HttpRequestEvent) events.get(0);
 
-            assertEquals(event.clientAddress(), clientIp);
+            assertThat(event.clientAddress()).isEqualTo(clientIp);
         }
     }
 
@@ -288,10 +288,10 @@ public class TestDelimitedRequestLog
             logger.stop();
 
             List<Object> events = eventClient.getEvents();
-            assertEquals(events.size(), 1);
+            assertThat(events.size()).isEqualTo(1);
             HttpRequestEvent event = (HttpRequestEvent) events.get(0);
 
-            assertEquals(event.clientAddress(), clientIp);
+            assertThat(event.clientAddress()).isEqualTo(clientIp);
         }
     }
 

--- a/http-server/src/test/java/io/airlift/http/server/TestHttpServerCipher.java
+++ b/http-server/src/test/java/io/airlift/http/server/TestHttpServerCipher.java
@@ -38,7 +38,7 @@ import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static com.google.common.io.Resources.getResource;
 import static java.nio.file.Files.createTempDirectory;
-import static org.testng.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 @Test(singleThreaded = true)
 public class TestHttpServerCipher

--- a/http-server/src/test/java/io/airlift/http/server/TestHttpServerInfo.java
+++ b/http-server/src/test/java/io/airlift/http/server/TestHttpServerInfo.java
@@ -24,7 +24,7 @@ import java.net.URI;
 import java.util.Optional;
 
 import static io.airlift.testing.Closeables.closeAll;
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestHttpServerInfo
 {
@@ -51,16 +51,16 @@ public class TestHttpServerInfo
         HttpServerInfo httpServerInfo = new HttpServerInfo(serverConfig, Optional.ofNullable(httpsConfig), nodeInfo);
 
         int httpPort = httpServerInfo.getHttpUri().getPort();
-        assertEquals(httpServerInfo.getHttpUri(), new URI("http://[::1]:" + httpPort));
-        assertEquals(httpServerInfo.getHttpExternalUri(), new URI("http://[2001:db8::2:1]:" + httpPort));
+        assertThat(httpServerInfo.getHttpUri()).isEqualTo(new URI("http://[::1]:" + httpPort));
+        assertThat(httpServerInfo.getHttpExternalUri()).isEqualTo(new URI("http://[2001:db8::2:1]:" + httpPort));
 
         int httpsPort = httpServerInfo.getHttpsUri().getPort();
-        assertEquals(httpServerInfo.getHttpsUri(), new URI("https://[::1]:" + httpsPort));
-        assertEquals(httpServerInfo.getHttpsExternalUri(), new URI("https://[2001:db8::2:1]:" + httpsPort));
+        assertThat(httpServerInfo.getHttpsUri()).isEqualTo(new URI("https://[::1]:" + httpsPort));
+        assertThat(httpServerInfo.getHttpsExternalUri()).isEqualTo(new URI("https://[2001:db8::2:1]:" + httpsPort));
 
         int adminPort = httpServerInfo.getAdminUri().getPort();
-        assertEquals(httpServerInfo.getAdminUri(), new URI("https://[::1]:" + adminPort));
-        assertEquals(httpServerInfo.getAdminExternalUri(), new URI("https://[2001:db8::2:1]:" + adminPort));
+        assertThat(httpServerInfo.getAdminUri()).isEqualTo(new URI("https://[::1]:" + adminPort));
+        assertThat(httpServerInfo.getAdminExternalUri()).isEqualTo(new URI("https://[2001:db8::2:1]:" + adminPort));
 
         closeChannels(httpServerInfo);
     }

--- a/http-server/src/test/java/io/airlift/http/server/TestHttpServerModule.java
+++ b/http-server/src/test/java/io/airlift/http/server/TestHttpServerModule.java
@@ -82,10 +82,7 @@ import static io.airlift.http.server.HttpServerBinder.httpServerBinder;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.Files.createTempDirectory;
 import static java.util.Collections.nCopies;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Test(singleThreaded = true)
 public class TestHttpServerModule
@@ -132,7 +129,7 @@ public class TestHttpServerModule
                 .initialize();
 
         HttpServer server = injector.getInstance(HttpServer.class);
-        assertNotNull(server);
+        assertThat(server).isNotNull();
     }
 
     @Test
@@ -157,15 +154,15 @@ public class TestHttpServerModule
 
         NodeInfo nodeInfo = injector.getInstance(NodeInfo.class);
         HttpServer server = injector.getInstance(HttpServer.class);
-        assertNotNull(server);
+        assertThat(server).isNotNull();
         server.start();
         try {
             HttpServerInfo httpServerInfo = injector.getInstance(HttpServerInfo.class);
-            assertNotNull(httpServerInfo);
-            assertNotNull(httpServerInfo.getHttpUri());
-            assertEquals(httpServerInfo.getHttpUri().getScheme(), "http");
-            assertEquals(httpServerInfo.getHttpUri().getHost(), nodeInfo.getInternalAddress());
-            assertNull(httpServerInfo.getHttpsUri());
+            assertThat(httpServerInfo).isNotNull();
+            assertThat(httpServerInfo.getHttpUri()).isNotNull();
+            assertThat(httpServerInfo.getHttpUri().getScheme()).isEqualTo("http");
+            assertThat(httpServerInfo.getHttpUri().getHost()).isEqualTo(nodeInfo.getInternalAddress());
+            assertThat(httpServerInfo.getHttpsUri()).isNull();
         }
         catch (Exception e) {
             server.stop();
@@ -218,16 +215,16 @@ public class TestHttpServerModule
             URI httpUri = httpServerInfo.getHttpUri();
             StatusResponse response = client.execute(prepareGet().setUri(httpUri).build(), createStatusResponseHandler());
 
-            assertEquals(response.getStatusCode(), HttpServletResponse.SC_OK);
+            assertThat(response.getStatusCode()).isEqualTo(HttpServletResponse.SC_OK);
 
             // test filter bound correctly
             response = client.execute(prepareGet().setUri(httpUri.resolve("/filter")).build(), createStatusResponseHandler());
-            assertEquals(response.getStatusCode(), HttpServletResponse.SC_PAYMENT_REQUIRED);
+            assertThat(response.getStatusCode()).isEqualTo(HttpServletResponse.SC_PAYMENT_REQUIRED);
 
             if (enableLegacyUriCompliance) {
                 // test legacy URI code for encoded slashes
                 response = client.execute(prepareGet().setUri(httpUri.resolve("/slashtest/one/two%2fthree/four/%2f/five")).build(), createStatusResponseHandler());
-                assertEquals(response.getStatusCode(), HttpServletResponse.SC_OK);
+                assertThat(response.getStatusCode()).isEqualTo(HttpServletResponse.SC_OK);
             }
 
             // test http resources
@@ -250,12 +247,12 @@ public class TestHttpServerModule
     {
         HttpUriBuilder uriBuilder = uriBuilderFrom(baseUri);
         StringResponse response = client.execute(prepareGet().setUri(uriBuilder.appendPath(path).build()).build(), createStringResponseHandler());
-        assertEquals(response.getStatusCode(), HttpStatus.OK.code());
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK.code());
         String contentType = response.getHeader(CONTENT_TYPE);
-        assertNotNull(contentType, CONTENT_TYPE + " header is absent");
+        assertThat(contentType).as(CONTENT_TYPE + " header is absent").isNotNull();
         MediaType mediaType = MediaType.parse(contentType);
-        assertTrue(PLAIN_TEXT_UTF_8.is(mediaType), "Expected text/plain but got " + mediaType);
-        assertEquals(response.getBody().trim(), contents);
+        assertThat(PLAIN_TEXT_UTF_8.is(mediaType)).as("Expected text/plain but got " + mediaType).isTrue();
+        assertThat(response.getBody().trim()).isEqualTo(contents);
     }
 
     private void assertRedirect(URI baseUri, HttpClient client, String path, String redirect)
@@ -267,10 +264,10 @@ public class TestHttpServerModule
                         .setUri(uriBuilder.appendPath(path).build())
                         .build(),
                 createStringResponseHandler());
-        assertEquals(response.getStatusCode(), HttpStatus.TEMPORARY_REDIRECT.code());
-        assertEquals(response.getHeader(LOCATION), redirect);
-        assertNull(response.getHeader(CONTENT_TYPE), CONTENT_TYPE + " header should be absent");
-        assertEquals(response.getBody(), "", "Response body");
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.TEMPORARY_REDIRECT.code());
+        assertThat(response.getHeader(LOCATION)).isEqualTo(redirect);
+        assertThat(response.getHeader(CONTENT_TYPE)).as(CONTENT_TYPE + " header should be absent").isNull();
+        assertThat(response.getBody()).as("Response body").isEqualTo("");
     }
 
     @Test
@@ -335,9 +332,9 @@ public class TestHttpServerModule
 
             afterRequest = System.currentTimeMillis();
 
-            assertEquals(response.getStatusCode(), responseCode);
-            assertEquals(response.getBody(), responseBody);
-            assertEquals(response.getHeader("Content-Type"), responseContentType);
+            assertThat(response.getStatusCode()).isEqualTo(responseCode);
+            assertThat(response.getBody()).isEqualTo(responseBody);
+            assertThat(response.getHeader("Content-Type")).isEqualTo(responseContentType);
 
             event = (HttpRequestEvent) eventClient.getEvent().get(10, TimeUnit.SECONDS);
         }
@@ -345,25 +342,25 @@ public class TestHttpServerModule
             server.stop();
         }
 
-        assertEquals(event.clientAddress(), echoServlet.remoteAddress);
-        assertEquals(event.protocol(), "http");
-        assertEquals(event.method(), "POST");
-        assertEquals(event.requestUri(), requestUri.getPath());
-        assertNull(event.user());
-        assertEquals(event.agent(), userAgent);
-        assertEquals(event.referrer(), referrer);
-        assertEquals(event.traceToken(), token);
+        assertThat(event.clientAddress()).isEqualTo(echoServlet.remoteAddress);
+        assertThat(event.protocol()).isEqualTo("http");
+        assertThat(event.method()).isEqualTo("POST");
+        assertThat(event.requestUri()).isEqualTo(requestUri.getPath());
+        assertThat(event.user()).isNull();
+        assertThat(event.agent()).isEqualTo(userAgent);
+        assertThat(event.referrer()).isEqualTo(referrer);
+        assertThat(event.traceToken()).isEqualTo(token);
 
-        assertEquals(event.requestSize(), requestBody.length());
-        assertEquals(event.requestContentType(), requestContentType);
-        assertEquals(event.responseSize(), responseBody.length());
-        assertEquals(event.responseCode(), responseCode);
-        assertEquals(event.responseContentType(), responseContentType);
-        assertTrue(event.timeStamp().toEpochMilli() >= beforeRequest);
-        assertTrue(event.timeToLastByte() <= afterRequest - beforeRequest);
-        assertTrue(event.timeToFirstByte() <= event.timeToLastByte());
-        assertTrue(event.timeToDispatch() <= event.timeToFirstByte());
-        assertTrue(event.timeToFirstByte() <= event.timeToLastByte());
+        assertThat(event.requestSize()).isEqualTo(requestBody.length());
+        assertThat(event.requestContentType()).isEqualTo(requestContentType);
+        assertThat(event.responseSize()).isEqualTo(responseBody.length());
+        assertThat(event.responseCode()).isEqualTo(responseCode);
+        assertThat(event.responseContentType()).isEqualTo(responseContentType);
+        assertThat(event.timeStamp().toEpochMilli()).isGreaterThanOrEqualTo(beforeRequest);
+        assertThat(event.timeToLastByte()).isLessThanOrEqualTo(afterRequest - beforeRequest);
+        assertThat(event.timeToFirstByte()).isLessThanOrEqualTo(event.timeToLastByte());
+        assertThat(event.timeToDispatch()).isLessThanOrEqualTo(event.timeToFirstByte());
+        assertThat(event.timeToFirstByte()).isLessThanOrEqualTo(event.timeToLastByte());
     }
 
     private static final class EchoServlet

--- a/http-server/src/test/java/io/airlift/http/server/TestHttpServerProvider.java
+++ b/http-server/src/test/java/io/airlift/http/server/TestHttpServerProvider.java
@@ -94,11 +94,6 @@ import static java.nio.file.Files.createTempDirectory;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
 
 @Test(singleThreaded = true)
 public class TestHttpServerProvider
@@ -146,22 +141,22 @@ public class TestHttpServerProvider
     @Test
     public void testConnectorDefaults()
     {
-        assertTrue(config.isHttpEnabled());
-        assertNotNull(httpServerInfo.getHttpUri());
-        assertNotNull(httpServerInfo.getHttpExternalUri());
-        assertNotNull(httpServerInfo.getHttpChannel());
-        assertEquals(httpServerInfo.getHttpUri().getScheme(), httpServerInfo.getHttpExternalUri().getScheme());
-        assertEquals(httpServerInfo.getHttpUri().getPort(), httpServerInfo.getHttpExternalUri().getPort());
-        assertEquals(httpServerInfo.getHttpUri().getScheme(), "http");
+        assertThat(config.isHttpEnabled()).isTrue();
+        assertThat(httpServerInfo.getHttpUri()).isNotNull();
+        assertThat(httpServerInfo.getHttpExternalUri()).isNotNull();
+        assertThat(httpServerInfo.getHttpChannel()).isNotNull();
+        assertThat(httpServerInfo.getHttpUri().getScheme()).isEqualTo(httpServerInfo.getHttpExternalUri().getScheme());
+        assertThat(httpServerInfo.getHttpUri().getPort()).isEqualTo(httpServerInfo.getHttpExternalUri().getPort());
+        assertThat(httpServerInfo.getHttpUri().getScheme()).isEqualTo("http");
 
-        assertFalse(config.isHttpsEnabled());
-        assertNull(httpServerInfo.getHttpsUri());
-        assertNull(httpServerInfo.getHttpsExternalUri());
-        assertNull(httpServerInfo.getHttpsChannel());
+        assertThat(config.isHttpsEnabled()).isFalse();
+        assertThat(httpServerInfo.getHttpsUri()).isNull();
+        assertThat(httpServerInfo.getHttpsExternalUri()).isNull();
+        assertThat(httpServerInfo.getHttpsChannel()).isNull();
 
-        assertNull(httpServerInfo.getAdminUri());
-        assertNull(httpServerInfo.getAdminExternalUri());
-        assertNull(httpServerInfo.getAdminChannel());
+        assertThat(httpServerInfo.getAdminUri()).isNull();
+        assertThat(httpServerInfo.getAdminExternalUri()).isNull();
+        assertThat(httpServerInfo.getAdminChannel()).isNull();
     }
 
     @Test
@@ -170,17 +165,17 @@ public class TestHttpServerProvider
         config.setHttpEnabled(false);
         httpServerInfo = createHttpServerInfo();
 
-        assertNull(httpServerInfo.getHttpUri());
-        assertNull(httpServerInfo.getHttpExternalUri());
-        assertNull(httpServerInfo.getHttpChannel());
+        assertThat(httpServerInfo.getHttpUri()).isNull();
+        assertThat(httpServerInfo.getHttpExternalUri()).isNull();
+        assertThat(httpServerInfo.getHttpChannel()).isNull();
 
-        assertNull(httpServerInfo.getHttpsUri());
-        assertNull(httpServerInfo.getHttpsExternalUri());
-        assertNull(httpServerInfo.getHttpsChannel());
+        assertThat(httpServerInfo.getHttpsUri()).isNull();
+        assertThat(httpServerInfo.getHttpsExternalUri()).isNull();
+        assertThat(httpServerInfo.getHttpsChannel()).isNull();
 
-        assertNull(httpServerInfo.getAdminUri());
-        assertNull(httpServerInfo.getAdminExternalUri());
-        assertNull(httpServerInfo.getAdminChannel());
+        assertThat(httpServerInfo.getAdminUri()).isNull();
+        assertThat(httpServerInfo.getAdminExternalUri()).isNull();
+        assertThat(httpServerInfo.getAdminChannel()).isNull();
     }
 
     @Test
@@ -189,23 +184,23 @@ public class TestHttpServerProvider
         config.setHttpsEnabled(true);
         httpServerInfo = createHttpServerInfo();
 
-        assertNotNull(httpServerInfo.getHttpUri());
-        assertNotNull(httpServerInfo.getHttpExternalUri());
-        assertNotNull(httpServerInfo.getHttpChannel());
-        assertEquals(httpServerInfo.getHttpUri().getScheme(), httpServerInfo.getHttpExternalUri().getScheme());
-        assertEquals(httpServerInfo.getHttpUri().getPort(), httpServerInfo.getHttpExternalUri().getPort());
-        assertEquals(httpServerInfo.getHttpUri().getScheme(), "http");
+        assertThat(httpServerInfo.getHttpUri()).isNotNull();
+        assertThat(httpServerInfo.getHttpExternalUri()).isNotNull();
+        assertThat(httpServerInfo.getHttpChannel()).isNotNull();
+        assertThat(httpServerInfo.getHttpUri().getScheme()).isEqualTo(httpServerInfo.getHttpExternalUri().getScheme());
+        assertThat(httpServerInfo.getHttpUri().getPort()).isEqualTo(httpServerInfo.getHttpExternalUri().getPort());
+        assertThat(httpServerInfo.getHttpUri().getScheme()).isEqualTo("http");
 
-        assertNotNull(httpServerInfo.getHttpsUri());
-        assertNotNull(httpServerInfo.getHttpsExternalUri());
-        assertNotNull(httpServerInfo.getHttpsChannel());
-        assertEquals(httpServerInfo.getHttpsUri().getScheme(), httpServerInfo.getHttpsExternalUri().getScheme());
-        assertEquals(httpServerInfo.getHttpsUri().getPort(), httpServerInfo.getHttpsExternalUri().getPort());
-        assertEquals(httpServerInfo.getHttpsUri().getScheme(), "https");
+        assertThat(httpServerInfo.getHttpsUri()).isNotNull();
+        assertThat(httpServerInfo.getHttpsExternalUri()).isNotNull();
+        assertThat(httpServerInfo.getHttpsChannel()).isNotNull();
+        assertThat(httpServerInfo.getHttpsUri().getScheme()).isEqualTo(httpServerInfo.getHttpsExternalUri().getScheme());
+        assertThat(httpServerInfo.getHttpsUri().getPort()).isEqualTo(httpServerInfo.getHttpsExternalUri().getPort());
+        assertThat(httpServerInfo.getHttpsUri().getScheme()).isEqualTo("https");
 
-        assertNull(httpServerInfo.getAdminUri());
-        assertNull(httpServerInfo.getAdminExternalUri());
-        assertNull(httpServerInfo.getAdminChannel());
+        assertThat(httpServerInfo.getAdminUri()).isNull();
+        assertThat(httpServerInfo.getAdminExternalUri()).isNull();
+        assertThat(httpServerInfo.getAdminChannel()).isNull();
 
         assertNotEquals(httpServerInfo.getHttpUri().getPort(), httpServerInfo.getHttpsUri().getPort());
     }
@@ -216,23 +211,23 @@ public class TestHttpServerProvider
         config.setAdminEnabled(true);
         httpServerInfo = createHttpServerInfo();
 
-        assertNotNull(httpServerInfo.getHttpUri());
-        assertNotNull(httpServerInfo.getHttpExternalUri());
-        assertNotNull(httpServerInfo.getHttpChannel());
-        assertEquals(httpServerInfo.getHttpUri().getScheme(), httpServerInfo.getHttpExternalUri().getScheme());
-        assertEquals(httpServerInfo.getHttpUri().getPort(), httpServerInfo.getHttpExternalUri().getPort());
-        assertEquals(httpServerInfo.getHttpUri().getScheme(), "http");
+        assertThat(httpServerInfo.getHttpUri()).isNotNull();
+        assertThat(httpServerInfo.getHttpExternalUri()).isNotNull();
+        assertThat(httpServerInfo.getHttpChannel()).isNotNull();
+        assertThat(httpServerInfo.getHttpUri().getScheme()).isEqualTo(httpServerInfo.getHttpExternalUri().getScheme());
+        assertThat(httpServerInfo.getHttpUri().getPort()).isEqualTo(httpServerInfo.getHttpExternalUri().getPort());
+        assertThat(httpServerInfo.getHttpUri().getScheme()).isEqualTo("http");
 
-        assertNull(httpServerInfo.getHttpsUri());
-        assertNull(httpServerInfo.getHttpsExternalUri());
-        assertNull(httpServerInfo.getHttpsChannel());
+        assertThat(httpServerInfo.getHttpsUri()).isNull();
+        assertThat(httpServerInfo.getHttpsExternalUri()).isNull();
+        assertThat(httpServerInfo.getHttpsChannel()).isNull();
 
-        assertNotNull(httpServerInfo.getAdminUri());
-        assertNotNull(httpServerInfo.getAdminExternalUri());
-        assertNotNull(httpServerInfo.getAdminChannel());
-        assertEquals(httpServerInfo.getAdminUri().getScheme(), httpServerInfo.getAdminExternalUri().getScheme());
-        assertEquals(httpServerInfo.getAdminUri().getPort(), httpServerInfo.getAdminExternalUri().getPort());
-        assertEquals(httpServerInfo.getAdminUri().getScheme(), "http");
+        assertThat(httpServerInfo.getAdminUri()).isNotNull();
+        assertThat(httpServerInfo.getAdminExternalUri()).isNotNull();
+        assertThat(httpServerInfo.getAdminChannel()).isNotNull();
+        assertThat(httpServerInfo.getAdminUri().getScheme()).isEqualTo(httpServerInfo.getAdminExternalUri().getScheme());
+        assertThat(httpServerInfo.getAdminUri().getPort()).isEqualTo(httpServerInfo.getAdminExternalUri().getPort());
+        assertThat(httpServerInfo.getAdminUri().getScheme()).isEqualTo("http");
 
         assertNotEquals(httpServerInfo.getHttpUri().getPort(), httpServerInfo.getAdminUri().getPort());
     }
@@ -244,26 +239,26 @@ public class TestHttpServerProvider
                 .setAdminEnabled(true);
         httpServerInfo = createHttpServerInfo();
 
-        assertNotNull(httpServerInfo.getHttpUri());
-        assertNotNull(httpServerInfo.getHttpExternalUri());
-        assertNotNull(httpServerInfo.getHttpChannel());
-        assertEquals(httpServerInfo.getHttpUri().getScheme(), httpServerInfo.getHttpExternalUri().getScheme());
-        assertEquals(httpServerInfo.getHttpUri().getPort(), httpServerInfo.getHttpExternalUri().getPort());
-        assertEquals(httpServerInfo.getHttpUri().getScheme(), "http");
+        assertThat(httpServerInfo.getHttpUri()).isNotNull();
+        assertThat(httpServerInfo.getHttpExternalUri()).isNotNull();
+        assertThat(httpServerInfo.getHttpChannel()).isNotNull();
+        assertThat(httpServerInfo.getHttpUri().getScheme()).isEqualTo(httpServerInfo.getHttpExternalUri().getScheme());
+        assertThat(httpServerInfo.getHttpUri().getPort()).isEqualTo(httpServerInfo.getHttpExternalUri().getPort());
+        assertThat(httpServerInfo.getHttpUri().getScheme()).isEqualTo("http");
 
-        assertNotNull(httpServerInfo.getHttpsUri());
-        assertNotNull(httpServerInfo.getHttpsExternalUri());
-        assertNotNull(httpServerInfo.getHttpsChannel());
-        assertEquals(httpServerInfo.getHttpsUri().getScheme(), httpServerInfo.getHttpsExternalUri().getScheme());
-        assertEquals(httpServerInfo.getHttpsUri().getPort(), httpServerInfo.getHttpsExternalUri().getPort());
-        assertEquals(httpServerInfo.getHttpsUri().getScheme(), "https");
+        assertThat(httpServerInfo.getHttpsUri()).isNotNull();
+        assertThat(httpServerInfo.getHttpsExternalUri()).isNotNull();
+        assertThat(httpServerInfo.getHttpsChannel()).isNotNull();
+        assertThat(httpServerInfo.getHttpsUri().getScheme()).isEqualTo(httpServerInfo.getHttpsExternalUri().getScheme());
+        assertThat(httpServerInfo.getHttpsUri().getPort()).isEqualTo(httpServerInfo.getHttpsExternalUri().getPort());
+        assertThat(httpServerInfo.getHttpsUri().getScheme()).isEqualTo("https");
 
-        assertNotNull(httpServerInfo.getAdminUri());
-        assertNotNull(httpServerInfo.getAdminExternalUri());
-        assertNotNull(httpServerInfo.getAdminChannel());
-        assertEquals(httpServerInfo.getAdminUri().getScheme(), httpServerInfo.getAdminExternalUri().getScheme());
-        assertEquals(httpServerInfo.getAdminUri().getPort(), httpServerInfo.getAdminExternalUri().getPort());
-        assertEquals(httpServerInfo.getAdminUri().getScheme(), "https");
+        assertThat(httpServerInfo.getAdminUri()).isNotNull();
+        assertThat(httpServerInfo.getAdminExternalUri()).isNotNull();
+        assertThat(httpServerInfo.getAdminChannel()).isNotNull();
+        assertThat(httpServerInfo.getAdminUri().getScheme()).isEqualTo(httpServerInfo.getAdminExternalUri().getScheme());
+        assertThat(httpServerInfo.getAdminUri().getPort()).isEqualTo(httpServerInfo.getAdminExternalUri().getPort());
+        assertThat(httpServerInfo.getAdminUri().getScheme()).isEqualTo("https");
 
         assertNotEquals(httpServerInfo.getHttpUri().getPort(), httpServerInfo.getHttpsUri().getPort());
         assertNotEquals(httpServerInfo.getHttpUri().getPort(), httpServerInfo.getAdminUri().getPort());
@@ -279,15 +274,15 @@ public class TestHttpServerProvider
         try (JettyHttpClient httpClient = new JettyHttpClient(new HttpClientConfig().setHttp2Enabled(false))) {
             StatusResponse response = httpClient.execute(prepareGet().setUri(httpServerInfo.getHttpUri()).build(), createStatusResponseHandler());
 
-            assertEquals(response.getStatusCode(), HttpServletResponse.SC_OK);
-            assertEquals(response.getHeader("X-Protocol"), "HTTP/1.1");
+            assertThat(response.getStatusCode()).isEqualTo(HttpServletResponse.SC_OK);
+            assertThat(response.getHeader("X-Protocol")).isEqualTo("HTTP/1.1");
         }
 
         try (JettyHttpClient httpClient = new JettyHttpClient(new HttpClientConfig().setHttp2Enabled(true))) {
             StatusResponse response = httpClient.execute(prepareGet().setUri(httpServerInfo.getHttpUri()).build(), createStatusResponseHandler());
 
-            assertEquals(response.getStatusCode(), HttpServletResponse.SC_OK);
-            assertEquals(response.getHeader("X-Protocol"), "HTTP/2.0");
+            assertThat(response.getStatusCode()).isEqualTo(HttpServletResponse.SC_OK);
+            assertThat(response.getHeader("X-Protocol")).isEqualTo("HTTP/2.0");
         }
     }
 
@@ -323,8 +318,8 @@ public class TestHttpServerProvider
         URI uri = URI.create(format("https://%s:%s", name, httpServerInfo.getHttpsUri().getPort()));
         StatusResponse response = httpClient.execute(prepareGet().setUri(uri).build(), createStatusResponseHandler());
 
-        assertEquals(response.getStatusCode(), HttpServletResponse.SC_OK);
-        assertEquals(response.getHeader("X-Protocol"), "HTTP/1.1");
+        assertThat(response.getStatusCode()).isEqualTo(HttpServletResponse.SC_OK);
+        assertThat(response.getHeader("X-Protocol")).isEqualTo("HTTP/1.1");
     }
 
     @Test
@@ -337,7 +332,7 @@ public class TestHttpServerProvider
         try (JettyHttpClient client = new JettyHttpClient()) {
             StatusResponse response = client.execute(prepareGet().setUri(httpServerInfo.getHttpUri().resolve("/filter")).build(), createStatusResponseHandler());
 
-            assertEquals(response.getStatusCode(), HttpServletResponse.SC_PAYMENT_REQUIRED);
+            assertThat(response.getStatusCode()).isEqualTo(HttpServletResponse.SC_PAYMENT_REQUIRED);
         }
     }
 
@@ -373,17 +368,17 @@ public class TestHttpServerProvider
             host.ifPresent(value -> builder.addHeader(X_FORWARDED_HOST, value));
             remoteHost.ifPresent(value -> builder.addHeader(X_FORWARDED_FOR, value));
             StringResponse response = client.execute(builder.build(), createStringResponseHandler());
-            assertEquals(response.getStatusCode(), 200);
+            assertThat(response.getStatusCode()).isEqualTo(200);
         }
 
         proto.ifPresent(uriBuilder::scheme);
         host.map(HostAndPort::fromString).ifPresent(uriBuilder::hostAndPort);
         URI forwardedUri = uriBuilder.build();
-        assertEquals(servlet.getRequestUrl(), forwardedUri.toString());
-        assertEquals(servlet.getScheme(), forwardedUri.getScheme());
-        assertEquals(servlet.getIsSecure(), (Boolean) forwardedUri.getScheme().equals("https"));
+        assertThat(servlet.getRequestUrl()).isEqualTo(forwardedUri.toString());
+        assertThat(servlet.getScheme()).isEqualTo(forwardedUri.getScheme());
+        assertThat(servlet.getIsSecure()).isEqualTo((Boolean) forwardedUri.getScheme().equals("https"));
 
-        remoteHost.ifPresent(value -> assertEquals(servlet.getRemoteAddress(), value));
+        remoteHost.ifPresent(value -> assertThat(servlet.getRemoteAddress()).isEqualTo(value));
     }
 
     @Test
@@ -406,8 +401,8 @@ public class TestHttpServerProvider
                             .build(),
                     createStringResponseHandler());
 
-            assertEquals(response.getStatusCode(), HttpServletResponse.SC_OK);
-            assertEquals(response.getBody(), "user");
+            assertThat(response.getStatusCode()).isEqualTo(HttpServletResponse.SC_OK);
+            assertThat(response.getBody()).isEqualTo("user");
         }
     }
 
@@ -464,8 +459,8 @@ public class TestHttpServerProvider
             URI uri = URI.create(format("https://%s:%s", name, httpServerInfo.getHttpsUri().getPort()));
             StringResponse response = httpClient.execute(prepareGet().setUri(uri).build(), createStringResponseHandler());
 
-            assertEquals(response.getStatusCode(), HttpServletResponse.SC_OK);
-            assertEquals(response.getBody(), "CN=testing,OU=Client,O=Airlift,L=Palo Alto,ST=CA,C=US");
+            assertThat(response.getStatusCode()).isEqualTo(HttpServletResponse.SC_OK);
+            assertThat(response.getBody()).isEqualTo("CN=testing,OU=Client,O=Airlift,L=Palo Alto,ST=CA,C=US");
         }
     }
 
@@ -500,7 +495,7 @@ public class TestHttpServerProvider
 
         try (HttpClient client = new JettyHttpClient()) {
             StringResponse response = client.execute(prepareGet().setUri(httpServerInfo.getHttpUri()).build(), createStringResponseHandler());
-            assertEquals(response.getStatusCode(), 500);
+            assertThat(response.getStatusCode()).isEqualTo(500);
             assertContains(response.getBody(), "ErrorServlet.java");
         }
     }
@@ -515,7 +510,7 @@ public class TestHttpServerProvider
 
         try (HttpClient client = new JettyHttpClient()) {
             StringResponse response = client.execute(prepareGet().setUri(httpServerInfo.getHttpUri()).build(), createStringResponseHandler());
-            assertEquals(response.getStatusCode(), 500);
+            assertThat(response.getStatusCode()).isEqualTo(500);
             assertThat(response.getBody()).doesNotContain("ErrorServlet.java");
         }
     }
@@ -610,7 +605,7 @@ public class TestHttpServerProvider
 
         createAndStartServer();
 
-        assertNull(server.getDaysUntilCertificateExpiration());
+        assertThat(server.getDaysUntilCertificateExpiration()).isNull();
     }
 
     @Test
@@ -636,9 +631,9 @@ public class TestHttpServerProvider
                     .setKeystorePath(tempFile.file().getAbsolutePath())
                     .setKeystorePassword("airlift");
             createAndStartServer();
-            assertEventually(() -> assertEquals(server.getCertificates().size(), 1));
+            assertEventually(() -> assertThat(server.getCertificates()).hasSize(1));
             appendCertificate(tempFile.file(), "certificate-2");
-            assertEventually(() -> assertEquals(server.getCertificates().size(), 2));
+            assertEventually(() -> assertThat(server.getCertificates()).hasSize(2));
         }
     }
 

--- a/http-server/src/test/java/io/airlift/http/server/TestInet4Network.java
+++ b/http-server/src/test/java/io/airlift/http/server/TestInet4Network.java
@@ -23,9 +23,7 @@ import java.net.Inet4Address;
 
 import static io.airlift.testing.EquivalenceTester.comparisonTester;
 import static io.airlift.testing.EquivalenceTester.equivalenceTester;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestInet4Network
 {
@@ -42,7 +40,7 @@ public class TestInet4Network
 
     private static void assertCidrValid(String cidr)
     {
-        assertEquals(Inet4Network.fromCidr(cidr).toString(), cidr);
+        assertThat(Inet4Network.fromCidr(cidr).toString()).isEqualTo(cidr);
     }
 
     @DataProvider(name = "invalidCidr")
@@ -92,8 +90,8 @@ public class TestInet4Network
     {
         String startingAddress = cidr.substring(0, cidr.indexOf('/'));
         Inet4Network network = Inet4Network.fromCidr(cidr);
-        assertEquals(network.getStartingAddress(), InetAddresses.forString(startingAddress));
-        assertEquals(network.getEndingAddress(), InetAddresses.forString(endingAddress));
+        assertThat(network.getStartingAddress()).isEqualTo(InetAddresses.forString(startingAddress));
+        assertThat(network.getEndingAddress()).isEqualTo(InetAddresses.forString(endingAddress));
     }
 
     @Test
@@ -109,7 +107,7 @@ public class TestInet4Network
     private static void assertAddressToLong(String address, long ip)
     {
         Inet4Address addr = (Inet4Address) InetAddresses.forString(address);
-        assertEquals(Inet4Network.addressToLong(addr), ip);
+        assertThat(Inet4Network.addressToLong(addr)).isEqualTo(ip);
     }
 
     @Test
@@ -124,7 +122,7 @@ public class TestInet4Network
     private static void assertFromAddress(String address, String cidr, int bits)
     {
         Inet4Address addr = (Inet4Address) InetAddresses.forString(address);
-        assertEquals(Inet4Network.fromAddress(addr, bits), Inet4Network.fromCidr(cidr));
+        assertThat(Inet4Network.fromAddress(addr, bits)).isEqualTo(Inet4Network.fromCidr(cidr));
     }
 
     @Test
@@ -144,35 +142,35 @@ public class TestInet4Network
     private static void assertTruncatedFromAddress(String address, String cidr, int bits)
     {
         Inet4Address addr = (Inet4Address) InetAddresses.forString(address);
-        assertEquals(Inet4Network.truncatedFromAddress(addr, bits), Inet4Network.fromCidr(cidr));
+        assertThat(Inet4Network.truncatedFromAddress(addr, bits)).isEqualTo(Inet4Network.fromCidr(cidr));
     }
 
     @Test
     public void testGetBits()
     {
-        assertEquals(Inet4Network.fromCidr("8.0.0.0/8").getBits(), 8);
-        assertEquals(Inet4Network.fromCidr("8.0.0.0/24").getBits(), 24);
-        assertEquals(Inet4Network.fromCidr("8.0.0.0/32").getBits(), 32);
+        assertThat(Inet4Network.fromCidr("8.0.0.0/8").getBits()).isEqualTo(8);
+        assertThat(Inet4Network.fromCidr("8.0.0.0/24").getBits()).isEqualTo(24);
+        assertThat(Inet4Network.fromCidr("8.0.0.0/32").getBits()).isEqualTo(32);
     }
 
     @Test
     public void testContainsAddress()
     {
-        assertTrue(containsAddress("0.0.0.0/0", "0.0.0.0"));
-        assertTrue(containsAddress("0.0.0.0/0", "1.2.3.4"));
-        assertTrue(containsAddress("0.0.0.0/0", "255.255.255.255"));
-        assertTrue(containsAddress("8.8.8.0/24", "8.8.8.0"));
-        assertTrue(containsAddress("8.8.8.0/24", "8.8.8.8"));
-        assertTrue(containsAddress("8.8.8.0/24", "8.8.8.255"));
-        assertTrue(containsAddress("202.12.128.0/18", "202.12.128.0"));
-        assertTrue(containsAddress("202.12.128.0/18", "202.12.128.255"));
-        assertTrue(containsAddress("202.12.128.0/18", "202.12.157.123"));
-        assertTrue(containsAddress("202.12.128.0/18", "202.12.191.255"));
+        assertThat(containsAddress("0.0.0.0/0", "0.0.0.0")).isTrue();
+        assertThat(containsAddress("0.0.0.0/0", "1.2.3.4")).isTrue();
+        assertThat(containsAddress("0.0.0.0/0", "255.255.255.255")).isTrue();
+        assertThat(containsAddress("8.8.8.0/24", "8.8.8.0")).isTrue();
+        assertThat(containsAddress("8.8.8.0/24", "8.8.8.8")).isTrue();
+        assertThat(containsAddress("8.8.8.0/24", "8.8.8.255")).isTrue();
+        assertThat(containsAddress("202.12.128.0/18", "202.12.128.0")).isTrue();
+        assertThat(containsAddress("202.12.128.0/18", "202.12.128.255")).isTrue();
+        assertThat(containsAddress("202.12.128.0/18", "202.12.157.123")).isTrue();
+        assertThat(containsAddress("202.12.128.0/18", "202.12.191.255")).isTrue();
 
-        assertFalse(containsAddress("8.8.8.0/24", "8.8.9.0"));
-        assertFalse(containsAddress("8.8.8.8/32", "8.8.8.9"));
-        assertFalse(containsAddress("202.12.128.0/18", "202.12.127.255"));
-        assertFalse(containsAddress("202.12.128.0/18", "202.12.192.0"));
+        assertThat(containsAddress("8.8.8.0/24", "8.8.9.0")).isFalse();
+        assertThat(containsAddress("8.8.8.8/32", "8.8.8.9")).isFalse();
+        assertThat(containsAddress("202.12.128.0/18", "202.12.127.255")).isFalse();
+        assertThat(containsAddress("202.12.128.0/18", "202.12.192.0")).isFalse();
     }
 
     private static boolean containsAddress(String cidr, String address)

--- a/http-server/src/test/java/io/airlift/http/server/TestInet4Networks.java
+++ b/http-server/src/test/java/io/airlift/http/server/TestInet4Networks.java
@@ -18,27 +18,26 @@ package io.airlift.http.server;
 import org.testng.annotations.Test;
 
 import static io.airlift.http.server.Inet4Networks.isPrivateNetworkAddress;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestInet4Networks
 {
     @Test
     public void test()
     {
-        assertTrue(isPrivateNetworkAddress("127.0.0.1"));
-        assertTrue(isPrivateNetworkAddress("127.1.2.3"));
-        assertTrue(isPrivateNetworkAddress("169.254.0.1"));
-        assertTrue(isPrivateNetworkAddress("169.254.1.2"));
-        assertTrue(isPrivateNetworkAddress("192.168.0.1"));
-        assertTrue(isPrivateNetworkAddress("192.168.1.2"));
-        assertTrue(isPrivateNetworkAddress("172.16.0.1"));
-        assertTrue(isPrivateNetworkAddress("172.16.1.2"));
-        assertTrue(isPrivateNetworkAddress("172.16.1.2"));
-        assertTrue(isPrivateNetworkAddress("10.0.0.1"));
-        assertTrue(isPrivateNetworkAddress("10.1.2.3"));
+        assertThat(isPrivateNetworkAddress("127.0.0.1")).isTrue();
+        assertThat(isPrivateNetworkAddress("127.1.2.3")).isTrue();
+        assertThat(isPrivateNetworkAddress("169.254.0.1")).isTrue();
+        assertThat(isPrivateNetworkAddress("169.254.1.2")).isTrue();
+        assertThat(isPrivateNetworkAddress("192.168.0.1")).isTrue();
+        assertThat(isPrivateNetworkAddress("192.168.1.2")).isTrue();
+        assertThat(isPrivateNetworkAddress("172.16.0.1")).isTrue();
+        assertThat(isPrivateNetworkAddress("172.16.1.2")).isTrue();
+        assertThat(isPrivateNetworkAddress("172.16.1.2")).isTrue();
+        assertThat(isPrivateNetworkAddress("10.0.0.1")).isTrue();
+        assertThat(isPrivateNetworkAddress("10.1.2.3")).isTrue();
 
-        assertFalse(isPrivateNetworkAddress("1.2.3.4"));
-        assertFalse(isPrivateNetworkAddress("172.33.0.0"));
+        assertThat(isPrivateNetworkAddress("1.2.3.4")).isFalse();
+        assertThat(isPrivateNetworkAddress("172.33.0.0")).isFalse();
     }
 }

--- a/http-server/src/test/java/io/airlift/http/server/TestJettyMultipleCerts.java
+++ b/http-server/src/test/java/io/airlift/http/server/TestJettyMultipleCerts.java
@@ -41,8 +41,8 @@ import static com.google.common.io.Resources.getResource;
 import static io.airlift.http.client.Request.Builder.prepareGet;
 import static io.airlift.http.client.StatusResponseHandler.createStatusResponseHandler;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.testng.Assert.assertEquals;
 
 public class TestJettyMultipleCerts
 {
@@ -154,7 +154,7 @@ public class TestJettyMultipleCerts
                             .setUri(URI.create("https://" + address))
                             .build(),
                     createStatusResponseHandler());
-            assertEquals(statusResponse.getStatusCode(), 200);
+            assertThat(statusResponse.getStatusCode()).isEqualTo(200);
         }
         catch (Exception e) {
             throw new RuntimeException(address.getHost() + " " + e.getMessage(), e);

--- a/http-server/src/test/java/io/airlift/http/server/TestRequestTimingEventHandler.java
+++ b/http-server/src/test/java/io/airlift/http/server/TestRequestTimingEventHandler.java
@@ -16,11 +16,11 @@ import static io.airlift.http.server.RequestTimingEventHandler.RESPONSE_CONTENT_
 import static io.airlift.http.server.RequestTimingEventHandler.timings;
 import static java.time.temporal.ChronoUnit.MILLIS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
-import static org.testng.Assert.assertEquals;
 
 public class TestRequestTimingEventHandler
 {
@@ -48,12 +48,12 @@ public class TestRequestTimingEventHandler
 
             RequestTiming timings = timings(request);
 
-            assertEquals(timings.requestStarted(), now.truncatedTo(MILLIS));
-            assertEquals(timings.timeToDispatch(), Duration.valueOf("100.00ns"));
-            assertEquals(timings.timeToHandling(), Duration.valueOf("110.00ns"));
-            assertEquals(timings.timeToFirstByte(), Duration.valueOf("200.00ns"));
-            assertEquals(timings.timeToLastByte(), Duration.valueOf("250.00ns"));
-            assertEquals(timings.timeToCompletion(), Duration.valueOf("500.00ns"));
+            assertThat(timings.requestStarted()).isEqualTo(now.truncatedTo(MILLIS));
+            assertThat(timings.timeToDispatch()).isEqualTo(Duration.valueOf("100.00ns"));
+            assertThat(timings.timeToHandling()).isEqualTo(Duration.valueOf("110.00ns"));
+            assertThat(timings.timeToFirstByte()).isEqualTo(Duration.valueOf("200.00ns"));
+            assertThat(timings.timeToLastByte()).isEqualTo(Duration.valueOf("250.00ns"));
+            assertThat(timings.timeToCompletion()).isEqualTo(Duration.valueOf("500.00ns"));
         }
     }
 }

--- a/http-server/src/test/java/io/airlift/http/server/testing/AbstractTestTestingHttpServer.java
+++ b/http-server/src/test/java/io/airlift/http/server/testing/AbstractTestTestingHttpServer.java
@@ -71,8 +71,6 @@ import static io.airlift.http.server.HttpServerBinder.httpServerBinder;
 import static io.airlift.testing.Assertions.assertGreaterThan;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 
 public abstract class AbstractTestTestingHttpServer
 {
@@ -104,7 +102,7 @@ public abstract class AbstractTestTestingHttpServer
 
         try {
             server.start();
-            assertEquals(servlet.getSampleInitParam(), "the value");
+            assertThat(servlet.getSampleInitParam()).isEqualTo("the value");
             assertGreaterThan(server.getPort(), 0);
         }
         finally {
@@ -126,8 +124,8 @@ public abstract class AbstractTestTestingHttpServer
             try (HttpClient client = new JettyHttpClient(new HttpClientConfig().setConnectTimeout(new Duration(1, SECONDS)))) {
                 StatusResponse response = client.execute(prepareGet().setUri(server.getBaseUrl()).build(), createStatusResponseHandler());
 
-                assertEquals(response.getStatusCode(), HttpServletResponse.SC_OK);
-                assertEquals(servlet.getCallCount(), 1);
+                assertThat(response.getStatusCode()).isEqualTo(HttpServletResponse.SC_OK);
+                assertThat(servlet.getCallCount()).isEqualTo(1);
             }
         }
         finally {
@@ -150,9 +148,9 @@ public abstract class AbstractTestTestingHttpServer
             try (HttpClient client = new JettyHttpClient(new HttpClientConfig().setConnectTimeout(new Duration(1, SECONDS)))) {
                 StatusResponse response = client.execute(prepareGet().setUri(server.getBaseUrl()).build(), createStatusResponseHandler());
 
-                assertEquals(response.getStatusCode(), HttpServletResponse.SC_OK);
-                assertEquals(servlet.getCallCount(), 1);
-                assertEquals(filter.getCallCount(), 1);
+                assertThat(response.getStatusCode()).isEqualTo(HttpServletResponse.SC_OK);
+                assertThat(servlet.getCallCount()).isEqualTo(1);
+                assertThat(filter.getCallCount()).isEqualTo(1);
             }
         }
         finally {
@@ -184,8 +182,8 @@ public abstract class AbstractTestTestingHttpServer
         try (HttpClient client = new JettyHttpClient(new HttpClientConfig().setConnectTimeout(new Duration(1, SECONDS)))) {
             StatusResponse response = client.execute(prepareGet().setUri(server.getBaseUrl()).build(), createStatusResponseHandler());
 
-            assertEquals(response.getStatusCode(), HttpServletResponse.SC_OK);
-            assertEquals(servlet.getCallCount(), 1);
+            assertThat(response.getStatusCode()).isEqualTo(HttpServletResponse.SC_OK);
+            assertThat(servlet.getCallCount()).isEqualTo(1);
         }
         finally {
             lifeCycleManager.stop();
@@ -218,9 +216,9 @@ public abstract class AbstractTestTestingHttpServer
         try (HttpClient client = new JettyHttpClient(new HttpClientConfig().setConnectTimeout(new Duration(1, SECONDS)))) {
             StatusResponse response = client.execute(prepareGet().setUri(server.getBaseUrl()).build(), createStatusResponseHandler());
 
-            assertEquals(response.getStatusCode(), HttpServletResponse.SC_OK);
-            assertEquals(servlet.getCallCount(), 1);
-            assertEquals(filter.getCallCount(), 1);
+            assertThat(response.getStatusCode()).isEqualTo(HttpServletResponse.SC_OK);
+            assertThat(servlet.getCallCount()).isEqualTo(1);
+            assertThat(filter.getCallCount()).isEqualTo(1);
         }
 
         finally {
@@ -270,7 +268,7 @@ public abstract class AbstractTestTestingHttpServer
             assertResource(uri, client, "path/user2.txt", "user2");
 
             // verify that servlet did not receive resource requests
-            assertEquals(servlet.getCallCount(), 0);
+            assertThat(servlet.getCallCount()).isEqualTo(0);
         }
         finally {
             lifeCycleManager.stop();
@@ -307,10 +305,10 @@ public abstract class AbstractTestTestingHttpServer
                 contentTypeHeader = servlet.contentTypeHeader;
             }
             if (enableCaseSensitiveHeaderCache) {
-                assertEquals(contentTypeHeader, finalContentType);
+                assertThat(contentTypeHeader).isEqualTo(finalContentType);
             }
             else {
-                assertEquals(contentTypeHeader, contentType);
+                assertThat(contentTypeHeader).isEqualTo(contentType);
             }
         }
         finally {
@@ -355,10 +353,10 @@ public abstract class AbstractTestTestingHttpServer
     {
         HttpUriBuilder uriBuilder = uriBuilderFrom(baseUri);
         StringResponseHandler.StringResponse data = client.execute(prepareGet().setUri(uriBuilder.appendPath(path).build()).build(), createStringResponseHandler());
-        assertEquals(data.getStatusCode(), HttpStatus.OK.code());
+        assertThat(data.getStatusCode()).isEqualTo(HttpStatus.OK.code());
         MediaType contentType = MediaType.parse(data.getHeader(HttpHeaders.CONTENT_TYPE));
-        assertTrue(PLAIN_TEXT_UTF_8.is(contentType), "Expected text/plain but got " + contentType);
-        assertEquals(data.getBody().trim(), contents);
+        assertThat(PLAIN_TEXT_UTF_8.is(contentType)).as("Expected text/plain but got " + contentType).isTrue();
+        assertThat(data.getBody().trim()).isEqualTo(contents);
     }
 
     private static TestingHttpServer createTestingHttpServer(boolean enableVirtualThreads, boolean enableLegacyUriCompliance, boolean enableCaseSensitiveHeaderCache, DummyServlet servlet, Map<String, String> params)

--- a/jaxrs-testing/src/test/java/io/airlift/jaxrs/testing/TestJaxrsTestingHttpProcessor.java
+++ b/jaxrs-testing/src/test/java/io/airlift/jaxrs/testing/TestJaxrsTestingHttpProcessor.java
@@ -20,8 +20,7 @@ import static io.airlift.http.client.StringResponseHandler.createStringResponseH
 import static jakarta.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 @Test
 public class TestJaxrsTestingHttpProcessor
@@ -39,9 +38,9 @@ public class TestJaxrsTestingHttpProcessor
 
         StringResponse response = HTTP_CLIENT.execute(request, createStringResponseHandler());
 
-        assertEquals(response.getStatusCode(), HttpStatus.OK.code());
-        assertEquals(response.getBody(), "Got xyz");
-        assertEquals(response.getHeader("X-Test-Out"), "Got abc");
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK.code());
+        assertThat(response.getBody()).isEqualTo("Got xyz");
+        assertThat(response.getHeader("X-Test-Out")).isEqualTo("Got abc");
     }
 
     @Test
@@ -56,7 +55,7 @@ public class TestJaxrsTestingHttpProcessor
             fail("expected exception");
         }
         catch (TestingException e) {
-            assertEquals(e.getMessage(), "testException");
+            assertThat(e.getMessage()).isEqualTo("testException");
         }
     }
 
@@ -68,7 +67,7 @@ public class TestJaxrsTestingHttpProcessor
                 .build();
 
         StringResponse response = HTTP_CLIENT.execute(request, createStringResponseHandler());
-        assertEquals(response.getStatusCode(), 404);
+        assertThat(response.getStatusCode()).isEqualTo(404);
     }
 
     @Test

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -175,6 +175,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/jaxrs/src/test/java/io/airlift/jaxrs/TestJsonMapper.java
+++ b/jaxrs/src/test/java/io/airlift/jaxrs/TestJsonMapper.java
@@ -31,9 +31,8 @@ import java.io.InputStream;
 import java.util.zip.ZipException;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class TestJsonMapper
 {
@@ -58,9 +57,9 @@ public class TestJsonMapper
         MultivaluedMap<String, Object> headers = new GuavaMultivaluedMap<>();
         jsonMapper.writeTo(value, String.class, null, null, null, headers, outputStream);
 
-        assertEquals(jsonCodec.fromJson(outputStream.toString(UTF_8)), value);
+        assertThat(jsonCodec.fromJson(outputStream.toString(UTF_8))).isEqualTo(value);
 
-        assertEquals(headers.getFirst(HttpHeaders.X_CONTENT_TYPE_OPTIONS), "nosniff");
+        assertThat(headers.getFirst(HttpHeaders.X_CONTENT_TYPE_OPTIONS)).isEqualTo("nosniff");
     }
 
     @Test
@@ -95,7 +94,7 @@ public class TestJsonMapper
             fail("Should have thrown a JsonMapperParsingException");
         }
         catch (JsonMapperParsingException e) {
-            assertTrue((e.getMessage()).startsWith("Invalid json for Java type"));
+            assertThat(e.getMessage()).startsWith("Invalid json for Java type");
         }
     }
 
@@ -131,7 +130,7 @@ public class TestJsonMapper
             fail("Should have thrown a JsonMapperParsingException");
         }
         catch (JsonMapperParsingException e) {
-            assertTrue((e.getMessage()).startsWith("Invalid json for Java type"));
+            assertThat(e.getMessage()).startsWith("Invalid json for Java type");
         }
     }
 
@@ -167,7 +166,7 @@ public class TestJsonMapper
             fail("Should have thrown an IOException");
         }
         catch (WebApplicationException e) {
-            fail("Should not have received a WebApplicationException", e);
+            org.assertj.core.api.Assertions.fail("Should not have received a WebApplicationException", e);
         }
     }
 

--- a/jaxrs/src/test/java/io/airlift/jaxrs/TestLegacyUriMode.java
+++ b/jaxrs/src/test/java/io/airlift/jaxrs/TestLegacyUriMode.java
@@ -32,7 +32,7 @@ import static io.airlift.http.server.HttpServerBinder.httpServerBinder;
 import static io.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
 import static io.airlift.json.JsonCodec.listJsonCodec;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestLegacyUriMode
 {
@@ -62,18 +62,18 @@ public class TestLegacyUriMode
     public void testLegacyUriModeDisabled()
     {
         doTest(false,
-                new Tester("/legacy/test1/one%2ftwo/%2f/three", response -> assertEquals(response.getStatusCode(), HttpStatus.BAD_REQUEST.code())),
-                new Tester("/legacy/test2/one%2ftwo/%2f/three", response -> assertEquals(response.getStatusCode(), HttpStatus.BAD_REQUEST.code())),
-                new Tester("/legacy/test2/one%2ftwo/%5C/three", response -> assertEquals(response.getStatusCode(), HttpStatus.BAD_REQUEST.code())));
+                new Tester("/legacy/test1/one%2ftwo/%2f/three", response -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST.code())),
+                new Tester("/legacy/test2/one%2ftwo/%2f/three", response -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST.code())),
+                new Tester("/legacy/test2/one%2ftwo/%5C/three", response -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST.code())));
     }
 
     @Test
     public void testLegacyUriMode()
     {
         doTest(true,
-                new Tester("/legacy/test1/one%2ftwo/%2f/three", response -> assertEquals(response.getValue(), ImmutableList.of("test1", "one/two", "/", "three"))),
-                new Tester("/legacy/test2/one%2ftwo/%2f/three", response -> assertEquals(response.getValue(), ImmutableList.of("test2", "one/two", "/", "three"))),
-                new Tester("/legacy/test2/one%5Cback%2ftwo/%2f/three", response -> assertEquals(response.getValue(), ImmutableList.of("test2", "one\\back/two", "/", "three"))));
+                new Tester("/legacy/test1/one%2ftwo/%2f/three", response -> assertThat(response.getValue()).isEqualTo(ImmutableList.of("test1", "one/two", "/", "three"))),
+                new Tester("/legacy/test2/one%2ftwo/%2f/three", response -> assertThat(response.getValue()).isEqualTo(ImmutableList.of("test2", "one/two", "/", "three"))),
+                new Tester("/legacy/test2/one%5Cback%2ftwo/%2f/three", response -> assertThat(response.getValue()).isEqualTo(ImmutableList.of("test2", "one\\back/two", "/", "three"))));
     }
 
     private record Tester(String path, Consumer<JsonResponse<List<String>>> responseConsumer) {}

--- a/jaxrs/src/test/java/io/airlift/jaxrs/programmatic/TestProgrammaticResource.java
+++ b/jaxrs/src/test/java/io/airlift/jaxrs/programmatic/TestProgrammaticResource.java
@@ -30,7 +30,7 @@ import java.util.List;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestProgrammaticResource
 {
@@ -57,9 +57,9 @@ public class TestProgrammaticResource
                 .filter(r -> r.getPath().equals("/foo/bar"))
                 .flatMap(r -> r.getAllMethods().stream())
                 .collect(toImmutableList());
-        assertEquals(foundMethods.size(), 1);
+        assertThat(foundMethods.size()).isEqualTo(1);
         ResourceMethod foundMethod = foundMethods.get(0);
-        assertEquals(foundMethod.getInvocable().getHandlingMethod(), getResultMethod);
-        assertEquals(foundMethod.getInvocable().getHandler().getHandlerClass(), getClass());
+        assertThat(foundMethod.getInvocable().getHandlingMethod()).isEqualTo(getResultMethod);
+        assertThat(foundMethod.getInvocable().getHandler().getHandlerClass()).isEqualTo(getClass());
     }
 }

--- a/jaxrs/src/test/java/io/airlift/jaxrs/testing/TestMockRequest.java
+++ b/jaxrs/src/test/java/io/airlift/jaxrs/testing/TestMockRequest.java
@@ -36,9 +36,7 @@ import static io.airlift.jaxrs.testing.MockRequest.put;
 import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
 import static jakarta.ws.rs.core.MediaType.TEXT_XML_TYPE;
 import static java.util.Locale.US;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestMockRequest
 {
@@ -69,13 +67,13 @@ public class TestMockRequest
     @Test(dataProvider = "requestBuilders")
     public void testMethod(ConditionalRequestBuilder request, String method, Variant variant)
     {
-        assertEquals(request.unconditionally().getMethod(), method);
+        assertThat(request.unconditionally().getMethod()).isEqualTo(method);
     }
 
     @Test(dataProvider = "requestBuilders")
     public void testSelectVariant(ConditionalRequestBuilder request, String method, Variant variant)
     {
-        assertEquals(request.unconditionally().selectVariant(VARIANTS), variant);
+        assertThat(request.unconditionally().selectVariant(VARIANTS)).isEqualTo(variant);
     }
 
     @Test(dataProvider = "requestBuilders")
@@ -148,27 +146,27 @@ public class TestMockRequest
 
     private void assertPreconditionsMet(ResponseBuilder responseBuilder)
     {
-        assertNull(responseBuilder, "Expected null response builder");
+        assertThat(responseBuilder).as("Expected null response builder").isNull();
     }
 
     private void assertPreconditionsFailed(ResponseBuilder responseBuilder)
     {
-        assertNotNull(responseBuilder, "Expected a response builder");
+        assertThat(responseBuilder).as("Expected a response builder").isNotNull();
         Response response = responseBuilder.build();
-        assertEquals(response.getStatus(), Status.PRECONDITION_FAILED.getStatusCode());
+        assertThat(response.getStatus()).isEqualTo(Status.PRECONDITION_FAILED.getStatusCode());
     }
 
     private void assertIfNoneMatchFailed(String method, ResponseBuilder responseBuilder)
     {
-        assertNotNull(responseBuilder, "Expected a response builder");
+        assertThat(responseBuilder).as("Expected a response builder").isNotNull();
         Response response = responseBuilder.build();
 
         // not modified only applies to GET and HEAD; otherwise it is a precondition failed
         if ("GET".equalsIgnoreCase(method) || "HEAD".equalsIgnoreCase(method)) {
-            assertEquals(response.getStatus(), Status.NOT_MODIFIED.getStatusCode());
+            assertThat(response.getStatus()).isEqualTo(Status.NOT_MODIFIED.getStatusCode());
         }
         else {
-            assertEquals(response.getStatus(), Status.PRECONDITION_FAILED.getStatusCode());
+            assertThat(response.getStatus()).isEqualTo(Status.PRECONDITION_FAILED.getStatusCode());
         }
     }
 
@@ -176,13 +174,13 @@ public class TestMockRequest
     {
         // if modified since only applies to GET and HEAD; otherwise it process request
         if (!("GET".equalsIgnoreCase(method) || "HEAD".equalsIgnoreCase(method))) {
-            assertNull(responseBuilder, "Did NOT expect a response builder");
+            assertThat(responseBuilder).as("Did NOT expect a response builder").isNull();
         }
         else {
-            assertNotNull(responseBuilder, "Expected a response builder");
+            assertThat(responseBuilder).as("Expected a response builder").isNotNull();
             Response response = responseBuilder.build();
 
-            assertEquals(response.getStatus(), Status.NOT_MODIFIED.getStatusCode());
+            assertThat(response.getStatus()).isEqualTo(Status.NOT_MODIFIED.getStatusCode());
         }
     }
 }

--- a/jmx-http-rpc/pom.xml
+++ b/jmx-http-rpc/pom.xml
@@ -76,6 +76,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/jmx-http-rpc/src/test/java/io/airlift/jmx/http/rpc/TestMBeanServerResource.java
+++ b/jmx-http-rpc/src/test/java/io/airlift/jmx/http/rpc/TestMBeanServerResource.java
@@ -45,9 +45,8 @@ import javax.management.remote.JMXServiceURL;
 import java.lang.management.ManagementFactory;
 import java.util.UUID;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.weakref.jmx.ObjectNames.generatedNameOf;
 
 @Test(singleThreaded = true)
@@ -105,95 +104,93 @@ public class TestMBeanServerResource
     public void testGetMBeanCount()
             throws Exception
     {
-        assertEquals(mbeanServerConnection.getMBeanCount(), platformMBeanServer.getMBeanCount());
+        assertThat(mbeanServerConnection.getMBeanCount()).isEqualTo(platformMBeanServer.getMBeanCount());
     }
 
     @Test
     public void testIsRegistered()
             throws Exception
     {
-        assertEquals(mbeanServerConnection.isRegistered(testMBeanName), true);
-        assertEquals(mbeanServerConnection.isRegistered(new ObjectName("fake", "fake", "fake")), false);
+        assertThat(mbeanServerConnection.isRegistered(testMBeanName)).isEqualTo(true);
+        assertThat(mbeanServerConnection.isRegistered(new ObjectName("fake", "fake", "fake"))).isEqualTo(false);
     }
 
     @Test
     public void testIsInstanceOf()
             throws Exception
     {
-        assertEquals(mbeanServerConnection.isInstanceOf(testMBeanName, TestMBean.class.getName()), true);
-        assertEquals(mbeanServerConnection.isInstanceOf(testMBeanName, Object.class.getName()), true);
-        assertEquals(mbeanServerConnection.isInstanceOf(testMBeanName, UUID.class.getName()), false);
+        assertThat(mbeanServerConnection.isInstanceOf(testMBeanName, TestMBean.class.getName())).isEqualTo(true);
+        assertThat(mbeanServerConnection.isInstanceOf(testMBeanName, Object.class.getName())).isEqualTo(true);
+        assertThat(mbeanServerConnection.isInstanceOf(testMBeanName, UUID.class.getName())).isEqualTo(false);
     }
 
     @Test
     public void testGetDefaultDomain()
             throws Exception
     {
-        assertEquals(mbeanServerConnection.getDefaultDomain(), platformMBeanServer.getDefaultDomain());
+        assertThat(mbeanServerConnection.getDefaultDomain()).isEqualTo(platformMBeanServer.getDefaultDomain());
     }
 
     @Test
     public void testGetDomains()
             throws Exception
     {
-        assertEquals(mbeanServerConnection.getDomains(), platformMBeanServer.getDomains());
+        assertThat(mbeanServerConnection.getDomains()).isEqualTo(platformMBeanServer.getDomains());
     }
 
     @Test
     public void testGetObjectInstance()
             throws Exception
     {
-        assertEquals(mbeanServerConnection.getObjectInstance(testMBeanName), platformMBeanServer.getObjectInstance(testMBeanName));
+        assertThat(mbeanServerConnection.getObjectInstance(testMBeanName)).isEqualTo(platformMBeanServer.getObjectInstance(testMBeanName));
     }
 
     @Test
     public void testGetMBeanInfo()
             throws Exception
     {
-        assertEquals(mbeanServerConnection.getMBeanInfo(testMBeanName), platformMBeanServer.getMBeanInfo(testMBeanName));
+        assertThat(mbeanServerConnection.getMBeanInfo(testMBeanName)).isEqualTo(platformMBeanServer.getMBeanInfo(testMBeanName));
     }
 
     @Test
     public void testGetQueryMBeanNames()
             throws Exception
     {
-        assertEquals(mbeanServerConnection.queryNames(testMBeanName, null), platformMBeanServer.queryNames(testMBeanName, null));
-        assertEquals(mbeanServerConnection.queryNames(new ObjectName("*:*"), null), platformMBeanServer.queryNames(new ObjectName("*:*"), null));
+        assertThat(mbeanServerConnection.queryNames(testMBeanName, null)).isEqualTo(platformMBeanServer.queryNames(testMBeanName, null));
+        assertThat(mbeanServerConnection.queryNames(new ObjectName("*:*"), null)).isEqualTo(platformMBeanServer.queryNames(new ObjectName("*:*"), null));
     }
 
     @Test
     public void testGetQueryMBeans()
             throws Exception
     {
-        assertEquals(mbeanServerConnection.queryMBeans(testMBeanName, null), platformMBeanServer.queryMBeans(testMBeanName, null));
-        assertEquals(mbeanServerConnection.queryMBeans(new ObjectName("*:*"), null), platformMBeanServer.queryMBeans(new ObjectName("*:*"), null));
+        assertThat(mbeanServerConnection.queryMBeans(testMBeanName, null)).isEqualTo(platformMBeanServer.queryMBeans(testMBeanName, null));
+        assertThat(mbeanServerConnection.queryMBeans(new ObjectName("*:*"), null)).isEqualTo(platformMBeanServer.queryMBeans(new ObjectName("*:*"), null));
     }
 
     @Test
     public void testGetAttribute()
             throws Exception
     {
-        assertEquals(mbeanServerConnection.getAttribute(testMBeanName, "Value"), null);
+        assertThat(mbeanServerConnection.getAttribute(testMBeanName, "Value")).isEqualTo(null);
         testMBean.setValue("FOO");
-        assertEquals(mbeanServerConnection.getAttribute(testMBeanName, "Value"), "FOO");
+        assertThat(mbeanServerConnection.getAttribute(testMBeanName, "Value")).isEqualTo("FOO");
 
-        assertEquals(mbeanServerConnection.getAttribute(testMBeanName, "ObjectValue"), null);
+        assertThat(mbeanServerConnection.getAttribute(testMBeanName, "ObjectValue")).isEqualTo(null);
         testMBean.setObjectValue(UUID.randomUUID());
-        assertEquals(mbeanServerConnection.getAttribute(testMBeanName, "ObjectValue"), testMBean.getObjectValue());
+        assertThat(mbeanServerConnection.getAttribute(testMBeanName, "ObjectValue")).isEqualTo(testMBean.getObjectValue());
     }
 
     @Test
     public void testGetAttributes()
             throws Exception
     {
-        assertEquals(mbeanServerConnection.getAttributes(testMBeanName, new String[] {"Value", "ObjectValue"}),
-                new AttributeList(ImmutableList.of(new Attribute("Value", null), new Attribute("ObjectValue", null))));
+        assertThat(mbeanServerConnection.getAttributes(testMBeanName, new String[] {"Value", "ObjectValue"})).isEqualTo(new AttributeList(ImmutableList.of(new Attribute("Value", null), new Attribute("ObjectValue", null))));
 
         testMBean.setValue("FOO");
         testMBean.setObjectValue(UUID.randomUUID());
 
-        assertEquals(mbeanServerConnection.getAttributes(testMBeanName, new String[] {"Value", "ObjectValue"}),
-                new AttributeList(ImmutableList.of(new Attribute("Value", "FOO"), new Attribute("ObjectValue", testMBean.getObjectValue()))));
+        assertThat(mbeanServerConnection.getAttributes(testMBeanName, new String[] {"Value", "ObjectValue"})).isEqualTo(new AttributeList(ImmutableList.of(new Attribute("Value", "FOO"), new Attribute("ObjectValue", testMBean.getObjectValue()))));
     }
 
     @Test
@@ -201,15 +198,15 @@ public class TestMBeanServerResource
             throws Exception
     {
         mbeanServerConnection.setAttribute(testMBeanName, new Attribute("Value", "Foo"));
-        assertEquals(testMBean.getValue(), "Foo");
+        assertThat(testMBean.getValue()).isEqualTo("Foo");
         mbeanServerConnection.setAttribute(testMBeanName, new Attribute("Value", null));
-        assertEquals(testMBean.getValue(), null);
+        assertThat(testMBean.getValue()).isEqualTo(null);
 
         UUID uuid = UUID.randomUUID();
         mbeanServerConnection.setAttribute(testMBeanName, new Attribute("ObjectValue", uuid));
-        assertEquals(testMBean.getObjectValue(), uuid);
+        assertThat(testMBean.getObjectValue()).isEqualTo(uuid);
         mbeanServerConnection.setAttribute(testMBeanName, new Attribute("ObjectValue", null));
-        assertEquals(testMBean.getObjectValue(), null);
+        assertThat(testMBean.getObjectValue()).isEqualTo(null);
     }
 
     @Test
@@ -218,24 +215,24 @@ public class TestMBeanServerResource
     {
         UUID uuid = UUID.randomUUID();
         mbeanServerConnection.setAttributes(testMBeanName, new AttributeList(ImmutableList.of(new Attribute("Value", "Foo"), new Attribute("ObjectValue", uuid))));
-        assertEquals(testMBean.getValue(), "Foo");
-        assertEquals(testMBean.getObjectValue(), uuid);
+        assertThat(testMBean.getValue()).isEqualTo("Foo");
+        assertThat(testMBean.getObjectValue()).isEqualTo(uuid);
 
         mbeanServerConnection.setAttributes(testMBeanName, new AttributeList(ImmutableList.of(new Attribute("Value", null), new Attribute("ObjectValue", null))));
-        assertEquals(testMBean.getValue(), null);
-        assertEquals(testMBean.getObjectValue(), null);
+        assertThat(testMBean.getValue()).isEqualTo(null);
+        assertThat(testMBean.getObjectValue()).isEqualTo(null);
     }
 
     @Test
     public void testInvoke()
             throws Exception
     {
-        assertEquals(testMBean.noArgsMethodInvoked, false);
+        assertThat(testMBean.noArgsMethodInvoked).isEqualTo(false);
         mbeanServerConnection.invoke(testMBeanName, "noArgsMethod", null, null);
-        assertEquals(testMBean.noArgsMethodInvoked, true);
+        assertThat(testMBean.noArgsMethodInvoked).isEqualTo(true);
 
         UUID uuid = UUID.randomUUID();
-        assertEquals(mbeanServerConnection.invoke(testMBeanName, "echo", new Object[] {uuid}, new String[] {Object.class.getName()}), uuid);
+        assertThat(mbeanServerConnection.invoke(testMBeanName, "echo", new Object[] {uuid}, new String[] {Object.class.getName()})).isEqualTo(uuid);
     }
 
     @Test
@@ -247,8 +244,8 @@ public class TestMBeanServerResource
             fail("Expected exception");
         }
         catch (MBeanException e) {
-            assertTrue(e.getCause() instanceof Exception);
-            assertEquals(e.getCause().getMessage(), "exception-message");
+            assertThat(e).hasCauseInstanceOf(Exception.class);
+            assertThat(e).hasStackTraceContaining("exception-message");
         }
     }
 

--- a/jmx-http/pom.xml
+++ b/jmx-http/pom.xml
@@ -100,6 +100,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/jmx-http/src/test/java/io/airlift/jmx/TestMBeanResource.java
+++ b/jmx-http/src/test/java/io/airlift/jmx/TestMBeanResource.java
@@ -41,8 +41,7 @@ import static io.airlift.testing.Assertions.assertContains;
 import static io.airlift.testing.Assertions.assertEqualsIgnoreOrder;
 import static java.lang.management.ManagementFactory.MEMORY_MXBEAN_NAME;
 import static java.lang.management.ManagementFactory.RUNTIME_MXBEAN_NAME;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestMBeanResource
 {
@@ -99,7 +98,7 @@ public class TestMBeanResource
                 prepareGet().setUri(uriFor("/v1/jmx")).build(),
                 createStringResponseHandler());
 
-        assertEquals(response.getStatusCode(), 200);
+        assertThat(response.getStatusCode()).isEqualTo(200);
         assertContentType(response, HTML_UTF_8);
         assertContains(response.getBody(), "<html>");
     }
@@ -123,12 +122,12 @@ public class TestMBeanResource
         List<String> names = new ArrayList<>();
         for (JsonNode mbean : mbeans) {
             JsonNode name = mbean.get("objectName");
-            assertTrue(name.isTextual());
+            assertThat(name.isTextual()).isTrue();
             names.add(name.asText());
         }
 
-        assertTrue(names.contains(MEMORY_MXBEAN_NAME));
-        assertTrue(names.contains(RUNTIME_MXBEAN_NAME));
+        assertThat(names).contains(MEMORY_MXBEAN_NAME);
+        assertThat(names).contains(RUNTIME_MXBEAN_NAME);
         assertEqualsIgnoreOrder(names, getMBeanNames());
     }
 
@@ -142,8 +141,8 @@ public class TestMBeanResource
         JsonNode mbean = jsonRequest(uri);
 
         JsonNode name = mbean.get("objectName");
-        assertTrue(name.isTextual());
-        assertEquals(name.asText(), mbeanName);
+        assertThat(name.isTextual()).isTrue();
+        assertThat(name.asText()).isEqualTo(mbeanName);
     }
 
     @Test(dataProvider = "mbeanNames")
@@ -156,8 +155,8 @@ public class TestMBeanResource
         JsonNode mbean = jsonpRequest(uri);
 
         JsonNode name = mbean.get("objectName");
-        assertTrue(name.isTextual());
-        assertEquals(name.asText(), mbeanName);
+        assertThat(name.isTextual()).isTrue();
+        assertThat(name.asText()).isEqualTo(mbeanName);
     }
 
     private JsonNode jsonRequest(URI uri)
@@ -166,7 +165,7 @@ public class TestMBeanResource
         Request request = prepareGet().setUri(uri).build();
         StringResponse response = client.execute(request, createStringResponseHandler());
 
-        assertEquals(response.getStatusCode(), 200, response.getBody());
+        assertThat(response.getStatusCode()).as(response.getBody()).isEqualTo(200);
         assertContentType(response, JSON_UTF_8);
 
         return new ObjectMapperProvider().get().readTree(response.getBody());
@@ -181,12 +180,12 @@ public class TestMBeanResource
         Request request = prepareGet().setUri(uri).build();
         StringResponse response = client.execute(request, createStringResponseHandler());
 
-        assertEquals(response.getStatusCode(), 200, response.getBody());
+        assertThat(response.getStatusCode()).as(response.getBody()).isEqualTo(200);
         assertContentType(response, JSON_UTF_8);
 
         String jsonp = response.getBody().trim();
-        assertTrue(jsonp.startsWith("test("), jsonp);
-        assertTrue(jsonp.endsWith(")"), jsonp);
+        assertThat(jsonp).startsWith("test(");
+        assertThat(jsonp).endsWith(")");
         jsonp = jsonp.substring(5, jsonp.length() - 1);
 
         return new ObjectMapperProvider().get().readTree(jsonp);
@@ -209,6 +208,6 @@ public class TestMBeanResource
     private static void assertContentType(StringResponse response, MediaType type)
     {
         String contentType = response.getHeader(CONTENT_TYPE);
-        assertTrue(MediaType.parse(contentType).is(type.withoutParameters()), contentType);
+        assertThat(MediaType.parse(contentType).is(type.withoutParameters())).as(contentType).isTrue();
     }
 }

--- a/json/src/test/java/io/airlift/json/ImmutablePerson.java
+++ b/json/src/test/java/io/airlift/json/ImmutablePerson.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ImmutablePerson
 {
@@ -38,10 +38,10 @@ public class ImmutablePerson
         ImmutablePerson expected = new ImmutablePerson("dain", true);
 
         String json = jsonCodec.toJson(expected);
-        assertEquals(jsonCodec.fromJson(json), expected);
+        assertThat(jsonCodec.fromJson(json)).isEqualTo(expected);
 
         byte[] bytes = jsonCodec.toJsonBytes(expected);
-        assertEquals(jsonCodec.fromJson(bytes), expected);
+        assertThat(jsonCodec.fromJson(bytes)).isEqualTo(expected);
     }
 
     public static void validatePersonListJsonCodec(JsonCodec<List<ImmutablePerson>> jsonCodec)
@@ -52,10 +52,10 @@ public class ImmutablePerson
                 new ImmutablePerson("mark", true));
 
         String json = jsonCodec.toJson(expected);
-        assertEquals(jsonCodec.fromJson(json), expected);
+        assertThat(jsonCodec.fromJson(json)).isEqualTo(expected);
 
         byte[] bytes = jsonCodec.toJsonBytes(expected);
-        assertEquals(jsonCodec.fromJson(bytes), expected);
+        assertThat(jsonCodec.fromJson(bytes)).isEqualTo(expected);
     }
 
     public static void validatePersonMapJsonCodec(JsonCodec<Map<String, ImmutablePerson>> jsonCodec)
@@ -67,10 +67,10 @@ public class ImmutablePerson
                 .build();
 
         String json = jsonCodec.toJson(expected);
-        assertEquals(jsonCodec.fromJson(json), expected);
+        assertThat(jsonCodec.fromJson(json)).isEqualTo(expected);
 
         byte[] bytes = jsonCodec.toJsonBytes(expected);
-        assertEquals(jsonCodec.fromJson(bytes), expected);
+        assertThat(jsonCodec.fromJson(bytes)).isEqualTo(expected);
     }
 
     @JsonCreator

--- a/json/src/test/java/io/airlift/json/Person.java
+++ b/json/src/test/java/io/airlift/json/Person.java
@@ -25,9 +25,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class Person
 {
@@ -41,31 +39,31 @@ public class Person
         Person expected = new Person().setName("dain").setRocks(true);
 
         String json = jsonCodec.toJson(expected);
-        assertFalse(json.contains("lastName"));
-        assertEquals(jsonCodec.fromJson(json), expected);
+        assertThat(json).doesNotContain("lastName");
+        assertThat(jsonCodec.fromJson(json)).isEqualTo(expected);
 
         byte[] bytes = jsonCodec.toJsonBytes(expected);
-        assertEquals(jsonCodec.fromJson(bytes), expected);
+        assertThat(jsonCodec.fromJson(bytes)).isEqualTo(expected);
 
         // create object with missing lastName
         expected.setLastName(Optional.empty());
 
         json = jsonCodec.toJson(expected);
-        assertFalse(json.contains("lastName"));
-        assertEquals(jsonCodec.fromJson(json), expected);
+        assertThat(json).doesNotContain("lastName");
+        assertThat(jsonCodec.fromJson(json)).isEqualTo(expected);
 
         bytes = jsonCodec.toJsonBytes(expected);
-        assertEquals(jsonCodec.fromJson(bytes), expected);
+        assertThat(jsonCodec.fromJson(bytes)).isEqualTo(expected);
 
         // create object with present lastName
         expected.setLastName(Optional.of("Awesome"));
 
         json = jsonCodec.toJson(expected);
-        assertTrue(json.contains("lastName"));
-        assertEquals(jsonCodec.fromJson(json), expected);
+        assertThat(json).contains("lastName");
+        assertThat(jsonCodec.fromJson(json)).isEqualTo(expected);
 
         bytes = jsonCodec.toJsonBytes(expected);
-        assertEquals(jsonCodec.fromJson(bytes), expected);
+        assertThat(jsonCodec.fromJson(bytes)).isEqualTo(expected);
     }
 
     public static void validatePersonListJsonCodec(JsonCodec<List<Person>> jsonCodec)
@@ -76,10 +74,10 @@ public class Person
                 new Person().setName("mark").setRocks(true));
 
         String json = jsonCodec.toJson(expected);
-        assertEquals(jsonCodec.fromJson(json), expected);
+        assertThat(jsonCodec.fromJson(json)).isEqualTo(expected);
 
         byte[] bytes = jsonCodec.toJsonBytes(expected);
-        assertEquals(jsonCodec.fromJson(bytes), expected);
+        assertThat(jsonCodec.fromJson(bytes)).isEqualTo(expected);
     }
 
     public static void validatePersonMapJsonCodec(JsonCodec<Map<String, Person>> jsonCodec)
@@ -91,10 +89,10 @@ public class Person
                 .build();
 
         String json = jsonCodec.toJson(expected);
-        assertEquals(jsonCodec.fromJson(json), expected);
+        assertThat(jsonCodec.fromJson(json)).isEqualTo(expected);
 
         byte[] bytes = jsonCodec.toJsonBytes(expected);
-        assertEquals(jsonCodec.fromJson(bytes), expected);
+        assertThat(jsonCodec.fromJson(bytes)).isEqualTo(expected);
     }
 
     @JsonProperty

--- a/json/src/test/java/io/airlift/json/TestJsonCodec.java
+++ b/json/src/test/java/io/airlift/json/TestJsonCodec.java
@@ -32,11 +32,8 @@ import static io.airlift.json.JsonCodec.jsonCodec;
 import static io.airlift.json.JsonCodec.listJsonCodec;
 import static io.airlift.json.JsonCodec.mapJsonCodec;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
 
 public class TestJsonCodec
 {
@@ -97,7 +94,7 @@ public class TestJsonCodec
         list.add(null);
         list.add("abc");
 
-        assertEquals(jsonCodec.fromJson(jsonCodec.toJson(list)), list);
+        assertThat(jsonCodec.fromJson(jsonCodec.toJson(list))).isEqualTo(list);
     }
 
     @Test
@@ -145,7 +142,7 @@ public class TestJsonCodec
         map.put("x", null);
         map.put("y", "abc");
 
-        assertEquals(jsonCodec.fromJson(jsonCodec.toJson(map)), map);
+        assertThat(jsonCodec.fromJson(jsonCodec.toJson(map))).isEqualTo(map);
     }
 
     @Test
@@ -161,7 +158,7 @@ public class TestJsonCodec
     {
         JsonCodec<ImmutablePerson> jsonCodec = jsonCodec(ImmutablePerson.class);
         ImmutablePerson immutablePerson = jsonCodec.fromJson("{ \"notWritable\": \"foo\" }");
-        assertNull(immutablePerson.getNotWritable());
+        assertThat(immutablePerson.getNotWritable()).isNull();
     }
 
     @Test
@@ -218,10 +215,10 @@ public class TestJsonCodec
         JsonCodec<ImmutablePerson> jsonCodec = jsonCodec(ImmutablePerson.class);
         ImmutablePerson person = new ImmutablePerson(Strings.repeat("a", 1000), false);
 
-        assertFalse(jsonCodec.toJsonWithLengthLimit(person, 0).isPresent());
-        assertFalse(jsonCodec.toJsonWithLengthLimit(person, 1000).isPresent());
-        assertFalse(jsonCodec.toJsonWithLengthLimit(person, 1035).isPresent());
-        assertTrue(jsonCodec.toJsonWithLengthLimit(person, 1036).isPresent());
+        assertThat(jsonCodec.toJsonWithLengthLimit(person, 0)).isNotPresent();
+        assertThat(jsonCodec.toJsonWithLengthLimit(person, 1000)).isNotPresent();
+        assertThat(jsonCodec.toJsonWithLengthLimit(person, 1035)).isNotPresent();
+        assertThat(jsonCodec.toJsonWithLengthLimit(person, 1036)).isPresent();
     }
 
     @Test
@@ -231,10 +228,10 @@ public class TestJsonCodec
         ImmutablePerson person = new ImmutablePerson(Strings.repeat("a", DEFAULT_MAX_STRING_LEN + 1), false);
 
         String json = jsonCodec.toJson(person);
-        assertEquals(jsonCodec.fromJson(json), person);
+        assertThat(jsonCodec.fromJson(json)).isEqualTo(person);
 
         byte[] bytes = jsonCodec.toJsonBytes(person);
-        assertEquals(jsonCodec.fromJson(bytes), person);
+        assertThat(jsonCodec.fromJson(bytes)).isEqualTo(person);
     }
 
     @Test
@@ -243,10 +240,10 @@ public class TestJsonCodec
         JsonCodec<ImmutablePerson> jsonCodec = jsonCodec(ImmutablePerson.class);
         ImmutablePerson person = new ImmutablePerson(Strings.repeat("\u0158", 1000), false);
 
-        assertFalse(jsonCodec.toJsonWithLengthLimit(person, 0).isPresent());
-        assertFalse(jsonCodec.toJsonWithLengthLimit(person, 1000).isPresent());
-        assertFalse(jsonCodec.toJsonWithLengthLimit(person, 1035).isPresent());
-        assertTrue(jsonCodec.toJsonWithLengthLimit(person, 1036).isPresent());
+        assertThat(jsonCodec.toJsonWithLengthLimit(person, 0)).isNotPresent();
+        assertThat(jsonCodec.toJsonWithLengthLimit(person, 1000)).isNotPresent();
+        assertThat(jsonCodec.toJsonWithLengthLimit(person, 1035)).isNotPresent();
+        assertThat(jsonCodec.toJsonWithLengthLimit(person, 1036)).isPresent();
     }
 
     @Test
@@ -256,10 +253,10 @@ public class TestJsonCodec
         ImmutablePerson person = new ImmutablePerson(Strings.repeat("a", 1000), false);
         List<ImmutablePerson> people = Collections.nCopies(10, person);
 
-        assertFalse(jsonCodec.toJsonWithLengthLimit(people, 0).isPresent());
-        assertFalse(jsonCodec.toJsonWithLengthLimit(people, 5000).isPresent());
-        assertFalse(jsonCodec.toJsonWithLengthLimit(people, 10381).isPresent());
-        assertTrue(jsonCodec.toJsonWithLengthLimit(people, 10382).isPresent());
+        assertThat(jsonCodec.toJsonWithLengthLimit(people, 0)).isNotPresent();
+        assertThat(jsonCodec.toJsonWithLengthLimit(people, 5000)).isNotPresent();
+        assertThat(jsonCodec.toJsonWithLengthLimit(people, 10381)).isNotPresent();
+        assertThat(jsonCodec.toJsonWithLengthLimit(people, 10382)).isPresent();
     }
 
     @Test
@@ -268,7 +265,7 @@ public class TestJsonCodec
         JsonCodec<ImmutablePerson> codec = jsonCodec(ImmutablePerson.class);
 
         String json = "{\"name\":\"Me\",\"rocks\":true}";
-        assertEquals(codec.fromJson(json).getName(), "Me");
+        assertThat(codec.fromJson(json).getName()).isEqualTo("Me");
 
         String jsonWithTrailingContent = json + " trailer";
         assertThatThrownBy(() -> codec.fromJson(jsonWithTrailingContent))
@@ -324,9 +321,7 @@ public class TestJsonCodec
                 }\
                 """);
 
-        assertEquals(
-                JsonCodec.jsonCodec(LegacyRecordAdditionalGetter.class).toJson(new LegacyRecordAdditionalGetter("my value")),
-                """
+        assertThat(JsonCodec.jsonCodec(LegacyRecordAdditionalGetter.class).toJson(new LegacyRecordAdditionalGetter("my value"))).isEqualTo("""
                 {
                   "bar" : "there is no bar field in the record",
                   "foo" : "not really a foo value",
@@ -337,8 +332,8 @@ public class TestJsonCodec
 
     private static <T> void assertSerializationRoundTrip(JsonCodec<T> codec, T object, String expected)
     {
-        assertEquals(codec.toJson(object), expected);
-        assertEquals(codec.fromJson(expected), object);
+        assertThat(codec.toJson(object)).isEqualTo(expected);
+        assertThat(codec.fromJson(expected)).isEqualTo(object);
     }
 
     public record MyRecord(String foo) {}

--- a/json/src/test/java/io/airlift/json/TestJsonCodecBinder.java
+++ b/json/src/test/java/io/airlift/json/TestJsonCodecBinder.java
@@ -18,26 +18,25 @@ package io.airlift.json;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
-import com.google.inject.Module;
 import com.google.inject.Scopes;
 import org.testng.annotations.Test;
 
 import static io.airlift.json.JsonCodecBinder.jsonCodecBinder;
-import static org.testng.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestJsonCodecBinder
 {
     @Test
     public void ignoresRepeatedBinding()
     {
-        Injector injector = Guice.createInjector((Module) binder -> {
+        Injector injector = Guice.createInjector(binder -> {
             jsonCodecBinder(binder).bindJsonCodec(Integer.class);
             jsonCodecBinder(binder).bindJsonCodec(Integer.class);
 
             binder.bind(Dummy.class).in(Scopes.SINGLETON);
         });
 
-        assertNotNull(injector.getInstance(Dummy.class).getCodec());
+        assertThat(injector.getInstance(Dummy.class).getCodec()).isNotNull();
     }
 
     private static class Dummy

--- a/json/src/test/java/io/airlift/json/TestJsonCodecFactory.java
+++ b/json/src/test/java/io/airlift/json/TestJsonCodecFactory.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.Map;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestJsonCodecFactory
 {
@@ -40,7 +40,7 @@ public class TestJsonCodecFactory
         Person expected = new Person().setName("dain").setRocks(true);
         String json = jsonCodec.toJson(expected);
         Person actual = jsonCodec.fromJson(json);
-        assertEquals(actual, expected);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -79,7 +79,7 @@ public class TestJsonCodecFactory
 
         String json = jsonCodec.toJson(expected);
         List<Person> actual = jsonCodec.fromJson(json);
-        assertEquals(actual, expected);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -119,7 +119,7 @@ public class TestJsonCodecFactory
 
         String json = jsonCodec.toJson(expected);
         Map<String, Person> actual = jsonCodec.fromJson(json);
-        assertEquals(actual, expected);
+        assertThat(actual).isEqualTo(expected);
     }
 
     public static class Person

--- a/json/src/test/java/io/airlift/json/TestJsonModule.java
+++ b/json/src/test/java/io/airlift/json/TestJsonModule.java
@@ -45,8 +45,8 @@ import java.util.Map;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.airlift.json.JsonBinder.jsonBinder;
 import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.joda.time.DateTimeZone.UTC;
-import static org.testng.Assert.assertEquals;
 
 public class TestJsonModule
 {
@@ -88,10 +88,10 @@ public class TestJsonModule
     public void testSetup()
             throws Exception
     {
-        assertEquals(CAR, CAR);
+        assertThat(CAR).isEqualTo(CAR);
         String json = objectMapper.writeValueAsString(CAR);
         Car actual = objectMapper.readValue(json, Car.class);
-        assertEquals(actual, CAR);
+        assertThat(actual).isEqualTo(CAR);
     }
 
     @Test
@@ -102,7 +102,7 @@ public class TestJsonModule
 
         // notes is not annotated so should not be included
         // color is null so should not be included
-        assertEquals(actual.keySet(), ImmutableSet.of("make", "model", "year", "purchased", "nameList"));
+        assertThat(actual.keySet()).isEqualTo(ImmutableSet.of("make", "model", "year", "purchased", "nameList"));
     }
 
     @Test
@@ -111,7 +111,7 @@ public class TestJsonModule
     {
         Map<String, Object> actual = createCarMap();
 
-        assertEquals(actual.get("purchased"), ISODateTimeFormat.dateTime().print(CAR.getPurchased()));
+        assertThat(actual.get("purchased")).isEqualTo(ISODateTimeFormat.dateTime().print(CAR.getPurchased()));
     }
 
     @Test
@@ -123,7 +123,7 @@ public class TestJsonModule
         String json = objectMapper.writeValueAsString(list);
         ImmutableList<Integer> actual = objectMapper.readValue(json, new TypeReference<ImmutableList<Integer>>() {});
 
-        assertEquals(actual, list);
+        assertThat(actual).isEqualTo(list);
     }
 
     @Test
@@ -136,7 +136,7 @@ public class TestJsonModule
         data.put("unknown", "bogus");
 
         // Jackson should deserialize the object correctly with the extra unknown data
-        assertEquals(objectMapper.readValue(objectMapper.writeValueAsString(data), Car.class), CAR);
+        assertThat(objectMapper.readValue(objectMapper.writeValueAsString(data), Car.class)).isEqualTo(CAR);
     }
 
     @Test
@@ -145,8 +145,8 @@ public class TestJsonModule
     {
         NoJsonPropertiesInJsonCreator value = new NoJsonPropertiesInJsonCreator("first value", "second value");
         NoJsonPropertiesInJsonCreator mapped = objectMapper.readValue(objectMapper.writeValueAsString(value), NoJsonPropertiesInJsonCreator.class);
-        assertEquals(mapped.getFirst(), "first value");
-        assertEquals(mapped.getSecond(), "second value");
+        assertThat(mapped.getFirst()).isEqualTo("first value");
+        assertThat(mapped.getSecond()).isEqualTo("second value");
     }
 
     @Test
@@ -155,7 +155,7 @@ public class TestJsonModule
     {
         JsonValueAndStaticFactoryMethod value = JsonValueAndStaticFactoryMethod.valueOf("some value");
         JsonValueAndStaticFactoryMethod mapped = objectMapper.readValue(objectMapper.writeValueAsString(value), JsonValueAndStaticFactoryMethod.class);
-        assertEquals(mapped.getValue(), "some value");
+        assertThat(mapped.getValue()).isEqualTo("some value");
     }
 
     private Map<String, Object> createCarMap()

--- a/json/src/test/java/io/airlift/json/Vehicle.java
+++ b/json/src/test/java/io/airlift/json/Vehicle.java
@@ -8,8 +8,7 @@ import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @JsonTypeInfo(
         use = JsonTypeInfo.Id.NAME,
@@ -25,20 +24,20 @@ public interface Vehicle
         Vehicle expected = new Car("bmw");
 
         String json = jsonCodec.toJson(expected);
-        assertEquals(jsonCodec.fromJson(json), expected);
-        assertTrue(json.contains("\"@type\" : \"car\""));
+        assertThat(jsonCodec.fromJson(json)).isEqualTo(expected);
+        assertThat(json.contains("\"@type\" : \"car\"")).isTrue();
 
         byte[] bytes = jsonCodec.toJsonBytes(expected);
-        assertEquals(jsonCodec.fromJson(bytes), expected);
+        assertThat(jsonCodec.fromJson(bytes)).isEqualTo(expected);
 
         expected = new Truck("volvo");
 
         json = jsonCodec.toJson(expected);
-        assertEquals(jsonCodec.fromJson(json), expected);
-        assertTrue(json.contains("\"@type\" : \"truck\""));
+        assertThat(jsonCodec.fromJson(json)).isEqualTo(expected);
+        assertThat(json.contains("\"@type\" : \"truck\"")).isTrue();
 
         bytes = jsonCodec.toJsonBytes(expected);
-        assertEquals(jsonCodec.fromJson(bytes), expected);
+        assertThat(jsonCodec.fromJson(bytes)).isEqualTo(expected);
     }
 
     static void validateVehicleListJsonCodec(JsonCodec<List<Vehicle>> jsonCodec)
@@ -48,10 +47,10 @@ public interface Vehicle
                 new Truck("volvo"));
 
         String json = jsonCodec.toJson(expected);
-        assertEquals(jsonCodec.fromJson(json), expected);
+        assertThat(jsonCodec.fromJson(json)).isEqualTo(expected);
 
         byte[] bytes = jsonCodec.toJsonBytes(expected);
-        assertEquals(jsonCodec.fromJson(bytes), expected);
+        assertThat(jsonCodec.fromJson(bytes)).isEqualTo(expected);
     }
 
     static void validateVehicleMapJsonCodec(JsonCodec<Map<String, Vehicle>> jsonCodec)
@@ -62,9 +61,9 @@ public interface Vehicle
                 .build();
 
         String json = jsonCodec.toJson(expected);
-        assertEquals(jsonCodec.fromJson(json), expected);
+        assertThat(jsonCodec.fromJson(json)).isEqualTo(expected);
 
         byte[] bytes = jsonCodec.toJsonBytes(expected);
-        assertEquals(jsonCodec.fromJson(bytes), expected);
+        assertThat(jsonCodec.fromJson(bytes)).isEqualTo(expected);
     }
 }

--- a/json/src/test/java/io/airlift/json/isolated/TestJsonCodecBinder.java
+++ b/json/src/test/java/io/airlift/json/isolated/TestJsonCodecBinder.java
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.Map;
 
 import static io.airlift.json.JsonCodecBinder.jsonCodecBinder;
-import static org.testng.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestJsonCodecBinder
 {
@@ -53,9 +53,9 @@ public class TestJsonCodecBinder
 
         injector.injectMembers(this);
 
-        assertNotNull(personJsonCodec);
-        assertNotNull(personListJsonCodec);
-        assertNotNull(personMapJsonCodec);
+        assertThat(personJsonCodec).isNotNull();
+        assertThat(personListJsonCodec).isNotNull();
+        assertThat(personMapJsonCodec).isNotNull();
 
         Person.validatePersonJsonCodec(personJsonCodec);
         Person.validatePersonListJsonCodec(personListJsonCodec);

--- a/json/src/test/java/io/airlift/json/subtype/TestJsonSubType.java
+++ b/json/src/test/java/io/airlift/json/subtype/TestJsonSubType.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
 
 import static io.airlift.json.JsonSubTypeBinder.jsonSubTypeBinder;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.testng.Assert.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestJsonSubType
 {
@@ -110,7 +110,8 @@ public class TestJsonSubType
     {
         ObjectMapper objectMapper = new ObjectMapperProvider().get();
 
-        assertThrows(InvalidDefinitionException.class, () -> internalTest(objectMapper));
+        assertThatThrownBy(() -> internalTest(objectMapper))
+                .isInstanceOf(InvalidDefinitionException.class);
     }
 
     @Test
@@ -123,7 +124,8 @@ public class TestJsonSubType
         Injector injector = Guice.createInjector(new JsonModule(), binder -> jsonSubTypeBinder(binder).bindJsonSubType(jsonSubType));
         ObjectMapper objectMapper = injector.getInstance(ObjectMapper.class);
 
-        assertThrows(IllegalArgumentException.class, () -> internalTest(objectMapper));
+        assertThatThrownBy(() -> internalTest(objectMapper))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/log-manager/src/test/java/io/airlift/log/TestJsonFormatter.java
+++ b/log-manager/src/test/java/io/airlift/log/TestJsonFormatter.java
@@ -21,7 +21,6 @@ import static io.airlift.json.JsonCodec.jsonCodec;
 import static io.airlift.json.JsonCodec.mapJsonCodec;
 import static java.time.temporal.ChronoUnit.NANOS;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.testng.Assert.assertEquals;
 
 public class TestJsonFormatter
 {
@@ -44,18 +43,16 @@ public class TestJsonFormatter
 
         assertThat(minimalJsonErrorLogLine).as("Log lines should end with newline").endsWith("\n");
 
-        assertEquals(
-                jsonCodec(JsonRecord.class).fromJson(minimalJsonErrorLogLine),
-                new JsonRecord(
-                        original.getTimestamp(),
-                        Level.ERROR,
-                        null,
-                        null,
-                        exception.getMessage(),
-                        (Object[]) null,
-                        null,
-                        Context.root(),
-                        ImmutableMap.of()));
+        assertThat(jsonCodec(JsonRecord.class).fromJson(minimalJsonErrorLogLine)).isEqualTo(new JsonRecord(
+                original.getTimestamp(),
+                Level.ERROR,
+                null,
+                null,
+                exception.getMessage(),
+                (Object[]) null,
+                null,
+                Context.root(),
+                ImmutableMap.of()));
     }
 
     @Test
@@ -82,18 +79,16 @@ public class TestJsonFormatter
                 Context.root(),
                 ImmutableMap.of());
 
-        assertEquals(
-                jsonCodec(JsonRecord.class).fromJson(jsonCodec(JsonRecord.class).toJson(original)),
-                new JsonRecord(
-                        original.getTimestamp(),
-                        original.getLevel(),
-                        original.getThread(),
-                        original.getLoggerName(),
-                        original.getMessage(),
-                        List.of(),
-                        null,
-                        Context.root(),
-                        ImmutableMap.of()));
+        assertThat(jsonCodec(JsonRecord.class).fromJson(jsonCodec(JsonRecord.class).toJson(original))).isEqualTo(new JsonRecord(
+                original.getTimestamp(),
+                original.getLevel(),
+                original.getThread(),
+                original.getLoggerName(),
+                original.getMessage(),
+                List.of(),
+                null,
+                Context.root(),
+                ImmutableMap.of()));
     }
 
     @Test
@@ -111,16 +106,16 @@ public class TestJsonFormatter
 
         assertThat(logMessage).as("Log lines should end with newline").endsWith("\n");
 
-        assertEquals(jsonRecord.getTimestamp().truncatedTo(NANOS), record.getInstant().truncatedTo(NANOS), "Ensure timestamps between the original LogRecord and Json are equal to the nano");
+        assertThat(jsonRecord.getTimestamp().truncatedTo(NANOS)).as("Ensure timestamps between the original LogRecord and Json are equal to the nano").isEqualTo(record.getInstant().truncatedTo(NANOS));
 
-        assertEquals(jsonRecord.getThread(), Thread.currentThread().getName());
-        assertEquals(jsonRecord.getLevel(), Level.fromJulLevel(record.getLevel()));
-        assertEquals(jsonRecord.getLoggerName(), record.getLoggerName());
-        assertEquals(jsonRecord.getMessage(), record.getMessage());
+        assertThat(jsonRecord.getThread()).isEqualTo(Thread.currentThread().getName());
+        assertThat(jsonRecord.getLevel()).isEqualTo(Level.fromJulLevel(record.getLevel()));
+        assertThat(jsonRecord.getLoggerName()).isEqualTo(record.getLoggerName());
+        assertThat(jsonRecord.getMessage()).isEqualTo(record.getMessage());
 
-        assertEquals(jsonMap.get("throwableClass"), testException.getClass().getName());
-        assertEquals(jsonMap.get("throwableMessage"), testException.getMessage());
-        assertEquals(jsonMap.get("stackTrace"), getStackTraceAsString(testException));
+        assertThat(jsonMap.get("throwableClass")).isEqualTo(testException.getClass().getName());
+        assertThat(jsonMap.get("throwableMessage")).isEqualTo(testException.getMessage());
+        assertThat(jsonMap.get("stackTrace")).isEqualTo(getStackTraceAsString(testException));
     }
 
     @Test
@@ -174,7 +169,7 @@ public class TestJsonFormatter
         Map<String, Object> jsonMap = mapJsonCodec(String.class, Object.class).fromJson(logMessage);
         JsonRecord jsonRecord = jsonCodec(JsonRecord.class).fromJson(logMessage);
 
-        assertEquals(jsonRecord.getMessage(), record.getMessage());
+        assertThat(jsonRecord.getMessage()).isEqualTo(record.getMessage());
         assertThat(jsonMap.get("annotations")).asInstanceOf(InstanceOfAssertFactories.map(String.class, String.class)).containsExactlyEntriesOf(logAnnotations);
     }
 }

--- a/log-manager/src/test/java/io/airlift/log/TestLogFileName.java
+++ b/log-manager/src/test/java/io/airlift/log/TestLogFileName.java
@@ -25,9 +25,7 @@ import java.util.OptionalInt;
 import static com.google.common.collect.Comparators.isInOrder;
 import static com.google.common.collect.Comparators.isInStrictOrder;
 import static java.util.Comparator.naturalOrder;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestLogFileName
 {
@@ -135,8 +133,8 @@ public class TestLogFileName
     {
         // note: no actual files are created here
         LogFileName logFileName = LogFileName.generateNextLogFileName(Paths.get(BASE_NAME), Optional.empty());
-        assertEquals(logFileName.getIndex(), OptionalInt.of(0));
-        assertEquals(logFileName.getLegacyIndex(), OptionalInt.empty());
+        assertThat(logFileName.getIndex()).isEqualTo(OptionalInt.of(0));
+        assertThat(logFileName.getLegacyIndex()).isEqualTo(OptionalInt.empty());
 
         // verify the name round trips
         assertEqualOrdering(LogFileName.parseHistoryLogFileName(BASE_NAME, logFileName.getFileName()).orElseThrow(AssertionError::new), logFileName);
@@ -151,22 +149,22 @@ public class TestLogFileName
     {
         Path path = Paths.get(BASE_NAME + "-" + suffix);
         Optional<LogFileName> logFile = LogFileName.parseHistoryLogFileName(BASE_NAME, path.getFileName().toString());
-        assertTrue(logFile.isPresent());
-        assertEquals(logFile.get().getDateTime(), dateTime);
-        assertEquals(logFile.get().getIndex(), index);
-        assertEquals(logFile.get().getLegacyIndex(), legacyIndex);
-        assertEquals(logFile.get().getSlug(), Optional.empty());
-        assertEquals(logFile.get().isCompressed(), compressed);
+        assertThat(logFile).isPresent();
+        assertThat(logFile.get().getDateTime()).isEqualTo(dateTime);
+        assertThat(logFile.get().getIndex()).isEqualTo(index);
+        assertThat(logFile.get().getLegacyIndex()).isEqualTo(legacyIndex);
+        assertThat(logFile.get().getSlug()).isEqualTo(Optional.empty());
+        assertThat(logFile.get().isCompressed()).isEqualTo(compressed);
     }
 
     private static void assertOrdering(LogFileName... logFileNames)
     {
-        assertTrue(isInStrictOrder(ImmutableList.copyOf(logFileNames), naturalOrder()));
+        assertThat(isInStrictOrder(ImmutableList.copyOf(logFileNames), naturalOrder())).isTrue();
     }
 
     private static void assertEqualOrdering(LogFileName... logFileNames)
     {
-        assertTrue(isInOrder(ImmutableList.copyOf(logFileNames), naturalOrder()));
-        assertFalse(isInStrictOrder(ImmutableList.copyOf(logFileNames), naturalOrder()));
+        assertThat(isInOrder(ImmutableList.copyOf(logFileNames), naturalOrder())).isTrue();
+        assertThat(isInStrictOrder(ImmutableList.copyOf(logFileNames), naturalOrder())).isFalse();
     }
 }

--- a/log-manager/src/test/java/io/airlift/log/TestLogHistoryManager.java
+++ b/log-manager/src/test/java/io/airlift/log/TestLogHistoryManager.java
@@ -29,7 +29,7 @@ import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static io.airlift.units.DataSize.Unit.BYTE;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static java.nio.file.StandardOpenOption.CREATE_NEW;
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestLogHistoryManager
 {
@@ -75,11 +75,11 @@ public class TestLogHistoryManager
 
     private static void assertLogFiles(LogHistoryManager logHistoryManager, List<LogFileName> expected)
     {
-        assertEquals(logHistoryManager.getTotalSize(), expected.size() * FILE_SIZE);
+        assertThat(logHistoryManager.getTotalSize()).isEqualTo(expected.size() * FILE_SIZE);
         List<LogFileName> files = logHistoryManager.getFiles().stream()
                 .sorted()
                 .collect(toImmutableList());
-        assertEquals(files, expected);
+        assertThat(files).isEqualTo(expected);
     }
 
     @Test

--- a/log-manager/src/test/java/io/airlift/log/TestLogging.java
+++ b/log-manager/src/test/java/io/airlift/log/TestLogging.java
@@ -26,8 +26,7 @@ import java.io.IOException;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static java.nio.file.Files.createTempDirectory;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Test(singleThreaded = true)
 public class TestLogging
@@ -67,13 +66,13 @@ public class TestLogging
         Logging logging = Logging.initialize();
         logging.configure(configuration);
 
-        assertTrue(logFile1.exists());
-        assertTrue(logFile2.exists());
-        assertFalse(tempLogFile1.exists());
-        assertFalse(tempLogFile2.exists());
+        assertThat(logFile1).exists();
+        assertThat(logFile2).exists();
+        assertThat(tempLogFile1).doesNotExist();
+        assertThat(tempLogFile2).doesNotExist();
 
-        assertTrue(new File(tempDir, "temp1.log").exists());
-        assertTrue(new File(tempDir, "temp2.log").exists());
+        assertThat(new File(tempDir, "temp1.log")).exists();
+        assertThat(new File(tempDir, "temp2.log")).exists();
     }
 
     @Test
@@ -84,20 +83,20 @@ public class TestLogging
         Logger logger = Logger.get("testPropagatesLevels");
 
         logging.setLevel("testPropagatesLevels", Level.ERROR);
-        assertFalse(logger.isDebugEnabled());
-        assertFalse(logger.isInfoEnabled());
+        assertThat(logger.isDebugEnabled()).isFalse();
+        assertThat(logger.isInfoEnabled()).isFalse();
 
         logging.setLevel("testPropagatesLevels", Level.WARN);
-        assertFalse(logger.isDebugEnabled());
-        assertFalse(logger.isInfoEnabled());
+        assertThat(logger.isDebugEnabled()).isFalse();
+        assertThat(logger.isInfoEnabled()).isFalse();
 
         logging.setLevel("testPropagatesLevels", Level.INFO);
-        assertFalse(logger.isDebugEnabled());
-        assertTrue(logger.isInfoEnabled());
+        assertThat(logger.isDebugEnabled()).isFalse();
+        assertThat(logger.isInfoEnabled()).isTrue();
 
         logging.setLevel("testPropagatesLevels", Level.DEBUG);
-        assertTrue(logger.isDebugEnabled());
-        assertTrue(logger.isInfoEnabled());
+        assertThat(logger.isDebugEnabled()).isTrue();
+        assertThat(logger.isInfoEnabled()).isTrue();
     }
 
     @Test
@@ -108,20 +107,20 @@ public class TestLogging
         Logger logger = Logger.get("testPropagatesLevelsHierarchical.child");
 
         logging.setLevel("testPropagatesLevelsHierarchical", Level.ERROR);
-        assertFalse(logger.isDebugEnabled());
-        assertFalse(logger.isInfoEnabled());
+        assertThat(logger.isDebugEnabled()).isFalse();
+        assertThat(logger.isInfoEnabled()).isFalse();
 
         logging.setLevel("testPropagatesLevelsHierarchical", Level.WARN);
-        assertFalse(logger.isDebugEnabled());
-        assertFalse(logger.isInfoEnabled());
+        assertThat(logger.isDebugEnabled()).isFalse();
+        assertThat(logger.isInfoEnabled()).isFalse();
 
         logging.setLevel("testPropagatesLevelsHierarchical", Level.INFO);
-        assertFalse(logger.isDebugEnabled());
-        assertTrue(logger.isInfoEnabled());
+        assertThat(logger.isDebugEnabled()).isFalse();
+        assertThat(logger.isInfoEnabled()).isTrue();
 
         logging.setLevel("testPropagatesLevelsHierarchical", Level.DEBUG);
-        assertTrue(logger.isDebugEnabled());
-        assertTrue(logger.isInfoEnabled());
+        assertThat(logger.isDebugEnabled()).isTrue();
+        assertThat(logger.isInfoEnabled()).isTrue();
     }
 
     @Test
@@ -133,8 +132,8 @@ public class TestLogging
 
         logging.setLevel("testChildLevelOverridesParent", Level.DEBUG);
         logging.setLevel("testChildLevelOverridesParent.child", Level.ERROR);
-        assertFalse(logger.isDebugEnabled());
-        assertFalse(logger.isInfoEnabled());
+        assertThat(logger.isDebugEnabled()).isFalse();
+        assertThat(logger.isInfoEnabled()).isFalse();
     }
 
     @Test
@@ -145,8 +144,8 @@ public class TestLogging
         Logger logger = Logger.get("testClearLevel");
 
         logging.setLevel("testClearLevel", Level.DEBUG);
-        assertTrue(logger.isDebugEnabled());
+        assertThat(logger.isDebugEnabled()).isTrue();
         logging.clearLevel("testClearLevel");
-        assertFalse(logger.isDebugEnabled());
+        assertThat(logger.isDebugEnabled()).isFalse();
     }
 }

--- a/log-manager/src/test/java/io/airlift/log/TestLoggingMBean.java
+++ b/log-manager/src/test/java/io/airlift/log/TestLoggingMBean.java
@@ -19,10 +19,8 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 @Test(singleThreaded = true)
 public class TestLoggingMBean
@@ -46,40 +44,40 @@ public class TestLoggingMBean
     @Test
     public void testGetAndSetRoot()
     {
-        assertEquals(logging.getRootLevel(), "INFO");
+        assertThat(logging.getRootLevel()).isEqualTo("INFO");
 
         logging.setRootLevel("WARN");
-        assertEquals(logging.getRootLevel(), "WARN");
+        assertThat(logging.getRootLevel()).isEqualTo("WARN");
 
         logging.setRootLevel("INFO");
-        assertEquals(logging.getRootLevel(), "INFO");
+        assertThat(logging.getRootLevel()).isEqualTo("INFO");
     }
 
     @Test
     public void testGetAndSetNonExisting()
     {
-        assertEquals(logging.getRootLevel(), "INFO");
+        assertThat(logging.getRootLevel()).isEqualTo("INFO");
 
         String name = "this.logger.does.not.exist.yet.Bogus";
-        assertFalse(logging.getAllLevels().containsKey(name));
-        assertEquals(logging.getLevel(name), "INFO");
+        assertThat(logging.getAllLevels()).doesNotContainKey(name);
+        assertThat(logging.getLevel(name)).isEqualTo("INFO");
         logging.setLevel(name, "WARN");
-        assertEquals(logging.getLevel(name), "WARN");
-        assertTrue(logging.getAllLevels().containsKey(name));
+        assertThat(logging.getLevel(name)).isEqualTo("WARN");
+        assertThat(logging.getAllLevels()).containsKey(name);
 
-        assertEquals(logging.getRootLevel(), "INFO");
+        assertThat(logging.getRootLevel()).isEqualTo("INFO");
     }
 
     @Test
     public void testSetInvalidLevel()
     {
-        assertEquals(logging.getRootLevel(), "INFO");
+        assertThat(logging.getRootLevel()).isEqualTo("INFO");
         try {
             logging.setRootLevel("FOO");
             fail("Expected IllegalArgumentException");
         }
         catch (IllegalArgumentException expected) {
         }
-        assertEquals(logging.getRootLevel(), "INFO");
+        assertThat(logging.getRootLevel()).isEqualTo("INFO");
     }
 }

--- a/log-manager/src/test/java/io/airlift/log/TestLoggingOutputStream.java
+++ b/log-manager/src/test/java/io/airlift/log/TestLoggingOutputStream.java
@@ -23,10 +23,7 @@ import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestLoggingOutputStream
 {
@@ -44,7 +41,7 @@ public class TestLoggingOutputStream
         stream.println(printed);
 
         assertLog(handler.takeRecord(), Level.INFO, logged);
-        assertTrue(handler.isEmpty());
+        assertThat(handler.isEmpty()).isTrue();
     }
 
     @DataProvider
@@ -60,9 +57,9 @@ public class TestLoggingOutputStream
 
     private void assertLog(LogRecord record, Level level, String message)
     {
-        assertEquals(record.getLevel(), level);
-        assertEquals(record.getMessage(), message);
-        assertNull(record.getThrown());
+        assertThat(record.getLevel()).isEqualTo(level);
+        assertThat(record.getMessage()).isEqualTo(message);
+        assertThat(record.getThrown()).isNull();
     }
 
     private static class MockHandler
@@ -89,7 +86,9 @@ public class TestLoggingOutputStream
 
         public LogRecord takeRecord()
         {
-            assertFalse(records.isEmpty(), "No messages logged");
+            assertThat(records)
+                    .as("No messages logged")
+                    .isNotEmpty();
             return records.remove(0);
         }
 

--- a/log-manager/src/test/java/io/airlift/log/TestSocketHandler.java
+++ b/log-manager/src/test/java/io/airlift/log/TestSocketHandler.java
@@ -20,8 +20,7 @@ import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
 import static io.airlift.log.Format.TEXT;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Test(timeOut = 5 * 60 * 1000)
 public class TestSocketHandler
@@ -49,8 +48,8 @@ public class TestSocketHandler
                 String[] lines = received.split("\n");
                 for (int i = 0; i < lines.length; i++) {
                     String[] parts = lines[i].split("\t");
-                    assertEquals(parts[1], io.airlift.log.Level.fromJulLevel(levels[i]).toString());
-                    assertEquals(parts[4], data[i]);
+                    assertThat(parts[1]).isEqualTo(io.airlift.log.Level.fromJulLevel(levels[i]).toString());
+                    assertThat(parts[4]).isEqualTo(data[i]);
                 }
             }
         }
@@ -69,7 +68,7 @@ public class TestSocketHandler
         handler.flush();
         handler.close();
 
-        assertTrue(((SocketMessageOutput) handler.getMessageOutput()).getFailedConnections() > 0);
+        assertThat(((SocketMessageOutput) handler.getMessageOutput()).getFailedConnections()).isGreaterThan(0);
     }
 
     private static BufferedHandler createSocketHandler(HostAndPort hostAndPort, Formatter formatter, ErrorManager errorManager)

--- a/log/pom.xml
+++ b/log/pom.xml
@@ -30,6 +30,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/log/src/test/java/io/airlift/log/TestLogger.java
+++ b/log/src/test/java/io/airlift/log/TestLogger.java
@@ -26,10 +26,7 @@ import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Test(singleThreaded = true)
 public class TestLogger
@@ -55,23 +52,25 @@ public class TestLogger
     @AfterMethod(alwaysRun = true)
     public void teardown()
     {
-        assertTrue(handler.isEmpty(), "Some log messages were not verified by test");
+        assertThat(handler.isEmpty())
+                .as("Some log messages were not verified by test")
+                .isTrue();
     }
 
     @Test
     public void testIsDebugEnabled()
     {
         inner.setLevel(Level.FINE);
-        assertTrue(logger.isDebugEnabled());
+        assertThat(logger.isDebugEnabled()).isTrue();
 
         inner.setLevel(Level.INFO);
-        assertFalse(logger.isDebugEnabled());
+        assertThat(logger.isDebugEnabled()).isFalse();
 
         inner.setLevel(Level.WARNING);
-        assertFalse(logger.isDebugEnabled());
+        assertThat(logger.isDebugEnabled()).isFalse();
 
         inner.setLevel(Level.SEVERE);
-        assertFalse(logger.isDebugEnabled());
+        assertThat(logger.isDebugEnabled()).isFalse();
     }
 
     @Test
@@ -134,7 +133,7 @@ public class TestLogger
     {
         inner.setLevel(Level.OFF);
         logger.debug("hello");
-        assertTrue(handler.isEmpty());
+        assertThat(handler.isEmpty()).isTrue();
     }
 
     @Test
@@ -142,7 +141,7 @@ public class TestLogger
     {
         inner.setLevel(Level.OFF);
         logger.info("hello");
-        assertTrue(handler.isEmpty());
+        assertThat(handler.isEmpty()).isTrue();
     }
 
     @Test
@@ -150,7 +149,7 @@ public class TestLogger
     {
         inner.setLevel(Level.OFF);
         logger.warn("hello");
-        assertTrue(handler.isEmpty());
+        assertThat(handler.isEmpty()).isTrue();
     }
 
     @Test
@@ -162,7 +161,7 @@ public class TestLogger
         Throwable e = new Throwable();
         logger.warn(e, "hello");
 
-        assertTrue(handler.isEmpty());
+        assertThat(handler.isEmpty()).isTrue();
     }
 
     @Test
@@ -170,7 +169,7 @@ public class TestLogger
     {
         inner.setLevel(Level.OFF);
         logger.error("hello");
-        assertTrue(handler.isEmpty());
+        assertThat(handler.isEmpty()).isTrue();
     }
 
     @Test
@@ -182,7 +181,7 @@ public class TestLogger
         Throwable e = new Throwable();
         logger.error(e, "hello");
 
-        assertTrue(handler.isEmpty());
+        assertThat(handler.isEmpty()).isTrue();
     }
 
     @Test
@@ -194,7 +193,7 @@ public class TestLogger
         Throwable e = new Throwable();
         logger.error(e);
 
-        assertTrue(handler.isEmpty());
+        assertThat(handler.isEmpty()).isTrue();
     }
 
     @Test
@@ -268,25 +267,25 @@ public class TestLogger
     private void assertLog(Level level, String message, Throwable exception)
     {
         LogRecord record = handler.takeRecord();
-        assertEquals(record.getLevel(), level);
-        assertEquals(record.getMessage(), message);
-        assertEquals(record.getThrown(), exception);
+        assertThat(record.getLevel()).isEqualTo(level);
+        assertThat(record.getMessage()).isEqualTo(message);
+        assertThat(record.getThrown()).isEqualTo(exception);
     }
 
     private void assertLog(Level level, String message)
     {
         LogRecord record = handler.takeRecord();
-        assertEquals(record.getLevel(), level);
-        assertEquals(record.getMessage(), message);
-        assertNull(record.getThrown());
+        assertThat(record.getLevel()).isEqualTo(level);
+        assertThat(record.getMessage()).isEqualTo(message);
+        assertThat(record.getThrown()).isNull();
     }
 
     private void assertLogLike(Level level, List<String> substrings, Class<? extends Throwable> exceptionClass)
     {
         LogRecord record = handler.takeRecord();
-        assertEquals(record.getLevel(), level);
-        assertTrue(stringContains(record.getMessage(), substrings));
-        assertTrue(exceptionClass.isAssignableFrom(record.getThrown().getClass()));
+        assertThat(record.getLevel()).isEqualTo(level);
+        assertThat(stringContains(record.getMessage(), substrings)).isTrue();
+        assertThat(exceptionClass.isAssignableFrom(record.getThrown().getClass())).isTrue();
     }
 
     private boolean stringContains(String value, List<String> substrings)
@@ -329,7 +328,7 @@ public class TestLogger
 
         public LogRecord takeRecord()
         {
-            assertTrue(!records.isEmpty(), "No messages logged");
+            assertThat(!records.isEmpty()).as("No messages logged").isTrue();
             return records.remove(0);
         }
 

--- a/node/pom.xml
+++ b/node/pom.xml
@@ -49,6 +49,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/node/src/test/java/io/airlift/node/TestAddressSource.java
+++ b/node/src/test/java/io/airlift/node/TestAddressSource.java
@@ -20,7 +20,7 @@ import java.util.Optional;
 
 import static io.airlift.node.AddressToHostname.encodeAddressAsHostname;
 import static io.airlift.node.AddressToHostname.tryDecodeHostnameToAddress;
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestAddressSource
 {
@@ -36,7 +36,7 @@ public class TestAddressSource
 
     private static void verifyEncoding(String addressString, String encodedHostname)
     {
-        assertEquals(encodeAddressAsHostname(InetAddresses.forString(addressString)), encodedHostname);
-        assertEquals(tryDecodeHostnameToAddress(encodedHostname), Optional.of(InetAddresses.forString(addressString)));
+        assertThat(encodeAddressAsHostname(InetAddresses.forString(addressString))).isEqualTo(encodedHostname);
+        assertThat(tryDecodeHostnameToAddress(encodedHostname)).isEqualTo(Optional.of(InetAddresses.forString(addressString)));
     }
 }

--- a/node/src/test/java/io/airlift/node/TestNodeInfo.java
+++ b/node/src/test/java/io/airlift/node/TestNodeInfo.java
@@ -27,8 +27,7 @@ import static io.airlift.node.NodeConfig.AddressSource.HOSTNAME;
 import static io.airlift.node.NodeConfig.AddressSource.IP;
 import static io.airlift.testing.Assertions.assertGreaterThanOrEqual;
 import static io.airlift.testing.Assertions.assertNotEquals;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestNodeInfo
 {
@@ -49,32 +48,32 @@ public class TestNodeInfo
         String externalAddress = "external";
 
         NodeInfo nodeInfo = new NodeInfo(ENVIRONMENT, POOL, nodeId, internalIp, bindIp, externalAddress, location, binarySpec, configSpec, IP, null);
-        assertEquals(nodeInfo.getEnvironment(), ENVIRONMENT);
-        assertEquals(nodeInfo.getPool(), POOL);
-        assertEquals(nodeInfo.getNodeId(), nodeId);
-        assertEquals(nodeInfo.getLocation(), location);
-        assertEquals(nodeInfo.getBinarySpec(), binarySpec);
-        assertEquals(nodeInfo.getConfigSpec(), configSpec);
-        assertNotNull(nodeInfo.getInstanceId());
+        assertThat(nodeInfo.getEnvironment()).isEqualTo(ENVIRONMENT);
+        assertThat(nodeInfo.getPool()).isEqualTo(POOL);
+        assertThat(nodeInfo.getNodeId()).isEqualTo(nodeId);
+        assertThat(nodeInfo.getLocation()).isEqualTo(location);
+        assertThat(nodeInfo.getBinarySpec()).isEqualTo(binarySpec);
+        assertThat(nodeInfo.getConfigSpec()).isEqualTo(configSpec);
+        assertThat(nodeInfo.getInstanceId()).isNotNull();
 
         assertNotEquals(nodeInfo.getNodeId(), nodeInfo.getInstanceId());
 
-        assertEquals(nodeInfo.getInternalAddress(), internalIp);
-        assertEquals(nodeInfo.getExternalAddress(), externalAddress);
-        assertEquals(nodeInfo.getBindIp(), bindIp);
+        assertThat(nodeInfo.getInternalAddress()).isEqualTo(internalIp);
+        assertThat(nodeInfo.getExternalAddress()).isEqualTo(externalAddress);
+        assertThat(nodeInfo.getBindIp()).isEqualTo(bindIp);
         assertGreaterThanOrEqual(nodeInfo.getStartTime(), testStartTime);
-        assertEquals(nodeInfo.getAnnotations().size(), 0);
+        assertThat(nodeInfo.getAnnotations().size()).isEqualTo(0);
 
         // make sure toString doesn't throw an exception
-        assertNotNull(nodeInfo.toString());
+        assertThat(nodeInfo.toString()).isNotNull();
     }
 
     @Test
     public void testDefaultAddresses()
     {
         NodeInfo nodeInfo = new NodeInfo(ENVIRONMENT, POOL, "nodeInfo", "10.0.0.22", null, null, null, null, null, IP, null);
-        assertEquals(nodeInfo.getExternalAddress(), "10.0.0.22");
-        assertEquals(nodeInfo.getBindIp(), InetAddresses.forString("0.0.0.0"));
+        assertThat(nodeInfo.getExternalAddress()).isEqualTo("10.0.0.22");
+        assertThat(nodeInfo.getBindIp()).isEqualTo(InetAddresses.forString("0.0.0.0"));
     }
 
     @Test
@@ -82,9 +81,9 @@ public class TestNodeInfo
             throws UnknownHostException
     {
         NodeInfo nodeInfo = new NodeInfo(ENVIRONMENT, POOL, "nodeInfo", null, null, null, null, null, null, IP, null);
-        assertNotNull(nodeInfo.getInternalAddress());
-        assertEquals(nodeInfo.getBindIp(), InetAddresses.forString("0.0.0.0"));
-        assertEquals(nodeInfo.getExternalAddress(), nodeInfo.getInternalAddress());
+        assertThat(nodeInfo.getInternalAddress()).isNotNull();
+        assertThat(nodeInfo.getBindIp()).isEqualTo(InetAddresses.forString("0.0.0.0"));
+        assertThat(nodeInfo.getExternalAddress()).isEqualTo(nodeInfo.getInternalAddress());
     }
 
     @Test
@@ -92,9 +91,9 @@ public class TestNodeInfo
             throws UnknownHostException
     {
         NodeInfo nodeInfo = new NodeInfo(ENVIRONMENT, POOL, "nodeInfo", null, null, null, null, null, null, HOSTNAME, null);
-        assertNotNull(nodeInfo.getInternalAddress());
-        assertEquals(nodeInfo.getBindIp(), InetAddresses.forString("0.0.0.0"));
-        assertEquals(nodeInfo.getExternalAddress(), InetAddress.getLocalHost().getHostName());
+        assertThat(nodeInfo.getInternalAddress()).isNotNull();
+        assertThat(nodeInfo.getBindIp()).isEqualTo(InetAddresses.forString("0.0.0.0"));
+        assertThat(nodeInfo.getExternalAddress()).isEqualTo(InetAddress.getLocalHost().getHostName());
     }
 
     @Test
@@ -102,9 +101,9 @@ public class TestNodeInfo
             throws UnknownHostException
     {
         NodeInfo nodeInfo = new NodeInfo(ENVIRONMENT, POOL, "nodeInfo", null, null, null, null, null, null, FQDN, null);
-        assertNotNull(nodeInfo.getInternalAddress());
-        assertEquals(nodeInfo.getBindIp(), InetAddresses.forString("0.0.0.0"));
-        assertEquals(nodeInfo.getExternalAddress(), InetAddress.getLocalHost().getCanonicalHostName());
+        assertThat(nodeInfo.getInternalAddress()).isNotNull();
+        assertThat(nodeInfo.getBindIp()).isEqualTo(InetAddresses.forString("0.0.0.0"));
+        assertThat(nodeInfo.getExternalAddress()).isEqualTo(InetAddress.getLocalHost().getCanonicalHostName());
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "nodeId .*")

--- a/node/src/test/java/io/airlift/node/TestNodeModule.java
+++ b/node/src/test/java/io/airlift/node/TestNodeModule.java
@@ -32,11 +32,7 @@ import java.util.Map;
 import static com.google.common.io.Resources.getResource;
 import static io.airlift.testing.Assertions.assertGreaterThanOrEqual;
 import static io.airlift.testing.Assertions.assertNotEquals;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestNodeModule
 {
@@ -49,26 +45,26 @@ public class TestNodeModule
         ConfigurationFactory configFactory = new ConfigurationFactory(ImmutableMap.<String, String>of("node.environment", "environment"));
         Injector injector = Guice.createInjector(new NodeModule(), new ConfigurationModule(configFactory));
         NodeInfo nodeInfo = injector.getInstance(NodeInfo.class);
-        assertNotNull(nodeInfo);
-        assertEquals(nodeInfo.getEnvironment(), "environment");
-        assertEquals(nodeInfo.getPool(), "general");
-        assertNotNull(nodeInfo.getNodeId());
-        assertNotNull(nodeInfo.getLocation());
-        assertNull(nodeInfo.getBinarySpec());
-        assertNull(nodeInfo.getConfigSpec());
-        assertNotNull(nodeInfo.getInstanceId());
+        assertThat(nodeInfo).isNotNull();
+        assertThat(nodeInfo.getEnvironment()).isEqualTo("environment");
+        assertThat(nodeInfo.getPool()).isEqualTo("general");
+        assertThat(nodeInfo.getNodeId()).isNotNull();
+        assertThat(nodeInfo.getLocation()).isNotNull();
+        assertThat(nodeInfo.getBinarySpec()).isNull();
+        assertThat(nodeInfo.getConfigSpec()).isNull();
+        assertThat(nodeInfo.getInstanceId()).isNotNull();
 
         assertNotEquals(nodeInfo.getNodeId(), nodeInfo.getInstanceId());
 
-        assertNotNull(nodeInfo.getInternalAddress());
-        assertFalse(InetAddress.getByName(nodeInfo.getInternalAddress()).isAnyLocalAddress());
-        assertNotNull(nodeInfo.getBindIp());
-        assertTrue(nodeInfo.getBindIp().isAnyLocalAddress());
+        assertThat(nodeInfo.getInternalAddress()).isNotNull();
+        assertThat(InetAddress.getByName(nodeInfo.getInternalAddress()).isAnyLocalAddress()).isFalse();
+        assertThat(nodeInfo.getBindIp()).isNotNull();
+        assertThat(nodeInfo.getBindIp().isAnyLocalAddress()).isTrue();
         assertGreaterThanOrEqual(nodeInfo.getStartTime(), testStartTime);
-        assertEquals(nodeInfo.getAnnotations().size(), 0);
+        assertThat(nodeInfo.getAnnotations().size()).isEqualTo(0);
 
         // make sure toString doesn't throw an exception
-        assertNotNull(nodeInfo.toString());
+        assertThat(nodeInfo.toString()).isNotNull();
     }
 
     @Test
@@ -99,23 +95,23 @@ public class TestNodeModule
 
         Injector injector = Guice.createInjector(new NodeModule(), new ConfigurationModule(configFactory));
         NodeInfo nodeInfo = injector.getInstance(NodeInfo.class);
-        assertNotNull(nodeInfo);
-        assertEquals(nodeInfo.getEnvironment(), environment);
-        assertEquals(nodeInfo.getPool(), pool);
-        assertEquals(nodeInfo.getNodeId(), nodeId);
-        assertEquals(nodeInfo.getLocation(), location);
-        assertEquals(nodeInfo.getBinarySpec(), binarySpec);
-        assertEquals(nodeInfo.getConfigSpec(), configSpec);
-        assertNotNull(nodeInfo.getInstanceId());
+        assertThat(nodeInfo).isNotNull();
+        assertThat(nodeInfo.getEnvironment()).isEqualTo(environment);
+        assertThat(nodeInfo.getPool()).isEqualTo(pool);
+        assertThat(nodeInfo.getNodeId()).isEqualTo(nodeId);
+        assertThat(nodeInfo.getLocation()).isEqualTo(location);
+        assertThat(nodeInfo.getBinarySpec()).isEqualTo(binarySpec);
+        assertThat(nodeInfo.getConfigSpec()).isEqualTo(configSpec);
+        assertThat(nodeInfo.getInstanceId()).isNotNull();
 
         assertNotEquals(nodeInfo.getNodeId(), nodeInfo.getInstanceId());
 
-        assertEquals(nodeInfo.getInternalAddress(), publicAddress);
-        assertEquals(nodeInfo.getBindIp(), InetAddresses.forString("0.0.0.0"));
+        assertThat(nodeInfo.getInternalAddress()).isEqualTo(publicAddress);
+        assertThat(nodeInfo.getBindIp()).isEqualTo(InetAddresses.forString("0.0.0.0"));
         assertGreaterThanOrEqual(nodeInfo.getStartTime(), testStartTime);
-        assertEquals(nodeInfo.getAnnotations(), Map.of("team", "a", "region", "b"));
+        assertThat(nodeInfo.getAnnotations()).isEqualTo(Map.of("team", "a", "region", "b"));
 
         // make sure toString doesn't throw an exception
-        assertNotNull(nodeInfo.toString());
+        assertThat(nodeInfo.toString()).isNotNull();
     }
 }

--- a/node/src/test/java/io/airlift/node/testing/TestTestingNodeModule.java
+++ b/node/src/test/java/io/airlift/node/testing/TestTestingNodeModule.java
@@ -11,10 +11,7 @@ import java.util.Optional;
 
 import static io.airlift.testing.Assertions.assertGreaterThanOrEqual;
 import static io.airlift.testing.Assertions.assertNotEquals;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestTestingNodeModule
 {
@@ -27,25 +24,25 @@ public class TestTestingNodeModule
         Injector injector = Guice.createInjector(new TestingNodeModule());
         NodeInfo nodeInfo = injector.getInstance(NodeInfo.class);
 
-        assertNotNull(nodeInfo);
-        assertTrue(nodeInfo.getEnvironment().matches("test\\d+"));
-        assertEquals(nodeInfo.getPool(), "general");
-        assertNotNull(nodeInfo.getNodeId());
-        assertNotNull(nodeInfo.getLocation());
-        assertNull(nodeInfo.getBinarySpec());
-        assertNull(nodeInfo.getConfigSpec());
-        assertNotNull(nodeInfo.getInstanceId());
+        assertThat(nodeInfo).isNotNull();
+        assertThat(nodeInfo.getEnvironment()).matches("test\\d+");
+        assertThat(nodeInfo.getPool()).isEqualTo("general");
+        assertThat(nodeInfo.getNodeId()).isNotNull();
+        assertThat(nodeInfo.getLocation()).isNotNull();
+        assertThat(nodeInfo.getBinarySpec()).isNull();
+        assertThat(nodeInfo.getConfigSpec()).isNull();
+        assertThat(nodeInfo.getInstanceId()).isNotNull();
 
         assertNotEquals(nodeInfo.getNodeId(), nodeInfo.getInstanceId());
 
-        assertEquals(nodeInfo.getInternalAddress(), "127.0.0.1");
-        assertEquals(nodeInfo.getBindIp(), InetAddress.getByName(nodeInfo.getInternalAddress()));
-        assertEquals(nodeInfo.getExternalAddress(), "127.0.0.1");
+        assertThat(nodeInfo.getInternalAddress()).isEqualTo("127.0.0.1");
+        assertThat(nodeInfo.getBindIp()).isEqualTo(InetAddress.getByName(nodeInfo.getInternalAddress()));
+        assertThat(nodeInfo.getExternalAddress()).isEqualTo("127.0.0.1");
 
         assertGreaterThanOrEqual(nodeInfo.getStartTime(), testStartTime);
 
         // make sure toString doesn't throw an exception
-        assertNotNull(nodeInfo.toString());
+        assertThat(nodeInfo.toString()).isNotNull();
     }
 
     @Test
@@ -54,8 +51,8 @@ public class TestTestingNodeModule
         Injector injector = Guice.createInjector(new TestingNodeModule("foo"));
         NodeInfo nodeInfo = injector.getInstance(NodeInfo.class);
 
-        assertNotNull(nodeInfo);
-        assertEquals(nodeInfo.getEnvironment(), "foo");
+        assertThat(nodeInfo).isNotNull();
+        assertThat(nodeInfo.getEnvironment()).isEqualTo("foo");
     }
 
     @Test
@@ -64,8 +61,8 @@ public class TestTestingNodeModule
         Injector injector = Guice.createInjector(new TestingNodeModule(Optional.of("foo")));
         NodeInfo nodeInfo = injector.getInstance(NodeInfo.class);
 
-        assertNotNull(nodeInfo);
-        assertEquals(nodeInfo.getEnvironment(), "foo");
+        assertThat(nodeInfo).isNotNull();
+        assertThat(nodeInfo.getEnvironment()).isEqualTo("foo");
     }
 
     @Test
@@ -74,7 +71,7 @@ public class TestTestingNodeModule
         Injector injector = Guice.createInjector(new TestingNodeModule(Optional.empty()));
         NodeInfo nodeInfo = injector.getInstance(NodeInfo.class);
 
-        assertNotNull(nodeInfo);
-        assertTrue(nodeInfo.getEnvironment().matches("test\\d+"));
+        assertThat(nodeInfo).isNotNull();
+        assertThat(nodeInfo.getEnvironment()).matches("test\\d+");
     }
 }

--- a/openmetrics/pom.xml
+++ b/openmetrics/pom.xml
@@ -68,6 +68,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/openmetrics/src/test/java/io/airlift/openmetrics/TestMetricExpositions.java
+++ b/openmetrics/src/test/java/io/airlift/openmetrics/TestMetricExpositions.java
@@ -23,7 +23,7 @@ import org.testng.annotations.Test;
 
 import java.math.BigInteger;
 
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestMetricExpositions
 {
@@ -38,8 +38,8 @@ public class TestMetricExpositions
 
         Counter counter = new Counter("metric_name", 0, ImmutableMap.of(), "metric_help");
         BigCounter bigCounter = new BigCounter("metric_name", BigInteger.ZERO, ImmutableMap.of(), "metric_help");
-        assertEquals(counter.getMetricExposition(), bigCounter.getMetricExposition());
-        assertEquals(counter.getMetricExposition(), expected);
+        assertThat(counter.getMetricExposition()).isEqualTo(bigCounter.getMetricExposition());
+        assertThat(counter.getMetricExposition()).isEqualTo(expected);
     }
 
     @Test
@@ -53,8 +53,8 @@ public class TestMetricExpositions
 
         Counter counter = new Counter("metric_name", 0, ImmutableMap.of("type", "cavendish"), "metric_help");
         BigCounter bigCounter = new BigCounter("metric_name", BigInteger.ZERO, ImmutableMap.of("type", "cavendish"), "metric_help");
-        assertEquals(counter.getMetricExposition(), bigCounter.getMetricExposition());
-        assertEquals(counter.getMetricExposition(), expected);
+        assertThat(counter.getMetricExposition()).isEqualTo(bigCounter.getMetricExposition());
+        assertThat(counter.getMetricExposition()).isEqualTo(expected);
     }
 
     @Test
@@ -66,7 +66,7 @@ public class TestMetricExpositions
                 metric_name 0.0
                 """;
 
-        assertEquals(new Gauge("metric_name", 0.0, ImmutableMap.of(), "metric_help").getMetricExposition(), expected);
+        assertThat(new Gauge("metric_name", 0.0, ImmutableMap.of(), "metric_help").getMetricExposition()).isEqualTo(expected);
     }
 
     @Test
@@ -78,7 +78,7 @@ public class TestMetricExpositions
                 metric_name{type="cavendish"} 0.0
                 """;
 
-        assertEquals(new Gauge("metric_name", 0.0, ImmutableMap.of("type", "cavendish"), "metric_help").getMetricExposition(), expected);
+        assertThat(new Gauge("metric_name", 0.0, ImmutableMap.of("type", "cavendish"), "metric_help").getMetricExposition()).isEqualTo(expected);
     }
 
     @Test
@@ -90,7 +90,7 @@ public class TestMetricExpositions
                 metric_name banana
                 """;
 
-        assertEquals(new Info("metric_name", "banana", ImmutableMap.of(), "metric_help").getMetricExposition(), expected);
+        assertThat(new Info("metric_name", "banana", ImmutableMap.of(), "metric_help").getMetricExposition()).isEqualTo(expected);
     }
 
     @Test
@@ -102,7 +102,7 @@ public class TestMetricExpositions
                 metric_name{type="cavendish"} banana
                 """;
 
-        assertEquals(new Info("metric_name", "banana", ImmutableMap.of("type", "cavendish"), "metric_help").getMetricExposition(), expected);
+        assertThat(new Info("metric_name", "banana", ImmutableMap.of("type", "cavendish"), "metric_help").getMetricExposition()).isEqualTo(expected);
     }
 
     @Test
@@ -117,7 +117,7 @@ public class TestMetricExpositions
                 metric_name{quantile="0.5"} 0.25
                 """;
 
-        assertEquals(new Summary("metric_name", 10L, 2.0, 3.0, ImmutableMap.of(0.5, 0.25), ImmutableMap.of(), "metric_help").getMetricExposition(), expected);
+        assertThat(new Summary("metric_name", 10L, 2.0, 3.0, ImmutableMap.of(0.5, 0.25), ImmutableMap.of(), "metric_help").getMetricExposition()).isEqualTo(expected);
     }
 
     @Test
@@ -132,6 +132,6 @@ public class TestMetricExpositions
                 metric_name{fruit="apple",quantile="0.5"} 0.25
                 """;
 
-        assertEquals(new Summary("metric_name", 10L, 2.0, 3.0, ImmutableMap.of(0.5, 0.25), ImmutableMap.of("fruit", "apple"), "metric_help").getMetricExposition(), expected);
+        assertThat(new Summary("metric_name", 10L, 2.0, 3.0, ImmutableMap.of(0.5, 0.25), ImmutableMap.of("fruit", "apple"), "metric_help").getMetricExposition()).isEqualTo(expected);
     }
 }

--- a/sample-server/src/test/java/io/airlift/sample/TestPersonRepresentation.java
+++ b/sample-server/src/test/java/io/airlift/sample/TestPersonRepresentation.java
@@ -21,7 +21,7 @@ import org.testng.annotations.Test;
 
 import static io.airlift.json.JsonCodec.jsonCodec;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestPersonRepresentation
 {
@@ -35,7 +35,7 @@ public class TestPersonRepresentation
         PersonRepresentation expected = new PersonRepresentation("alice@example.com", "Alice", null);
         String json = codec.toJson(expected);
         PersonRepresentation actual = codec.fromJson(json);
-        assertEquals(actual, expected);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -47,6 +47,6 @@ public class TestPersonRepresentation
         String json = Resources.toString(Resources.getResource("single.json"), UTF_8);
         PersonRepresentation actual = codec.fromJson(json);
 
-        assertEquals(actual, expected);
+        assertThat(actual).isEqualTo(expected);
     }
 }

--- a/sample-server/src/test/java/io/airlift/sample/TestPersonResource.java
+++ b/sample-server/src/test/java/io/airlift/sample/TestPersonResource.java
@@ -27,8 +27,7 @@ import java.net.URI;
 import static io.airlift.sample.PersonEvent.personAdded;
 import static io.airlift.sample.PersonEvent.personRemoved;
 import static io.airlift.sample.PersonEvent.personUpdated;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Test(singleThreaded = true)
 public class TestPersonResource
@@ -49,7 +48,7 @@ public class TestPersonResource
     public void testNotFound()
     {
         Response response = resource.get("foo", MockUriInfo.from(URI.create("http://localhost/v1/person/1")));
-        assertEquals(response.getStatus(), Response.Status.NOT_FOUND.getStatusCode());
+        assertThat(response.getStatus()).isEqualTo(Response.Status.NOT_FOUND.getStatusCode());
     }
 
     @Test
@@ -58,9 +57,9 @@ public class TestPersonResource
         store.put("foo", new Person("foo@example.com", "Mr Foo"));
 
         Response response = resource.get("foo", MockUriInfo.from(URI.create("http://localhost/v1/person/1")));
-        assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
-        assertEquals(response.getEntity(), new PersonRepresentation("foo@example.com", "Mr Foo", URI.create("http://localhost/v1/person/1")));
-        assertNull(response.getMetadata().get("Content-Type")); // content type is set by JAX-RS based on @Produces
+        assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+        assertThat(response.getEntity()).isEqualTo(new PersonRepresentation("foo@example.com", "Mr Foo", URI.create("http://localhost/v1/person/1")));
+        assertThat(response.getMetadata().get("Content-Type")).isNull(); // content type is set by JAX-RS based on @Produces
     }
 
     @Test(expectedExceptions = NullPointerException.class)
@@ -74,13 +73,13 @@ public class TestPersonResource
     {
         Response response = resource.put("foo", new PersonRepresentation("foo@example.com", "Mr Foo", null));
 
-        assertEquals(response.getStatus(), Response.Status.CREATED.getStatusCode());
-        assertNull(response.getEntity());
-        assertNull(response.getMetadata().get("Content-Type")); // content type is set by JAX-RS based on @Produces
+        assertThat(response.getStatus()).isEqualTo(Response.Status.CREATED.getStatusCode());
+        assertThat(response.getEntity()).isNull();
+        assertThat(response.getMetadata().get("Content-Type")).isNull(); // content type is set by JAX-RS based on @Produces
 
-        assertEquals(store.get("foo"), new Person("foo@example.com", "Mr Foo"));
+        assertThat(store.get("foo")).isEqualTo(new Person("foo@example.com", "Mr Foo"));
 
-        assertEquals(eventClient.getEvents(), ImmutableList.of(
+        assertThat(eventClient.getEvents()).isEqualTo(ImmutableList.of(
                 personAdded("foo", new Person("foo@example.com", "Mr Foo"))));
     }
 
@@ -103,13 +102,13 @@ public class TestPersonResource
 
         Response response = resource.put("foo", new PersonRepresentation("bar@example.com", "Mr Bar", null));
 
-        assertEquals(response.getStatus(), Response.Status.NO_CONTENT.getStatusCode());
-        assertNull(response.getEntity());
-        assertNull(response.getMetadata().get("Content-Type")); // content type is set by JAX-RS based on @Produces
+        assertThat(response.getStatus()).isEqualTo(Response.Status.NO_CONTENT.getStatusCode());
+        assertThat(response.getEntity()).isNull();
+        assertThat(response.getMetadata().get("Content-Type")).isNull(); // content type is set by JAX-RS based on @Produces
 
-        assertEquals(store.get("foo"), new Person("bar@example.com", "Mr Bar"));
+        assertThat(store.get("foo")).isEqualTo(new Person("bar@example.com", "Mr Bar"));
 
-        assertEquals(eventClient.getEvents(), ImmutableList.of(
+        assertThat(eventClient.getEvents()).isEqualTo(ImmutableList.of(
                 personAdded("foo", new Person("foo@example.com", "Mr Foo")),
                 personUpdated("foo", new Person("bar@example.com", "Mr Bar"))));
     }
@@ -120,12 +119,12 @@ public class TestPersonResource
         store.put("foo", new Person("foo@example.com", "Mr Foo"));
 
         Response response = resource.delete("foo");
-        assertEquals(response.getStatus(), Response.Status.NO_CONTENT.getStatusCode());
-        assertNull(response.getEntity());
+        assertThat(response.getStatus()).isEqualTo(Response.Status.NO_CONTENT.getStatusCode());
+        assertThat(response.getEntity()).isNull();
 
-        assertNull(store.get("foo"));
+        assertThat(store.get("foo")).isNull();
 
-        assertEquals(eventClient.getEvents(), ImmutableList.of(
+        assertThat(eventClient.getEvents()).isEqualTo(ImmutableList.of(
                 personAdded("foo", new Person("foo@example.com", "Mr Foo")),
                 personRemoved("foo", new Person("foo@example.com", "Mr Foo"))));
     }
@@ -134,8 +133,8 @@ public class TestPersonResource
     public void testDeleteMissing()
     {
         Response response = resource.delete("foo");
-        assertEquals(response.getStatus(), Response.Status.NOT_FOUND.getStatusCode());
-        assertNull(response.getEntity());
+        assertThat(response.getStatus()).isEqualTo(Response.Status.NOT_FOUND.getStatusCode());
+        assertThat(response.getEntity()).isNull();
     }
 
     @Test(expectedExceptions = NullPointerException.class)

--- a/sample-server/src/test/java/io/airlift/sample/TestPersonStore.java
+++ b/sample-server/src/test/java/io/airlift/sample/TestPersonStore.java
@@ -26,9 +26,7 @@ import static io.airlift.sample.PersonEvent.personAdded;
 import static io.airlift.sample.PersonEvent.personRemoved;
 import static io.airlift.sample.PersonEvent.personUpdated;
 import static java.util.Arrays.asList;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestPersonStore
 {
@@ -36,7 +34,7 @@ public class TestPersonStore
     public void testStartsEmpty()
     {
         PersonStore store = new PersonStore(new StoreConfig(), new InMemoryEventClient());
-        assertTrue(store.getAll().isEmpty());
+        assertThat(store.getAll()).isEmpty();
     }
 
     @Test
@@ -49,7 +47,7 @@ public class TestPersonStore
         PersonStore store = new PersonStore(config, new InMemoryEventClient());
         store.put("foo", new Person("foo@example.com", "Mr Foo"));
         Thread.sleep(2);
-        assertNull(store.get("foo"));
+        assertThat(store.get("foo")).isNull();
     }
 
     @Test
@@ -59,10 +57,10 @@ public class TestPersonStore
         PersonStore store = new PersonStore(new StoreConfig(), eventClient);
         store.put("foo", new Person("foo@example.com", "Mr Foo"));
 
-        assertEquals(new Person("foo@example.com", "Mr Foo"), store.get("foo"));
-        assertEquals(store.getAll().size(), 1);
+        assertThat(new Person("foo@example.com", "Mr Foo")).isEqualTo(store.get("foo"));
+        assertThat(store.getAll().size()).isEqualTo(1);
 
-        assertEquals(eventClient.getEvents(), ImmutableList.of(personAdded("foo", new Person("foo@example.com", "Mr Foo"))));
+        assertThat(eventClient.getEvents()).isEqualTo(ImmutableList.of(personAdded("foo", new Person("foo@example.com", "Mr Foo"))));
     }
 
     @Test
@@ -73,10 +71,10 @@ public class TestPersonStore
         store.put("foo", new Person("foo@example.com", "Mr Foo"));
         store.put("foo", new Person("foo@example.com", "Mr Bar"));
 
-        assertEquals(new Person("foo@example.com", "Mr Bar"), store.get("foo"));
-        assertEquals(store.getAll().size(), 1);
+        assertThat(new Person("foo@example.com", "Mr Bar")).isEqualTo(store.get("foo"));
+        assertThat(store.getAll().size()).isEqualTo(1);
 
-        assertEquals(eventClient.getEvents(), ImmutableList.of(
+        assertThat(eventClient.getEvents()).isEqualTo(ImmutableList.of(
                 personAdded("foo", new Person("foo@example.com", "Mr Foo")),
                 personUpdated("foo", new Person("foo@example.com", "Mr Bar"))));
     }
@@ -89,10 +87,10 @@ public class TestPersonStore
         store.put("foo", new Person("foo@example.com", "Mr Foo"));
         store.delete("foo");
 
-        assertNull(store.get("foo"));
-        assertTrue(store.getAll().isEmpty());
+        assertThat(store.get("foo")).isNull();
+        assertThat(store.getAll()).isEmpty();
 
-        assertEquals(eventClient.getEvents(), ImmutableList.of(
+        assertThat(eventClient.getEvents()).isEqualTo(ImmutableList.of(
                 personAdded("foo", new Person("foo@example.com", "Mr Foo")),
                 personRemoved("foo", new Person("foo@example.com", "Mr Foo"))));
     }
@@ -105,14 +103,14 @@ public class TestPersonStore
         store.put("foo", new Person("foo@example.com", "Mr Foo"));
 
         store.delete("foo");
-        assertTrue(store.getAll().isEmpty());
-        assertNull(store.get("foo"));
+        assertThat(store.getAll()).isEmpty();
+        assertThat(store.get("foo")).isNull();
 
         store.delete("foo");
-        assertTrue(store.getAll().isEmpty());
-        assertNull(store.get("foo"));
+        assertThat(store.getAll()).isEmpty();
+        assertThat(store.get("foo")).isNull();
 
-        assertEquals(eventClient.getEvents(), ImmutableList.of(
+        assertThat(eventClient.getEvents()).isEqualTo(ImmutableList.of(
                 personAdded("foo", new Person("foo@example.com", "Mr Foo")),
                 personRemoved("foo", new Person("foo@example.com", "Mr Foo"))));
     }
@@ -125,7 +123,7 @@ public class TestPersonStore
         store.put("foo", new Person("foo@example.com", "Mr Foo"));
         store.put("bar", new Person("bar@example.com", "Mr Bar"));
 
-        assertEquals(store.getAll().size(), 2);
-        assertEquals(store.getAll(), asList(new Person("foo@example.com", "Mr Foo"), new Person("bar@example.com", "Mr Bar")));
+        assertThat(store.getAll().size()).isEqualTo(2);
+        assertThat(store.getAll()).isEqualTo(asList(new Person("foo@example.com", "Mr Foo"), new Person("bar@example.com", "Mr Bar")));
     }
 }

--- a/sample-server/src/test/java/io/airlift/sample/TestPersonsResource.java
+++ b/sample-server/src/test/java/io/airlift/sample/TestPersonsResource.java
@@ -25,7 +25,7 @@ import java.util.Collection;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static io.airlift.testing.Assertions.assertInstanceOf;
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Test(singleThreaded = true)
 public class TestPersonsResource
@@ -44,9 +44,9 @@ public class TestPersonsResource
     public void testEmpty()
     {
         Response response = resource.listAll();
-        assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
+        assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
         assertInstanceOf(response.getEntity(), Collection.class);
-        assertEquals((Collection<?>) response.getEntity(), new ArrayList<>());
+        assertThat((Collection<?>) response.getEntity()).isEqualTo(new ArrayList<>());
     }
 
     @Test
@@ -56,9 +56,9 @@ public class TestPersonsResource
         store.put("bar", new Person("bar@example.com", "Mr Bar"));
 
         Response response = resource.listAll();
-        assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
+        assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
         assertInstanceOf(response.getEntity(), Collection.class);
-        assertEquals((Collection<?>) response.getEntity(), newArrayList(
+        assertThat((Collection<?>) response.getEntity()).isEqualTo(newArrayList(
                 new PersonRepresentation("foo@example.com", "Mr Foo", null),
                 new PersonRepresentation("bar@example.com", "Mr Bar", null)));
     }

--- a/sample-server/src/test/java/io/airlift/sample/TestServer.java
+++ b/sample-server/src/test/java/io/airlift/sample/TestServer.java
@@ -64,8 +64,6 @@ import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
 
 @Test(singleThreaded = true)
 public class TestServer
@@ -124,7 +122,7 @@ public class TestServer
                 prepareGet().setUri(uriFor("/v1/person")).build(),
                 createJsonResponseHandler(listCodec));
 
-        assertEquals(response, ImmutableList.of());
+        assertThat(response).isEqualTo(ImmutableList.of());
     }
 
     @Test
@@ -158,7 +156,7 @@ public class TestServer
                 prepareGet().setUri(requestUri).build(),
                 createJsonResponseHandler(mapCodec));
 
-        assertEquals(actual, expected);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -175,11 +173,11 @@ public class TestServer
                         .build(),
                 createStatusResponseHandler());
 
-        assertEquals(response.getStatusCode(), HTTP_CREATED);
+        assertThat(response.getStatusCode()).isEqualTo(HTTP_CREATED);
 
-        assertEquals(store.get("foo"), new Person("foo@example.com", "Mr Foo"));
+        assertThat(store.get("foo")).isEqualTo(new Person("foo@example.com", "Mr Foo"));
 
-        assertEquals(eventClient.getEvents(), ImmutableList.of(
+        assertThat(eventClient.getEvents()).isEqualTo(ImmutableList.of(
                 personAdded("foo", new Person("foo@example.com", "Mr Foo"))));
     }
 
@@ -195,11 +193,11 @@ public class TestServer
                         .build(),
                 createStatusResponseHandler());
 
-        assertEquals(response.getStatusCode(), HTTP_NO_CONTENT);
+        assertThat(response.getStatusCode()).isEqualTo(HTTP_NO_CONTENT);
 
-        assertNull(store.get("foo"));
+        assertThat(store.get("foo")).isNull();
 
-        assertEquals(eventClient.getEvents(), ImmutableList.of(
+        assertThat(eventClient.getEvents()).isEqualTo(ImmutableList.of(
                 personAdded("foo", new Person("foo@example.com", "Mr Foo")),
                 personRemoved("foo", new Person("foo@example.com", "Mr Foo"))));
     }
@@ -214,7 +212,7 @@ public class TestServer
                         .build(),
                 createStatusResponseHandler());
 
-        assertEquals(response.getStatusCode(), HTTP_NOT_FOUND);
+        assertThat(response.getStatusCode()).isEqualTo(HTTP_NOT_FOUND);
     }
 
     @Test
@@ -231,9 +229,9 @@ public class TestServer
                         .build(),
                 createStatusResponseHandler());
 
-        assertEquals(response.getStatusCode(), HTTP_BAD_METHOD);
+        assertThat(response.getStatusCode()).isEqualTo(HTTP_BAD_METHOD);
 
-        assertNull(store.get("foo"));
+        assertThat(store.get("foo")).isNull();
     }
 
     @Test

--- a/security-jwks/src/test/java/io/airlift/security/jwks/TestJwksDecoder.java
+++ b/security-jwks/src/test/java/io/airlift/security/jwks/TestJwksDecoder.java
@@ -36,9 +36,7 @@ import java.util.Optional;
 import static io.airlift.security.jwks.JwksDecoder.decodeKeys;
 import static io.airlift.testing.Assertions.assertInstanceOf;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertSame;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestJwksDecoder
 {
@@ -67,7 +65,7 @@ public class TestJwksDecoder
                 "    }\n" +
                 "  ]\n" +
                 "}");
-        assertEquals(keys.size(), 2);
+        assertThat(keys.size()).isEqualTo(2);
         assertInstanceOf(keys.get("example-rsa"), JwkRsaPublicKey.class);
         assertInstanceOf(keys.get("example-ec"), JwkEcPublicKey.class);
     }
@@ -95,7 +93,7 @@ public class TestJwksDecoder
                 "    }\n" +
                 "  ]\n" +
                 "}");
-        assertEquals(keys.size(), 0);
+        assertThat(keys.size()).isEqualTo(0);
     }
 
     @Test
@@ -113,7 +111,7 @@ public class TestJwksDecoder
                 "    }\n" +
                 "  ]\n" +
                 "}");
-        assertEquals(keys.size(), 0);
+        assertThat(keys.size()).isEqualTo(0);
     }
 
     @Test
@@ -131,7 +129,7 @@ public class TestJwksDecoder
                 "    }\n" +
                 "  ]\n" +
                 "}");
-        assertEquals(keys.size(), 0);
+        assertThat(keys.size()).isEqualTo(0);
     }
 
     @Test
@@ -150,7 +148,7 @@ public class TestJwksDecoder
                 "    }\n" +
                 "  ]\n" +
                 "}");
-        assertEquals(keys.size(), 0);
+        assertThat(keys.size()).isEqualTo(0);
     }
 
     @Test
@@ -169,7 +167,7 @@ public class TestJwksDecoder
                 "    }\n" +
                 "  ]\n" +
                 "}");
-        assertEquals(keys.size(), 0);
+        assertThat(keys.size()).isEqualTo(0);
     }
 
     @Test
@@ -180,11 +178,11 @@ public class TestJwksDecoder
         Map<String, PublicKey> keys = decodeKeys(jwksJson);
 
         RSAPublicKey publicKey = (RSAPublicKey) keys.get("test-rsa");
-        assertNotNull(publicKey);
+        assertThat(publicKey).isNotNull();
 
         RSAPublicKey expectedPublicKey = (RSAPublicKey) PemReader.loadPublicKey(new File(Resources.getResource("jwks/jwk-rsa-public.pem").getPath()));
-        assertEquals(publicKey.getPublicExponent(), expectedPublicKey.getPublicExponent());
-        assertEquals(publicKey.getModulus(), expectedPublicKey.getModulus());
+        assertThat(publicKey.getPublicExponent()).isEqualTo(expectedPublicKey.getPublicExponent());
+        assertThat(publicKey.getModulus()).isEqualTo(expectedPublicKey.getModulus());
 
         PrivateKey privateKey = PemReader.loadPrivateKey(new File(Resources.getResource("jwks/jwk-rsa-private.pem").getPath()), Optional.empty());
         String jwt = Jwts.builder()
@@ -198,13 +196,13 @@ public class TestJwksDecoder
         Jws<Claims> claimsJws = Jwts.parser()
                 .keyLocator(header -> {
                     String keyId = ((DefaultJwsHeader) header).getKeyId();
-                    assertEquals(keyId, "test-rsa");
+                    assertThat(keyId).isEqualTo("test-rsa");
                     return publicKey;
                 })
                 .build()
                 .parseSignedClaims(jwt);
 
-        assertEquals(claimsJws.getPayload().getSubject(), "test-user");
+        assertThat(claimsJws.getPayload().getSubject()).isEqualTo("test-user");
     }
 
     @Test
@@ -222,7 +220,7 @@ public class TestJwksDecoder
                 "    }\n" +
                 "  ]\n" +
                 "}");
-        assertEquals(keys.size(), 1);
+        assertThat(keys.size()).isEqualTo(1);
         assertInstanceOf(keys.get("test-ec"), JwkEcPublicKey.class);
     }
 
@@ -241,7 +239,7 @@ public class TestJwksDecoder
                 "    }\n" +
                 "  ]\n" +
                 "}");
-        assertEquals(keys.size(), 0);
+        assertThat(keys.size()).isEqualTo(0);
     }
 
     @Test
@@ -259,7 +257,7 @@ public class TestJwksDecoder
                 "    }\n" +
                 "  ]\n" +
                 "}");
-        assertEquals(keys.size(), 0);
+        assertThat(keys.size()).isEqualTo(0);
     }
 
     @Test
@@ -277,7 +275,7 @@ public class TestJwksDecoder
                 "    }\n" +
                 "  ]\n" +
                 "}");
-        assertEquals(keys.size(), 0);
+        assertThat(keys.size()).isEqualTo(0);
     }
 
     @Test
@@ -296,16 +294,16 @@ public class TestJwksDecoder
         Map<String, PublicKey> keys = decodeKeys(jwksJson);
 
         ECPublicKey publicKey = (ECPublicKey) keys.get(keyName);
-        assertNotNull(publicKey);
+        assertThat(publicKey).isNotNull();
 
-        assertSame(publicKey.getParams(), expectedSpec);
+        assertThat(publicKey.getParams()).isSameAs(expectedSpec);
 
         ECPublicKey expectedPublicKey = (ECPublicKey) PemReader.loadPublicKey(new File(Resources.getResource("jwks/" + keyName + "-public.pem").getPath()));
-        assertEquals(publicKey.getW(), expectedPublicKey.getW());
-        assertEquals(publicKey.getParams().getCurve(), expectedPublicKey.getParams().getCurve());
-        assertEquals(publicKey.getParams().getGenerator(), expectedPublicKey.getParams().getGenerator());
-        assertEquals(publicKey.getParams().getOrder(), expectedPublicKey.getParams().getOrder());
-        assertEquals(publicKey.getParams().getCofactor(), expectedPublicKey.getParams().getCofactor());
+        assertThat(publicKey.getW()).isEqualTo(expectedPublicKey.getW());
+        assertThat(publicKey.getParams().getCurve()).isEqualTo(expectedPublicKey.getParams().getCurve());
+        assertThat(publicKey.getParams().getGenerator()).isEqualTo(expectedPublicKey.getParams().getGenerator());
+        assertThat(publicKey.getParams().getOrder()).isEqualTo(expectedPublicKey.getParams().getOrder());
+        assertThat(publicKey.getParams().getCofactor()).isEqualTo(expectedPublicKey.getParams().getCofactor());
 
         PrivateKey privateKey = PemReader.loadPrivateKey(new File(Resources.getResource("jwks/" + keyName + "-private.pem").getPath()), Optional.empty());
         String jwt = Jwts.builder()
@@ -319,14 +317,14 @@ public class TestJwksDecoder
         Jws<Claims> claimsJws = Jwts.parser()
                 .keyLocator(header -> {
                     String keyId = ((DefaultJwsHeader) header).getKeyId();
-                    assertEquals(keyId, keyName);
+                    assertThat(keyId).isEqualTo(keyName);
                     String algorithmName = header.getAlgorithm();
-                    assertEquals(algorithmName, signatureAlgorithm.getId());
+                    assertThat(algorithmName).isEqualTo(signatureAlgorithm.getId());
                     return publicKey;
                 })
                 .build()
                 .parseSignedClaims(jwt);
 
-        assertEquals(claimsJws.getPayload().getSubject(), "test-user");
+        assertThat(claimsJws.getPayload().getSubject()).isEqualTo("test-user");
     }
 }

--- a/security-jwks/src/test/java/io/airlift/security/jwks/TestJwksService.java
+++ b/security-jwks/src/test/java/io/airlift/security/jwks/TestJwksService.java
@@ -30,9 +30,8 @@ import static com.google.common.net.MediaType.JSON_UTF_8;
 import static io.airlift.http.client.testing.TestingResponse.mockResponse;
 import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 
 public class TestJwksService
 {
@@ -191,15 +190,15 @@ public class TestJwksService
 
     private static void assertEmptyKeys(JwksService service)
     {
-        assertEquals(service.getKeys().size(), 0);
+        assertThat(service.getKeys().size()).isEqualTo(0);
     }
 
     private static void assertTestKeys(JwksService service)
     {
         Map<String, PublicKey> keys = service.getKeys();
-        assertEquals(keys.size(), 3);
-        assertTrue(keys.containsKey("test-rsa"));
-        assertTrue(keys.containsKey("test-ec"));
-        assertTrue(keys.containsKey("test-certificate-chain"));
+        assertThat(keys).hasSize(3);
+        assertThat(keys).containsKey("test-rsa");
+        assertThat(keys).containsKey("test-ec");
+        assertThat(keys).containsKey("test-certificate-chain");
     }
 }

--- a/security/src/test/java/io/airlift/security/cert/TestCertificateBuilder.java
+++ b/security/src/test/java/io/airlift/security/cert/TestCertificateBuilder.java
@@ -30,7 +30,7 @@ import java.time.LocalDate;
 import static io.airlift.security.cert.CertificateBuilder.certificateBuilder;
 import static java.time.ZoneOffset.UTC;
 import static java.time.temporal.ChronoUnit.YEARS;
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestCertificateBuilder
 {
@@ -55,12 +55,12 @@ public class TestCertificateBuilder
                 .setSubject(subject)
                 .buildSelfSigned();
 
-        assertEquals(certificate.getSerialNumber(), BigInteger.valueOf(12345));
-        assertEquals(certificate.getIssuerX500Principal(), issuer);
-        assertEquals(certificate.getNotBefore().toInstant(), notBefore.atStartOfDay().toInstant(UTC));
-        assertEquals(certificate.getNotAfter().toInstant(), notAfter.atTime(23, 59, 59).toInstant(UTC));
-        assertEquals(certificate.getSubjectX500Principal(), subject);
-        assertEquals(certificate.getPublicKey(), keyPair.getPublic());
+        assertThat(certificate.getSerialNumber()).isEqualTo(BigInteger.valueOf(12345));
+        assertThat(certificate.getIssuerX500Principal()).isEqualTo(issuer);
+        assertThat(certificate.getNotBefore().toInstant()).isEqualTo(notBefore.atStartOfDay().toInstant(UTC));
+        assertThat(certificate.getNotAfter().toInstant()).isEqualTo(notAfter.atTime(23, 59, 59).toInstant(UTC));
+        assertThat(certificate.getSubjectX500Principal()).isEqualTo(subject);
+        assertThat(certificate.getPublicKey()).isEqualTo(keyPair.getPublic());
 
         // verify certificate trusts itself
         KeyStore keyStore = KeyStore.getInstance("JKS");

--- a/security/src/test/java/io/airlift/security/csr/TestCertificationRequest.java
+++ b/security/src/test/java/io/airlift/security/csr/TestCertificationRequest.java
@@ -29,7 +29,7 @@ import java.security.spec.ECGenParameterSpec;
 
 import static com.google.common.io.BaseEncoding.base16;
 import static io.airlift.security.csr.SignatureAlgorithmIdentifier.findSignatureAlgorithmIdentifier;
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestCertificationRequest
 {
@@ -49,19 +49,17 @@ public class TestCertificationRequest
         byte[] signature = certificationRequestInfo.sign(signatureAlgorithmIdentifier, keyPair.getPrivate());
 
         CertificationRequest certificationRequest = new CertificationRequest(certificationRequestInfo, signatureAlgorithmIdentifier, signature);
-        assertEquals(certificationRequest.getCertificationRequestInfo(), certificationRequestInfo);
-        assertEquals(certificationRequest.getSignatureAlgorithmIdentifier(), signatureAlgorithmIdentifier);
-        assertEquals(base16().encode(certificationRequest.getSignature()), base16().encode(signature));
-        assertEquals(certificationRequest, certificationRequest);
-        assertEquals(certificationRequest.hashCode(), certificationRequest.hashCode());
+        assertThat(certificationRequest.getCertificationRequestInfo()).isEqualTo(certificationRequestInfo);
+        assertThat(certificationRequest.getSignatureAlgorithmIdentifier()).isEqualTo(signatureAlgorithmIdentifier);
+        assertThat(base16().encode(certificationRequest.getSignature())).isEqualTo(base16().encode(signature));
+        assertThat(certificationRequest).isEqualTo(certificationRequest);
+        assertThat(certificationRequest.hashCode()).isEqualTo(certificationRequest.hashCode());
 
         PKCS10CertificationRequest expectedCertificationRequest = new PKCS10CertificationRequest(new org.bouncycastle.asn1.pkcs.CertificationRequest(
                 new org.bouncycastle.asn1.pkcs.CertificationRequestInfo(new X500Name(name), SubjectPublicKeyInfo.getInstance(keyPair.getPublic().getEncoded()), new DERSet()),
                 new DefaultSignatureAlgorithmIdentifierFinder().find("SHA256withECDSA"),
                 new DERBitString(signature)));
 
-        assertEquals(
-                base16().encode(certificationRequest.getEncoded()),
-                base16().encode(expectedCertificationRequest.getEncoded()));
+        assertThat(base16().encode(certificationRequest.getEncoded())).isEqualTo(base16().encode(expectedCertificationRequest.getEncoded()));
     }
 }

--- a/security/src/test/java/io/airlift/security/csr/TestCertificationRequestInfo.java
+++ b/security/src/test/java/io/airlift/security/csr/TestCertificationRequestInfo.java
@@ -27,8 +27,7 @@ import java.security.spec.ECGenParameterSpec;
 
 import static com.google.common.io.BaseEncoding.base16;
 import static io.airlift.security.csr.SignatureAlgorithmIdentifier.findSignatureAlgorithmIdentifier;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestCertificationRequestInfo
 {
@@ -44,22 +43,20 @@ public class TestCertificationRequestInfo
         KeyPair keyPair = generator.generateKeyPair();
 
         CertificationRequestInfo actualInfo = new CertificationRequestInfo(new X500Principal(name), keyPair.getPublic());
-        assertEquals(actualInfo.getPublicKey(), keyPair.getPublic());
-        assertEquals(actualInfo.getSubject().getName(), name);
-        assertEquals(actualInfo, actualInfo);
-        assertEquals(actualInfo.hashCode(), actualInfo.hashCode());
+        assertThat(actualInfo.getPublicKey()).isEqualTo(keyPair.getPublic());
+        assertThat(actualInfo.getSubject().getName()).isEqualTo(name);
+        assertThat(actualInfo).isEqualTo(actualInfo);
+        assertThat(actualInfo.hashCode()).isEqualTo(actualInfo.hashCode());
 
         org.bouncycastle.asn1.pkcs.CertificationRequestInfo expectedInfo = new org.bouncycastle.asn1.pkcs.CertificationRequestInfo(new X500Name(name), SubjectPublicKeyInfo.getInstance(keyPair.getPublic().getEncoded()), new DERSet());
 
-        assertEquals(
-                base16().encode(actualInfo.getEncoded()),
-                base16().encode(expectedInfo.getEncoded("DER")));
+        assertThat(base16().encode(actualInfo.getEncoded())).isEqualTo(base16().encode(expectedInfo.getEncoded("DER")));
 
         SignatureAlgorithmIdentifier signatureAlgorithmIdentifier = findSignatureAlgorithmIdentifier("SHA256withECDSA");
         byte[] actualSignature = actualInfo.sign(signatureAlgorithmIdentifier, keyPair.getPrivate());
         Signature signature = Signature.getInstance(signatureAlgorithmIdentifier.getName());
         signature.initVerify(keyPair.getPublic());
         signature.update(actualInfo.getEncoded());
-        assertTrue(signature.verify(actualSignature));
+        assertThat(signature.verify(actualSignature)).isTrue();
     }
 }

--- a/security/src/test/java/io/airlift/security/csr/TestSignatureAlgorithmIdentifier.java
+++ b/security/src/test/java/io/airlift/security/csr/TestSignatureAlgorithmIdentifier.java
@@ -21,7 +21,6 @@ import java.util.Map.Entry;
 
 import static com.google.common.io.BaseEncoding.base16;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.testng.Assert.assertEquals;
 
 public class TestSignatureAlgorithmIdentifier
 {
@@ -32,7 +31,7 @@ public class TestSignatureAlgorithmIdentifier
         int verifiedCount = 0;
         for (Entry<String, SignatureAlgorithmIdentifier> entry : SignatureAlgorithmIdentifier.getAllSignatureAlgorithmIdentifiers().entrySet()) {
             SignatureAlgorithmIdentifier signatureAlgorithmIdentifier = entry.getValue();
-            assertEquals(signatureAlgorithmIdentifier.getName(), entry.getKey());
+            assertThat(signatureAlgorithmIdentifier.getName()).isEqualTo(entry.getKey());
 
             AlgorithmIdentifier algorithmIdentifier;
             try {
@@ -42,14 +41,10 @@ public class TestSignatureAlgorithmIdentifier
                 // Bouncy is missing some algorithms the JVM supports
                 continue;
             }
-            assertEquals(
-                    signatureAlgorithmIdentifier.getOid(),
-                    algorithmIdentifier.getAlgorithm().getId());
-            assertEquals(
-                    base16().encode(signatureAlgorithmIdentifier.getEncoded()),
-                    base16().encode(algorithmIdentifier.getAlgorithm().getEncoded("DER")));
-            assertEquals(algorithmIdentifier, algorithmIdentifier);
-            assertEquals(algorithmIdentifier.hashCode(), algorithmIdentifier.hashCode());
+            assertThat(signatureAlgorithmIdentifier.getOid()).isEqualTo(algorithmIdentifier.getAlgorithm().getId());
+            assertThat(base16().encode(signatureAlgorithmIdentifier.getEncoded())).isEqualTo(base16().encode(algorithmIdentifier.getAlgorithm().getEncoded("DER")));
+            assertThat(algorithmIdentifier).isEqualTo(algorithmIdentifier);
+            assertThat(algorithmIdentifier.hashCode()).isEqualTo(algorithmIdentifier.hashCode());
             verifiedCount++;
         }
         assertThat(verifiedCount).as("Algorithm identifiers verified").isGreaterThanOrEqualTo(10);

--- a/security/src/test/java/io/airlift/security/pem/TestPemReader.java
+++ b/security/src/test/java/io/airlift/security/pem/TestPemReader.java
@@ -51,9 +51,7 @@ import static io.airlift.security.pem.PemWriter.writeCertificate;
 import static io.airlift.security.pem.PemWriter.writePrivateKey;
 import static io.airlift.security.pem.PemWriter.writePublicKey;
 import static java.nio.charset.StandardCharsets.US_ASCII;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestPemReader
 {
@@ -93,14 +91,14 @@ public class TestPemReader
     {
         KeyStore keyStore = loadKeyStore(getResourceFile(certFile), getResourceFile(keyFile), keyPassword);
         assertCertificateChain(keyStore, expectedName);
-        assertNotNull(keyStore.getCertificate("key"));
+        assertThat(keyStore.getCertificate("key")).isNotNull();
 
         Key key = keyStore.getKey("key", new char[0]);
-        assertNotNull(key);
-        assertTrue(key instanceof PrivateKey);
+        assertThat(key).isNotNull();
+        assertThat(key).isInstanceOf(PrivateKey.class);
         PrivateKey privateKey = (PrivateKey) key;
         String encodedPrivateKey = writePrivateKey(privateKey);
-        assertEquals(key, loadPrivateKey(encodedPrivateKey, Optional.empty()));
+        assertThat(key).isEqualTo(loadPrivateKey(encodedPrivateKey, Optional.empty()));
     }
 
     @Test
@@ -126,14 +124,14 @@ public class TestPemReader
             throws Exception
     {
         File file = getResourceFile(keyFile);
-        assertTrue(isPem(file));
+        assertThat(isPem(file)).isTrue();
         PublicKey publicKey = loadPublicKey(file);
-        assertNotNull(publicKey);
+        assertThat(publicKey).isNotNull();
         X509Certificate certificate = readCertificateChain(getResourceFile(certFile)).stream().collect(onlyElement());
-        assertEquals(publicKey, certificate.getPublicKey());
+        assertThat(publicKey).isEqualTo(certificate.getPublicKey());
 
         String encodedPrivateKey = writePublicKey(publicKey);
-        assertEquals(publicKey, loadPublicKey(encodedPrivateKey));
+        assertThat(publicKey).isEqualTo(loadPublicKey(encodedPrivateKey));
     }
 
     @Test
@@ -142,7 +140,7 @@ public class TestPemReader
     {
         byte[] pkcs8 = loadPublicKeyData("rsa.client.pkcs8.pub");
         byte[] pkcs1 = loadPublicKeyData("rsa.client.pkcs1.pub");
-        assertEquals(rsaPublicKeyPkcs1ToPkcs8(pkcs1), pkcs8);
+        assertThat(rsaPublicKeyPkcs1ToPkcs8(pkcs1)).isEqualTo(pkcs8);
     }
 
     @Test
@@ -151,7 +149,7 @@ public class TestPemReader
     {
         byte[] pkcs8 = loadPrivateKeyData("rsa.client.pkcs8.key");
         byte[] pkcs1 = loadPrivateKeyData("rsa.client.pkcs1.key");
-        assertEquals(rsaPkcs1ToPkcs8(pkcs1), pkcs8);
+        assertThat(rsaPkcs1ToPkcs8(pkcs1)).isEqualTo(pkcs8);
     }
 
     @Test
@@ -160,7 +158,7 @@ public class TestPemReader
     {
         byte[] pkcs8 = loadPrivateKeyData("dsa.client.pkcs8.key");
         byte[] pkcs1 = loadPrivateKeyData("dsa.client.pkcs1.key");
-        assertEquals(dsaPkcs1ToPkcs8(pkcs1), pkcs8);
+        assertThat(dsaPkcs1ToPkcs8(pkcs1)).isEqualTo(pkcs8);
     }
 
     @Test
@@ -169,18 +167,18 @@ public class TestPemReader
     {
         byte[] pkcs8 = loadPrivateKeyData("ec.client.pkcs8.key");
         byte[] pkcs1 = loadPrivateKeyData("ec.client.pkcs1.key");
-        assertEquals(ecPkcs1ToPkcs8(pkcs1), pkcs8);
+        assertThat(ecPkcs1ToPkcs8(pkcs1)).isEqualTo(pkcs8);
     }
 
     private static void assertCertificateChain(KeyStore keyStore, String expectedName)
             throws Exception
     {
         ArrayList<String> aliases = Collections.list(keyStore.aliases());
-        assertEquals(aliases.size(), 1);
+        assertThat(aliases.size()).isEqualTo(1);
         Certificate certificate = keyStore.getCertificate(aliases.get(0));
-        assertNotNull(certificate);
+        assertThat(certificate).isNotNull();
 
-        assertTrue(certificate instanceof X509Certificate);
+        assertThat(certificate).isInstanceOf(X509Certificate.class);
         X509Certificate x509Certificate = (X509Certificate) certificate;
 
         assertX509Certificate(x509Certificate, expectedName);
@@ -193,14 +191,14 @@ public class TestPemReader
             throws InvalidNameException
     {
         LdapName ldapName = new LdapName(x509Certificate.getSubjectX500Principal().getName());
-        assertEquals(ldapName.toString(), expectedName);
+        assertThat(ldapName.toString()).isEqualTo(expectedName);
     }
 
     private static byte[] loadPrivateKeyData(String keyFile)
             throws IOException, KeyStoreException
     {
         File file = getResourceFile(keyFile);
-        assertTrue(isPem(file));
+        assertThat(isPem(file)).isTrue();
         String privateKey = asCharSource(file, US_ASCII).read();
         Matcher matcher = PRIVATE_KEY_PATTERN.matcher(privateKey);
         if (!matcher.find()) {
@@ -214,7 +212,7 @@ public class TestPemReader
             throws IOException, KeyStoreException
     {
         File file = getResourceFile(keyFile);
-        assertTrue(isPem(file));
+        assertThat(isPem(file)).isTrue();
         String privateKey = asCharSource(file, US_ASCII).read();
         Matcher matcher = PUBLIC_KEY_PATTERN.matcher(privateKey);
         if (!matcher.find()) {

--- a/skeleton-server/pom.xml
+++ b/skeleton-server/pom.xml
@@ -126,6 +126,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>org.testng</groupId>

--- a/skeleton-server/src/test/java/io/airlift/skeleton/TestServer.java
+++ b/skeleton-server/src/test/java/io/airlift/skeleton/TestServer.java
@@ -22,7 +22,7 @@ import java.net.URI;
 import static io.airlift.http.client.Request.Builder.prepareGet;
 import static io.airlift.http.client.StatusResponseHandler.createStatusResponseHandler;
 import static jakarta.ws.rs.core.Response.Status.OK;
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Test(singleThreaded = true)
 public class TestServer
@@ -70,7 +70,7 @@ public class TestServer
                 prepareGet().setUri(uriFor("/v1/jmx/mbean")).build(),
                 createStatusResponseHandler());
 
-        assertEquals(response.getStatusCode(), OK.getStatusCode());
+        assertThat(response.getStatusCode()).isEqualTo(OK.getStatusCode());
     }
 
     private URI uriFor(String path)

--- a/stats/src/test/java/io/airlift/stats/TestCpuTimer.java
+++ b/stats/src/test/java/io/airlift/stats/TestCpuTimer.java
@@ -5,10 +5,8 @@ import org.testng.annotations.Test;
 
 import static io.airlift.units.Duration.succinctDuration;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
 
 public class TestCpuTimer
 {
@@ -16,32 +14,32 @@ public class TestCpuTimer
     public void testCpuTimerWithUserTimeEnabled()
     {
         CpuTimer timer = new CpuTimer();
-        assertTrue(timer.elapsedTime().hasUser());
-        assertTrue(timer.startNewInterval().hasUser());
-        assertTrue(timer.elapsedIntervalTime().hasUser());
-        assertTrue(timer.elapsedTime().add(new CpuTimer.CpuDuration()).hasUser());
-        assertTrue(timer.elapsedTime().subtract(new CpuTimer.CpuDuration()).hasUser());
+        assertThat(timer.elapsedTime().hasUser()).isTrue();
+        assertThat(timer.startNewInterval().hasUser()).isTrue();
+        assertThat(timer.elapsedIntervalTime().hasUser()).isTrue();
+        assertThat(timer.elapsedTime().add(new CpuTimer.CpuDuration()).hasUser()).isTrue();
+        assertThat(timer.elapsedTime().subtract(new CpuTimer.CpuDuration()).hasUser()).isTrue();
     }
 
     @Test
     public void testCpuTimerWithoutUserTimeEnabled()
     {
         CpuTimer timer = new CpuTimer(false);
-        assertFalse(timer.elapsedTime().hasUser());
-        assertFalse(timer.startNewInterval().hasUser());
-        assertFalse(timer.elapsedIntervalTime().hasUser());
+        assertThat(timer.elapsedTime().hasUser()).isFalse();
+        assertThat(timer.startNewInterval().hasUser()).isFalse();
+        assertThat(timer.elapsedIntervalTime().hasUser()).isFalse();
 
         CpuTimer.CpuDuration withUser = new CpuTimer.CpuDuration();
         CpuTimer.CpuDuration withoutUser = timer.elapsedTime();
 
-        assertTrue(withUser.hasUser());
-        assertFalse(withoutUser.hasUser());
+        assertThat(withUser.hasUser()).isTrue();
+        assertThat(withoutUser.hasUser()).isFalse();
 
-        assertFalse(withUser.add(withoutUser).hasUser());
-        assertFalse(withoutUser.add(withUser).hasUser());
+        assertThat(withUser.add(withoutUser).hasUser()).isFalse();
+        assertThat(withoutUser.add(withUser).hasUser()).isFalse();
 
-        assertFalse(withUser.subtract(withoutUser).hasUser());
-        assertFalse(withoutUser.subtract(withUser).hasUser());
+        assertThat(withUser.subtract(withoutUser).hasUser()).isFalse();
+        assertThat(withoutUser.subtract(withUser).hasUser()).isFalse();
     }
 
     @Test
@@ -58,6 +56,6 @@ public class TestCpuTimer
         TestingTicker ticker = new TestingTicker();
         CpuTimer timer = new CpuTimer(ticker, true);
         ticker.increment(1, SECONDS);
-        assertEquals(timer.elapsedTime().getWall(), succinctDuration(1, SECONDS));
+        assertThat(timer.elapsedTime().getWall()).isEqualTo(succinctDuration(1, SECONDS));
     }
 }

--- a/stats/src/test/java/io/airlift/stats/TestDecayCounter.java
+++ b/stats/src/test/java/io/airlift/stats/TestDecayCounter.java
@@ -5,8 +5,7 @@ import org.testng.annotations.Test;
 
 import java.util.concurrent.TimeUnit;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestDecayCounter
 {
@@ -19,7 +18,7 @@ public class TestDecayCounter
         counter.add(1);
         ticker.increment(1, TimeUnit.MINUTES);
 
-        assertTrue(Math.abs(counter.getCount() - 1 / Math.E) < 1e-9);
+        assertThat(Math.abs(counter.getCount() - 1 / Math.E)).isLessThan(1e-9);
     }
 
     @Test
@@ -33,7 +32,7 @@ public class TestDecayCounter
         counter.add(2);
 
         double expected = 2 + 1 / Math.E;
-        assertTrue(Math.abs(counter.getCount() - expected) < 1e-9);
+        assertThat(Math.abs(counter.getCount() - expected)).isLessThan(1e-9);
     }
 
     @Test
@@ -46,7 +45,7 @@ public class TestDecayCounter
         ticker.increment(1, TimeUnit.MINUTES);
 
         DecayCounter copy = counter.duplicate();
-        assertEquals(copy.getCount(), counter.getCount());
-        assertEquals(copy.getAlpha(), counter.getAlpha());
+        assertThat(copy.getCount()).isEqualTo(counter.getCount());
+        assertThat(copy.getAlpha()).isEqualTo(counter.getAlpha());
     }
 }

--- a/stats/src/test/java/io/airlift/stats/TestDecayTDigest.java
+++ b/stats/src/test/java/io/airlift/stats/TestDecayTDigest.java
@@ -9,7 +9,6 @@ import java.util.concurrent.TimeUnit;
 import static io.airlift.stats.DecayTDigest.RESCALE_THRESHOLD_SECONDS;
 import static io.airlift.stats.DecayTDigest.ZERO_WEIGHT_THRESHOLD;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.testng.Assert.assertEquals;
 
 public class TestDecayTDigest
 {
@@ -22,13 +21,13 @@ public class TestDecayTDigest
         digest.add(5);
         digest.add(1);
 
-        assertEquals(digest.getMin(), 1.0);
-        assertEquals(digest.getMax(), 5.0);
+        assertThat(digest.getMin()).isEqualTo(1.0);
+        assertThat(digest.getMax()).isEqualTo(5.0);
 
         ticker.increment(51, TimeUnit.SECONDS);
 
-        assertEquals(digest.getMin(), 1.0);
-        assertEquals(digest.getMax(), 5.0);
+        assertThat(digest.getMin()).isEqualTo(1.0);
+        assertThat(digest.getMax()).isEqualTo(5.0);
     }
 
     @Test
@@ -44,7 +43,7 @@ public class TestDecayTDigest
         // incrementing time by this amount should cause the weight of the existing value to become "zero"
         ticker.increment((long) Math.ceil(Math.log(1 / ZERO_WEIGHT_THRESHOLD) / decayFactor), TimeUnit.SECONDS);
 
-        assertEquals(digest.getCount(), 0.0);
+        assertThat(digest.getCount()).isEqualTo(0.0);
     }
 
     @Test

--- a/stats/src/test/java/io/airlift/stats/TestDistribution.java
+++ b/stats/src/test/java/io/airlift/stats/TestDistribution.java
@@ -2,7 +2,7 @@ package io.airlift.stats;
 
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestDistribution
 {
@@ -12,13 +12,13 @@ public class TestDistribution
         Distribution distribution = new Distribution(0.1);
 
         distribution.add(10);
-        assertEquals(distribution.getCount(), 1D);
-        assertEquals(distribution.getAvg(), 10D);
+        assertThat(distribution.getCount()).isEqualTo(1D);
+        assertThat(distribution.getAvg()).isEqualTo(10D);
 
         distribution.reset();
 
-        assertEquals(distribution.getCount(), 0D);
-        assertEquals(distribution.getAvg(), Double.NaN);
+        assertThat(distribution.getCount()).isEqualTo(0D);
+        assertThat(distribution.getAvg()).isNaN();
     }
 
     @Test
@@ -30,7 +30,7 @@ public class TestDistribution
 
         Distribution copy = distribution.duplicate();
 
-        assertEquals(copy.getCount(), distribution.getCount());
-        assertEquals(copy.getTotal(), distribution.getTotal());
+        assertThat(copy.getCount()).isEqualTo(distribution.getCount());
+        assertThat(copy.getTotal()).isEqualTo(distribution.getTotal());
     }
 }

--- a/stats/src/test/java/io/airlift/stats/TestJmxGcMonitor.java
+++ b/stats/src/test/java/io/airlift/stats/TestJmxGcMonitor.java
@@ -5,7 +5,7 @@ import org.testng.annotations.Test;
 
 import static io.airlift.testing.Assertions.assertGreaterThanOrEqual;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestJmxGcMonitor
 {
@@ -14,8 +14,8 @@ public class TestJmxGcMonitor
             throws Exception
     {
         JmxGcMonitor gcMonitor = new JmxGcMonitor();
-        assertEquals(gcMonitor.getMajorGcCount(), 0);
-        assertEquals(gcMonitor.getMajorGcTime(), new Duration(0, NANOSECONDS));
+        assertThat(gcMonitor.getMajorGcCount()).isEqualTo(0);
+        assertThat(gcMonitor.getMajorGcTime()).isEqualTo(new Duration(0, NANOSECONDS));
         try {
             gcMonitor.start();
             assertGreaterThanOrEqual(gcMonitor.getMajorGcCount(), (long) 0);

--- a/stats/src/test/java/io/airlift/stats/TestQuantileDigest.java
+++ b/stats/src/test/java/io/airlift/stats/TestQuantileDigest.java
@@ -18,9 +18,7 @@ import java.util.stream.LongStream;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestQuantileDigest
 {
@@ -33,10 +31,10 @@ public class TestQuantileDigest
         digest.validate();
 
         // should have no compressions with so few values and the allowed error
-        assertEquals(digest.getConfidenceFactor(), 0.0);
+        assertThat(digest.getConfidenceFactor()).isEqualTo(0.0);
 
-        assertEquals(digest.getCount(), (double) 1);
-        assertEquals(digest.getNodeCount(), 1);
+        assertThat(digest.getCount()).isEqualTo(1);
+        assertThat(digest.getNodeCount()).isEqualTo(1);
     }
 
     @Test
@@ -45,7 +43,7 @@ public class TestQuantileDigest
         QuantileDigest digest = new QuantileDigest(1);
         addAll(digest, asList(-1, -2, -3, -4, -5, 0, 1, 2, 3, 4, 5));
 
-        assertEquals(digest.getCount(), (double) 11);
+        assertThat(digest.getCount()).isEqualTo(11);
     }
 
     @Test
@@ -58,10 +56,10 @@ public class TestQuantileDigest
         digest.validate();
 
         // should have no compressions with so few values and the allowed error
-        assertEquals(digest.getConfidenceFactor(), 0.0);
+        assertThat(digest.getConfidenceFactor()).isEqualTo(0.0);
 
-        assertEquals(digest.getCount(), (double) 2);
-        assertEquals(digest.getNodeCount(), 1);
+        assertThat(digest.getCount()).isEqualTo(2);
+        assertThat(digest.getNodeCount()).isEqualTo(1);
     }
 
     @Test
@@ -74,9 +72,9 @@ public class TestQuantileDigest
         digest.validate();
 
         // should have no compressions with so few values and the allowed error
-        assertEquals(digest.getConfidenceFactor(), 0.0);
-        assertEquals(digest.getCount(), (double) 2);
-        assertEquals(digest.getNodeCount(), 3);
+        assertThat(digest.getConfidenceFactor()).isEqualTo(0.0);
+        assertThat(digest.getCount()).isEqualTo(2);
+        assertThat(digest.getNodeCount()).isEqualTo(3);
     }
 
     @Test
@@ -87,7 +85,7 @@ public class TestQuantileDigest
         List<Integer> values = asList(0, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 4, 5, 6, 7);
         addAll(digest, values);
 
-        assertEquals(digest.getCount(), (double) values.size());
+        assertThat(digest.getCount()).isEqualTo(values.size());
     }
 
     @Test
@@ -98,7 +96,7 @@ public class TestQuantileDigest
         List<Integer> values = asList(0, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 4, 5, 6, 7);
         addAll(digest, Lists.reverse(values));
 
-        assertEquals(digest.getCount(), (double) values.size());
+        assertThat(digest.getCount()).isEqualTo(values.size());
     }
 
     @Test
@@ -113,9 +111,9 @@ public class TestQuantileDigest
         digest.compress();
         digest.validate();
 
-        assertEquals(digest.getCount(), (double) values.size());
-        assertEquals(digest.getNodeCount(), 7);
-        assertEquals(digest.getConfidenceFactor(), 0.2);
+        assertThat(digest.getCount()).isEqualTo(values.size());
+        assertThat(digest.getNodeCount()).isEqualTo(7);
+        assertThat(digest.getConfidenceFactor()).isEqualTo(0.2);
     }
 
     @Test
@@ -140,19 +138,19 @@ public class TestQuantileDigest
         addAll(digest, asList(0, 1, 2, 3, 4, 5, 6, 7, 8, 9));
 
         // should have no compressions with so few values and the allowed error
-        assertEquals(digest.getConfidenceFactor(), 0.0);
+        assertThat(digest.getConfidenceFactor()).isEqualTo(0.0);
 
-        assertEquals(digest.getQuantile(0.0), 0);
-        assertEquals(digest.getQuantile(0.1), 1);
-        assertEquals(digest.getQuantile(0.2), 2);
-        assertEquals(digest.getQuantile(0.3), 3);
-        assertEquals(digest.getQuantile(0.4), 4);
-        assertEquals(digest.getQuantile(0.5), 5);
-        assertEquals(digest.getQuantile(0.6), 6);
-        assertEquals(digest.getQuantile(0.7), 7);
-        assertEquals(digest.getQuantile(0.8), 8);
-        assertEquals(digest.getQuantile(0.9), 9);
-        assertEquals(digest.getQuantile(1), 9);
+        assertThat(digest.getQuantile(0.0)).isEqualTo(0);
+        assertThat(digest.getQuantile(0.1)).isEqualTo(1);
+        assertThat(digest.getQuantile(0.2)).isEqualTo(2);
+        assertThat(digest.getQuantile(0.3)).isEqualTo(3);
+        assertThat(digest.getQuantile(0.4)).isEqualTo(4);
+        assertThat(digest.getQuantile(0.5)).isEqualTo(5);
+        assertThat(digest.getQuantile(0.6)).isEqualTo(6);
+        assertThat(digest.getQuantile(0.7)).isEqualTo(7);
+        assertThat(digest.getQuantile(0.8)).isEqualTo(8);
+        assertThat(digest.getQuantile(0.9)).isEqualTo(9);
+        assertThat(digest.getQuantile(1)).isEqualTo(9);
     }
 
     @Test
@@ -162,17 +160,15 @@ public class TestQuantileDigest
 
         addRange(digest, 1, 100);
 
-        assertEquals(digest.getQuantileLowerBound(0.0), 1);
+        assertThat(digest.getQuantileLowerBound(0.0)).isEqualTo(1);
         for (int i = 1; i <= 10; i++) {
-            assertTrue(digest.getQuantileLowerBound(i / 10.0) <= i * 10);
+            assertThat(digest.getQuantileLowerBound(i / 10.0) <= i * 10).isTrue();
             if (i > 5) {
-                assertTrue(digest.getQuantileLowerBound(i / 10.0) >= (i - 5) * 10);
+                assertThat(digest.getQuantileLowerBound(i / 10.0) >= (i - 5) * 10).isTrue();
             }
         }
 
-        assertEquals(
-                digest.getQuantilesLowerBound(ImmutableList.of(0.0, 0.1, 0.2)),
-                ImmutableList.of(digest.getQuantileLowerBound(0.0), digest.getQuantileLowerBound(0.1), digest.getQuantileLowerBound(0.2)));
+        assertThat(digest.getQuantilesLowerBound(ImmutableList.of(0.0, 0.1, 0.2))).isEqualTo(ImmutableList.of(digest.getQuantileLowerBound(0.0), digest.getQuantileLowerBound(0.1), digest.getQuantileLowerBound(0.2)));
     }
 
     @Test
@@ -182,17 +178,15 @@ public class TestQuantileDigest
 
         addRange(digest, 1, 100);
 
-        assertEquals(digest.getQuantileUpperBound(1.0), 99);
+        assertThat(digest.getQuantileUpperBound(1.0)).isEqualTo(99);
         for (int i = 0; i < 10; i++) {
-            assertTrue(digest.getQuantileUpperBound(i / 10.0) >= i * 10);
+            assertThat(digest.getQuantileUpperBound(i / 10.0) >= i * 10).isTrue();
             if (i < 5) {
-                assertTrue(digest.getQuantileUpperBound(i / 10.0) <= (i + 5) * 10);
+                assertThat(digest.getQuantileUpperBound(i / 10.0) <= (i + 5) * 10).isTrue();
             }
         }
 
-        assertEquals(
-                digest.getQuantilesUpperBound(ImmutableList.of(0.8, 0.9, 1.0)),
-                ImmutableList.of(digest.getQuantileUpperBound(0.8), digest.getQuantileUpperBound(0.9), digest.getQuantileUpperBound(1.0)));
+        assertThat(digest.getQuantilesUpperBound(ImmutableList.of(0.8, 0.9, 1.0))).isEqualTo(ImmutableList.of(digest.getQuantileUpperBound(0.8), digest.getQuantileUpperBound(0.9), digest.getQuantileUpperBound(1.0)));
     }
 
     @Test
@@ -207,19 +201,19 @@ public class TestQuantileDigest
         digest.validate();
 
         // should have no compressions with so few values and the allowed error
-        assertEquals(digest.getConfidenceFactor(), 0.0);
+        assertThat(digest.getConfidenceFactor()).isEqualTo(0.0);
 
-        assertEquals(digest.getQuantile(0.0), 0);
-        assertEquals(digest.getQuantile(0.1), 0);
-        assertEquals(digest.getQuantile(0.2), 0);
-        assertEquals(digest.getQuantile(0.3), 2);
-        assertEquals(digest.getQuantile(0.4), 4);
-        assertEquals(digest.getQuantile(0.5), 4);
-        assertEquals(digest.getQuantile(0.6), 4);
-        assertEquals(digest.getQuantile(0.7), 4);
-        assertEquals(digest.getQuantile(0.8), 4);
-        assertEquals(digest.getQuantile(0.9), 5);
-        assertEquals(digest.getQuantile(1), 5);
+        assertThat(digest.getQuantile(0.0)).isEqualTo(0);
+        assertThat(digest.getQuantile(0.1)).isEqualTo(0);
+        assertThat(digest.getQuantile(0.2)).isEqualTo(0);
+        assertThat(digest.getQuantile(0.3)).isEqualTo(2);
+        assertThat(digest.getQuantile(0.4)).isEqualTo(4);
+        assertThat(digest.getQuantile(0.5)).isEqualTo(4);
+        assertThat(digest.getQuantile(0.6)).isEqualTo(4);
+        assertThat(digest.getQuantile(0.7)).isEqualTo(4);
+        assertThat(digest.getQuantile(0.8)).isEqualTo(4);
+        assertThat(digest.getQuantile(0.9)).isEqualTo(5);
+        assertThat(digest.getQuantile(1)).isEqualTo(5);
     }
 
     @Test
@@ -231,10 +225,9 @@ public class TestQuantileDigest
         addAll(digest, asList(0, 1, 2, 3, 4, 5, 6, 7, 8, 9));
 
         // should have no compressions with so few values and the allowed error
-        assertEquals(digest.getConfidenceFactor(), 0.0);
+        assertThat(digest.getConfidenceFactor()).isEqualTo(0.0);
 
-        assertEquals(digest.getQuantiles(asList(0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0)),
-                asList(0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 9L));
+        assertThat(digest.getQuantiles(asList(0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0))).isEqualTo(asList(0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 9L));
     }
 
     @Test
@@ -246,31 +239,28 @@ public class TestQuantileDigest
         addAll(digest, asList(0, 1, 2, 3, 4, 5, 6, 7, 8, 9));
 
         // should have no compressions with so few values and the allowed error
-        assertEquals(digest.getConfidenceFactor(), 0.0);
+        assertThat(digest.getConfidenceFactor()).isEqualTo(0.0);
 
-        assertEquals(digest.getHistogram(asList(0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L)),
-                asList(new QuantileDigest.Bucket(0, Double.NaN),
-                        new QuantileDigest.Bucket(1, 0),
-                        new QuantileDigest.Bucket(1, 1),
-                        new QuantileDigest.Bucket(1, 2),
-                        new QuantileDigest.Bucket(1, 3),
-                        new QuantileDigest.Bucket(1, 4),
-                        new QuantileDigest.Bucket(1, 5),
-                        new QuantileDigest.Bucket(1, 6),
-                        new QuantileDigest.Bucket(1, 7),
-                        new QuantileDigest.Bucket(1, 8),
-                        new QuantileDigest.Bucket(1, 9)));
+        assertThat(digest.getHistogram(asList(0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L))).isEqualTo(asList(new QuantileDigest.Bucket(0, Double.NaN),
+                new QuantileDigest.Bucket(1, 0),
+                new QuantileDigest.Bucket(1, 1),
+                new QuantileDigest.Bucket(1, 2),
+                new QuantileDigest.Bucket(1, 3),
+                new QuantileDigest.Bucket(1, 4),
+                new QuantileDigest.Bucket(1, 5),
+                new QuantileDigest.Bucket(1, 6),
+                new QuantileDigest.Bucket(1, 7),
+                new QuantileDigest.Bucket(1, 8),
+                new QuantileDigest.Bucket(1, 9)));
 
-        assertEquals(digest.getHistogram(asList(7L, 10L)),
-                asList(new QuantileDigest.Bucket(7, 3),
-                        new QuantileDigest.Bucket(3, 8)));
+        assertThat(digest.getHistogram(asList(7L, 10L))).isEqualTo(asList(new QuantileDigest.Bucket(7, 3),
+                new QuantileDigest.Bucket(3, 8)));
 
         // test some edge conditions
-        assertEquals(digest.getHistogram(asList(0L)), asList(new QuantileDigest.Bucket(0, Double.NaN)));
-        assertEquals(digest.getHistogram(asList(9L)), asList(new QuantileDigest.Bucket(9, 4)));
-        assertEquals(digest.getHistogram(asList(10L)), asList(new QuantileDigest.Bucket(10, 4.5)));
-        assertEquals(digest.getHistogram(asList(Long.MAX_VALUE)),
-                asList(new QuantileDigest.Bucket(10, 4.5)));
+        assertThat(digest.getHistogram(asList(0L))).isEqualTo(asList(new QuantileDigest.Bucket(0, Double.NaN)));
+        assertThat(digest.getHistogram(asList(9L))).isEqualTo(asList(new QuantileDigest.Bucket(9, 4)));
+        assertThat(digest.getHistogram(asList(10L))).isEqualTo(asList(new QuantileDigest.Bucket(10, 4.5)));
+        assertThat(digest.getHistogram(asList(Long.MAX_VALUE))).isEqualTo(asList(new QuantileDigest.Bucket(10, 4.5)));
     }
 
     @Test
@@ -283,7 +273,7 @@ public class TestQuantileDigest
                 .boxed()
                 .forEach(digest::add);
 
-        assertEquals(digest.getConfidenceFactor(), 0.0);
+        assertThat(digest.getConfidenceFactor()).isEqualTo(0.0);
 
         List<Long> bucketUpperBounds = LongStream.range(-10, 10)
                 .map(TestQuantileDigest::doubleToSortableLong)
@@ -306,26 +296,18 @@ public class TestQuantileDigest
                 .map(i -> new QuantileDigest.Bucket(1, i - 1))
                 .collect(Collectors.toList());
         expected.add(0, new QuantileDigest.Bucket(0, Double.NaN));
-        assertEquals(digest.getHistogram(bucketUpperBounds, middleFunction),
-                expected);
+        assertThat(digest.getHistogram(bucketUpperBounds, middleFunction)).isEqualTo(expected);
 
-        assertEquals(digest.getHistogram(asList(doubleToSortableLong(7), doubleToSortableLong(10)), middleFunction),
-                asList(new QuantileDigest.Bucket(17, -2.0),
-                        new QuantileDigest.Bucket(3, 8)));
+        assertThat(digest.getHistogram(asList(doubleToSortableLong(7), doubleToSortableLong(10)), middleFunction)).isEqualTo(asList(new QuantileDigest.Bucket(17, -2.0),
+                new QuantileDigest.Bucket(3, 8)));
 
         // edge cases
-        assertEquals(digest.getHistogram(asList(doubleToSortableLong(-1 * Double.MAX_VALUE)), middleFunction),
-                asList(new QuantileDigest.Bucket(0, Double.NaN)));
-        assertEquals(digest.getHistogram(asList(doubleToSortableLong(-1 * Double.MAX_VALUE), doubleToSortableLong(-1 * Double.MAX_VALUE + 1)), middleFunction),
-                asList(new QuantileDigest.Bucket(0, Double.NaN), new QuantileDigest.Bucket(0, Double.NaN)));
-        assertEquals(digest.getHistogram(asList(doubleToSortableLong(0)), middleFunction),
-                asList(new QuantileDigest.Bucket(10.0, -5.5)));
-        assertEquals(digest.getHistogram(asList(doubleToSortableLong(9)), middleFunction),
-                asList(new QuantileDigest.Bucket(19, -1.0)));
-        assertEquals(digest.getHistogram(asList(doubleToSortableLong(10)), middleFunction),
-                asList(new QuantileDigest.Bucket(20, -0.5)));
-        assertEquals(digest.getHistogram(asList(doubleToSortableLong(Double.MAX_VALUE)), middleFunction),
-                asList(new QuantileDigest.Bucket(20, -0.5)));
+        assertThat(digest.getHistogram(asList(doubleToSortableLong(-1 * Double.MAX_VALUE)), middleFunction)).isEqualTo(asList(new QuantileDigest.Bucket(0, Double.NaN)));
+        assertThat(digest.getHistogram(asList(doubleToSortableLong(-1 * Double.MAX_VALUE), doubleToSortableLong(-1 * Double.MAX_VALUE + 1)), middleFunction)).isEqualTo(asList(new QuantileDigest.Bucket(0, Double.NaN), new QuantileDigest.Bucket(0, Double.NaN)));
+        assertThat(digest.getHistogram(asList(doubleToSortableLong(0)), middleFunction)).isEqualTo(asList(new QuantileDigest.Bucket(10.0, -5.5)));
+        assertThat(digest.getHistogram(asList(doubleToSortableLong(9)), middleFunction)).isEqualTo(asList(new QuantileDigest.Bucket(19, -1.0)));
+        assertThat(digest.getHistogram(asList(doubleToSortableLong(10)), middleFunction)).isEqualTo(asList(new QuantileDigest.Bucket(20, -0.5)));
+        assertThat(digest.getHistogram(asList(doubleToSortableLong(Double.MAX_VALUE)), middleFunction)).isEqualTo(asList(new QuantileDigest.Bucket(20, -0.5)));
     }
 
     @Test
@@ -338,7 +320,7 @@ public class TestQuantileDigest
         addRange(digest, 0, total);
 
         // compression should've run at this error rate and count
-        assertTrue(digest.getConfidenceFactor() > 0.0);
+        assertThat(digest.getConfidenceFactor() > 0.0).isTrue();
 
         double actualMaxError = digest.getConfidenceFactor();
 
@@ -346,7 +328,7 @@ public class TestQuantileDigest
             QuantileDigest.Bucket bucket = digest.getHistogram(asList(value)).get(0);
 
             // estimated count should have an absolute error smaller than 2 * maxError * N
-            assertTrue(Math.abs(bucket.getCount() - value) < 2 * actualMaxError * total);
+            assertThat(Math.abs(bucket.getCount() - value)).isLessThan(2 * actualMaxError * total);
         }
     }
 
@@ -361,8 +343,8 @@ public class TestQuantileDigest
         addRange(digest, 0, count);
 
         // compression should've run at this error rate and count
-        assertTrue(digest.getConfidenceFactor() > 0);
-        assertTrue(digest.getConfidenceFactor() < maxError);
+        assertThat(digest.getConfidenceFactor()).isGreaterThan(0);
+        assertThat(digest.getConfidenceFactor()).isLessThan(maxError);
 
         for (int value = 0; value < count; ++value) {
             double quantile = value * 1.0 / count;
@@ -370,9 +352,9 @@ public class TestQuantileDigest
 
             // true rank of estimatedValue is == estimatedValue because
             // we've inserted a list of ordered numbers starting at 0
-            double error = Math.abs(estimatedValue - quantile * count) * 1.0 / count;
+            double error = Math.abs(estimatedValue - quantile * count) / count;
 
-            assertTrue(error < maxError);
+            assertThat(error < maxError).isTrue();
         }
     }
 
@@ -386,7 +368,7 @@ public class TestQuantileDigest
         addAll(digest, asList(0, 1, 2, 3, 4, 5, 6, 7, 8, 9));
 
         // should have no compressions with so few values and the allowed error
-        assertEquals(digest.getConfidenceFactor(), 0.0);
+        assertThat(digest.getConfidenceFactor()).isEqualTo(0.0);
 
         ticker.increment(60, TimeUnit.SECONDS);
         addAll(digest, asList(10, 11, 12, 13, 14, 15, 16, 17, 18, 19));
@@ -394,7 +376,7 @@ public class TestQuantileDigest
         // Considering that the first 10 values now have a weight of 0.5 per the alpha factor, they only contributed a count
         // of 5 to rank computations. Therefore, the 50th percentile is equivalent to a weighted rank of (5 + 10) / 2 = 7.5,
         // which corresponds to value 12
-        assertEquals(digest.getQuantile(0.5), 12);
+        assertThat(digest.getQuantile(0.5)).isEqualTo(12);
     }
 
     @Test
@@ -407,12 +389,12 @@ public class TestQuantileDigest
         addAll(digest, asList(0, 1, 2, 3, 4, 5, 6, 7, 8, 9));
 
         // should have no compressions with so few values and the allowed error
-        assertEquals(digest.getConfidenceFactor(), 0.0);
+        assertThat(digest.getConfidenceFactor()).isEqualTo(0.0);
 
         ticker.increment(60, TimeUnit.SECONDS);
         addAll(digest, asList(10, 11, 12, 13, 14, 15, 16, 17, 18, 19));
 
-        assertEquals(digest.getCount(), 15.0);
+        assertThat(digest.getCount()).isEqualTo(15.0);
     }
 
     @Test
@@ -429,7 +411,7 @@ public class TestQuantileDigest
         ticker.increment(targetAgeInSeconds, TimeUnit.SECONDS);
         addAll(digest, asList(10, 11, 12, 13, 14, 15, 16, 17, 18, 19));
 
-        assertEquals(digest.getCount(), 15.0);
+        assertThat(digest.getCount()).isEqualTo(15.0);
     }
 
     @Test
@@ -442,8 +424,8 @@ public class TestQuantileDigest
         int to = 700;
         addRange(digest, from, to + 1);
 
-        assertEquals(digest.getMin(), from);
-        assertEquals(digest.getMax(), to);
+        assertThat(digest.getMin()).isEqualTo(from);
+        assertThat(digest.getMax()).isEqualTo(to);
     }
 
     @Test
@@ -465,8 +447,8 @@ public class TestQuantileDigest
 
         digest.validate();
 
-        assertEquals(digest.getMin(), from);
-        assertEquals(digest.getMax(), to);
+        assertThat(digest.getMin()).isEqualTo(from);
+        assertThat(digest.getMax()).isEqualTo(to);
     }
 
     @Test
@@ -488,7 +470,7 @@ public class TestQuantileDigest
             ticker.increment(targetAgeInSeconds, TimeUnit.SECONDS);
         }
 
-        assertEquals(digest.getNodeCount(), 1);
+        assertThat(digest.getNodeCount()).isEqualTo(1);
     }
 
     @Test
@@ -498,7 +480,7 @@ public class TestQuantileDigest
         QuantileDigest a = new QuantileDigest(0.01);
         QuantileDigest b = new QuantileDigest(0.01);
 
-        assertTrue(a.equivalent(b));
+        assertThat(a.equivalent(b)).isTrue();
     }
 
     @Test
@@ -511,7 +493,7 @@ public class TestQuantileDigest
         a.add(1);
         b.add(1);
 
-        assertTrue(a.equivalent(b));
+        assertThat(a.equivalent(b)).isTrue();
     }
 
     @Test
@@ -524,7 +506,7 @@ public class TestQuantileDigest
         a.add(1);
         b.add(2);
 
-        assertFalse(a.equivalent(b));
+        assertThat(a.equivalent(b)).isFalse();
     }
 
     @Test
@@ -537,7 +519,7 @@ public class TestQuantileDigest
         addAll(a, asList(0, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 4, 5, 6, 7));
         addAll(b, asList(0, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 4, 5, 6, 7));
 
-        assertTrue(a.equivalent(b));
+        assertThat(a.equivalent(b)).isTrue();
     }
 
     @Test
@@ -550,7 +532,7 @@ public class TestQuantileDigest
         addAll(a, asList(0, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 4, 5, 6, 7));
         addAll(b, asList(0, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 4, 5, 6, 7, 8));
 
-        assertFalse(a.equivalent(b));
+        assertThat(a.equivalent(b)).isFalse();
     }
 
     @Test
@@ -566,13 +548,13 @@ public class TestQuantileDigest
         a.validate();
         b.validate();
 
-        assertTrue(b.equivalent(pristineB));
+        assertThat(b.equivalent(pristineB)).isTrue();
 
-        assertEquals(a.getCount(), 0.0);
-        assertEquals(a.getNodeCount(), 0);
+        assertThat(a.getCount()).isEqualTo(0.0);
+        assertThat(a.getNodeCount()).isEqualTo(0);
 
-        assertEquals(b.getCount(), 0.0);
-        assertEquals(b.getNodeCount(), 0);
+        assertThat(b.getCount()).isEqualTo(0.0);
+        assertThat(b.getNodeCount()).isEqualTo(0);
     }
 
     @Test
@@ -591,13 +573,13 @@ public class TestQuantileDigest
         a.validate();
         b.validate();
 
-        assertTrue(b.equivalent(pristineB));
+        assertThat(b.equivalent(pristineB)).isTrue();
 
-        assertEquals(a.getCount(), 1.0);
-        assertEquals(a.getNodeCount(), 1);
+        assertThat(a.getCount()).isEqualTo(1.0);
+        assertThat(a.getNodeCount()).isEqualTo(1);
 
-        assertEquals(b.getCount(), 1.0);
-        assertEquals(b.getNodeCount(), 1);
+        assertThat(b.getCount()).isEqualTo(1.0);
+        assertThat(b.getNodeCount()).isEqualTo(1);
     }
 
     @Test
@@ -614,13 +596,13 @@ public class TestQuantileDigest
         a.validate();
         b.validate();
 
-        assertTrue(b.equivalent(pristineB));
+        assertThat(b.equivalent(pristineB)).isTrue();
 
-        assertEquals(a.getCount(), 1.0);
-        assertEquals(a.getNodeCount(), 1);
+        assertThat(a.getCount()).isEqualTo(1.0);
+        assertThat(a.getNodeCount()).isEqualTo(1);
 
-        assertEquals(b.getCount(), 0.0);
-        assertEquals(b.getNodeCount(), 0);
+        assertThat(b.getCount()).isEqualTo(0.0);
+        assertThat(b.getNodeCount()).isEqualTo(0);
     }
 
     @Test
@@ -637,8 +619,8 @@ public class TestQuantileDigest
 
         a.validate();
 
-        assertEquals(a.getCount(), 3.0);
-        assertEquals(a.getNodeCount(), 5);
+        assertThat(a.getCount()).isEqualTo(3.0);
+        assertThat(a.getNodeCount()).isEqualTo(5);
     }
 
     @Test
@@ -656,13 +638,13 @@ public class TestQuantileDigest
 
         a.merge(b);
 
-        assertTrue(b.equivalent(pristineB));
+        assertThat(b.equivalent(pristineB)).isTrue();
 
-        assertEquals(a.getCount(), 2.0);
-        assertEquals(a.getNodeCount(), 3);
+        assertThat(a.getCount()).isEqualTo(2.0);
+        assertThat(a.getNodeCount()).isEqualTo(3);
 
-        assertEquals(b.getCount(), 1.0);
-        assertEquals(b.getNodeCount(), 1);
+        assertThat(b.getCount()).isEqualTo(1.0);
+        assertThat(b.getNodeCount()).isEqualTo(1);
     }
 
     @Test
@@ -686,10 +668,10 @@ public class TestQuantileDigest
 
         a.merge(b);
 
-        assertTrue(b.equivalent(pristineB));
+        assertThat(b.equivalent(pristineB)).isTrue();
 
-        assertEquals(a.getCount(), 14.0);
-        assertEquals(b.getCount(), 13.0);
+        assertThat(a.getCount()).isEqualTo(14.0);
+        assertThat(b.getCount()).isEqualTo(13.0);
     }
 
     @Test
@@ -709,13 +691,13 @@ public class TestQuantileDigest
 
         a.merge(b);
 
-        assertTrue(b.equivalent(pristineB));
+        assertThat(b.equivalent(pristineB)).isTrue();
 
-        assertEquals(a.getCount(), 15.0);
-        assertEquals(a.getNodeCount(), 7);
+        assertThat(a.getCount()).isEqualTo(15.0);
+        assertThat(a.getNodeCount()).isEqualTo(7);
 
-        assertEquals(b.getCount(), 2.0);
-        assertEquals(b.getNodeCount(), 3);
+        assertThat(b.getCount()).isEqualTo(2.0);
+        assertThat(b.getNodeCount()).isEqualTo(3);
     }
 
     // test merging two digests that have a node at the highest level to make sure
@@ -736,10 +718,10 @@ public class TestQuantileDigest
         a.validate();
         b.validate();
 
-        assertTrue(b.equivalent(pristineB));
+        assertThat(b.equivalent(pristineB)).isTrue();
 
-        assertEquals(a.getCount(), 4.0);
-        assertEquals(a.getNodeCount(), 7);
+        assertThat(a.getCount()).isEqualTo(4.0);
+        assertThat(a.getNodeCount()).isEqualTo(7);
     }
 
     @Test
@@ -756,13 +738,13 @@ public class TestQuantileDigest
 
         a.merge(b);
 
-        assertTrue(b.equivalent(pristineB));
+        assertThat(b.equivalent(pristineB)).isTrue();
 
-        assertEquals(a.getCount(), 2.0);
-        assertEquals(a.getNodeCount(), 1);
+        assertThat(a.getCount()).isEqualTo(2.0);
+        assertThat(a.getNodeCount()).isEqualTo(1);
 
-        assertEquals(b.getCount(), 1.0);
-        assertEquals(b.getNodeCount(), 1);
+        assertThat(b.getCount()).isEqualTo(1.0);
+        assertThat(b.getNodeCount()).isEqualTo(1);
     }
 
     @Test
@@ -772,7 +754,7 @@ public class TestQuantileDigest
         QuantileDigest digest = new QuantileDigest(0.01);
         QuantileDigest deserialized = deserialize(digest.serialize());
 
-        assertTrue(digest.equivalent(deserialized));
+        assertThat(digest.equivalent(deserialized)).isTrue();
     }
 
     @Test
@@ -782,7 +764,7 @@ public class TestQuantileDigest
         QuantileDigest digest = new QuantileDigest(0.01);
         digest.add(1);
 
-        assertTrue(digest.equivalent(deserialize(digest.serialize())));
+        assertThat(digest.equivalent(deserialize(digest.serialize()))).isTrue();
     }
 
     @Test
@@ -792,11 +774,11 @@ public class TestQuantileDigest
         QuantileDigest digest = new QuantileDigest(1);
         addAll(digest, asList(0, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 4, 5, 6, 7));
 
-        assertTrue(digest.equivalent(deserialize(digest.serialize())));
+        assertThat(digest.equivalent(deserialize(digest.serialize()))).isTrue();
 
         digest.compress();
 
-        assertTrue(digest.equivalent(deserialize(digest.serialize())));
+        assertThat(digest.equivalent(deserialize(digest.serialize()))).isTrue();
     }
 
     @Test
@@ -807,11 +789,11 @@ public class TestQuantileDigest
         digest.add(Long.MIN_VALUE);
         digest.add(Long.MAX_VALUE);
 
-        assertTrue(digest.equivalent(deserialize(digest.serialize())));
+        assertThat(digest.equivalent(deserialize(digest.serialize()))).isTrue();
 
         digest.compress();
 
-        assertTrue(digest.equivalent(deserialize(digest.serialize())));
+        assertThat(digest.equivalent(deserialize(digest.serialize()))).isTrue();
     }
 
     @Test(invocationCount = 1000)
@@ -827,7 +809,7 @@ public class TestQuantileDigest
 
         addAll(digest, values);
 
-        assertTrue(digest.equivalent(deserialize(digest.serialize())), format("Serialization roundtrip failed for input: %s", values));
+        assertThat(digest.equivalent(deserialize(digest.serialize()))).as(format("Serialization roundtrip failed for input: %s", values)).isTrue();
     }
 
     private QuantileDigest deserialize(Slice serialized)

--- a/stats/src/test/java/io/airlift/stats/TestTDigest.java
+++ b/stats/src/test/java/io/airlift/stats/TestTDigest.java
@@ -18,6 +18,7 @@ import com.google.common.collect.Lists;
 import com.google.common.io.Resources;
 import com.google.common.primitives.Doubles;
 import io.airlift.slice.Slices;
+import org.assertj.core.data.Offset;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -29,9 +30,9 @@ import java.util.stream.IntStream;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Arrays.asList;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertThrows;
-import static org.testng.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.within;
 
 public class TestTDigest
 {
@@ -39,13 +40,14 @@ public class TestTDigest
     public void testEmpty()
     {
         TDigest digest = new TDigest();
-        assertTrue(Double.isNaN(digest.valueAt(0.5)));
-        assertTrue(Double.isNaN(digest.getMin()));
-        assertTrue(Double.isNaN(digest.getMax()));
+        assertThat(digest.valueAt(0.5)).isNaN();
+        assertThat(digest.getMin()).isNaN();
+        assertThat(digest.getMax()).isNaN();
         double[] quantiles = new double[] {0.1, 0.2, 0.5, 0.9};
         double[] expected = new double[] {Double.NaN, Double.NaN, Double.NaN, Double.NaN};
-        assertEquals(digest.valuesAt(quantiles), expected);
-        assertEquals(digest.valuesAt(Doubles.asList(quantiles)), Doubles.asList(expected));
+        assertThat(digest.valuesAt(quantiles)).isEqualTo(expected);
+        assertThat(digest.valuesAt(Doubles.asList(quantiles)))
+                .allSatisfy(value -> assertThat(value).isNaN());
     }
 
     @Test
@@ -59,7 +61,7 @@ public class TestTDigest
         double previous = -1;
         for (double quantile = 0; quantile <= 1; quantile += 1e-5) {
             double value = digest.valueAt(quantile);
-            assertTrue(value >= previous);
+            assertThat(value >= previous).isTrue();
             previous = value;
         }
     }
@@ -73,11 +75,11 @@ public class TestTDigest
         }
         digest.add(1_000_000);
 
-        assertEquals(digest.valueAt(0.89999999), 18.0);
-        assertEquals(digest.valueAt(0.9), 19.0);
-        assertEquals(digest.valueAt(0.949999999), 19.0);
-        assertEquals(digest.valueAt(0.95), 1_000_000.0);
-        assertEquals(digest.valuesAt(0.89999999, 0.9, 0.949999999, 0.95), new double[] {18.0, 19.0, 19.0, 1_000_000.0});
+        assertThat(digest.valueAt(0.89999999)).isEqualTo(18.0);
+        assertThat(digest.valueAt(0.9)).isEqualTo(19.0);
+        assertThat(digest.valueAt(0.949999999)).isEqualTo(19.0);
+        assertThat(digest.valueAt(0.95)).isEqualTo(1_000_000.0);
+        assertThat(digest.valuesAt(0.89999999, 0.9, 0.949999999, 0.95)).isEqualTo(new double[] {18.0, 19.0, 19.0, 1_000_000.0});
     }
 
     @Test
@@ -89,9 +91,9 @@ public class TestTDigest
         }
         digest.add(1_000_000);
 
-        assertEquals(digest.valueAt(0.998), 999.0);
-        assertEquals(digest.valueAt(0.999), 1_000_000.0);
-        assertEquals(digest.valuesAt(0.998, 0.999), new double[] {999.0, 1_000_000.0});
+        assertThat(digest.valueAt(0.998)).isEqualTo(999.0);
+        assertThat(digest.valueAt(0.999)).isEqualTo(1_000_000.0);
+        assertThat(digest.valuesAt(0.998, 0.999)).isEqualTo(new double[] {999.0, 1_000_000.0});
     }
 
     @Test
@@ -100,16 +102,16 @@ public class TestTDigest
         TDigest digest = new TDigest(200);
         addAll(digest, Lists.newArrayList(15, 20, 32, 60));
 
-        assertEquals(digest.valueAt(0.4), 20, 1e-10);
-        assertEquals(digest.valueAt(0.25), 20, 1e-10);
-        assertEquals(digest.valueAt(0.25 - 1e-10), 15, 1e-10);
-        assertEquals(digest.valueAt(0.5 - 1e-10), 20, 1e-10);
-        assertEquals(digest.valueAt(0.5), 32, 1e-10);
+        assertThat(digest.valueAt(0.4)).isCloseTo(20, within(1e-10));
+        assertThat(digest.valueAt(0.25)).isCloseTo(20, within(1e-10));
+        assertThat(digest.valueAt(0.25 - 1e-10)).isCloseTo(15, within(1e-10));
+        assertThat(digest.valueAt(0.5 - 1e-10)).isCloseTo(20, within(1e-10));
+        assertThat(digest.valueAt(0.5)).isCloseTo(32, within(1e-10));
 
         double[] quantiles = new double[] {0.25 - 1e-10, 0.25, 0.4, 0.5 - 1e-10, 0.5};
         double[] values = digest.valuesAt(quantiles);
         for (int i = 0; i < quantiles.length; i++) {
-            assertEquals(values[i], digest.valueAt(quantiles[i]));
+            assertThat(values[i]).isEqualTo(digest.valueAt(quantiles[i]));
         }
     }
 
@@ -134,8 +136,8 @@ public class TestTDigest
                 .map(digest::valueAt)
                 .collect(toImmutableList());
         List<Double> valuesAtQuantilesMultiple = digest.valuesAt(quantiles);
-        assertEquals(expectedValues, valuesAtQuantilesSingle);
-        assertEquals(expectedValues, valuesAtQuantilesMultiple);
+        assertThat(expectedValues).isEqualTo(valuesAtQuantilesSingle);
+        assertThat(expectedValues).isEqualTo(valuesAtQuantilesMultiple);
     }
 
     @Test
@@ -145,10 +147,10 @@ public class TestTDigest
         double value = ThreadLocalRandom.current().nextDouble() * 1000;
         digest.add(value);
 
-        assertEquals(digest.valueAt(0), value, 0.001f);
-        assertEquals(digest.valueAt(0.5), value, 0.001f);
-        assertEquals(digest.valueAt(1), value, 0.001f);
-        assertEquals(digest.valuesAt(0d, 0.5d, 1d), new double[] {digest.valueAt(0), digest.valueAt(0.5), digest.valueAt(1)});
+        assertThat(digest.valueAt(0)).isCloseTo(value, within(0.001));
+        assertThat(digest.valueAt(0.5)).isCloseTo(value, within(0.001));
+        assertThat(digest.valueAt(1)).isCloseTo(value, within(0.001));
+        assertThat(digest.valuesAt(0d, 0.5d, 1d)).isEqualTo(new double[] {digest.valueAt(0), digest.valueAt(0.5), digest.valueAt(1)});
     }
 
     @Test
@@ -158,11 +160,11 @@ public class TestTDigest
         digest.add(1, 80);
         digest.add(2, 20);
 
-        assertEquals(digest.valueAt(0), 1.0);
-        assertEquals(digest.valueAt(0.3), 1.0);
-        assertEquals(digest.valueAt(0.9), 2.0);
-        assertEquals(digest.valueAt(1), 2.0);
-        assertEquals(digest.valuesAt(0d, 0.3d, 0.9d, 1d), new double[] {1.0, 1.0, 2.0, 2.0});
+        assertThat(digest.valueAt(0)).isEqualTo(1.0);
+        assertThat(digest.valueAt(0.3)).isEqualTo(1.0);
+        assertThat(digest.valueAt(0.9)).isEqualTo(2.0);
+        assertThat(digest.valueAt(1)).isEqualTo(2.0);
+        assertThat(digest.valuesAt(0d, 0.3d, 0.9d, 1d)).isEqualTo(new double[] {1.0, 1.0, 2.0, 2.0});
     }
 
     @Test
@@ -174,7 +176,7 @@ public class TestTDigest
         digest.add(3);
         digest.add(4);
 
-        assertEquals(digest.valuesAt(0d, 0.6d, 1d), new double[] {1.0, 3.0, 4.0});
+        assertThat(digest.valuesAt(0d, 0.6d, 1d)).isEqualTo(new double[] {1.0, 3.0, 4.0});
     }
 
     @Test
@@ -187,8 +189,8 @@ public class TestTDigest
 
         // ensure the internal arrays are initialized properly
         deserialized.add(10);
-        assertEquals(deserialized.getCount(), 1.0);
-        assertEquals(deserialized.valueAt(0.5), 10.0);
+        assertThat(deserialized.getCount()).isEqualTo(1.0);
+        assertThat(deserialized.valueAt(0.5)).isEqualTo(10.0);
     }
 
     @Test
@@ -200,8 +202,8 @@ public class TestTDigest
         TDigest deserialized = TDigest.deserialize(digest.serialize());
 
         assertSimilar(deserialized, digest);
-        assertEquals(deserialized.valueAt(0), digest.valueAt(0));
-        assertEquals(deserialized.valueAt(1), digest.valueAt(1));
+        assertThat(deserialized.valueAt(0)).isEqualTo(digest.valueAt(0));
+        assertThat(deserialized.valueAt(1)).isEqualTo(digest.valueAt(1));
     }
 
     @Test
@@ -215,7 +217,7 @@ public class TestTDigest
         assertSimilar(deserialized, digest);
 
         for (double quantile = 0; quantile <= 1; quantile += 0.1) {
-            assertEquals(deserialized.valueAt(quantile), digest.valueAt(quantile));
+            assertThat(deserialized.valueAt(quantile)).isEqualTo(digest.valueAt(quantile));
         }
     }
 
@@ -236,7 +238,7 @@ public class TestTDigest
         assertSimilar(deserialized, digest);
 
         for (double quantile = 0; quantile <= 1; quantile += 0.1) {
-            assertEquals(deserialized.valueAt(quantile), digest.valueAt(quantile));
+            assertThat(deserialized.valueAt(quantile)).isEqualTo(digest.valueAt(quantile));
         }
     }
 
@@ -245,8 +247,10 @@ public class TestTDigest
     {
         TDigest digest = new TDigest();
 
-        assertThrows(IllegalArgumentException.class, () -> digest.add(1, Double.NaN));
-        assertThrows(IllegalArgumentException.class, () -> digest.add(Double.NaN, 1));
+        assertThatThrownBy(() -> digest.add(1, Double.NaN))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> digest.add(Double.NaN, 1))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
@@ -261,7 +265,7 @@ public class TestTDigest
         assertSimilar(copy, digest);
 
         for (double quantile = 0; quantile <= 1; quantile += 0.1) {
-            assertEquals(copy.valueAt(quantile), digest.valueAt(quantile));
+            assertThat(copy.valueAt(quantile)).isEqualTo(digest.valueAt(quantile));
         }
     }
 
@@ -274,8 +278,8 @@ public class TestTDigest
 
         // ensure the internal arrays are initialized properly
         copy.add(10);
-        assertEquals(copy.getCount(), 1.0);
-        assertEquals(copy.valueAt(0.5), 10.0);
+        assertThat(copy.getCount()).isEqualTo(1.0);
+        assertThat(copy.valueAt(0.5)).isEqualTo(10.0);
     }
 
     @Test
@@ -290,13 +294,13 @@ public class TestTDigest
         TDigest merged = TDigest.copyOf(first);
         merged.mergeWith(second);
 
-        assertEquals(merged.getMin(), 1.0);
-        assertEquals(merged.getMax(), 8.0);
-        assertEquals(merged.getCount(), 10.0);
+        assertThat(merged.getMin()).isEqualTo(1.0);
+        assertThat(merged.getMax()).isEqualTo(8.0);
+        assertThat(merged.getCount()).isEqualTo(10.0);
 
-        assertEquals(merged.valueAt(0), 1.0);
-        assertEquals(merged.valueAt(0.5), 5.0);
-        assertEquals(merged.valueAt(1), 8.0);
+        assertThat(merged.valueAt(0)).isEqualTo(1.0);
+        assertThat(merged.valueAt(0.5)).isEqualTo(5.0);
+        assertThat(merged.valueAt(1)).isEqualTo(8.0);
     }
 
     @Test
@@ -310,7 +314,7 @@ public class TestTDigest
         // validate the assumption
         int centroids = digest.getCentroidCount();
         digest.forceMerge();
-        assertEquals(digest.getCentroidCount(), centroids, "Assumption that digest is not mergeable no longer holds");
+        assertThat(digest.getCentroidCount()).as("Assumption that digest is not mergeable no longer holds").isEqualTo(centroids);
 
         for (int i = 0; i < 1000; i++) {
             // add some values somewhere in the middle of the distribution
@@ -324,12 +328,12 @@ public class TestTDigest
         TDigest digest = new TDigest();
         digest.add(10, 99999.999999999);
         digest.add(10, 99999.999999999);
-        assertEquals(10.0, digest.valueAt(0.75));
+        assertThat(10.0).isEqualTo(digest.valueAt(0.75));
 
         digest = new TDigest();
         digest.add(10, 99999.999999999);
         digest.add(20, 99999.999999999);
-        assertEquals(20.0, digest.valueAt(0.75));
+        assertThat(20.0).isEqualTo(digest.valueAt(0.75));
     }
 
     @Test
@@ -338,22 +342,24 @@ public class TestTDigest
         TDigest digest = new TDigest();
 
         // empty quantiles list
-        assertEquals(ImmutableList.of(), digest.valuesAt(ImmutableList.of()));
-        assertEquals(new double[0], digest.valuesAt());
-        assertEquals(new double[0], digest.valuesAt(new double[0]));
+        assertThat(ImmutableList.of()).isEqualTo(digest.valuesAt(ImmutableList.of()));
+        assertThat(new double[0]).isEqualTo(digest.valuesAt());
+        assertThat(new double[0]).isEqualTo(digest.valuesAt());
 
         // quantiles not sorted
-        assertThrows(IllegalArgumentException.class, () -> digest.valuesAt(ImmutableList.of(0.9, 0.1)));
+        assertThatThrownBy(() -> digest.valuesAt(ImmutableList.of(0.9, 0.1)))
+                .isInstanceOf(IllegalArgumentException.class);
 
         // quantile out of range [0, 1]
-        assertThrows(IllegalArgumentException.class, () -> digest.valuesAt(ImmutableList.of(-0.9, 0.9)));
+        assertThatThrownBy(() -> digest.valuesAt(ImmutableList.of(-0.9, 0.9)))
+                .isInstanceOf(IllegalArgumentException.class);
 
         // empty digest
-        assertEquals(ImmutableList.of(Double.NaN, Double.NaN), digest.valuesAt(ImmutableList.of(0.5, 0.75)));
+        assertThat(ImmutableList.of(Double.NaN, Double.NaN)).isEqualTo(digest.valuesAt(ImmutableList.of(0.5, 0.75)));
 
         // single centroid
         digest.add(10);
-        assertEquals(ImmutableList.of(10.0, 10.0, 10.0, 10.0), digest.valuesAt(ImmutableList.of(0.0, 0.5, 0.75, 1.0)));
+        assertThat(ImmutableList.of(10.0, 10.0, 10.0, 10.0)).isEqualTo(digest.valuesAt(ImmutableList.of(0.0, 0.5, 0.75, 1.0)));
     }
 
     @Test
@@ -362,28 +368,28 @@ public class TestTDigest
         TDigest digest = new TDigest();
         addAll(digest, ImmutableList.of(10, 20, 30, 40));
         // quantiles at centroid borders
-        assertEquals(ImmutableList.of(10.0, 20.0, 30.0, 40.0, 40.0), digest.valuesAt(ImmutableList.of(0.0, 0.25, 0.5, 0.75, 1.0)));
+        assertThat(ImmutableList.of(10.0, 20.0, 30.0, 40.0, 40.0)).isEqualTo(digest.valuesAt(ImmutableList.of(0.0, 0.25, 0.5, 0.75, 1.0)));
         // quantiles inside centroids
-        assertEquals(ImmutableList.of(10.0, 10.0, 20.0, 20.0, 30.0, 30.0, 40.0, 40.0), digest.valuesAt(ImmutableList.of(0.001, 0.249, 0.251, 0.499, 0.501, 0.749, 0.751, 0.999)));
+        assertThat(ImmutableList.of(10.0, 10.0, 20.0, 20.0, 30.0, 30.0, 40.0, 40.0)).isEqualTo(digest.valuesAt(ImmutableList.of(0.001, 0.249, 0.251, 0.499, 0.501, 0.749, 0.751, 0.999)));
 
         digest = new TDigest();
         digest.add(10, 2);
         digest.add(20, 2);
         // min value and value at offset 1
-        assertEquals(ImmutableList.of(10.0, 10.0), digest.valuesAt(ImmutableList.of(0.1, 0.25)));
+        assertThat(ImmutableList.of(10.0, 10.0)).isEqualTo(digest.valuesAt(ImmutableList.of(0.1, 0.25)));
         // short-circuit to last centroid
-        assertEquals(ImmutableList.of(20.0, 20.0), digest.valuesAt(ImmutableList.of(0.9, 1.0)));
-        assertEquals(ImmutableList.of(20.0, 20.0), digest.valuesAt(ImmutableList.of(0.75, 1.0)));
+        assertThat(ImmutableList.of(20.0, 20.0)).isEqualTo(digest.valuesAt(ImmutableList.of(0.9, 1.0)));
+        assertThat(ImmutableList.of(20.0, 20.0)).isEqualTo(digest.valuesAt(ImmutableList.of(0.75, 1.0)));
         // pass through the structure until last centroid
-        assertEquals(ImmutableList.of(15.0, 20.0), digest.valuesAt(ImmutableList.of(0.5, 1.0)));
+        assertThat(ImmutableList.of(15.0, 20.0)).isEqualTo(digest.valuesAt(ImmutableList.of(0.5, 1.0)));
 
         digest = new TDigest();
         digest.add(10, 4);
         digest.add(20, 4);
         // min value and value at offset 1
-        assertEquals(ImmutableList.of(10.0, 10.0), digest.valuesAt(ImmutableList.of(0.1, 0.125)));
+        assertThat(ImmutableList.of(10.0, 10.0)).isEqualTo(digest.valuesAt(ImmutableList.of(0.1, 0.125)));
         // short-circuit to last centroid
-        assertEquals(ImmutableList.of(20.0, 20.0, 20.0), digest.valuesAt(ImmutableList.of(0.75, 0.875, 1.0)));
+        assertThat(ImmutableList.of(20.0, 20.0, 20.0)).isEqualTo(digest.valuesAt(ImmutableList.of(0.75, 0.875, 1.0)));
 
         digest = new TDigest();
         digest.add(10, 4);
@@ -392,7 +398,7 @@ public class TestTDigest
         digest.add(40, 2);
         digest.add(50, 2);
         // single-element vs multi-element clusters
-        assertEquals(ImmutableList.of(19.5, 20.0, 20.0, 30.0, 30.0, 30.999999999999996, 44.5, 45.50000000000001), digest.valuesAt(ImmutableList.of(0.39, 0.41, 0.49, 0.51, 0.59, 0.61, 0.79, 0.81)));
+        assertThat(ImmutableList.of(19.5, 20.0, 20.0, 30.0, 30.0, 30.999999999999996, 44.5, 45.50000000000001)).isEqualTo(digest.valuesAt(ImmutableList.of(0.39, 0.41, 0.49, 0.51, 0.59, 0.61, 0.79, 0.81)));
     }
 
     private void addAll(TDigest digest, List<Integer> values)
@@ -404,9 +410,9 @@ public class TestTDigest
 
     private void assertSimilar(TDigest actual, TDigest expected)
     {
-        assertEquals(actual.getMin(), expected.getMin());
-        assertEquals(actual.getMax(), expected.getMax());
-        assertEquals(actual.getCount(), expected.getCount());
+        assertThat(actual.getMin()).isEqualTo(expected.getMin(), Offset.offset(0.0));
+        assertThat(actual.getMax()).isEqualTo(expected.getMax(), Offset.offset(0.0));
+        assertThat(actual.getCount()).isEqualTo(expected.getCount(), Offset.offset(0.0));
     }
 
     private static double interpolate(double x, double x0, double y0, double x1, double y1)

--- a/stats/src/test/java/io/airlift/stats/TestTestingGcMonitor.java
+++ b/stats/src/test/java/io/airlift/stats/TestTestingGcMonitor.java
@@ -5,7 +5,7 @@ import io.airlift.units.Duration;
 import org.testng.annotations.Test;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestTestingGcMonitor
 {
@@ -15,17 +15,17 @@ public class TestTestingGcMonitor
     {
         TestingGcMonitor gcMonitor = new TestingGcMonitor();
 
-        assertEquals(gcMonitor.getMajorGcCount(), 0);
-        assertEquals(gcMonitor.getMajorGcTime(), new Duration(0, SECONDS));
+        assertThat(gcMonitor.getMajorGcCount()).isEqualTo(0);
+        assertThat(gcMonitor.getMajorGcTime()).isEqualTo(new Duration(0, SECONDS));
 
         gcMonitor.recordMajorGc(new Duration(3, SECONDS));
 
-        assertEquals(gcMonitor.getMajorGcCount(), 1);
-        assertEquals(gcMonitor.getMajorGcTime(), new Duration(3, SECONDS));
+        assertThat(gcMonitor.getMajorGcCount()).isEqualTo(1);
+        assertThat(gcMonitor.getMajorGcTime()).isEqualTo(new Duration(3, SECONDS));
 
         gcMonitor.recordMajorGc(new Duration(7, SECONDS));
 
-        assertEquals(gcMonitor.getMajorGcCount(), 2);
-        assertEquals(gcMonitor.getMajorGcTime(), new Duration(10, SECONDS));
+        assertThat(gcMonitor.getMajorGcCount()).isEqualTo(2);
+        assertThat(gcMonitor.getMajorGcTime()).isEqualTo(new Duration(10, SECONDS));
     }
 }

--- a/stats/src/test/java/io/airlift/stats/TimedStatTest.java
+++ b/stats/src/test/java/io/airlift/stats/TimedStatTest.java
@@ -27,9 +27,8 @@ import java.util.concurrent.locks.LockSupport;
 import static io.airlift.testing.Assertions.assertGreaterThanOrEqual;
 import static java.lang.Math.min;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 @SuppressWarnings("deprecation")
 public class TimedStatTest
@@ -50,10 +49,10 @@ public class TimedStatTest
         }
         Collections.sort(values);
 
-        assertEquals(stat.getCount(), values.size());
-        assertEquals(stat.getMax(), values.get(values.size() - 1));
-        assertEquals(stat.getMin(), values.get(0));
-        assertEquals(stat.getMean(), (values.get(0) + values.get(values.size() - 1)) / 2.0);
+        assertThat(stat.getCount()).isEqualTo(values.size());
+        assertThat(stat.getMax()).isEqualTo(values.get(values.size() - 1));
+        assertThat(stat.getMin()).isEqualTo(values.get(0));
+        assertThat(stat.getMean()).isEqualTo((values.get(0) + values.get(values.size() - 1)) / 2.0);
 
         assertPercentile("tp50", stat.getTP50(), values, 0.50);
         assertPercentile("tp90", stat.getTP90(), values, 0.90);
@@ -68,14 +67,14 @@ public class TimedStatTest
     public void testEmpty()
     {
         TimedStat stat = new TimedStat();
-        assertTrue(Double.isNaN(stat.getMin()));
-        assertTrue(Double.isNaN(stat.getMax()));
-        assertTrue(Double.isNaN(stat.getTP50()));
-        assertTrue(Double.isNaN(stat.getTP90()));
-        assertTrue(Double.isNaN(stat.getTP99()));
-        assertTrue(Double.isNaN(stat.getTP999()));
-        assertTrue(Double.isNaN(stat.getPercentile(0.80)));
-        assertTrue(Double.isNaN(stat.getPercentile(0.20)));
+        assertThat(Double.isNaN(stat.getMin())).isTrue();
+        assertThat(Double.isNaN(stat.getMax())).isTrue();
+        assertThat(Double.isNaN(stat.getTP50())).isTrue();
+        assertThat(Double.isNaN(stat.getTP90())).isTrue();
+        assertThat(Double.isNaN(stat.getTP99())).isTrue();
+        assertThat(Double.isNaN(stat.getTP999())).isTrue();
+        assertThat(Double.isNaN(stat.getPercentile(0.80))).isTrue();
+        assertThat(Double.isNaN(stat.getPercentile(0.20))).isTrue();
     }
 
     @Test
@@ -88,8 +87,8 @@ public class TimedStatTest
             return null;
         });
 
-        assertEquals(stat.getCount(), 1);
-        assertEquals(stat.getMin(), stat.getMax());
+        assertThat(stat.getCount()).isEqualTo(1);
+        assertThat(stat.getMin()).isEqualTo(stat.getMax());
         assertGreaterThanOrEqual(stat.getMax(), 10.0);
     }
 

--- a/stats/src/test/java/io/airlift/stats/cardinality/TestDenseHll.java
+++ b/stats/src/test/java/io/airlift/stats/cardinality/TestDenseHll.java
@@ -22,7 +22,7 @@ import java.util.List;
 import static io.airlift.slice.testing.SliceAssertions.assertSlicesEqual;
 import static io.airlift.stats.cardinality.TestUtils.sequence;
 import static io.airlift.stats.cardinality.Utils.numberOfBuckets;
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestDenseHll
 {
@@ -49,10 +49,10 @@ public class TestDenseHll
         merged.mergeWith(current);
 
         for (int i = 0; i < numberOfBuckets(prefixBitLength); i++) {
-            assertEquals(single.getValue(i), merged.getValue(i));
+            assertThat(single.getValue(i)).isEqualTo(merged.getValue(i));
         }
 
-        assertEquals(single.cardinality(), merged.cardinality());
+        assertThat(single.cardinality()).isEqualTo(merged.cardinality());
     }
 
     @Test(dataProvider = "bits")
@@ -164,14 +164,14 @@ public class TestDenseHll
         hll1.mergeWith(hll2);
         hll1.verify();
 
-        assertEquals(hll1.cardinality(), expected.cardinality());
+        assertThat(hll1.cardinality()).isEqualTo(expected.cardinality());
         assertSlicesEqual(hll1.serialize(), expected.serialize());
     }
 
     private static void assertSameBuckets(TestingHll testingHll, DenseHll hll)
     {
         for (int i = 0; i < testingHll.getBuckets().length; i++) {
-            assertEquals(hll.getValue(i), testingHll.getBuckets()[i]);
+            assertThat(hll.getValue(i)).isEqualTo(testingHll.getBuckets()[i]);
         }
     }
 

--- a/stats/src/test/java/io/airlift/stats/cardinality/TestDenseSerialization.java
+++ b/stats/src/test/java/io/airlift/stats/cardinality/TestDenseSerialization.java
@@ -21,7 +21,7 @@ import org.testng.annotations.Test;
 
 import static io.airlift.slice.testing.SliceAssertions.assertSlicesEqual;
 import static io.airlift.stats.cardinality.Utils.numberOfBuckets;
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestDenseSerialization
 {
@@ -261,7 +261,7 @@ public class TestDenseSerialization
 
         DenseHll deserialized = new DenseHll(serialized);
         for (int i = 0; i < numberOfBuckets; i++) {
-            assertEquals(deserialized.getValue(i), 10);
+            assertThat(deserialized.getValue(i)).isEqualTo(10);
         }
         deserialized.verify();
     }
@@ -289,10 +289,10 @@ public class TestDenseSerialization
         DenseHll deserialized = new DenseHll(serialized);
         for (int i = 0; i < numberOfBuckets; i++) {
             if (i == 1) {
-                assertEquals(deserialized.getValue(i), 17);
+                assertThat(deserialized.getValue(i)).isEqualTo(17);
             }
             else {
-                assertEquals(deserialized.getValue(i), 2);
+                assertThat(deserialized.getValue(i)).isEqualTo(2);
             }
         }
         deserialized.verify();
@@ -321,10 +321,10 @@ public class TestDenseSerialization
         DenseHll deserialized = new DenseHll(serialized);
         for (int i = 0; i < numberOfBuckets; i++) {
             if (i == 1) {
-                assertEquals(deserialized.getValue(i), 20);
+                assertThat(deserialized.getValue(i)).isEqualTo(20);
             }
             else {
-                assertEquals(deserialized.getValue(i), 2);
+                assertThat(deserialized.getValue(i)).isEqualTo(2);
             }
         }
         deserialized.verify();

--- a/stats/src/test/java/io/airlift/stats/cardinality/TestHyperLogLog.java
+++ b/stats/src/test/java/io/airlift/stats/cardinality/TestHyperLogLog.java
@@ -25,8 +25,7 @@ import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.testing.SliceAssertions.assertSlicesEqual;
 import static io.airlift.stats.cardinality.TestUtils.sequence;
 import static java.lang.Math.toIntExact;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestHyperLogLog
 {
@@ -65,12 +64,11 @@ public class TestHyperLogLog
 
             for (Map.Entry<Integer, Stats> entry : errors.entrySet()) {
                 // Give an extra error margin. This is mostly a sanity check to catch egregious errors
-                assertTrue(entry.getValue().stdev() <= expectedStandardError * 1.1,
-                        String.format("Failed at p = %s, cardinality = %s. Expected std error = %s, actual = %s",
-                                indexBits,
-                                entry.getKey(),
-                                expectedStandardError,
-                                entry.getValue().stdev()));
+                assertThat(entry.getValue().stdev() <= expectedStandardError * 1.1).as(String.format("Failed at p = %s, cardinality = %s. Expected std error = %s, actual = %s",
+                        indexBits,
+                        entry.getKey(),
+                        expectedStandardError,
+                        entry.getValue().stdev())).isTrue();
             }
         }
     }
@@ -79,9 +77,7 @@ public class TestHyperLogLog
     public void testRetainedSize()
             throws Exception
     {
-        assertEquals(
-                HyperLogLog.newInstance(8).estimatedInMemorySize(),
-                toIntExact(instanceSize(HyperLogLog.class) + (new SparseHll(10)).estimatedInMemorySize()));
+        assertThat(HyperLogLog.newInstance(8).estimatedInMemorySize()).isEqualTo(toIntExact(instanceSize(HyperLogLog.class) + (new SparseHll(10)).estimatedInMemorySize()));
     }
 
     @Test
@@ -124,8 +120,8 @@ public class TestHyperLogLog
         hll1.mergeWith(hll2);
         hll1.verify();
 
-        assertEquals(hll1.cardinality(), expected.cardinality());
-        assertEquals(hll1.serialize(), expected.serialize());
+        assertThat(hll1.cardinality()).isEqualTo(expected.cardinality());
+        assertThat(hll1.serialize()).isEqualTo(expected.serialize());
     }
 
     @Test
@@ -153,7 +149,7 @@ public class TestHyperLogLog
         HyperLogLog deserialized = HyperLogLog.newInstance(serialized);
         deserialized.verify();
 
-        assertEquals(hll.cardinality(), deserialized.cardinality());
+        assertThat(hll.cardinality()).isEqualTo(deserialized.cardinality());
 
         Slice reserialized = deserialized.serialize();
         assertSlicesEqual(serialized, reserialized);

--- a/stats/src/test/java/io/airlift/stats/cardinality/TestSparseHll.java
+++ b/stats/src/test/java/io/airlift/stats/cardinality/TestSparseHll.java
@@ -24,7 +24,7 @@ import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.airlift.slice.testing.SliceAssertions.assertSlicesEqual;
 import static io.airlift.stats.cardinality.TestUtils.sequence;
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestSparseHll
 {
@@ -40,8 +40,8 @@ public class TestSparseHll
             SparseHll sparseHll = new SparseHll(indexBitLength);
             sparseHll.insertHash(hash);
             sparseHll.eachBucket((bucket, value) -> {
-                assertEquals(bucket, 0);
-                assertEquals(value, expectedValue);
+                assertThat(bucket).isEqualTo(0);
+                assertThat(value).isEqualTo(expectedValue);
             });
         }
     }
@@ -91,7 +91,7 @@ public class TestSparseHll
                 entries = new int[value + 10];
                 retainedSize = sizeOf(entries) + SPARSE_HLL_INSTANCE_SIZE;
             }
-            assertEquals(sparseHll.estimatedInMemorySize(), retainedSize);
+            assertThat(sparseHll.estimatedInMemorySize()).isEqualTo(retainedSize);
         }
     }
 
@@ -120,7 +120,7 @@ public class TestSparseHll
         hll1.mergeWith(hll2);
         hll1.verify();
 
-        assertEquals(hll1.cardinality(), expected.cardinality());
+        assertThat(hll1.cardinality()).isEqualTo(expected.cardinality());
         assertSlicesEqual(hll1.serialize(), expected.serialize());
     }
 

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -36,6 +36,12 @@
             <artifactId>hibernate-validator</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>org.testng</groupId>

--- a/testing/src/test/java/io/airlift/testing/TestAssertions.java
+++ b/testing/src/test/java/io/airlift/testing/TestAssertions.java
@@ -35,10 +35,8 @@ import static io.airlift.testing.Assertions.assertLessThan;
 import static io.airlift.testing.Assertions.assertLessThanOrEqual;
 import static io.airlift.testing.TestAssertions.SubComparable.createSubComparable;
 import static io.airlift.testing.TestAssertions.SuperComparable.createSuperComparable;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class TestAssertions
 {
@@ -471,36 +469,36 @@ public class TestAssertions
 
     private void verifyExceptionMessage(AssertionError e, String message, Object... values)
     {
-        assertNotNull(e);
+        assertThat(e).isNotNull();
         String actualMessage = e.getMessage();
-        assertNotNull(actualMessage);
+        assertThat(actualMessage).isNotNull();
         if (message != null) {
-            assertTrue(actualMessage.startsWith(message + " "));
+            assertThat(actualMessage).startsWith(message + " ");
         }
         else {
-            assertFalse(actualMessage.startsWith(" "));
+            assertThat(actualMessage).doesNotStartWith(" ");
         }
 
         for (Object value : values) {
-            assertTrue(actualMessage.contains("<" + value + ">"));
+            assertThat(actualMessage).contains("<" + value + ">");
         }
     }
 
     private void verifyExceptionMessageList(AssertionError e, String message, Iterable<?>... lists)
     {
-        assertNotNull(e);
+        assertThat(e).isNotNull();
         String actualMessage = e.getMessage();
-        assertNotNull(actualMessage);
+        assertThat(actualMessage).isNotNull();
         if (message != null) {
-            assertTrue(actualMessage.startsWith(message + " "));
+            assertThat(actualMessage).startsWith(message + " ");
         }
         else {
-            assertFalse(actualMessage.startsWith(" "));
+            assertThat(actualMessage).doesNotStartWith(" ");
         }
 
         for (Iterable<?> values : lists) {
             for (Object value : values) {
-                assertTrue(actualMessage.contains(value.toString()));
+                assertThat(actualMessage).contains(value.toString());
             }
         }
     }

--- a/testing/src/test/java/io/airlift/testing/TestEquivalenceTester.java
+++ b/testing/src/test/java/io/airlift/testing/TestEquivalenceTester.java
@@ -48,8 +48,8 @@ import static io.airlift.testing.EquivalenceTester.EquivalenceFailureType.NOT_RE
 import static io.airlift.testing.EquivalenceTester.comparisonTester;
 import static io.airlift.testing.EquivalenceTester.equivalenceTester;
 import static java.util.Objects.requireNonNull;
-import static org.testng.Assert.assertEquals;
-import static org.testng.FileAssert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class TestEquivalenceTester
 {
@@ -58,8 +58,8 @@ public class TestEquivalenceTester
     {
         Object o1 = new Object();
         Object o2 = new Object();
-        assertEquals(new ElementCheckFailure(EQUAL, 0, 0, o1), new ElementCheckFailure(EQUAL, 0, 0, o1));
-        assertEquals(new PairCheckFailure(EQUAL, 0, 0, o1, 1, 0, o2), new PairCheckFailure(EQUAL, 0, 0, o1, 1, 0, o2));
+        assertThat(new ElementCheckFailure(EQUAL, 0, 0, o1)).isEqualTo(new ElementCheckFailure(EQUAL, 0, 0, o1));
+        assertThat(new PairCheckFailure(EQUAL, 0, 0, o1, 1, 0, o2)).isEqualTo(new PairCheckFailure(EQUAL, 0, 0, o1, 1, 0, o2));
     }
 
     @Test

--- a/testing/src/test/java/io/airlift/testing/TestTempFile.java
+++ b/testing/src/test/java/io/airlift/testing/TestTempFile.java
@@ -4,9 +4,7 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestTempFile
 {
@@ -18,25 +16,25 @@ public class TestTempFile
         TempFile tempFile = new TempFile();
         File file = tempFile.file();
 
-        assertEquals(file, tempFile.path().toFile());
-        assertTrue(file.exists());
-        assertTrue(file.isFile());
-        assertTrue(file.canRead());
-        assertTrue(file.canWrite());
+        assertThat(file).isEqualTo(tempFile.path().toFile());
+        assertThat(file).exists();
+        assertThat(file).isFile();
+        assertThat(file).canRead();
+        assertThat(file).canWrite();
 
         tempFile.close();
 
-        assertFalse(file.exists());
+        assertThat(file).doesNotExist();
 
         // verify close does not delete file again
 
-        assertTrue(file.createNewFile());
-        assertTrue(file.exists());
+        assertThat(file.createNewFile()).isTrue();
+        assertThat(file).exists();
 
         tempFile.close();
 
-        assertTrue(file.exists());
+        assertThat(file).exists();
 
-        assertTrue(file.delete());
+        assertThat(file.delete()).isTrue();
     }
 }

--- a/testing/src/test/java/io/airlift/testing/TestTestingClock.java
+++ b/testing/src/test/java/io/airlift/testing/TestTestingClock.java
@@ -18,7 +18,7 @@ import org.testng.annotations.Test;
 import java.time.Instant;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestTestingClock
 {
@@ -36,7 +36,7 @@ public class TestTestingClock
         clock.increment(42, SECONDS);
         Instant instant3 = clock.instant();
 
-        assertEquals(instant2, instant1);
-        assertEquals(instant3, instant1.plusSeconds(42));
+        assertThat(instant2).isEqualTo(instant1);
+        assertThat(instant3).isEqualTo(instant1.plusSeconds(42));
     }
 }

--- a/testing/src/test/java/io/airlift/testing/TestValidationAssertions.java
+++ b/testing/src/test/java/io/airlift/testing/TestValidationAssertions.java
@@ -23,9 +23,7 @@ import java.lang.annotation.Annotation;
 import static io.airlift.testing.Assertions.assertContains;
 import static io.airlift.testing.ValidationAssertions.assertFailsValidation;
 import static io.airlift.testing.ValidationAssertions.assertValidates;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestValidationAssertions
 {
@@ -51,7 +49,7 @@ public class TestValidationAssertions
             ok = true;
             verifyExceptionMessage(e, null, INVALID_OBJECT, null, null);
         }
-        assertTrue(ok, "Expected AssertionError");
+        assertThat(ok).as("Expected AssertionError").isTrue();
     }
 
     @Test
@@ -66,7 +64,7 @@ public class TestValidationAssertions
             // success
             verifyExceptionMessage(e, MESSAGE, INVALID_OBJECT, null, null);
         }
-        assertTrue(ok, "Expected AssertionError");
+        assertThat(ok).as("Expected AssertionError").isTrue();
     }
 
     @Test
@@ -93,7 +91,7 @@ public class TestValidationAssertions
             verifyExceptionMessage(e, null, VALID_OBJECT, "value", NotNull.class);
         }
 
-        assertTrue(ok, "Expected AssertionError");
+        assertThat(ok).as("Expected AssertionError").isTrue();
     }
 
     @Test
@@ -108,19 +106,19 @@ public class TestValidationAssertions
             // success
             verifyExceptionMessage(e, MESSAGE, VALID_OBJECT, "value", NotNull.class);
         }
-        assertTrue(ok, "Expected AssertionError");
+        assertThat(ok).as("Expected AssertionError").isTrue();
     }
 
     private void verifyExceptionMessage(AssertionError e, String message, Object value, String property, Class<? extends Annotation> annotation)
     {
-        assertNotNull(e);
+        assertThat(e).isNotNull();
         String actualMessage = e.getMessage();
-        assertNotNull(actualMessage);
+        assertThat(actualMessage).isNotNull();
         if (message != null) {
-            assertTrue(actualMessage.startsWith(message + " "));
+            assertThat(actualMessage.startsWith(message + " ")).isTrue();
         }
         else {
-            assertFalse(actualMessage.startsWith(" "));
+            assertThat(actualMessage).doesNotStartWith(" ");
         }
 
         assertContains(actualMessage, "<" + value + ">");

--- a/trace-token/pom.xml
+++ b/trace-token/pom.xml
@@ -20,6 +20,12 @@
             <artifactId>guice</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>org.testng</groupId>

--- a/trace-token/src/test/java/io/airlift/tracetoken/TestTraceTokenManager.java
+++ b/trace-token/src/test/java/io/airlift/tracetoken/TestTraceTokenManager.java
@@ -17,9 +17,7 @@ package io.airlift.tracetoken;
 
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotEquals;
-import static org.testng.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestTraceTokenManager
 {
@@ -27,7 +25,7 @@ public class TestTraceTokenManager
     public void testNoToken()
     {
         TraceTokenManager manager = new TraceTokenManager();
-        assertNull(manager.getCurrentRequestToken());
+        assertThat(manager.getCurrentRequestToken()).isNull();
     }
 
     @Test
@@ -36,12 +34,12 @@ public class TestTraceTokenManager
         TraceTokenManager manager = new TraceTokenManager();
 
         String token = manager.createAndRegisterNewRequestToken();
-        assertEquals(manager.getCurrentRequestToken(), token);
-        assertEquals(manager.getCurrentRequestToken(), token);
+        assertThat(manager.getCurrentRequestToken()).isEqualTo(token);
+        assertThat(manager.getCurrentRequestToken()).isEqualTo(token);
 
         String token2 = manager.createAndRegisterNewRequestToken();
-        assertEquals(manager.getCurrentRequestToken(), token2);
-        assertNotEquals(token2, token);
+        assertThat(manager.getCurrentRequestToken()).isEqualTo(token2);
+        assertThat(token2).isNotEqualTo(token);
     }
 
     @Test
@@ -50,7 +48,7 @@ public class TestTraceTokenManager
         TraceTokenManager manager = new TraceTokenManager();
         manager.registerRequestToken("abc");
 
-        assertEquals(manager.getCurrentRequestToken(), "abc");
+        assertThat(manager.getCurrentRequestToken()).isEqualTo("abc");
     }
 
     @Test
@@ -59,9 +57,9 @@ public class TestTraceTokenManager
         TraceTokenManager manager = new TraceTokenManager();
         String oldToken = manager.createAndRegisterNewRequestToken();
 
-        assertEquals(manager.getCurrentRequestToken(), oldToken);
+        assertThat(manager.getCurrentRequestToken()).isEqualTo(oldToken);
 
         manager.registerRequestToken("abc");
-        assertEquals(manager.getCurrentRequestToken(), "abc");
+        assertThat(manager.getCurrentRequestToken()).isEqualTo("abc");
     }
 }


### PR DESCRIPTION
Changed automatically by openrewrite recipe
https://github.com/openrewrite/rewrite-testing-frameworks/pull/520
```
<plugins>
    <plugin>
        <groupId>org.openrewrite.maven</groupId>
        <artifactId>rewrite-maven-plugin</artifactId>
        <version>5.32.0</version>
        <configuration>
            <activeRecipes>
                <recipe>org.openrewrite.java.testing.assertj.TestNgToAssertj</recipe>
            </activeRecipes>
        </configuration>
        <dependencies>
            <dependency>
                <groupId>org.openrewrite.recipe</groupId>
                <artifactId>rewrite-testing-frameworks</artifactId>
                <version>2.11.0-SNAPSHOT</version>
            </dependency>
        </dependencies>
    </plugin>
</plugins>
```

run
```
./mvnw rewrite:run -Dmaven.javadoc.skip=true -DskipTests=true -Dmaven
.site.skip=true -Dmaven.artifact.threads=16 -T 1C -e -Dair.check.skip-all=true --no-snapshot-updates
```