### PR TITLE
Update Airbase from 167 to 168

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.airlift</groupId>
         <artifactId>airbase</artifactId>
-        <version>167</version>
+        <version>168</version>
     </parent>
 
     <artifactId>airlift</artifactId>

--- a/tracing/src/main/java/io/airlift/tracing/OpenTelemetryModule.java
+++ b/tracing/src/main/java/io/airlift/tracing/OpenTelemetryModule.java
@@ -70,7 +70,7 @@ public class OpenTelemetryModule
                 .put(ServiceAttributes.SERVICE_NAME, serviceName)
                 .put(ServiceAttributes.SERVICE_VERSION, serviceVersion)
                 .put(ServiceIncubatingAttributes.SERVICE_INSTANCE_ID, nodeInfo.getNodeId())
-                .put(DeploymentIncubatingAttributes.DEPLOYMENT_ENVIRONMENT, nodeInfo.getEnvironment())
+                .put(DeploymentIncubatingAttributes.DEPLOYMENT_ENVIRONMENT_NAME, nodeInfo.getEnvironment())
                 .put(ProcessIncubatingAttributes.PROCESS_RUNTIME_NAME, System.getProperty("java.runtime.name"))
                 .put(ProcessIncubatingAttributes.PROCESS_RUNTIME_VERSION, System.getProperty("java.runtime.version"))
                 .put(ProcessIncubatingAttributes.PROCESS_RUNTIME_DESCRIPTION, processRuntime())

--- a/tracing/src/test/java/io/airlift/tracing/TestTracingModule.java
+++ b/tracing/src/test/java/io/airlift/tracing/TestTracingModule.java
@@ -90,6 +90,6 @@ public class TestTracingModule
         assertThat(span.getResource().getAttributes().asMap()).contains(
                 entry(ServiceAttributes.SERVICE_NAME, "testService"),
                 entry(ServiceAttributes.SERVICE_VERSION, "testVersion"),
-                entry(DeploymentIncubatingAttributes.DEPLOYMENT_ENVIRONMENT, environment));
+                entry(DeploymentIncubatingAttributes.DEPLOYMENT_ENVIRONMENT_NAME, environment));
     }
 }


### PR DESCRIPTION
This update includes a bump in OpenTelemetry, which deprecates the deployment.environment common attribute in favor of deployment.environment.name.

Supersedes #1251 

<!-- Thank you for submitting pull request to Airlift -->

# Airlift contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [x] All automated tests are passing.
 - [ ] Pull request was categorized using one of the existing labels.
