### PR TITLE
Introduce pluggable secrets provider

### DIFF
--- a/bootstrap/pom.xml
+++ b/bootstrap/pom.xml
@@ -65,4 +65,17 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <environmentVariables>
+                        <TEST_KEY>test_value</TEST_KEY>
+                    </environmentVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/bootstrap/src/test/java/io/airlift/bootstrap/TestBootstrapWithSecretsProvider.java
+++ b/bootstrap/src/test/java/io/airlift/bootstrap/TestBootstrapWithSecretsProvider.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.bootstrap;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Injector;
+import io.airlift.configuration.Config;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static io.airlift.configuration.ConfigBinder.configBinder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+final class TestBootstrapWithSecretsProvider
+{
+    @Test
+    void testBootstrapWithDefaultSecretsProvider()
+    {
+        Bootstrap bootstrap = new Bootstrap(binder -> configBinder(binder).bindConfig(FooConfig.class))
+                .setRequiredConfigurationProperties(ImmutableMap.of("foo.value", "${ENV:TEST_KEY}"));
+
+        Injector injector = bootstrap.initialize();
+
+        assertThat(injector.getInstance(FooConfig.class).getValue()).isEqualTo("test_value");
+    }
+
+    @Test
+    void testBootstrapWithEnvironmentSecretsProviderDisabled()
+            throws Exception
+    {
+        Path configurationPluginDirectory = Files.createTempDirectory(null);
+
+        File configurationResolverFile = createConfigurationResolverFile("secrets-plugins-dir=\"%s\"".formatted(configurationPluginDirectory));
+
+        System.setProperty("secretsConfig", configurationResolverFile.getAbsolutePath());
+
+        Bootstrap bootstrap = new Bootstrap(binder -> configBinder(binder).bindConfig(FooConfig.class))
+                .loadSecretsPlugins()
+                .setRequiredConfigurationProperties(ImmutableMap.of("foo.value", "${ENV:TEST_KEY}"));
+
+        assertThatThrownBy(() -> bootstrap.initialize())
+                .hasMessageContaining("No secret provider for key 'env'");
+    }
+
+    @Test
+    void testBootstrapWithEnvironmentSecretsProviderEnabled()
+            throws Exception
+    {
+        Path configurationPluginDirectory = Files.createTempDirectory(null);
+
+        File configurationResolverFile = createConfigurationResolverFile("""
+                secrets-plugins-dir="%s
+                
+                [env]
+                secrets-provider.name="env"
+                """.formatted(configurationPluginDirectory));
+
+        System.setProperty("secretsConfig", configurationResolverFile.getAbsolutePath());
+
+        Bootstrap bootstrap = new Bootstrap(binder -> configBinder(binder).bindConfig(FooConfig.class))
+                .loadSecretsPlugins()
+                .setRequiredConfigurationProperties(ImmutableMap.of("foo.value", "${ENV:TEST_KEY}"));
+
+        Injector injector = bootstrap.initialize();
+
+        assertThat(injector.getInstance(FooConfig.class).getValue()).isEqualTo("test_value");
+    }
+
+    @Test
+    void testBootstrapWithEnvironmentSecretsProviderWithDifferentNamespace()
+            throws Exception
+    {
+        Path configurationPluginDirectory = Files.createTempDirectory(null);
+
+        File configurationResolverFile = createConfigurationResolverFile("""
+                secrets-plugins-dir="%s
+                
+                [multi]
+                secrets-provider.name="env"
+                """.formatted(configurationPluginDirectory));
+
+        System.setProperty("secretsConfig", configurationResolverFile.getAbsolutePath());
+
+        Bootstrap bootstrap = new Bootstrap(binder -> configBinder(binder).bindConfig(FooConfig.class))
+                .loadSecretsPlugins()
+                .setRequiredConfigurationProperties(ImmutableMap.of("foo.value", "${MULTI:TEST_KEY}"));
+
+        Injector injector = bootstrap.initialize();
+
+        assertThat(injector.getInstance(FooConfig.class).getValue()).isEqualTo("test_value");
+    }
+
+    private File createConfigurationResolverFile(String configurationFile)
+            throws Exception
+    {
+        File tomlFile = File.createTempFile("config_resolver", ".toml");
+        tomlFile.deleteOnExit();
+
+        try (FileWriter writer = new FileWriter(tomlFile)) {
+            writer.append(configurationFile);
+        }
+
+        return tomlFile;
+    }
+
+    public static class FooConfig
+    {
+        private String value;
+
+        public String getValue()
+        {
+            return value;
+        }
+
+        @Config("foo.value")
+        public FooConfig setValue(String value)
+        {
+            this.value = value;
+            return this;
+        }
+    }
+}

--- a/configuration/pom.xml
+++ b/configuration/pom.xml
@@ -34,6 +34,16 @@
         </dependency>
 
         <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>secrets-spi</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
             <optional>true</optional>

--- a/configuration/pom.xml
+++ b/configuration/pom.xml
@@ -38,6 +38,7 @@
             <artifactId>jakarta.annotation-api</artifactId>
             <optional>true</optional>
         </dependency>
+
         <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
@@ -51,6 +52,11 @@
         <dependency>
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.tomlj</groupId>
+            <artifactId>tomlj</artifactId>
         </dependency>
 
         <dependency>

--- a/configuration/src/main/java/io/airlift/configuration/TomlConfiguration.java
+++ b/configuration/src/main/java/io/airlift/configuration/TomlConfiguration.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.configuration;
+
+import com.google.common.collect.Iterators;
+import org.tomlj.Toml;
+import org.tomlj.TomlArray;
+import org.tomlj.TomlTable;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
+
+public class TomlConfiguration
+{
+    public static TomlConfiguration createTomlConfiguration(File file)
+    {
+        checkArgument(file.getName().endsWith(".toml"), "TOML files must end with '.toml'");
+        try {
+            return new TomlConfiguration(Toml.parse(file.toPath()));
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private final TomlTable tomlTable;
+
+    public TomlConfiguration(TomlTable tomlTable)
+    {
+        this.tomlTable = requireNonNull(tomlTable, "tomlTable is null");
+    }
+
+    public Map<String, String> getParentConfiguration()
+    {
+        return this.tomlTable.entryPathSet().stream()
+                .filter(entry -> entry.getKey().size() == 1)
+                .collect(toImmutableMap(
+                        entry -> Iterators.getOnlyElement(entry.getKey().iterator()),
+                        entry -> tomlValueToString(entry.getValue())));
+    }
+
+    public Set<String> getNamespaces()
+    {
+        return this.tomlTable.entrySet().stream()
+                .filter(entry -> entry.getValue() instanceof TomlTable)
+                .map(Entry::getKey)
+                .collect(toImmutableSet());
+    }
+
+    public Map<String, String> getNamespaceConfiguration(String namespace)
+    {
+        checkArgument(tomlTable.contains(namespace), "Namespace %s not found", namespace);
+        return this.tomlTable.getTable(namespace).dottedEntrySet().stream()
+                .collect(toImmutableMap(Entry::getKey, entry -> tomlValueToString(entry.getValue())));
+    }
+
+    private static String tomlValueToString(Object object)
+    {
+        if (object instanceof TomlArray tomlArray) {
+            return tomlArray.toList().stream()
+                    .map(TomlConfiguration::tomlValueToString)
+                    .collect(joining(","));
+        }
+        return object.toString();
+    }
+}

--- a/configuration/src/main/java/io/airlift/configuration/secrets/SecretsPluginClassLoader.java
+++ b/configuration/src/main/java/io/airlift/configuration/secrets/SecretsPluginClassLoader.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.configuration.secrets;
+
+import com.google.common.collect.ImmutableList;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Enumeration;
+import java.util.List;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.lang.System.identityHashCode;
+import static java.util.Objects.requireNonNull;
+
+class SecretsPluginClassLoader
+        extends URLClassLoader
+{
+    private final String pluginName;
+    private final ClassLoader spiClassLoader;
+    private final List<String> spiPackages;
+    private final List<String> spiResources;
+
+    public SecretsPluginClassLoader(
+            String pluginName,
+            List<URL> urls,
+            ClassLoader spiClassLoader,
+            List<String> spiPackages)
+    {
+        this(pluginName,
+                urls,
+                spiClassLoader,
+                spiPackages,
+                spiPackages.stream()
+                        .map(SecretsPluginClassLoader::classNameToResource)
+                        .collect(toImmutableList()));
+    }
+
+    private SecretsPluginClassLoader(
+            String pluginName,
+            List<URL> urls,
+            ClassLoader spiClassLoader,
+            Iterable<String> spiPackages,
+            Iterable<String> spiResources)
+    {
+        // plugins should not have access to the system (application) class loader
+        super(urls.toArray(new URL[0]), getPlatformClassLoader());
+        this.pluginName = requireNonNull(pluginName, "pluginName is null");
+        this.spiClassLoader = requireNonNull(spiClassLoader, "spiClassLoader is null");
+        this.spiPackages = ImmutableList.copyOf(spiPackages);
+        this.spiResources = ImmutableList.copyOf(spiResources);
+    }
+
+    public String getId()
+    {
+        return pluginName;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .omitNullValues()
+                .add("plugin", pluginName)
+                .add("identityHash", "@" + Integer.toHexString(identityHashCode(this)))
+                .toString();
+    }
+
+    @Override
+    protected Class<?> loadClass(String name, boolean resolve)
+            throws ClassNotFoundException
+    {
+        // grab the magic lock
+        synchronized (getClassLoadingLock(name)) {
+            // Check if class is in the loaded classes cache
+            Class<?> cachedClass = findLoadedClass(name);
+            if (cachedClass != null) {
+                return resolveClass(cachedClass, resolve);
+            }
+
+            // If this is an SPI class, only check SPI class loader
+            if (isSpiClass(name)) {
+                return resolveClass(spiClassLoader.loadClass(name), resolve);
+            }
+
+            // Look for class locally
+            return super.loadClass(name, resolve);
+        }
+    }
+
+    private Class<?> resolveClass(Class<?> clazz, boolean resolve)
+    {
+        if (resolve) {
+            resolveClass(clazz);
+        }
+        return clazz;
+    }
+
+    @Override
+    public URL getResource(String name)
+    {
+        // If this is an SPI resource, only check SPI class loader
+        if (isSpiResource(name)) {
+            return spiClassLoader.getResource(name);
+        }
+
+        // Look for resource locally
+        return super.getResource(name);
+    }
+
+    @Override
+    public Enumeration<URL> getResources(String name)
+            throws IOException
+    {
+        // If this is an SPI resource, use SPI resources
+        if (isSpiClass(name)) {
+            return spiClassLoader.getResources(name);
+        }
+
+        // Use local resources
+        return super.getResources(name);
+    }
+
+    private boolean isSpiClass(String name)
+    {
+        // todo maybe make this more precise and only match base package
+        return spiPackages.stream().anyMatch(name::startsWith);
+    }
+
+    private boolean isSpiResource(String name)
+    {
+        // todo maybe make this more precise and only match base package
+        return spiResources.stream().anyMatch(name::startsWith);
+    }
+
+    private static String classNameToResource(String className)
+    {
+        return className.replace('.', '/');
+    }
+}

--- a/configuration/src/main/java/io/airlift/configuration/secrets/SecretsPluginConfig.java
+++ b/configuration/src/main/java/io/airlift/configuration/secrets/SecretsPluginConfig.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.configuration.secrets;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.validation.FileExists;
+
+import java.io.File;
+
+public class SecretsPluginConfig
+{
+    private File secretsPluginsDir = new File("secrets-plugin");
+
+    @FileExists
+    public File getSecretsPluginsDir()
+    {
+        return secretsPluginsDir;
+    }
+
+    @Config("secrets-plugins-dir")
+    public SecretsPluginConfig setSecretsPluginsDir(File secretsPluginsDir)
+    {
+        this.secretsPluginsDir = secretsPluginsDir;
+        return this;
+    }
+}

--- a/configuration/src/main/java/io/airlift/configuration/secrets/SecretsPluginManager.java
+++ b/configuration/src/main/java/io/airlift/configuration/secrets/SecretsPluginManager.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.configuration.secrets;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.configuration.ConfigurationFactory;
+import io.airlift.configuration.TomlConfiguration;
+import io.airlift.configuration.secrets.env.EnvironmentVariableSecretsPlugin;
+import io.airlift.log.Logger;
+import io.airlift.spi.secrets.SecretProvider;
+import io.airlift.spi.secrets.SecretProviderFactory;
+import io.airlift.spi.secrets.SecretsPlugin;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Streams.stream;
+import static io.airlift.configuration.ConfigurationUtils.replaceEnvironmentVariables;
+import static java.nio.file.Files.newDirectoryStream;
+import static java.util.Arrays.asList;
+import static java.util.Objects.requireNonNull;
+
+public final class SecretsPluginManager
+{
+    private static final ImmutableList<String> SPI_PACKAGES = ImmutableList.<String>builder()
+            .add("io.airlift.spi.secrets")
+            .build();
+
+    private static final Logger log = Logger.get(SecretsPluginManager.class);
+
+    private static final String SECRETS_PROVIDER_NAME_PROPERTY = "secrets-provider.name";
+
+    private static final Pattern SECRETS_PROVIDER_NAME_PATTERN = Pattern.compile("[a-z][a-z0-9_-]*");
+
+    private final Map<String, SecretProviderFactory> secretsProviderFactories = new ConcurrentHashMap<>();
+    private final AtomicReference<Map<String, SecretProvider>> secretsProviders = new AtomicReference<>(ImmutableMap.of());
+    private final File installedSecretPluginsDir;
+    private final TomlConfiguration tomlConfiguration;
+
+    public SecretsPluginManager(TomlConfiguration tomlConfiguration)
+    {
+        this.tomlConfiguration = requireNonNull(tomlConfiguration, "tomlConfiguration is null");
+        ConfigurationFactory configurationFactory = new ConfigurationFactory(tomlConfiguration.getParentConfiguration());
+        SecretsPluginConfig config = configurationFactory.build(SecretsPluginConfig.class);
+        this.installedSecretPluginsDir = config.getSecretsPluginsDir();
+    }
+
+    public void installPlugins()
+    {
+        installSecretsPlugin(new EnvironmentVariableSecretsPlugin());
+
+        listFiles(installedSecretPluginsDir).stream()
+                .filter(File::isDirectory)
+                .forEach(file -> loadConfigurationResolvers(file.getAbsolutePath(), () -> createClassLoader(file.getName(), buildClassPath(file))));
+    }
+
+    @VisibleForTesting
+    void installSecretsPlugin(SecretsPlugin secretsPlugin)
+    {
+        secretsPlugin.getSecretProviderFactories()
+                .forEach(this::addSecretProviderFactory);
+    }
+
+    private void addSecretProviderFactory(SecretProviderFactory secretProviderFactory)
+    {
+        verify(SECRETS_PROVIDER_NAME_PATTERN.matcher(secretProviderFactory.getName()).matches(), "Secret provider name '%s' doesn't match pattern '%s'", secretProviderFactory.getName(), SECRETS_PROVIDER_NAME_PATTERN);
+        secretsProviderFactories.put(
+                secretProviderFactory.getName(),
+                secretProviderFactory);
+    }
+
+    public void load()
+    {
+        ImmutableMap.Builder<String, SecretProvider> builder = ImmutableMap.builder();
+
+        for (String namespace : tomlConfiguration.getNamespaces()) {
+            Map<String, String> properties = new HashMap<>(tomlConfiguration.getNamespaceConfiguration(namespace));
+            properties = replaceEnvironmentVariables(properties);
+            String name = properties.remove(SECRETS_PROVIDER_NAME_PROPERTY);
+            checkState(!isNullOrEmpty(name), "Configuration resolver configuration '%s' does not contain '%s'", namespace, SECRETS_PROVIDER_NAME_PROPERTY);
+            builder.put(namespace, loadConfigProvider(name, properties));
+        }
+        this.secretsProviders.set(builder.buildOrThrow());
+    }
+
+    public SecretsResolver getSecretsResolver()
+    {
+        return new SecretsResolver(secretsProviders.get());
+    }
+
+    private void loadConfigurationResolvers(String plugin, Supplier<SecretsPluginClassLoader> createClassLoader)
+    {
+        log.info("-- Loading plugin %s --", plugin);
+
+        SecretsPluginClassLoader pluginClassLoader = createClassLoader.get();
+
+        log.debug("Classpath for plugin:");
+        for (URL url : pluginClassLoader.getURLs()) {
+            log.debug("    %s", url.getPath());
+        }
+
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(pluginClassLoader)) {
+            loadConfigurationPlugin(pluginClassLoader);
+        }
+
+        log.info("-- Finished loading plugin %s --", plugin);
+    }
+
+    private void loadConfigurationPlugin(SecretsPluginClassLoader pluginClassLoader)
+    {
+        ServiceLoader<SecretsPlugin> serviceLoader = ServiceLoader.load(SecretsPlugin.class, pluginClassLoader);
+        List<SecretsPlugin> plugins = ImmutableList.copyOf(serviceLoader);
+        checkState(!plugins.isEmpty(), "No service providers of type %s in the classpath: %s", SecretsPlugin.class.getName(), asList(pluginClassLoader.getURLs()));
+
+        for (SecretsPlugin plugin : plugins) {
+            log.info("Installing %s", plugin.getClass().getName());
+            installSecretsPlugin(plugin);
+        }
+    }
+
+    private SecretProvider loadConfigProvider(String configProviderName, Map<String, String> properties)
+    {
+        log.info("-- Loading secret provider --");
+
+        SecretProviderFactory factory = secretsProviderFactories.get(configProviderName);
+        checkState(factory != null, "Secret provider '%s' is not registered", configProviderName);
+
+        SecretProvider secretProvider;
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(factory.getClass().getClassLoader())) {
+            secretProvider = factory.createSecretProvider(ImmutableMap.copyOf(properties));
+        }
+
+        log.info("-- Loaded secret provider %s --", configProviderName);
+        return secretProvider;
+    }
+
+    private static List<URL> buildClassPath(File path)
+    {
+        return listFiles(path).stream()
+                .map(SecretsPluginManager::fileToUrl)
+                .collect(toImmutableList());
+    }
+
+    private static SecretsPluginClassLoader createClassLoader(String pluginName, List<URL> urls)
+    {
+        ClassLoader parent = SecretsPluginManager.class.getClassLoader();
+        return new SecretsPluginClassLoader(pluginName, urls, parent, SPI_PACKAGES);
+    }
+
+    private static List<File> listFiles(File path)
+    {
+        try {
+            try (DirectoryStream<Path> directoryStream = newDirectoryStream(path.toPath())) {
+                return stream(directoryStream)
+                        .map(Path::toFile)
+                        .sorted()
+                        .collect(toImmutableList());
+            }
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static URL fileToUrl(File file)
+    {
+        try {
+            return file.toURI().toURL();
+        }
+        catch (MalformedURLException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/configuration/src/main/java/io/airlift/configuration/secrets/SecretsResolver.java
+++ b/configuration/src/main/java/io/airlift/configuration/secrets/SecretsResolver.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.configuration.secrets;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.spi.secrets.SecretProvider;
+
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
+import static java.util.regex.Matcher.quoteReplacement;
+
+public class SecretsResolver
+{
+    private static final Pattern PATTERN = Pattern.compile("\\$\\{([a-zA-Z][a-zA-Z0-9_-]*):([a-zA-Z][a-zA-Z0-9_-]*)}");
+
+    private final Map<String, SecretProvider> secretProviders;
+
+    public SecretsResolver(Map<String, SecretProvider> secretProviders)
+    {
+        this.secretProviders = ImmutableMap.copyOf(requireNonNull(secretProviders, "secretProviders is null"));
+    }
+
+    public Map<String, String> getResolvedConfiguration(Map<String, String> properties)
+    {
+        return getResolvedConfiguration(properties, (propertyKey, throwable) -> {
+            throw new RuntimeException(throwable.getMessage());
+        });
+    }
+
+    public Map<String, String> getResolvedConfiguration(Map<String, String> properties, BiConsumer<String, Throwable> onError)
+    {
+        ImmutableMap.Builder<String, String> builder = ImmutableMap.builderWithExpectedSize(properties.size());
+        properties.forEach((propertyKey, propertyValue) -> {
+            try {
+                builder.put(propertyKey, resolveConfiguration(propertyValue));
+            }
+            catch (RuntimeException exception) {
+                onError.accept(propertyKey, exception);
+            }
+        });
+        return builder.buildOrThrow();
+    }
+
+    private String resolveConfiguration(String configurationValue)
+    {
+        StringBuilder replacedPropertyValue = new StringBuilder();
+        Matcher matcher = PATTERN.matcher(configurationValue);
+        while (matcher.find()) {
+            String secretProviderName = matcher.group(1).toLowerCase(ENGLISH);
+            SecretProvider secretProvider = secretProviders.get(secretProviderName);
+            checkArgument(secretProvider != null, "No secret provider for key '%s'", secretProviderName);
+            String keyName = matcher.group(2);
+            matcher.appendReplacement(replacedPropertyValue, quoteReplacement(secretProvider.resolveSecretValue(keyName)));
+        }
+        matcher.appendTail(replacedPropertyValue);
+        return replacedPropertyValue.toString();
+    }
+}

--- a/configuration/src/main/java/io/airlift/configuration/secrets/ThreadContextClassLoader.java
+++ b/configuration/src/main/java/io/airlift/configuration/secrets/ThreadContextClassLoader.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.configuration.secrets;
+
+import java.io.Closeable;
+
+class ThreadContextClassLoader
+        implements Closeable
+{
+    private final ClassLoader originalThreadContextClassLoader;
+
+    public ThreadContextClassLoader(ClassLoader newThreadContextClassLoader)
+    {
+        this.originalThreadContextClassLoader = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(newThreadContextClassLoader);
+    }
+
+    @Override
+    public void close()
+    {
+        Thread.currentThread().setContextClassLoader(originalThreadContextClassLoader);
+    }
+}

--- a/configuration/src/main/java/io/airlift/configuration/secrets/env/EnvironmentVariableSecretProvider.java
+++ b/configuration/src/main/java/io/airlift/configuration/secrets/env/EnvironmentVariableSecretProvider.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.configuration.secrets.env;
+
+import io.airlift.spi.secrets.SecretProvider;
+
+public class EnvironmentVariableSecretProvider
+        implements SecretProvider
+{
+    @Override
+    public String resolveSecretValue(String key)
+    {
+        String envValue = System.getenv().get(key);
+        if (envValue == null) {
+            throw new RuntimeException("Environment variable is not set: " + key);
+        }
+        return envValue;
+    }
+}

--- a/configuration/src/main/java/io/airlift/configuration/secrets/env/EnvironmentVariableSecretProviderFactory.java
+++ b/configuration/src/main/java/io/airlift/configuration/secrets/env/EnvironmentVariableSecretProviderFactory.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.configuration.secrets.env;
+
+import io.airlift.spi.secrets.SecretProvider;
+import io.airlift.spi.secrets.SecretProviderFactory;
+
+import java.util.Map;
+
+public class EnvironmentVariableSecretProviderFactory
+        implements SecretProviderFactory
+{
+    @Override
+    public String getName()
+    {
+        return "env";
+    }
+
+    @Override
+    public SecretProvider createSecretProvider(Map<String, String> config)
+    {
+        return new EnvironmentVariableSecretProvider();
+    }
+}

--- a/configuration/src/main/java/io/airlift/configuration/secrets/env/EnvironmentVariableSecretsPlugin.java
+++ b/configuration/src/main/java/io/airlift/configuration/secrets/env/EnvironmentVariableSecretsPlugin.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.configuration.secrets.env;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.spi.secrets.SecretProviderFactory;
+import io.airlift.spi.secrets.SecretsPlugin;
+
+import java.util.List;
+
+public class EnvironmentVariableSecretsPlugin
+        implements SecretsPlugin
+{
+    @Override
+    public List<SecretProviderFactory> getSecretProviderFactories()
+    {
+        return ImmutableList.of(new EnvironmentVariableSecretProviderFactory());
+    }
+}

--- a/configuration/src/test/java/io/airlift/configuration/TestTomlConfiguration.java
+++ b/configuration/src/test/java/io/airlift/configuration/TestTomlConfiguration.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.configuration;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.io.Resources;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+final class TestTomlConfiguration
+{
+    @Test
+    void testTomlConfigurationWithInvalidExtension()
+    {
+        assertThatThrownBy(() -> TomlConfiguration.createTomlConfiguration(new File("configuration.properties")));
+        assertThatThrownBy(() -> TomlConfiguration.createTomlConfiguration(new File("configuration.tom")));
+    }
+
+    @Test
+    void testTomlParentConfiguration()
+    {
+        TomlConfiguration tomlConfiguration = TomlConfiguration.createTomlConfiguration(new File(Resources.getResource("configuration.toml").getPath()));
+        assertThat(tomlConfiguration.getParentConfiguration()).isEqualTo(ImmutableMap.of("title", "TOML Example"));
+    }
+
+    @Test
+    void testTomlNamespace()
+    {
+        TomlConfiguration tomlConfiguration = TomlConfiguration.createTomlConfiguration(new File(Resources.getResource("configuration.toml").getPath()));
+        assertThat(tomlConfiguration.getNamespaces()).isEqualTo(ImmutableSet.of("owner", "database", "servers"));
+    }
+
+    @Test
+    void testTomlNamespaceConfiguration()
+    {
+        TomlConfiguration tomlConfiguration = TomlConfiguration.createTomlConfiguration(new File(Resources.getResource("configuration.toml").getPath()));
+        assertThat(tomlConfiguration.getNamespaceConfiguration("servers")).isEqualTo(ImmutableMap.of(
+                "alpha.ip", "10.0.0.1",
+                "alpha.role", "frontend",
+                "beta.ip", "10.0.0.2",
+                "beta.role", "backend",
+                "beta.secret", "${ENV:SECRET_VALUE}"));
+    }
+
+    @Test
+    void testTomlWithInvalidNamespace()
+    {
+        TomlConfiguration tomlConfiguration = TomlConfiguration.createTomlConfiguration(new File(Resources.getResource("configuration.toml").getPath()));
+        assertThatThrownBy(() -> tomlConfiguration.getNamespaceConfiguration("invalid"))
+                .hasMessageContaining("Namespace invalid not found");
+    }
+}

--- a/configuration/src/test/java/io/airlift/configuration/secrets/TestSecretsPluginConfig.java
+++ b/configuration/src/test/java/io/airlift/configuration/secrets/TestSecretsPluginConfig.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.configuration.secrets;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+final class TestSecretsPluginConfig
+{
+    @Test
+    void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(SecretsPluginConfig.class)
+                .setSecretsPluginsDir(new File("secrets-plugin")));
+    }
+
+    @Test
+    void testExplicitPropertyMappings()
+            throws Exception
+    {
+        Path configPluginDirectory = Files.createTempFile(null, null);
+
+        Map<String, String> properties = ImmutableMap.of("secrets-plugins-dir", configPluginDirectory.toString());
+
+        SecretsPluginConfig expected = new SecretsPluginConfig()
+                .setSecretsPluginsDir(configPluginDirectory.toFile());
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/configuration/src/test/java/io/airlift/configuration/secrets/TestSecretsPluginManager.java
+++ b/configuration/src/test/java/io/airlift/configuration/secrets/TestSecretsPluginManager.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.configuration.secrets;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.configuration.TomlConfiguration;
+import io.airlift.spi.secrets.SecretProvider;
+import io.airlift.spi.secrets.SecretProviderFactory;
+import org.junit.jupiter.api.Test;
+import org.tomlj.Toml;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+final class TestSecretsPluginManager
+{
+    @Test
+    void testInvalidSecretProviderName()
+            throws Exception
+    {
+        assertInvalidSecretProviderFactory("$invalid");
+        assertInvalidSecretProviderFactory("1invalid");
+        assertInvalidSecretProviderFactory("invAlid");
+    }
+
+    @Test
+    void testLoadingWithUnknownConfigurationResolverName()
+            throws Exception
+    {
+        Path configPluginDirectory = Files.createTempDirectory("config-plugins");
+        SecretsPluginManager configurationPluginManager = new SecretsPluginManager(
+                new TomlConfiguration(Toml.parse("""
+                secrets-plugins-dir="%s"
+                
+                [resolver-1]
+                secrets-provider.name="unknown"
+                """.formatted(configPluginDirectory.toAbsolutePath()))));
+
+        assertThatThrownBy(configurationPluginManager::load)
+                .hasMessageContaining("Secret provider 'unknown' is not registered");
+    }
+
+    @Test
+    void testConfigurationResolutionWithoutEnvironmentVariableResolverConfigured()
+            throws Exception
+    {
+        Path configPluginDirectory = Files.createTempDirectory("config-plugins");
+        SecretsPluginManager configurationPluginManager = new SecretsPluginManager(
+                new TomlConfiguration(Toml.parse("""
+                secrets-plugins-dir="%s"
+                """.formatted(configPluginDirectory.toAbsolutePath()))));
+
+        configurationPluginManager.installPlugins();
+        configurationPluginManager.load();
+
+        assertThatThrownBy(() -> configurationPluginManager.getSecretsResolver().getResolvedConfiguration(ImmutableMap.of("key", "${ENV:test}")))
+                .hasMessageContaining("No secret provider for key 'env'");
+    }
+
+    private void assertInvalidSecretProviderFactory(String secretProviderName)
+            throws Exception
+    {
+        Path configPluginDirectory = Files.createTempDirectory("config-plugins");
+        SecretsPluginManager configurationPluginManager = new SecretsPluginManager(
+                new TomlConfiguration(Toml.parse("""
+                secrets-plugins-dir="%s"
+                
+                [resolver-1]
+                secrets-provider.name="%s"
+                """.formatted(configPluginDirectory.toAbsolutePath(), secretProviderName))));
+
+        assertThatThrownBy(() -> configurationPluginManager.installSecretsPlugin(() -> ImmutableList.of(new SecretProviderFactory() {
+            @Override
+            public String getName()
+            {
+                return secretProviderName;
+            }
+
+            @Override
+            public SecretProvider createSecretProvider(Map<String, String> config)
+            {
+                return key -> key;
+            }
+        }))).hasMessageContaining("Secret provider name '%s' doesn't match pattern '[a-z][a-z0-9_-]*'".formatted(secretProviderName));
+    }
+}

--- a/configuration/src/test/java/io/airlift/configuration/secrets/TestSecretsResolver.java
+++ b/configuration/src/test/java/io/airlift/configuration/secrets/TestSecretsResolver.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.configuration.secrets;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.spi.secrets.SecretProvider;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+final class TestSecretsResolver
+{
+    @Test
+    public void testSecretsResolution()
+    {
+        SecretsResolver secretsResolver = new SecretsResolver(
+                ImmutableMap.of("prefix", new PrefixedSecretProvider()));
+
+        assertThat(secretsResolver.getResolvedConfiguration(ImmutableMap.of(
+                "key1", "${prefix:key}",
+                "key2", "${prefix:key}-abc",
+                "key3", "${PREFIX:key}",
+                "key4", "${PReFIX:key}",
+                "key5", "normal_key")))
+                .isEqualTo(ImmutableMap.of(
+                        "key1", "prefix-key",
+                        "key2", "prefix-key-abc",
+                        "key3", "prefix-key",
+                        "key4", "prefix-key",
+                        "key5", "normal_key"));
+    }
+
+    @Test
+    public void testSecretsResolutionWithMultipleKey()
+    {
+        SecretsResolver secretsResolver = new SecretsResolver(
+                ImmutableMap.of(
+                        "prefix", new PrefixedSecretProvider(),
+                        "prefix2", new PrefixedSecretProvider(),
+                        "suffix", new SuffixedSecretProvider()));
+
+        assertThat(secretsResolver.getResolvedConfiguration(ImmutableMap.of("key", "${prefix:key}-${prefix2:key2}-${suffix:key}")))
+                .isEqualTo(ImmutableMap.of("key", "prefix-key-prefix-key2-key-suffix"));
+    }
+
+    @Test
+    public void testSecretsResolverWithSpecialKeys()
+    {
+        SecretsResolver secretsResolver = new SecretsResolver(
+                ImmutableMap.of(
+                        "prefix", new PrefixedSecretProvider(),
+                        "prefix2", new PrefixedSecretProvider()));
+
+        assertThat(secretsResolver.getResolvedConfiguration(ImmutableMap.of(
+                "key1", "${prefix2:${prefix:key}}",
+                "key2", "${prefix:key",
+                "key3", "{prefix:key}")))
+                .isEqualTo(ImmutableMap.of(
+                        "key1", "${prefix2:prefix-key}",
+                        "key2", "${prefix:key",
+                        "key3", "{prefix:key}"));
+    }
+
+    @Test
+    public void testSecretsResolutionWithUnknownResolver()
+    {
+        SecretsResolver secretsResolver = new SecretsResolver(
+                ImmutableMap.of("prefix", new PrefixedSecretProvider()));
+
+        assertThatThrownBy(() -> secretsResolver.getResolvedConfiguration(ImmutableMap.of("key", "${unknown_key:key}")))
+                .hasMessageContaining("No secret provider for key 'unknown_key'");
+    }
+
+    @Test
+    public void testSecretResolutionFailures()
+    {
+        SecretsResolver secretsResolver = new SecretsResolver(
+                ImmutableMap.of("resolver", new FailureSecretProvider()));
+
+        ImmutableList.Builder<String> errorMessages = ImmutableList.builder();
+
+        assertThat(secretsResolver.getResolvedConfiguration(ImmutableMap.of("key", "${resolver:key}"), (propertyKey, throwable) -> errorMessages.add(throwable.getMessage()))).isEmpty();
+
+        assertThat(errorMessages.build()).isEqualTo(ImmutableList.of("Invalid key: key"));
+    }
+
+    private static class PrefixedSecretProvider
+            implements SecretProvider
+    {
+        @Override
+        public String resolveSecretValue(String key)
+        {
+            return "prefix-" + key;
+        }
+    }
+
+    private static class SuffixedSecretProvider
+            implements SecretProvider
+    {
+        @Override
+        public String resolveSecretValue(String key)
+        {
+            return key + "-suffix";
+        }
+    }
+
+    private static class FailureSecretProvider
+            implements SecretProvider
+    {
+        @Override
+        public String resolveSecretValue(String key)
+        {
+            throw new RuntimeException("Invalid key: " + key);
+        }
+    }
+}

--- a/configuration/src/test/resources/configuration.toml
+++ b/configuration/src/test/resources/configuration.toml
@@ -1,0 +1,24 @@
+# This is a TOML document
+
+title = "TOML Example"
+
+[owner]
+name = "Tom Preston-Werner"
+dob = 1979-05-27T07:32:00-08:00
+
+[database]
+enabled = true
+ports = [ 8000, 8001, 8002 ]
+data = [ ["delta", "phi"], [3.14] ]
+temp_targets = { cpu = 79.5, case = 72.0 }
+
+[servers]
+
+[servers.alpha]
+ip = "10.0.0.1"
+role = "frontend"
+
+[servers.beta]
+ip = "10.0.0.2"
+role = "backend"
+secret = "${ENV:SECRET_VALUE}"

--- a/launcher/src/main/scripts/bin/launcher.py
+++ b/launcher/src/main/scripts/bin/launcher.py
@@ -170,7 +170,7 @@ def create_symlink(source, target):
 
 def create_app_symlinks(options):
     """
-    Symlink the 'etc' and 'plugin' directory into the data directory.
+    Symlink the 'etc' and 'plugin' directories into the data directory.
 
     This is needed to support programs that reference 'etc/xyz' from within
     their config files: log.levels-file=etc/log.properties

--- a/launcher/src/main/scripts/bin/launcher.py
+++ b/launcher/src/main/scripts/bin/launcher.py
@@ -170,7 +170,7 @@ def create_symlink(source, target):
 
 def create_app_symlinks(options):
     """
-    Symlink the 'etc' and 'plugin' directories into the data directory.
+    Symlink the 'etc', 'plugin' and 'secrets-plugin' directories into the data directory.
 
     This is needed to support programs that reference 'etc/xyz' from within
     their config files: log.levels-file=etc/log.properties
@@ -184,6 +184,9 @@ def create_app_symlinks(options):
         create_symlink(
             pathjoin(options.install_path, 'plugin'),
             pathjoin(options.data_dir, 'plugin'))
+        create_symlink(
+             pathjoin(options.install_path, 'secrets-plugin'),
+             pathjoin(options.data_dir, 'secrets-plugin'))
 
 
 def build_java_execution(options, daemon):
@@ -216,6 +219,9 @@ def build_java_execution(options, daemon):
         raise Exception("Launcher config is missing 'main-class' property")
 
     properties['config'] = options.config_path
+
+    if exists(options.secrets_config_path):
+        properties['secretsConfig'] = options.secrets_config_path
 
     system_properties = ['-D%s=%s' % i for i in properties.items()]
     classpath = pathjoin(options.install_path, 'lib', '*')
@@ -370,6 +376,7 @@ def create_parser():
     parser.add_option('--node-config', metavar='FILE', help='Defaults to ETC_DIR/node.properties')
     parser.add_option('--jvm-config', metavar='FILE', help='Defaults to ETC_DIR/jvm.config')
     parser.add_option('--config', metavar='FILE', help='Defaults to ETC_DIR/config.properties')
+    parser.add_option('--secrets-config', metavar='FILE', help='Defaults to ETC_DIR/secrets.toml')
     parser.add_option('--log-levels-file', metavar='FILE', help='Defaults to ETC_DIR/log.properties')
     parser.add_option('--data-dir', metavar='DIR', help='Defaults to INSTALL_PATH')
     parser.add_option('--pid-file', metavar='FILE', help='Defaults to DATA_DIR/var/run/launcher.pid')
@@ -436,6 +443,7 @@ def main():
     o.node_config = realpath(options.node_config or pathjoin(o.etc_dir, 'node.properties'))
     o.jvm_config = realpath(options.jvm_config or pathjoin(o.etc_dir, 'jvm.config'))
     o.config_path = realpath(options.config or pathjoin(o.etc_dir, 'config.properties'))
+    o.secrets_config_path = realpath(options.secrets_config or pathjoin(o.etc_dir, 'secrets.toml'))
     o.log_levels = realpath(options.log_levels_file or pathjoin(o.etc_dir, 'log.properties'))
     o.log_levels_set = bool(options.log_levels_file)
     o.jvm_options = options.jvm_options or []

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
         <module>openmetrics</module>
         <module>packaging</module>
         <module>sample-server</module>
+        <module>secrets-spi</module>
         <module>security</module>
         <module>security-jwks</module>
 
@@ -253,6 +254,12 @@
             <dependency>
                 <groupId>io.airlift</groupId>
                 <artifactId>packaging</artifactId>
+                <version>${dep.airlift.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.airlift</groupId>
+                <artifactId>secrets-spi</artifactId>
                 <version>${dep.airlift.version}</version>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -333,6 +333,12 @@
                     </exclusion>
                 </exclusions>
             </dependency>
+
+            <dependency>
+                <groupId>org.tomlj</groupId>
+                <artifactId>tomlj</artifactId>
+                <version>1.1.1</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
         <module>openmetrics</module>
         <module>packaging</module>
         <module>sample-server</module>
+        <module>secrets-keystore-plugin</module>
         <module>secrets-spi</module>
         <module>security</module>
         <module>security-jwks</module>
@@ -254,6 +255,12 @@
             <dependency>
                 <groupId>io.airlift</groupId>
                 <artifactId>packaging</artifactId>
+                <version>${dep.airlift.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.airlift</groupId>
+                <artifactId>secrets-keystore-plugin</artifactId>
                 <version>${dep.airlift.version}</version>
             </dependency>
 

--- a/secrets-keystore-plugin/pom.xml
+++ b/secrets-keystore-plugin/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.airlift</groupId>
+        <artifactId>airlift</artifactId>
+        <version>255-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>secrets-keystore-plugin</artifactId>
+    <packaging>trino-plugin</packaging>
+    <description>Secrets keystore plugins</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>bootstrap</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>secrets-spi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- for testing -->
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>ca.vanzyl.provisio.maven.plugins</groupId>
+                <artifactId>provisio-maven-plugin</artifactId>
+                <version>1.0.25</version>
+            </plugin>
+            <plugin>
+                <groupId>io.trino</groupId>
+                <artifactId>trino-maven-plugin</artifactId>
+                <version>15</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <pluginClassName>io.airlift.spi.secrets.SecretsPlugin</pluginClassName>
+                    <skipCheckSpiDependencies>true</skipCheckSpiDependencies>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/secrets-keystore-plugin/src/main/java/io/airlift/secrets/AirliftSecretsPlugin.java
+++ b/secrets-keystore-plugin/src/main/java/io/airlift/secrets/AirliftSecretsPlugin.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.secrets;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.secrets.keystore.KeystoreSecretProviderFactory;
+import io.airlift.spi.secrets.SecretProviderFactory;
+import io.airlift.spi.secrets.SecretsPlugin;
+
+import java.util.List;
+
+public class AirliftSecretsPlugin
+        implements SecretsPlugin
+{
+    @Override
+    public List<SecretProviderFactory> getSecretProviderFactories()
+    {
+        return ImmutableList.of(new KeystoreSecretProviderFactory());
+    }
+}

--- a/secrets-keystore-plugin/src/main/java/io/airlift/secrets/keystore/KeystoreSecretProvider.java
+++ b/secrets-keystore-plugin/src/main/java/io/airlift/secrets/keystore/KeystoreSecretProvider.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.secrets.keystore;
+
+import com.google.inject.Inject;
+import io.airlift.spi.secrets.SecretProvider;
+
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+
+public class KeystoreSecretProvider
+        implements SecretProvider
+{
+    private final KeyStore keyStore;
+    private final char[] keystorePassword;
+
+    @Inject
+    public KeystoreSecretProvider(KeystoreSecretProviderConfig config)
+            throws GeneralSecurityException, IOException
+    {
+        keystorePassword = config.getKeyStorePassword().toCharArray();
+        keyStore = KeyStore.getInstance(config.getKeyStoreType());
+        keyStore.load(new FileInputStream(config.getKeyStoreFilePath()), keystorePassword);
+    }
+
+    @Override
+    public String resolveSecretValue(String key)
+    {
+        try {
+            KeyStore.SecretKeyEntry secretKeyEntry = (KeyStore.SecretKeyEntry) keyStore.getEntry(key, new KeyStore.PasswordProtection(keystorePassword));
+
+            if (secretKeyEntry == null) {
+                throw new RuntimeException("Key not found in keystore: " + key);
+            }
+            SecretKeyFactory factory = SecretKeyFactory.getInstance("PBE");
+            PBEKeySpec keySpec = (PBEKeySpec) factory.getKeySpec(secretKeyEntry.getSecretKey(), PBEKeySpec.class);
+            return new String(keySpec.getPassword());
+        }
+        catch (GeneralSecurityException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/secrets-keystore-plugin/src/main/java/io/airlift/secrets/keystore/KeystoreSecretProviderConfig.java
+++ b/secrets-keystore-plugin/src/main/java/io/airlift/secrets/keystore/KeystoreSecretProviderConfig.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.secrets.keystore;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigSecuritySensitive;
+import io.airlift.configuration.validation.FileExists;
+import jakarta.validation.constraints.NotNull;
+
+public class KeystoreSecretProviderConfig
+{
+    private String keyStoreFilePath;
+    private String keyStoreType;
+    private String keyStorePassword;
+
+    @Config("keystore-file-path")
+    public KeystoreSecretProviderConfig setKeyStoreFilePath(String keyStoreFilePath)
+    {
+        this.keyStoreFilePath = keyStoreFilePath;
+        return this;
+    }
+
+    @NotNull
+    @FileExists
+    public String getKeyStoreFilePath()
+    {
+        return keyStoreFilePath;
+    }
+
+    @Config("keystore-type")
+    public KeystoreSecretProviderConfig setKeyStoreType(String keyStoreType)
+    {
+        this.keyStoreType = keyStoreType;
+        return this;
+    }
+
+    @NotNull
+    public String getKeyStoreType()
+    {
+        return keyStoreType;
+    }
+
+    @Config("keystore-password")
+    @ConfigSecuritySensitive
+    public KeystoreSecretProviderConfig setKeyStorePassword(String keyStorePassword)
+    {
+        this.keyStorePassword = keyStorePassword;
+        return this;
+    }
+
+    public String getKeyStorePassword()
+    {
+        return keyStorePassword;
+    }
+}

--- a/secrets-keystore-plugin/src/main/java/io/airlift/secrets/keystore/KeystoreSecretProviderFactory.java
+++ b/secrets-keystore-plugin/src/main/java/io/airlift/secrets/keystore/KeystoreSecretProviderFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.secrets.keystore;
+
+import com.google.inject.Injector;
+import com.google.inject.Scopes;
+import io.airlift.bootstrap.Bootstrap;
+import io.airlift.spi.secrets.SecretProvider;
+import io.airlift.spi.secrets.SecretProviderFactory;
+
+import java.util.Map;
+
+import static io.airlift.configuration.ConfigBinder.configBinder;
+
+public class KeystoreSecretProviderFactory
+        implements SecretProviderFactory
+{
+    @Override
+    public String getName()
+    {
+        return "keystore";
+    }
+
+    @Override
+    public SecretProvider createSecretProvider(Map<String, String> config)
+    {
+        Bootstrap app = new Bootstrap(
+                binder -> {
+                    configBinder(binder).bindConfig(KeystoreSecretProviderConfig.class);
+                    binder.bind(SecretProvider.class).to(KeystoreSecretProvider.class).in(Scopes.SINGLETON);
+                });
+
+        Injector injector = app
+                .doNotInitializeLogging()
+                .setRequiredConfigurationProperties(config)
+                .initialize();
+
+        return injector.getInstance(SecretProvider.class);
+    }
+}

--- a/secrets-keystore-plugin/src/test/java/io/airlift/secrets/keystore/TestKeystoreSecretProvider.java
+++ b/secrets-keystore-plugin/src/test/java/io/airlift/secrets/keystore/TestKeystoreSecretProvider.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.secrets.keystore;
+
+import io.airlift.testing.TempFile;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+
+import java.io.FileOutputStream;
+import java.security.KeyStore;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+@TestInstance(PER_CLASS)
+final class TestKeystoreSecretProvider
+{
+    private TempFile keystoreFile;
+
+    private KeystoreSecretProvider secretProvider;
+
+    @BeforeAll
+    public void setup()
+            throws Exception
+    {
+        keystoreFile = new TempFile();
+
+        char[] password = "password".toCharArray();
+        KeyStore keystore = KeyStore.getInstance("pkcs12");
+        keystore.load(null, password);
+
+        SecretKeyFactory factory = SecretKeyFactory.getInstance("PBE");
+
+        keystore.setEntry(
+                "key",
+                new KeyStore.SecretKeyEntry(factory.generateSecret(new PBEKeySpec("value".toCharArray()))),
+                new KeyStore.PasswordProtection(password));
+
+        try (FileOutputStream outputStream = new FileOutputStream(keystoreFile.file())) {
+            keystore.store(outputStream, password);
+        }
+
+        secretProvider = new KeystoreSecretProvider(new KeystoreSecretProviderConfig()
+                .setKeyStoreType("jks")
+                .setKeyStoreFilePath(keystoreFile.file().getAbsolutePath())
+                .setKeyStorePassword("password"));
+    }
+
+    @AfterAll
+    public void teardown()
+    {
+        if (keystoreFile != null) {
+            keystoreFile.close();
+        }
+    }
+
+    @Test
+    public void testConfigurationResolver()
+    {
+        assertThat(secretProvider.resolveSecretValue("key")).isEqualTo("value");
+    }
+
+    @Test
+    public void testConfigurationResolverWithInvalidKey()
+    {
+        assertThatThrownBy(() -> secretProvider.resolveSecretValue("invalid_key"))
+                .hasMessageContaining("Key not found in keystore: invalid_key");
+    }
+
+    @Test
+    public void testKeystoreWithInvalidPassword()
+    {
+        assertThatThrownBy(() ->
+                new KeystoreSecretProvider(new KeystoreSecretProviderConfig()
+                        .setKeyStoreType("jks")
+                        .setKeyStoreFilePath(keystoreFile.file().getAbsolutePath())
+                        .setKeyStorePassword("invalid_password"))
+                        .resolveSecretValue("key"))
+                .hasMessageContaining("Failed PKCS12 integrity checking");
+    }
+}

--- a/secrets-keystore-plugin/src/test/java/io/airlift/secrets/keystore/TestKeystoreSecretProviderConfig.java
+++ b/secrets-keystore-plugin/src/test/java/io/airlift/secrets/keystore/TestKeystoreSecretProviderConfig.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.secrets.keystore;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+final class TestKeystoreSecretProviderConfig
+{
+    @Test
+    void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(KeystoreSecretProviderConfig.class)
+                .setKeyStoreFilePath(null)
+                .setKeyStoreType(null)
+                .setKeyStorePassword(null));
+    }
+
+    @Test
+    void testExplicitPropertyMappings()
+            throws IOException
+    {
+        Path keystoreFile = Files.createTempFile(null, null);
+
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("keystore-file-path", keystoreFile.toString())
+                .put("keystore-type", "JCEKS")
+                .put("keystore-password", "keystore_password")
+                .buildOrThrow();
+
+        KeystoreSecretProviderConfig expected = new KeystoreSecretProviderConfig()
+                .setKeyStoreFilePath(keystoreFile.toString())
+                .setKeyStoreType("JCEKS")
+                .setKeyStorePassword("keystore_password");
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/secrets-spi/pom.xml
+++ b/secrets-spi/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.airlift</groupId>
+        <artifactId>airlift</artifactId>
+        <version>255-SNAPSHOT</version>
+    </parent>
+    <artifactId>secrets-spi</artifactId>
+    <packaging>jar</packaging>
+    <name>configuration</name>
+
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
+    <dependencies />
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skipTests>true</skipTests>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/secrets-spi/src/main/java/io/airlift/spi/secrets/SecretProvider.java
+++ b/secrets-spi/src/main/java/io/airlift/spi/secrets/SecretProvider.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.spi.secrets;
+
+public interface SecretProvider
+{
+    /**
+     * Resolves and returns the secret value for the given key.
+     *
+     * @return resolved secret value
+     * @throws RuntimeException if key cannot be resolved.
+     */
+    String resolveSecretValue(String key);
+}

--- a/secrets-spi/src/main/java/io/airlift/spi/secrets/SecretProviderFactory.java
+++ b/secrets-spi/src/main/java/io/airlift/spi/secrets/SecretProviderFactory.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.spi.secrets;
+
+import java.util.Map;
+
+public interface SecretProviderFactory
+{
+    String getName();
+
+    SecretProvider createSecretProvider(Map<String, String> config);
+}

--- a/secrets-spi/src/main/java/io/airlift/spi/secrets/SecretsPlugin.java
+++ b/secrets-spi/src/main/java/io/airlift/spi/secrets/SecretsPlugin.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.spi.secrets;
+
+import java.util.List;
+
+public interface SecretsPlugin
+{
+    List<SecretProviderFactory> getSecretProviderFactories();
+}


### PR DESCRIPTION
This PR introduces a framework for injecting custom secrets provider which allows us to add secrets to  the configurations dynamically. The configurations be resolved are of a pattern like ${resolver_name:key_for_resolving_config_property} - We have also introduced SecretProviderFactory and SecretProvider which allows us to resolve configuration in runtime. We have migrated the environment loader to this framework

