### PR TITLE
Do not bother checking Object.class for annotated methods

### DIFF
--- a/configuration/src/main/java/io/airlift/configuration/ConfigurationMetadata.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigurationMetadata.java
@@ -674,6 +674,10 @@ public class ConfigurationMetadata<T>
 
     public static Method findAnnotatedMethod(Class<?> configClass, Class<? extends java.lang.annotation.Annotation> annotation, String methodName, Class<?>... paramTypes)
     {
+        if (configClass.equals(Object.class)) {
+            return null;
+        }
+
         try {
             Method method = configClass.getDeclaredMethod(methodName, paramTypes);
             if (method != null && method.isAnnotationPresent(annotation)) {


### PR DESCRIPTION
It always throw NoSuchMethodException when doing that, and it pollutes JFR reports and adds slight overhead for each config class