### PR TITLE
Allow special character in Secrets Resolver pattern

### DIFF
--- a/configuration/src/main/java/io/airlift/configuration/secrets/SecretsResolver.java
+++ b/configuration/src/main/java/io/airlift/configuration/secrets/SecretsResolver.java
@@ -28,7 +28,7 @@ import static java.util.regex.Matcher.quoteReplacement;
 
 public class SecretsResolver
 {
-    private static final Pattern PATTERN = Pattern.compile("\\$\\{([a-zA-Z][a-zA-Z0-9_-]*):([a-zA-Z][a-zA-Z0-9_-]*)}");
+    private static final Pattern PATTERN = Pattern.compile("\\$\\{([a-zA-Z][a-zA-Z0-9_-]*):(?<key>[^}]+?)}");
 
     private final Map<String, SecretProvider> secretProviders;
 


### PR DESCRIPTION
<!-- Thank you for submitting pull request to Airlift -->

Allow special character in Secrets Resolver pattern, like path characters/slashes and semicolons

# Airlift contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [x] All automated tests are passing.
 - [x] Pull request was categorized using one of the existing labels.
