### PR TITLE
Test with JDK 24-ea

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,16 +10,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java-version:
-          - 21
-          - 22
-          - 23-ea
+        java:
+          - version: 21
+            distribution: temurin
+          - version: 22
+            distribution: temurin
+          - version: 23-ea
+            distribution: temurin
+          - version: 24-ea
+            distribution: adopt
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: ${{ matrix.java-version }}
+          distribution: ${{ matrix.java.distribution }}
+          java-version: ${{ matrix.java.version }}
       - name: Maven Install
         run: ./mvnw install -B -V -DskipTests -Dair.check.skip-all
       - name: Maven Tests


### PR DESCRIPTION
Testing in advance allows us to catch regressions/issues before we stumble upon them