### PR TITLE
Enable RESPONSE_SET_STATUS_OVER_SEND_ERROR for jax-rs container

### DIFF
--- a/jaxrs/src/main/java/io/airlift/jaxrs/JaxrsModule.java
+++ b/jaxrs/src/main/java/io/airlift/jaxrs/JaxrsModule.java
@@ -15,6 +15,7 @@
  */
 package io.airlift.jaxrs;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Binder;
 import com.google.inject.Key;
 import com.google.inject.Provides;
@@ -32,6 +33,7 @@ import java.util.Set;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static io.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
+import static org.glassfish.jersey.server.ServerProperties.RESPONSE_SET_STATUS_OVER_SEND_ERROR;
 
 public class JaxrsModule
         extends AbstractConfigurationAwareModule
@@ -70,7 +72,8 @@ public class JaxrsModule
     @Provides
     public static ResourceConfig createResourceConfig(@JaxrsResource Set<Object> jaxRsSingletons)
     {
-        return new JaxrsResourceConfig(jaxRsSingletons);
+        return new JaxrsResourceConfig(jaxRsSingletons)
+                .setProperties(ImmutableMap.of(RESPONSE_SET_STATUS_OVER_SEND_ERROR, "true"));
     }
 
     @Provides


### PR DESCRIPTION
Whenever response status is 4xx or 5xx it is possible to choose between sendError or setStatus on container specific Response implementation. E.g. on servlet container Jersey can call HttpServletResponse.setStatus(...) or HttpServletResponse.sendError(...). Calling sendError(...) method usually resets entity, response headers and provide error page for specified status code (e.g. servlet error-page configuration). However if you want to post-process response (e.g. by servlet filter) the only way to do it is calling setStatus(...) on container Response object.

If property value is true the method Response.setStatus(...) is used over default Response.sendError(...).

Type of the property value is boolean. The default value is false.

https://eclipse-ee4j.github.io/jersey.github.io/apidocs/3.1.1/jersey/org/glassfish/jersey/server/ServerProperties.html#RESPONSE_SET_STATUS_OVER_SEND_ERROR