### PR TITLE
Add strict event ordering

### DIFF
--- a/http-client/src/main/java/io/airlift/http/client/HttpClientConfig.java
+++ b/http-client/src/main/java/io/airlift/http/client/HttpClientConfig.java
@@ -22,6 +22,7 @@ import com.google.inject.ConfigurationException;
 import com.google.inject.spi.Message;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
+import io.airlift.configuration.ConfigHidden;
 import io.airlift.configuration.ConfigSecuritySensitive;
 import io.airlift.configuration.DefunctConfig;
 import io.airlift.configuration.LegacyConfig;
@@ -84,6 +85,7 @@ public class HttpClientConfig
     private List<String> includedCipherSuites = ImmutableList.of();
     private String automaticHttpsSharedSecret;
     private Optional<Duration> tcpKeepAliveIdleTime = Optional.empty();
+    private boolean strictEventOrdering;
 
     /**
      * This property is initialized with Jetty's default excluded ciphers list.
@@ -660,6 +662,19 @@ public class HttpClientConfig
     public HttpClientConfig setTcpKeepAliveIdleTime(Duration tcpKeepAliveIdleTime)
     {
         this.tcpKeepAliveIdleTime = Optional.ofNullable(tcpKeepAliveIdleTime);
+        return this;
+    }
+
+    public boolean isStrictEventOrdering()
+    {
+        return strictEventOrdering;
+    }
+
+    @ConfigHidden
+    @Config("http-client.strict-event-ordering")
+    public HttpClientConfig setStrictEventOrdering(boolean strictEventOrdering)
+    {
+        this.strictEventOrdering = strictEventOrdering;
         return this;
     }
 

--- a/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
@@ -314,6 +314,7 @@ public class JettyHttpClient
         httpClient.setByteBufferPool(new ArrayByteBufferPool());
         httpClient.setExecutor(createExecutor(name, config.getMinThreads(), config.getMaxThreads()));
         httpClient.setScheduler(createScheduler(name, config.getTimeoutConcurrency(), config.getTimeoutThreads()));
+        httpClient.setStrictEventOrdering(config.isStrictEventOrdering());
 
         JettyAsyncSocketAddressResolver resolver = new JettyAsyncSocketAddressResolver(
                 httpClient.getExecutor(),

--- a/http-client/src/test/java/io/airlift/http/client/TestHttpClientConfig.java
+++ b/http-client/src/test/java/io/airlift/http/client/TestHttpClientConfig.java
@@ -87,7 +87,8 @@ public class TestHttpClientConfig
                 .setLogBufferSize(DataSize.of(1, MEGABYTE))
                 .setLogFlushInterval(new Duration(10, SECONDS))
                 .setLogCompressionEnabled(true)
-                .setTcpKeepAliveIdleTime(null));
+                .setTcpKeepAliveIdleTime(null)
+                .setStrictEventOrdering(false));
     }
 
     @Test
@@ -135,6 +136,7 @@ public class TestHttpClientConfig
                 .put("http-client.log.flush-interval", "99s")
                 .put("http-client.log.compression.enabled", "false")
                 .put("http-client.tcp-keep-alive-idle-time", "1m")
+                .put("http-client.strict-event-ordering", "true")
                 .build();
 
         HttpClientConfig expected = new HttpClientConfig()
@@ -178,7 +180,8 @@ public class TestHttpClientConfig
                 .setLogBufferSize(DataSize.of(3, MEGABYTE))
                 .setLogFlushInterval(new Duration(99, SECONDS))
                 .setLogCompressionEnabled(false)
-                .setTcpKeepAliveIdleTime(new Duration(1, MINUTES));
+                .setTcpKeepAliveIdleTime(new Duration(1, MINUTES))
+                .setStrictEventOrdering(true);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
I need it to understand whether async jetty client is sensitive to event ordering