### PR TITLE
Export cache size stats by fixing the method name

### DIFF
--- a/jmx/src/main/java/io/airlift/jmx/CacheStatsMBean.java
+++ b/jmx/src/main/java/io/airlift/jmx/CacheStatsMBean.java
@@ -28,7 +28,7 @@ public class CacheStatsMBean
     }
 
     @Managed
-    public long size()
+    public long getSize()
     {
         return cache.size();
     }


### PR DESCRIPTION
## Summary
* The cache size is not exported. E.g.
```
trino:default> describe jmx."current"."trino.sql.gen:name=joinfilterfunctioncompiler";
                   Column                    |  Type   | Extra | Comment 
---------------------------------------------+---------+-------+---------
 joinfilterfunctionfactorystats.hitrate      | double  |       |         
 joinfilterfunctionfactorystats.missrate     | double  |       |         
 joinfilterfunctionfactorystats.requestcount | bigint  |       |         
 node                                        | varchar |       |         
 object_name                                 | varchar |       |         
(5 rows)
```