### PR TITLE
Log warning when Major GC fails to recover significant memory

### DIFF
--- a/stats/src/test/java/io/airlift/stats/GcMonitorTester.java
+++ b/stats/src/test/java/io/airlift/stats/GcMonitorTester.java
@@ -24,14 +24,14 @@ import java.util.concurrent.ThreadLocalRandom;
  * <p>
  * Test should always be run with:
  * <pre>
- * {@code   -Xmx1g -Xms1g -XX:+PrintGCApplicationStoppedTime}
+ * {@code   -Xmx1g -Xms1g}
  * </pre>
  * All GC algorithms should be tested:
  * <ul>
  * <li>Serial: {@code -XX:+UseSerialGC }</li>
  * <li>Parallel: {@code -XX:+UseParallelGC}</li>
- * <li>CMS: {@code -XX:+UseConcMarkSweepGC}</li>
  * <li>G1: {@code -XX:+UseG1GC}</li>
+ * <li>Z: {@code -XX:+UseZGC -XX:+ZGenerational}</li>
  * </ul>
  * Verifying stopped time in GC log to the stopped time from GCMonitor.
  */
@@ -39,7 +39,7 @@ public final class GcMonitorTester
 {
     private static final List<byte[]> VALUES = new ArrayList<>();
     private static final int VALUE_SIZE = 100 * 1024;
-    private static final long MAX_MEMORY_SIZE = (long) (0.9 * 1024 * 1024 * 1024);
+    private static final long MAX_MEMORY_SIZE = (long) (0.87 * 1024 * 1024 * 1024);
     private static long memorySize;
 
     private GcMonitorTester() {}

--- a/stats/src/test/java/io/airlift/stats/TestJmxGcMonitor.java
+++ b/stats/src/test/java/io/airlift/stats/TestJmxGcMonitor.java
@@ -3,6 +3,8 @@ package io.airlift.stats;
 import io.airlift.units.Duration;
 import org.junit.jupiter.api.Test;
 
+import static io.airlift.stats.JmxGcMonitor.FRACTION_OF_MAX_HEAP_TO_TRIGGER_WARN;
+import static io.airlift.stats.JmxGcMonitor.percentOfMaxHeapReclaimed;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -23,5 +25,16 @@ public class TestJmxGcMonitor
         finally {
             gcMonitor.stop();
         }
+    }
+
+    @Test
+    public void testWarnTrigger()
+    {
+        // Don't warn when max heap is not specified
+        assertThat(percentOfMaxHeapReclaimed(-1, 100.0, 100.0)).isEqualTo(100.0);
+        // Don't warn when totalBeforeGcMemory / maxHeapMemoryUsage < FRACTION_OF_MAX_HEAP_TO_TRIGGER_WARN
+        assertThat(percentOfMaxHeapReclaimed(100, FRACTION_OF_MAX_HEAP_TO_TRIGGER_WARN * 100 - 1, 300)).isEqualTo(100.0);
+        // Return fraction of heap used when totalBeforeGcMemory / maxHeapMemoryUsage >= FRACTION_OF_MAX_HEAP_TO_TRIGGER_WARN
+        assertThat(percentOfMaxHeapReclaimed(100, FRACTION_OF_MAX_HEAP_TO_TRIGGER_WARN * 100, 300)).isLessThan(100.0);
     }
 }


### PR DESCRIPTION
There are instances where processes spin in GC loops when Major GCs fail to recover enough memory. By providing a warning before this condition is reached, it should be possible to act on the warning by taking a JFR before the JVM completely runs out of memory.