### PR TITLE
Improve confusing error message

### DIFF
--- a/http-client/src/main/java/io/airlift/http/client/JsonResponseHandler.java
+++ b/http-client/src/main/java/io/airlift/http/client/JsonResponseHandler.java
@@ -87,7 +87,7 @@ public class JsonResponseHandler<T>
         }
         catch (IllegalArgumentException e) {
             String json = new String(bytes, UTF_8);
-            throw new IllegalArgumentException(String.format("Unable to create %s from JSON response:\n<%s>", jsonCodec.getType(), json), e);
+            throw new IllegalArgumentException(String.format("Unable to create %s from JSON response: <%s>", jsonCodec.getType(), json), e);
         }
     }
 }

--- a/http-client/src/main/java/io/airlift/http/client/JsonResponseHandler.java
+++ b/http-client/src/main/java/io/airlift/http/client/JsonResponseHandler.java
@@ -87,7 +87,7 @@ public class JsonResponseHandler<T>
         }
         catch (IllegalArgumentException e) {
             String json = new String(bytes, UTF_8);
-            throw new IllegalArgumentException(String.format("Unable to create %s from JSON response:\n[%s]", jsonCodec.getType(), json), e);
+            throw new IllegalArgumentException(String.format("Unable to create %s from JSON response:\n<%s>", jsonCodec.getType(), json), e);
         }
     }
 }

--- a/http-client/src/test/java/io/airlift/http/client/TestJsonResponseHandler.java
+++ b/http-client/src/test/java/io/airlift/http/client/TestJsonResponseHandler.java
@@ -40,7 +40,7 @@ public class TestJsonResponseHandler
             handler.handle(null, mockResponse(OK, JSON_UTF_8, json));
         }
         catch (IllegalArgumentException e) {
-            assertThat(e.getMessage()).isEqualTo(format("Unable to create %s from JSON response:\n<%s>", User.class, json));
+            assertThat(e.getMessage()).isEqualTo(format("Unable to create %s from JSON response: <%s>", User.class, json));
             assertThat(e).hasCauseInstanceOf(IllegalArgumentException.class);
             assertThat(e).hasStackTraceContaining("Invalid JSON bytes for [simple type, class io.airlift.http.client.TestFullJsonResponseHandler$User]");
         }

--- a/http-client/src/test/java/io/airlift/http/client/TestJsonResponseHandler.java
+++ b/http-client/src/test/java/io/airlift/http/client/TestJsonResponseHandler.java
@@ -40,7 +40,7 @@ public class TestJsonResponseHandler
             handler.handle(null, mockResponse(OK, JSON_UTF_8, json));
         }
         catch (IllegalArgumentException e) {
-            assertThat(e.getMessage()).isEqualTo(format("Unable to create %s from JSON response:\n[%s]", User.class, json));
+            assertThat(e.getMessage()).isEqualTo(format("Unable to create %s from JSON response:\n<%s>", User.class, json));
             assertThat(e).hasCauseInstanceOf(IllegalArgumentException.class);
             assertThat(e).hasStackTraceContaining("Invalid JSON bytes for [simple type, class io.airlift.http.client.TestFullJsonResponseHandler$User]");
         }


### PR DESCRIPTION
Wrapping with [] make the error message look like the returned JSON was always an array which could be confusing to the developer.