### PR TITLE
Add separate modes for X-Forwarded processing

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@
 - Add support for per-request max content length to the http client
 - Introduce modes for processing X-Forwarded-* headers on the server
 - Update Jetty to 12.0.12
+- Add Jetty BOM to Airlift BOM
 
 252
 

--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@
 
 - Add support for per-request timeouts in the http client
 - Add support for per-request max content length to the http client
+- Introduce modes for processing X-Forwarded-* headers on the server
 
 252
 

--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@
 - Add support for per-request timeouts in the http client
 - Add support for per-request max content length to the http client
 - Introduce modes for processing X-Forwarded-* headers on the server
+- Update Jetty to 12.0.12
 
 252
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -14,6 +14,15 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- jetty bom -->
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-bom</artifactId>
+                <version>${dep.jetty.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
             <dependency>
                 <groupId>io.airlift</groupId>
                 <artifactId>bootstrap</artifactId>

--- a/http-server/src/main/java/io/airlift/http/server/HttpServer.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServer.java
@@ -178,12 +178,13 @@ public class HttpServer
         baseHttpConfiguration.setSendServerVersion(false);
         baseHttpConfiguration.setSendXPoweredBy(false);
         baseHttpConfiguration.setNotifyRemoteAsyncErrors(true); // Pass remote exceptions to AsyncContext
-        if (config.isProcessForwarded()) {
-            baseHttpConfiguration.addCustomizer(new ForwardedRequestCustomizer());
-        }
-        else {
-            baseHttpConfiguration.addCustomizer(new RejectForwardedRequestCustomizer());
-        }
+
+        baseHttpConfiguration.addCustomizer(switch (config.getProcessForwarded()) {
+            case REJECT -> new RejectForwardedRequestCustomizer();
+            case ACCEPT -> new ForwardedRequestCustomizer();
+            case IGNORE -> new IgnoreForwardedRequestCustomizer();
+        });
+
         if (config.getMaxRequestHeaderSize() != null) {
             baseHttpConfiguration.setRequestHeaderSize(toIntExact(config.getMaxRequestHeaderSize().toBytes()));
         }

--- a/http-server/src/main/java/io/airlift/http/server/HttpServerConfig.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServerConfig.java
@@ -25,8 +25,10 @@ import io.airlift.units.MinDataSize;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
+import static io.airlift.http.server.HttpServerConfig.ProcessForwardedMode.REJECT;
 import static io.airlift.units.DataSize.Unit.KILOBYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static java.util.Locale.ENGLISH;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -62,7 +64,7 @@ public class HttpServerConfig
     private DataSize logMaxFileSize = DataSize.of(100, MEGABYTE);
     private boolean logCompressionEnabled = true;
 
-    private boolean processForwarded;
+    private ProcessForwardedMode processForwarded = REJECT;
 
     private Integer httpAcceptorThreads;
     private Integer httpSelectorThreads;
@@ -174,14 +176,14 @@ public class HttpServerConfig
         return this;
     }
 
-    public boolean isProcessForwarded()
+    public ProcessForwardedMode getProcessForwarded()
     {
         return processForwarded;
     }
 
     @Config("http-server.process-forwarded")
     @ConfigDescription("Process Forwarded and X-Forwarded headers (for proxied environments)")
-    public HttpServerConfig setProcessForwarded(boolean processForwarded)
+    public HttpServerConfig setProcessForwarded(ProcessForwardedMode processForwarded)
     {
         this.processForwarded = processForwarded;
         return this;
@@ -494,5 +496,21 @@ public class HttpServerConfig
     {
         this.http2StreamIdleTimeout = http2StreamIdleTimeout;
         return this;
+    }
+
+    public enum ProcessForwardedMode
+    {
+        ACCEPT,
+        REJECT,
+        IGNORE;
+
+        public static ProcessForwardedMode fromString(String value)
+        {
+            return switch (value.toUpperCase(ENGLISH)) {
+                case "TRUE" -> ACCEPT;
+                case "FALSE" -> REJECT;
+                default -> valueOf(value.toUpperCase(ENGLISH));
+            };
+        }
     }
 }

--- a/http-server/src/main/java/io/airlift/http/server/IgnoreForwardedRequestCustomizer.java
+++ b/http-server/src/main/java/io/airlift/http/server/IgnoreForwardedRequestCustomizer.java
@@ -1,0 +1,46 @@
+package io.airlift.http.server;
+
+import org.eclipse.jetty.http.HttpField;
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.Request;
+
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+
+public class IgnoreForwardedRequestCustomizer
+        implements HttpConfiguration.Customizer
+{
+    private static final String X_FORWARDED_PREFIX = "x-forwarded-";
+
+    @Override
+    public Request customize(Request request, HttpFields.Mutable responseHeaders)
+    {
+        Set<HttpField> headersToRemove = request.getHeaders().stream()
+                .filter(IgnoreForwardedRequestCustomizer::isForwardingHeader)
+                .collect(toImmutableSet());
+
+        HttpFields original = request.getHeaders();
+        HttpFields.Mutable builder = HttpFields.build(original.size() - headersToRemove.size());
+        original.forEach(httpField -> {
+            if (!headersToRemove.contains(httpField)) {
+                builder.add(httpField);
+            }
+        });
+
+        final HttpFields headers = builder.asImmutable();
+
+        return new Request.Wrapper(request) {
+            public HttpFields getHeaders()
+            {
+                return headers;
+            }
+        };
+    }
+
+    private static boolean isForwardingHeader(HttpField httpField)
+    {
+        return httpField.getName().regionMatches(true, 0, X_FORWARDED_PREFIX, 0, X_FORWARDED_PREFIX.length());
+    }
+}

--- a/http-server/src/test/java/io/airlift/http/server/TestHttpServerConfig.java
+++ b/http-server/src/test/java/io/airlift/http/server/TestHttpServerConfig.java
@@ -25,6 +25,8 @@ import java.util.Map;
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static io.airlift.http.server.HttpServerConfig.ProcessForwardedMode.IGNORE;
+import static io.airlift.http.server.HttpServerConfig.ProcessForwardedMode.REJECT;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static io.airlift.units.DataSize.Unit.KILOBYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
@@ -41,7 +43,7 @@ public class TestHttpServerConfig
                 .setHttpPort(8080)
                 .setHttpAcceptQueueSize(8000)
                 .setHttpsEnabled(false)
-                .setProcessForwarded(false)
+                .setProcessForwarded(REJECT)
                 .setLogPath("var/log/http-request.log")
                 .setLogEnabled(true)
                 .setLogMaxFileSize(DataSize.of(100, MEGABYTE))
@@ -79,7 +81,7 @@ public class TestHttpServerConfig
                 .put("http-server.http.port", "1")
                 .put("http-server.accept-queue-size", "1024")
                 .put("http-server.https.enabled", "true")
-                .put("http-server.process-forwarded", "true")
+                .put("http-server.process-forwarded", "ignore")
                 .put("http-server.log.path", "/log")
                 .put("http-server.log.enabled", "false")
                 .put("http-server.log.max-size", "1GB")
@@ -114,7 +116,7 @@ public class TestHttpServerConfig
                 .setHttpPort(1)
                 .setHttpAcceptQueueSize(1024)
                 .setHttpsEnabled(true)
-                .setProcessForwarded(true)
+                .setProcessForwarded(IGNORE)
                 .setLogPath("/log")
                 .setLogEnabled(false)
                 .setLogMaxFileSize(DataSize.of(1, GIGABYTE))

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <dep.jersey.version>3.1.7</dep.jersey.version>
         <dep.jjwt.version>0.12.6</dep.jjwt.version>
         <dep.jackson.version>2.17.2</dep.jackson.version>
-        <dep.jetty.version>12.0.11</dep.jetty.version>
+        <dep.jetty.version>12.0.12</dep.jetty.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
These are:
- ACCEPT: process X-Forwarded-Header(s).
- DROP: remove X-Forwarded-Header(s) from the request. Application won't receive these headers.
- REJECT: reject X-Forwarder-Header(s) if present. This results in HTTP 406 if X-Forwarder-* header is present.

The existing configuration `http-server.process-forwarded` previously accepting boolean values maps to new modes:
- true => ACCEPT
- false => REJECT

Fixes https://github.com/trinodb/trino/issues/22865