### PR TITLE
Add option to retrieve used properties metadata from Bootstrap

### DIFF
--- a/bootstrap/src/main/java/io/airlift/bootstrap/Bootstrap.java
+++ b/bootstrap/src/main/java/io/airlift/bootstrap/Bootstrap.java
@@ -80,6 +80,7 @@ public class Bootstrap
     private boolean initializeLogging = true;
     private boolean quiet;
     private boolean loadSecretsPlugins;
+    private boolean skipErrorReporting;
 
     private State state = State.UNINITIALIZED;
     private ConfigurationFactory configurationFactory;
@@ -146,6 +147,12 @@ public class Bootstrap
     public Bootstrap loadSecretsPlugins()
     {
         this.loadSecretsPlugins = true;
+        return this;
+    }
+
+    public Bootstrap skipErrorReporting()
+    {
+        this.skipErrorReporting = true;
         return this;
     }
 
@@ -241,7 +248,7 @@ public class Bootstrap
         }
 
         // If there are configuration errors, fail-fast to keep output clean
-        if (!errors.isEmpty()) {
+        if (!skipErrorReporting && !errors.isEmpty()) {
             throw new ApplicationConfigurationException(errors, warnings);
         }
 
@@ -251,7 +258,7 @@ public class Bootstrap
         }
 
         // Log any warnings
-        if (!warnings.isEmpty()) {
+        if (!skipErrorReporting && !warnings.isEmpty()) {
             StringBuilder message = new StringBuilder();
             message.append("Configuration warnings\n");
             message.append("==========\n\n");

--- a/bootstrap/src/test/java/io/airlift/bootstrap/TestBootstrap.java
+++ b/bootstrap/src/test/java/io/airlift/bootstrap/TestBootstrap.java
@@ -15,14 +15,19 @@
  */
 package io.airlift.bootstrap;
 
+import com.google.inject.Binder;
 import com.google.inject.ConfigurationException;
 import com.google.inject.Inject;
 import com.google.inject.ProvisionException;
 import com.google.inject.Scopes;
 import com.google.inject.spi.Message;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigPropertyMetadata;
+import io.airlift.configuration.ConfigSecuritySensitive;
 import org.junit.jupiter.api.Test;
 
+import static io.airlift.configuration.ConditionalModule.conditionalModule;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -128,13 +133,76 @@ public class TestBootstrap
             binder.bind(FooInstance.class).in(Scopes.SINGLETON);
         });
         bootstrap.setOptionalConfigurationProperty("foo.enabled", "true");
+        bootstrap.setOptionalConfigurationProperty("foo.password", "secret");
         bootstrap.setOptionalConfigurationProperty("bar.enabled", "true");
 
         fooInstanceCreated = false;
-        assertThat(bootstrap.configure()).containsExactly("foo.enabled");
+        assertThat(bootstrap.configure()).containsExactly(
+                new ConfigPropertyMetadata("foo.enabled", false),
+                new ConfigPropertyMetadata("foo.password", true));
         assertThat(fooInstanceCreated).isFalse();
         bootstrap.initialize();
         assertThat(fooInstanceCreated).isTrue();
+    }
+
+    @Test
+    public void testConfigureWithConditionalModule()
+    {
+        AbstractConfigurationAwareModule module = new AbstractConfigurationAwareModule()
+        {
+            @Override
+            protected void setup(Binder binder)
+            {
+                install(conditionalModule(
+                        FooConfig.class,
+                        FooConfig::isFoo,
+                        innerBinder -> configBinder(innerBinder).bindConfig(BarConfig.class)));
+            }
+        };
+        Bootstrap bootstrap = new Bootstrap(module);
+        bootstrap.setOptionalConfigurationProperty("foo.enabled", "true");
+        bootstrap.setOptionalConfigurationProperty("foo.password", "secret");
+        bootstrap.setOptionalConfigurationProperty("bar.enabled", "false");
+        bootstrap.setOptionalConfigurationProperty("bar.password", "password");
+
+        assertThat(bootstrap.configure())
+                .containsExactly(
+                        new ConfigPropertyMetadata("bar.enabled", false),
+                        new ConfigPropertyMetadata("bar.password", true),
+                        new ConfigPropertyMetadata("foo.enabled", false),
+                        new ConfigPropertyMetadata("foo.password", true));
+    }
+
+    @Test
+    public void testConfigureWithPropertyPrefix()
+    {
+        Bootstrap bootstrap = new Bootstrap(
+                binder -> configBinder(binder).bindConfig(BarConfig.class, "foo"));
+        bootstrap.setOptionalConfigurationProperty("foo.bar.enabled", "true");
+        bootstrap.setOptionalConfigurationProperty("foo.bar.password", "secret");
+        bootstrap.setOptionalConfigurationProperty("bar.enabled", "true");
+        bootstrap.setOptionalConfigurationProperty("bar.password", "secret");
+
+        assertThat(bootstrap.configure())
+                .containsExactly(
+                        new ConfigPropertyMetadata("foo.bar.enabled", false),
+                        new ConfigPropertyMetadata("foo.bar.password", true));
+    }
+
+    @SuppressWarnings("AssignmentToStaticFieldFromInstanceMethod")
+    @Test
+    public void testConfigureDoesNotInitializeEagerSingletons()
+    {
+        fooInstanceCreated = false;
+
+        Bootstrap bootstrap = new Bootstrap(binder -> {
+            configBinder(binder).bindConfig(FooConfig.class);
+            binder.bind(FooInstance.class).asEagerSingleton();
+        });
+        bootstrap.setOptionalConfigurationProperty("foo.enabled", "true");
+
+        bootstrap.configure();
+        assertThat(fooInstanceCreated).isFalse();
     }
 
     public static class Instance {}
@@ -164,6 +232,7 @@ public class TestBootstrap
     public static class FooConfig
     {
         private boolean foo;
+        public String password;
 
         public boolean isFoo()
         {
@@ -174,6 +243,50 @@ public class TestBootstrap
         public FooConfig setFoo(boolean foo)
         {
             this.foo = foo;
+            return this;
+        }
+
+        public String getPassword()
+        {
+            return password;
+        }
+
+        @ConfigSecuritySensitive
+        @Config("foo.password")
+        public FooConfig setPassword(String password)
+        {
+            this.password = password;
+            return this;
+        }
+    }
+
+    public static class BarConfig
+    {
+        private boolean bar;
+        public String password;
+
+        public boolean isBar()
+        {
+            return bar;
+        }
+
+        @Config("bar.enabled")
+        public BarConfig setBar(boolean bar)
+        {
+            this.bar = bar;
+            return this;
+        }
+
+        public String getPassword()
+        {
+            return password;
+        }
+
+        @ConfigSecuritySensitive
+        @Config("bar.password")
+        public BarConfig setPassword(String password)
+        {
+            this.password = password;
             return this;
         }
     }

--- a/configuration/src/main/java/io/airlift/configuration/AbstractConfigurationAwareModule.java
+++ b/configuration/src/main/java/io/airlift/configuration/AbstractConfigurationAwareModule.java
@@ -52,9 +52,9 @@ public abstract class AbstractConfigurationAwareModule
         }
     }
 
-    protected void consumeProperty(String name)
+    protected void consumeProperty(ConfigPropertyMetadata property)
     {
-        configurationFactory.consumeProperty(name);
+        configurationFactory.consumeProperty(property);
     }
 
     protected Map<String, String> getProperties()

--- a/configuration/src/main/java/io/airlift/configuration/ConfigPropertyMetadata.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigPropertyMetadata.java
@@ -1,0 +1,11 @@
+package io.airlift.configuration;
+
+public record ConfigPropertyMetadata(String name, boolean securitySensitive)
+        implements Comparable<ConfigPropertyMetadata>
+{
+    @Override
+    public int compareTo(ConfigPropertyMetadata that)
+    {
+        return name.compareTo(that.name);
+    }
+}

--- a/configuration/src/main/java/io/airlift/configuration/ConfigurationFactory.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigurationFactory.java
@@ -106,7 +106,7 @@ public class ConfigurationFactory
     private final Map<String, String> properties;
     private final WarningsMonitor warningsMonitor;
     private final ConcurrentMap<ConfigurationProvider<?>, Object> instanceCache = new ConcurrentHashMap<>();
-    private final Set<String> usedProperties = newConcurrentHashSet();
+    private final Set<ConfigPropertyMetadata> usedProperties = newConcurrentHashSet();
     private final Set<ConfigurationProvider<?>> registeredProviders = newConcurrentHashSet();
     @GuardedBy("this")
     private final List<Consumer<ConfigurationProvider<?>>> configurationBindingListeners = new ArrayList<>();
@@ -131,13 +131,13 @@ public class ConfigurationFactory
     /**
      * Marks the specified property as consumed.
      */
-    public void consumeProperty(String property)
+    public void consumeProperty(ConfigPropertyMetadata property)
     {
         requireNonNull(property, "property is null");
         usedProperties.add(property);
     }
 
-    public Set<String> getUsedProperties()
+    public Set<ConfigPropertyMetadata> getUsedProperties()
     {
         return ImmutableSortedSet.copyOf(usedProperties);
     }
@@ -545,7 +545,7 @@ public class ConfigurationFactory
             throws InvalidConfigurationException
     {
         String name = prefix + injectionPoint.getProperty();
-        usedProperties.add(name);
+        usedProperties.add(new ConfigPropertyMetadata(name, attribute.isSecuritySensitive()));
 
         // Get the property value
         String value = properties.get(name);

--- a/configuration/src/test/java/io/airlift/configuration/TestConfigurationFactory.java
+++ b/configuration/src/test/java/io/airlift/configuration/TestConfigurationFactory.java
@@ -426,7 +426,9 @@ public class TestConfigurationFactory
         ConfigurationFactory configurationFactory = new ConfigurationFactory(properties);
         configurationFactory.registerConfigurationClasses(ImmutableList.of(binder -> configBinder(binder).bindConfig(AnnotatedSetter.class)));
         configurationFactory.validateRegisteredConfigurationProvider();
-        assertThat(configurationFactory.getUsedProperties()).hasSameElementsAs(ImmutableSet.of("string-value", "boolean-value"));
+        assertThat(configurationFactory.getUsedProperties())
+                .extracting(ConfigPropertyMetadata::name)
+                .hasSameElementsAs(ImmutableSet.of("string-value", "boolean-value"));
     }
 
     @Test
@@ -440,7 +442,9 @@ public class TestConfigurationFactory
         configurationFactory.registerConfigurationClasses(ImmutableList.of(binder -> configBinder(binder).bindConfig(AnnotatedSetter.class)));
         List<Message> messages = configurationFactory.validateRegisteredConfigurationProvider();
         assertMessagesMatch(messages, ImmutableList.of(".*Invalid value 'invalid' for type boolean \\(property 'boolean-value'\\).*AnnotatedSetter.*"));
-        assertThat(configurationFactory.getUsedProperties()).isEqualTo(properties.keySet());
+        assertThat(configurationFactory.getUsedProperties())
+                .extracting(ConfigPropertyMetadata::name)
+                .hasSameElementsAs(properties.keySet());
     }
 
     private static Injector createInjector(Map<String, String> properties, Module module, WarningsMonitor warningsMonitor)
@@ -448,7 +452,9 @@ public class TestConfigurationFactory
         ConfigurationFactory configurationFactory = new ConfigurationFactory(properties, warningsMonitor);
         configurationFactory.registerConfigurationClasses(ImmutableList.of(module));
         List<Message> messages = configurationFactory.validateRegisteredConfigurationProvider();
-        assertThat(configurationFactory.getUsedProperties()).hasSameElementsAs(properties.keySet());
+        assertThat(configurationFactory.getUsedProperties())
+                .extracting(ConfigPropertyMetadata::name)
+                .hasSameElementsAs(properties.keySet());
         return Guice.createInjector(new ConfigurationModule(configurationFactory), module, new ValidationErrorModule(messages));
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting pull request to Airlift -->

This PR introduces the following changes:
* Adds the `Bootstrap.configureAndGetUsedProperties()` method, which is analogous to the existing `Bootstrap.configure()` but returns more information. Instead of returning just a set of used property names, it provides metadata for the used properties.
* Adds:
    * `ConfigurationFactory.consumeProperty(ConfigPropertyMetadata)` 
    * `ConfigurationFactory.getUsedPropertiesWithMetadata()`
    * `AbstractConfigurationAwareModule.consumeProperty(ConfigPropertyMetadata)`
    
   Additionally, it deprecates the corresponding methods that operate on raw property names.
* Adds an option to suppress configuration errors and warnings, which is helpful for retrieving used properties without triggering the logging typical of a full application bootstrap.

Examples of usage:
* [Bootstrap.configureAndGetUsedProperties()]( https://github.com/trinodb/trino/blob/47db44be99415cf51d9e33929dce3f11de2f307f/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConnectorFactory.java#L99C62-L99C91)
* [Bootstrap.suppressErrorsAndWarnings()](https://github.com/trinodb/trino/blob/47db44be99415cf51d9e33929dce3f11de2f307f/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConnectorFactory.java#L198-L199)
* [getUsedPropertiesWithMetadata()/consumeProperty()](https://github.com/trinodb/trino/blob/47db44be99415cf51d9e33929dce3f11de2f307f/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/FileSystemModule.java#L91)

# Airlift contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [x] All automated tests are passing.
 - [x] Pull request was categorized using one of the existing labels.
