### PR TITLE
Upgrade test testExpectedJson by removing non-determinism

### DIFF
--- a/json/src/test/java/io/airlift/json/subtype/Employee.java
+++ b/json/src/test/java/io/airlift/json/subtype/Employee.java
@@ -13,6 +13,8 @@
  */
 package io.airlift.json.subtype;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
 import java.util.List;
 
 public sealed interface Employee
@@ -20,6 +22,7 @@ public sealed interface Employee
     record Programmer(String name)
             implements Employee {}
 
+    @JsonPropertyOrder({"name", "reports"})
     record Manager(String name, List<Employee> reports)
             implements Employee {}
 }


### PR DESCRIPTION
<!-- Thank you for submitting pull request to Airlift -->
The test TestJsonSubType#testExpectedJson fails non-deterministically due to non-deterministic ordering of fields. This happens because `objectMapper.writeValueAsString()` internally uses `java.lang.Class.getDeclaredFields` method and according to [javadocs](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/Class.html#getDeclaredFields()), 'The elements in the returned array are not sorted and are not in any particular order.' 
## How to reproduce the issue: 
`mvn -pl json edu.illinois:nondex-maven-plugin:2.2.1:nondex -Dtest=TestJsonSubType#testExpectedJson -DnondexRuns=10`
## Error
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.983 s <<< FAILURE! -- in io.airlift.json.subtype.TestJsonSubType
[ERROR] io.airlift.json.subtype.TestJsonSubType.testExpectedJson -- Time elapsed: 0.903 s <<< FAILURE!
org.opentest4j.AssertionFailedError: 

expected: "{"name":"Jane","reports":[{"name":"Joe","type":"Programmer"},{"name":"Rachel","type":"Programmer"}],"type":"Manager"}"
 but was: "{"reports":[{"name":"Joe","type":"Programmer"},{"name":"Rachel","type":"Programmer"}],"name":"Jane","type":"Manager"}"
	at io.airlift.json.subtype.TestJsonSubType.testExpectedJson(TestJsonSubType.java:208)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)

## Proposed Solution
Add JsonPropertyOrder to record Manager to specify deterministic order of fields at the time of serialization. 
Happy to discuss if you have any questions or need any additional justification/changes from my side.



# Airlift contribution check list

 - [ ] Git commit messages follow https://cbea.ms/git-commit/.
 - [ ] All automated tests are passing.
 - [ ] Pull request was categorized using one of the existing labels.
 
 
