### PR TITLE
Add streaming read methods to JsonCodec

### DIFF
--- a/discovery/src/main/java/io/airlift/discovery/client/HttpDiscoveryLookupClient.java
+++ b/discovery/src/main/java/io/airlift/discovery/client/HttpDiscoveryLookupClient.java
@@ -138,15 +138,14 @@ public class HttpDiscoveryLookupClient
                     throw new DiscoveryException(format("Lookup of %s failed with status code %s", type, response.getStatusCode()));
                 }
 
-                byte[] json;
+                ServiceDescriptorsRepresentation serviceDescriptorsRepresentation;
                 try (InputStream stream = response.getInputStream()) {
-                    json = stream.readAllBytes();
+                    serviceDescriptorsRepresentation = serviceDescriptorsCodec.fromJson(stream);
                 }
                 catch (IOException e) {
                     throw new DiscoveryException(format("Lookup of %s failed", type), e);
                 }
 
-                ServiceDescriptorsRepresentation serviceDescriptorsRepresentation = serviceDescriptorsCodec.fromJson(json);
                 if (!environment.equals(serviceDescriptorsRepresentation.getEnvironment())) {
                     throw new DiscoveryException(format("Expected environment to be %s, but was %s", environment, serviceDescriptorsRepresentation.getEnvironment()));
                 }

--- a/discovery/src/main/java/io/airlift/discovery/client/ServiceInventory.java
+++ b/discovery/src/main/java/io/airlift/discovery/client/ServiceInventory.java
@@ -42,7 +42,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.http.client.JsonResponseHandler.createJsonResponseHandler;
 import static io.airlift.http.client.Request.Builder.prepareGet;
-import static java.nio.file.Files.readAllBytes;
+import static java.nio.file.Files.newBufferedReader;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
 import static java.util.stream.Collectors.toList;
@@ -156,7 +156,7 @@ public class ServiceInventory
             }
             else {
                 File file = new File(serviceInventoryUri);
-                serviceDescriptorsRepresentation = serviceDescriptorsCodec.fromJson(readAllBytes(file.toPath()));
+                serviceDescriptorsRepresentation = serviceDescriptorsCodec.fromJson(newBufferedReader(file.toPath()));
             }
 
             if (!environment.equals(serviceDescriptorsRepresentation.getEnvironment())) {

--- a/http-client/src/main/java/io/airlift/http/client/DefaultingJsonResponseHandler.java
+++ b/http-client/src/main/java/io/airlift/http/client/DefaultingJsonResponseHandler.java
@@ -73,7 +73,7 @@ public class DefaultingJsonResponseHandler<T>
             return defaultValue;
         }
         try (InputStream inputStream = response.getInputStream()) {
-            return jsonCodec.fromJson(inputStream.readAllBytes());
+            return jsonCodec.fromJson(inputStream);
         }
         catch (Exception e) {
             return defaultValue;

--- a/json/src/main/java/io/airlift/json/JsonCodec.java
+++ b/json/src/main/java/io/airlift/json/JsonCodec.java
@@ -24,6 +24,8 @@ import com.google.common.reflect.TypeToken;
 import io.airlift.json.LengthLimitedWriter.LengthLimitExceededException;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
 import java.io.StringWriter;
 import java.lang.reflect.Type;
 import java.util.List;
@@ -218,6 +220,46 @@ public class JsonCodec<T>
         }
         catch (IOException e) {
             throw new IllegalArgumentException(format("%s could not be converted to JSON", instance.getClass().getName()), e);
+        }
+    }
+
+    /**
+     * Coverts the specified {@link InputStream} (UTF-8) into an instance of type T.
+     *
+     * @param json the json stream (UTF-8) to parse
+     * @return parsed response; never null
+     * @throws IllegalArgumentException if the json bytes can not be converted to the type T
+     */
+    public T fromJson(InputStream json)
+            throws IllegalArgumentException
+    {
+        try (JsonParser parser = mapper.createParser(json)) {
+            T value = mapper.readerFor(javaType).readValue(parser);
+            checkArgument(parser.nextToken() == null, "Found characters after the expected end of input");
+            return value;
+        }
+        catch (IOException e) {
+            throw new IllegalArgumentException(format("Invalid JSON bytes for %s", javaType), e);
+        }
+    }
+
+    /**
+     * Coverts the specified {@link Reader} into an instance of type T.
+     *
+     * @param json the json character stream to parse
+     * @return parsed response; never null
+     * @throws IllegalArgumentException if the json characters can not be converted to the type T
+     */
+    public T fromJson(Reader json)
+            throws IllegalArgumentException
+    {
+        try (JsonParser parser = mapper.createParser(json)) {
+            T value = mapper.readerFor(javaType).readValue(parser);
+            checkArgument(parser.nextToken() == null, "Found characters after the expected end of input");
+            return value;
+        }
+        catch (IOException e) {
+            throw new IllegalArgumentException(format("Invalid JSON characters for %s", javaType), e);
         }
     }
 

--- a/json/src/test/java/io/airlift/json/ImmutablePerson.java
+++ b/json/src/test/java/io/airlift/json/ImmutablePerson.java
@@ -20,11 +20,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStreamReader;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ImmutablePerson
@@ -42,6 +45,10 @@ public class ImmutablePerson
 
         byte[] bytes = jsonCodec.toJsonBytes(expected);
         assertThat(jsonCodec.fromJson(bytes)).isEqualTo(expected);
+
+        assertThat(jsonCodec.fromJson(new ByteArrayInputStream(bytes))).isEqualTo(expected);
+
+        assertThat(jsonCodec.fromJson(new InputStreamReader(new ByteArrayInputStream(bytes), UTF_8))).isEqualTo(expected);
     }
 
     public static void validatePersonListJsonCodec(JsonCodec<List<ImmutablePerson>> jsonCodec)
@@ -56,6 +63,10 @@ public class ImmutablePerson
 
         byte[] bytes = jsonCodec.toJsonBytes(expected);
         assertThat(jsonCodec.fromJson(bytes)).isEqualTo(expected);
+
+        assertThat(jsonCodec.fromJson(new ByteArrayInputStream(bytes))).isEqualTo(expected);
+
+        assertThat(jsonCodec.fromJson(new InputStreamReader(new ByteArrayInputStream(bytes), UTF_8))).isEqualTo(expected);
     }
 
     public static void validatePersonMapJsonCodec(JsonCodec<Map<String, ImmutablePerson>> jsonCodec)
@@ -71,6 +82,10 @@ public class ImmutablePerson
 
         byte[] bytes = jsonCodec.toJsonBytes(expected);
         assertThat(jsonCodec.fromJson(bytes)).isEqualTo(expected);
+
+        assertThat(jsonCodec.fromJson(new ByteArrayInputStream(bytes))).isEqualTo(expected);
+
+        assertThat(jsonCodec.fromJson(new InputStreamReader(new ByteArrayInputStream(bytes), UTF_8))).isEqualTo(expected);
     }
 
     @JsonCreator

--- a/json/src/test/java/io/airlift/json/Person.java
+++ b/json/src/test/java/io/airlift/json/Person.java
@@ -19,12 +19,15 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStreamReader;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class Person
@@ -45,6 +48,10 @@ public class Person
         byte[] bytes = jsonCodec.toJsonBytes(expected);
         assertThat(jsonCodec.fromJson(bytes)).isEqualTo(expected);
 
+        assertThat(jsonCodec.fromJson(new ByteArrayInputStream(bytes))).isEqualTo(expected);
+
+        assertThat(jsonCodec.fromJson(new InputStreamReader(new ByteArrayInputStream(bytes), UTF_8))).isEqualTo(expected);
+
         // create object with missing lastName
         expected.setLastName(Optional.empty());
 
@@ -55,6 +62,10 @@ public class Person
         bytes = jsonCodec.toJsonBytes(expected);
         assertThat(jsonCodec.fromJson(bytes)).isEqualTo(expected);
 
+        assertThat(jsonCodec.fromJson(new ByteArrayInputStream(bytes))).isEqualTo(expected);
+
+        assertThat(jsonCodec.fromJson(new InputStreamReader(new ByteArrayInputStream(bytes), UTF_8))).isEqualTo(expected);
+
         // create object with present lastName
         expected.setLastName(Optional.of("Awesome"));
 
@@ -64,6 +75,10 @@ public class Person
 
         bytes = jsonCodec.toJsonBytes(expected);
         assertThat(jsonCodec.fromJson(bytes)).isEqualTo(expected);
+
+        assertThat(jsonCodec.fromJson(new ByteArrayInputStream(bytes))).isEqualTo(expected);
+
+        assertThat(jsonCodec.fromJson(new InputStreamReader(new ByteArrayInputStream(bytes), UTF_8))).isEqualTo(expected);
     }
 
     public static void validatePersonListJsonCodec(JsonCodec<List<Person>> jsonCodec)
@@ -78,6 +93,10 @@ public class Person
 
         byte[] bytes = jsonCodec.toJsonBytes(expected);
         assertThat(jsonCodec.fromJson(bytes)).isEqualTo(expected);
+
+        assertThat(jsonCodec.fromJson(new ByteArrayInputStream(bytes))).isEqualTo(expected);
+
+        assertThat(jsonCodec.fromJson(new InputStreamReader(new ByteArrayInputStream(bytes), UTF_8))).isEqualTo(expected);
     }
 
     public static void validatePersonMapJsonCodec(JsonCodec<Map<String, Person>> jsonCodec)
@@ -93,6 +112,10 @@ public class Person
 
         byte[] bytes = jsonCodec.toJsonBytes(expected);
         assertThat(jsonCodec.fromJson(bytes)).isEqualTo(expected);
+
+        assertThat(jsonCodec.fromJson(new ByteArrayInputStream(bytes))).isEqualTo(expected);
+
+        assertThat(jsonCodec.fromJson(new InputStreamReader(new ByteArrayInputStream(bytes), UTF_8))).isEqualTo(expected);
     }
 
     @JsonProperty

--- a/json/src/test/java/io/airlift/json/Vehicle.java
+++ b/json/src/test/java/io/airlift/json/Vehicle.java
@@ -5,9 +5,12 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStreamReader;
 import java.util.List;
 import java.util.Map;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @JsonTypeInfo(
@@ -30,6 +33,10 @@ public interface Vehicle
         byte[] bytes = jsonCodec.toJsonBytes(expected);
         assertThat(jsonCodec.fromJson(bytes)).isEqualTo(expected);
 
+        assertThat(jsonCodec.fromJson(new ByteArrayInputStream(bytes))).isEqualTo(expected);
+
+        assertThat(jsonCodec.fromJson(new InputStreamReader(new ByteArrayInputStream(bytes), UTF_8))).isEqualTo(expected);
+
         expected = new Truck("volvo");
 
         json = jsonCodec.toJson(expected);
@@ -38,6 +45,10 @@ public interface Vehicle
 
         bytes = jsonCodec.toJsonBytes(expected);
         assertThat(jsonCodec.fromJson(bytes)).isEqualTo(expected);
+
+        assertThat(jsonCodec.fromJson(new ByteArrayInputStream(bytes))).isEqualTo(expected);
+
+        assertThat(jsonCodec.fromJson(new InputStreamReader(new ByteArrayInputStream(bytes), UTF_8))).isEqualTo(expected);
     }
 
     static void validateVehicleListJsonCodec(JsonCodec<List<Vehicle>> jsonCodec)
@@ -51,6 +62,10 @@ public interface Vehicle
 
         byte[] bytes = jsonCodec.toJsonBytes(expected);
         assertThat(jsonCodec.fromJson(bytes)).isEqualTo(expected);
+
+        assertThat(jsonCodec.fromJson(new ByteArrayInputStream(bytes))).isEqualTo(expected);
+
+        assertThat(jsonCodec.fromJson(new InputStreamReader(new ByteArrayInputStream(bytes), UTF_8))).isEqualTo(expected);
     }
 
     static void validateVehicleMapJsonCodec(JsonCodec<Map<String, Vehicle>> jsonCodec)
@@ -65,5 +80,9 @@ public interface Vehicle
 
         byte[] bytes = jsonCodec.toJsonBytes(expected);
         assertThat(jsonCodec.fromJson(bytes)).isEqualTo(expected);
+
+        assertThat(jsonCodec.fromJson(new ByteArrayInputStream(bytes))).isEqualTo(expected);
+
+        assertThat(jsonCodec.fromJson(new InputStreamReader(new ByteArrayInputStream(bytes), UTF_8))).isEqualTo(expected);
     }
 }


### PR DESCRIPTION
They can be more efficient than reading all contents to memory as bytes and then processing them.

<!-- Thank you for submitting pull request to Airlift -->

# Airlift contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [x] All automated tests are passing.
 - [x] Pull request was categorized using one of the existing labels.
