### PR TITLE
Prevent NoSuchMethodExceptions being thrown

### DIFF
--- a/configuration/src/main/java/io/airlift/configuration/ConfigurationMetadata.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigurationMetadata.java
@@ -26,6 +26,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -678,14 +679,11 @@ public class ConfigurationMetadata<T>
             return null;
         }
 
-        try {
-            Method method = configClass.getDeclaredMethod(methodName, paramTypes);
-            if (method != null && method.isAnnotationPresent(annotation)) {
+        Method[] configClassMethods = configClass.getDeclaredMethods();
+        for (Method method : configClassMethods) {
+            if (method.getName().equals(methodName) && Arrays.equals(method.getParameterTypes(), paramTypes) && method.isAnnotationPresent(annotation)) {
                 return method;
             }
-        }
-        catch (NoSuchMethodException e) {
-            // ignore
         }
 
         if (configClass.getSuperclass() != null) {

--- a/event/src/main/java/io/airlift/event/client/AnnotationUtils.java
+++ b/event/src/main/java/io/airlift/event/client/AnnotationUtils.java
@@ -19,6 +19,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 
 final class AnnotationUtils
@@ -58,14 +59,15 @@ final class AnnotationUtils
 
     private static Method findAnnotatedMethod(Class<?> clazz, Class<? extends Annotation> annotation, String methodName, Class<?>... paramTypes)
     {
-        try {
-            Method method = clazz.getDeclaredMethod(methodName, paramTypes);
-            if (method.isAnnotationPresent(annotation)) {
+        if (clazz.equals(Object.class)) {
+            return null;
+        }
+
+        Method[] configClassMethods = clazz.getDeclaredMethods();
+        for (Method method : configClassMethods) {
+            if (method.getName().equals(methodName) && Arrays.equals(method.getParameterTypes(), paramTypes) && method.isAnnotationPresent(annotation)) {
                 return method;
             }
-        }
-        catch (NoSuchMethodException e) {
-            // ignore
         }
 
         if (clazz.getSuperclass() != null) {


### PR DESCRIPTION
Do not call getMethod directly, instead filter methods