### PR TITLE
Honor java.net.preferIPv6Address configuration in NodeInfo

### DIFF
--- a/node/src/test/java/io/airlift/node/TestNodeInfo.java
+++ b/node/src/test/java/io/airlift/node/TestNodeInfo.java
@@ -85,6 +85,21 @@ public class TestNodeInfo
     }
 
     @Test
+    public void testIpDiscoveryIpv6Preferred()
+    {
+        NodeInfo.setPreferIpv6ForTest(true);
+        NodeInfo nodeInfo = new NodeInfo(ENVIRONMENT, POOL, "nodeInfo", null, null, null, null, null, null, IP, null);
+        try {
+            assertThat(nodeInfo.getInternalAddress()).isNotNull();
+            assertThat(nodeInfo.getBindIp()).isEqualTo(InetAddresses.forString("0.0.0.0"));
+            assertThat(nodeInfo.getExternalAddress()).isEqualTo(nodeInfo.getInternalAddress());
+        }
+        finally {
+            NodeInfo.setPreferIpv6ForTest(false);
+        }
+    }
+
+    @Test
     public void testHostnameDiscovery()
             throws UnknownHostException
     {


### PR DESCRIPTION
This commit add support for honoring the preference of selecting ipv6 over ipv4 ip address in the internal address selection


# Airlift contribution check list

 - [Y] Git commit messages follow https://cbea.ms/git-commit/.
 - [Y] All automated tests are passing.
 - [ ] Pull request was categorized using one of the existing labels.
