### PR TITLE
Support multiple HttpServers via prefixed configuration

### DIFF
--- a/configuration/src/main/java/io/airlift/configuration/ConditionalModule.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConditionalModule.java
@@ -67,6 +67,11 @@ public class ConditionalModule<T>
         return new ConditionalModule<>(config, Optional.of(prefix), predicate, module);
     }
 
+    public static <T> Module conditionalModule(Class<T> config, Optional<String> prefix, Predicate<T> predicate, Module module)
+    {
+        return new ConditionalModule<>(config, prefix, predicate, module);
+    }
+
     private final Class<T> config;
     private final Optional<String> prefix;
     private final Predicate<T> predicate;

--- a/http-server/pom.xml
+++ b/http-server/pom.xml
@@ -192,6 +192,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>5.14.2</version>

--- a/http-server/src/test/java/io/airlift/http/server/TestHttpServerModule.java
+++ b/http-server/src/test/java/io/airlift/http/server/TestHttpServerModule.java
@@ -35,9 +35,10 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.File;
 import java.io.IOException;
@@ -86,16 +87,19 @@ public class TestHttpServerModule
         deleteRecursively(tempDir.toPath(), ALLOW_INSECURE);
     }
 
-    @Test
-    public void testCanConstructServer()
+    @ParameterizedTest
+    @ValueSource(strings = {"", "testPrefix"})
+    public void testCanConstructServer(String configPrefix)
     {
+        String propertyPrefix = configPrefix.isEmpty() ? "" : (configPrefix + ".");
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
-                .put("http-server.http.port", "0")
-                .put("http-server.log.path", new File(tempDir, "http-request.log").getAbsolutePath())
+                .put(propertyPrefix + "http-server.http.port", "0")
+                .put(propertyPrefix + "http-server.log.path", new File(tempDir, "http-request.log").getAbsolutePath())
                 .build();
 
+        HttpServerModule httpServerModule = configPrefix.isEmpty() ? new HttpServerModule() : new HttpServerModule(configPrefix);
         Bootstrap app = new Bootstrap(
-                new HttpServerModule(),
+                httpServerModule,
                 new TestingNodeModule(),
                 binder -> binder.bind(Servlet.class).to(DummyServlet.class));
 
@@ -108,17 +112,20 @@ public class TestHttpServerModule
         assertThat(server).isNotNull();
     }
 
-    @Test
-    public void testHttpServerUri()
+    @ParameterizedTest
+    @ValueSource(strings = {"", "testPrefix"})
+    public void testHttpServerUri(String configPrefix)
             throws Exception
     {
+        String propertyPrefix = configPrefix.isEmpty() ? "" : (configPrefix + ".");
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
-                .put("http-server.http.port", "0")
-                .put("http-server.log.path", new File(tempDir, "http-request.log").getAbsolutePath())
+                .put(propertyPrefix + "http-server.http.port", "0")
+                .put(propertyPrefix + "http-server.log.path", new File(tempDir, "http-request.log").getAbsolutePath())
                 .build();
 
+        HttpServerModule httpServerModule = configPrefix.isEmpty() ? new HttpServerModule() : new HttpServerModule(configPrefix);
         Bootstrap app = new Bootstrap(
-                new HttpServerModule(),
+                httpServerModule,
                 new TestingNodeModule(),
                 binder -> binder.bind(Servlet.class).to(DummyServlet.class));
 
@@ -144,24 +151,27 @@ public class TestHttpServerModule
         }
     }
 
-    @Test
-    public void testServer()
+    @ParameterizedTest
+    @ValueSource(strings = {"", "testPrefix"})
+    public void testServer(String configPrefix)
             throws Exception
     {
-        doTestServerCompliance(true);
-        doTestServerCompliance(false);
+        doTestServerCompliance(configPrefix, true);
+        doTestServerCompliance(configPrefix, false);
     }
 
-    public void doTestServerCompliance(boolean enableLegacyUriCompliance)
+    public void doTestServerCompliance(String configPrefix, boolean enableLegacyUriCompliance)
             throws Exception
     {
+        String propertyPrefix = configPrefix.isEmpty() ? "" : (configPrefix + ".");
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
-                .put("http-server.http.port", "0")
-                .put("http-server.log.path", new File(tempDir, "http-request.log").getAbsolutePath())
+                .put(propertyPrefix + "http-server.http.port", "0")
+                .put(propertyPrefix + "http-server.log.path", new File(tempDir, "http-request.log").getAbsolutePath())
                 .build();
 
+        HttpServerModule httpServerModule = configPrefix.isEmpty() ? new HttpServerModule() : new HttpServerModule(configPrefix);
         Bootstrap app = new Bootstrap(
-                new HttpServerModule(),
+                httpServerModule,
                 new TestingNodeModule(),
                 binder -> {
                     binder.bind(Servlet.class).to(DummyServlet.class);


### PR DESCRIPTION
Provide alternate HttpServerModule that accepts a config prefix. This allows multiple Bootstrapped servers each with their own config namespace enabling Airlift to run multiple simultaneous http servers.

# Airlift contribution check list

 - [X] Git commit messages follow https://cbea.ms/git-commit/.
 - [X] All automated tests are passing.
 - [ ] Pull request was categorized using one of the existing labels.
