### PR TITLE
Always propagate IOException for streaming JSON

### DIFF
--- a/json/src/main/java/io/airlift/json/JsonCodec.java
+++ b/json/src/main/java/io/airlift/json/JsonCodec.java
@@ -16,6 +16,7 @@
 package io.airlift.json;
 
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Suppliers;
@@ -231,14 +232,14 @@ public class JsonCodec<T>
      * @throws IllegalArgumentException if the json bytes can not be converted to the type T
      */
     public T fromJson(InputStream json)
-            throws IllegalArgumentException
+            throws IllegalArgumentException, IOException
     {
         try (JsonParser parser = mapper.createParser(json)) {
             T value = mapper.readerFor(javaType).readValue(parser);
             checkArgument(parser.nextToken() == null, "Found characters after the expected end of input");
             return value;
         }
-        catch (IOException e) {
+        catch (JsonProcessingException e) {
             throw new IllegalArgumentException(format("Invalid JSON bytes for %s", javaType), e);
         }
     }
@@ -251,15 +252,15 @@ public class JsonCodec<T>
      * @throws IllegalArgumentException if the json characters can not be converted to the type T
      */
     public T fromJson(Reader json)
-            throws IllegalArgumentException
+            throws IllegalArgumentException, IOException
     {
         try (JsonParser parser = mapper.createParser(json)) {
             T value = mapper.readerFor(javaType).readValue(parser);
             checkArgument(parser.nextToken() == null, "Found characters after the expected end of input");
             return value;
         }
-        catch (IOException e) {
-            throw new IllegalArgumentException(format("Invalid JSON characters for %s", javaType), e);
+        catch (JsonProcessingException e) {
+            throw new IllegalArgumentException(format("Invalid JSON bytes for %s", javaType), e);
         }
     }
 

--- a/json/src/test/java/io/airlift/json/ImmutablePerson.java
+++ b/json/src/test/java/io/airlift/json/ImmutablePerson.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.List;
 import java.util.Map;
@@ -37,6 +38,7 @@ public class ImmutablePerson
     private final String notWritable = null;
 
     public static void validatePersonJsonCodec(JsonCodec<ImmutablePerson> jsonCodec)
+            throws IOException
     {
         ImmutablePerson expected = new ImmutablePerson("dain", true);
 
@@ -52,6 +54,7 @@ public class ImmutablePerson
     }
 
     public static void validatePersonListJsonCodec(JsonCodec<List<ImmutablePerson>> jsonCodec)
+            throws IOException
     {
         ImmutableList<ImmutablePerson> expected = ImmutableList.of(
                 new ImmutablePerson("dain", true),
@@ -70,6 +73,7 @@ public class ImmutablePerson
     }
 
     public static void validatePersonMapJsonCodec(JsonCodec<Map<String, ImmutablePerson>> jsonCodec)
+            throws IOException
     {
         ImmutableMap<String, ImmutablePerson> expected = ImmutableMap.<String, ImmutablePerson>builder()
                 .put("dain", new ImmutablePerson("dain", true))

--- a/json/src/test/java/io/airlift/json/Person.java
+++ b/json/src/test/java/io/airlift/json/Person.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.List;
 import java.util.Map;
@@ -37,6 +38,7 @@ public class Person
     private Optional<String> lastName;
 
     public static void validatePersonJsonCodec(JsonCodec<Person> jsonCodec)
+            throws IOException
     {
         // create object with null lastName
         Person expected = new Person().setName("dain").setRocks(true);
@@ -82,6 +84,7 @@ public class Person
     }
 
     public static void validatePersonListJsonCodec(JsonCodec<List<Person>> jsonCodec)
+            throws IOException
     {
         ImmutableList<Person> expected = ImmutableList.of(
                 new Person().setName("dain").setRocks(true),
@@ -100,6 +103,7 @@ public class Person
     }
 
     public static void validatePersonMapJsonCodec(JsonCodec<Map<String, Person>> jsonCodec)
+            throws IOException
     {
         ImmutableMap<String, Person> expected = ImmutableMap.<String, Person>builder()
                 .put("dain", new Person().setName("dain").setRocks(true))

--- a/json/src/test/java/io/airlift/json/TestJsonCodec.java
+++ b/json/src/test/java/io/airlift/json/TestJsonCodec.java
@@ -22,6 +22,7 @@ import com.google.common.reflect.TypeToken;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.StringReader;
 import java.util.ArrayList;
@@ -42,6 +43,7 @@ public class TestJsonCodec
 {
     @Test
     public void testJsonCodec()
+            throws IOException
     {
         JsonCodec<Person> jsonCodec = jsonCodec(Person.class);
 
@@ -54,6 +56,7 @@ public class TestJsonCodec
 
     @Test
     public void testListJsonCodec()
+            throws IOException
     {
         JsonCodec<List<Person>> jsonCodec = listJsonCodec(Person.class);
 
@@ -66,6 +69,7 @@ public class TestJsonCodec
 
     @Test
     public void testListJsonCodecFromJsonCodec()
+            throws IOException
     {
         JsonCodec<List<Person>> jsonCodec = listJsonCodec(jsonCodec(Person.class));
 
@@ -78,6 +82,7 @@ public class TestJsonCodec
 
     @Test
     public void testTypeTokenList()
+            throws IOException
     {
         JsonCodec<List<Person>> jsonCodec = jsonCodec(new TypeToken<List<Person>>() {});
 
@@ -102,6 +107,7 @@ public class TestJsonCodec
 
     @Test
     public void testMapJsonCodec()
+            throws IOException
     {
         JsonCodec<Map<String, Person>> jsonCodec = mapJsonCodec(String.class, Person.class);
 
@@ -114,6 +120,7 @@ public class TestJsonCodec
 
     @Test
     public void testMapJsonCodecFromJsonCodec()
+            throws IOException
     {
         JsonCodec<Map<String, Person>> jsonCodec = mapJsonCodec(String.class, jsonCodec(Person.class));
 
@@ -126,6 +133,7 @@ public class TestJsonCodec
 
     @Test
     public void testTypeLiteralMap()
+            throws IOException
     {
         JsonCodec<Map<String, Person>> jsonCodec = jsonCodec(new TypeToken<Map<String, Person>>() {});
 
@@ -150,6 +158,7 @@ public class TestJsonCodec
 
     @Test
     public void testImmutableJsonCodec()
+            throws IOException
     {
         JsonCodec<ImmutablePerson> jsonCodec = jsonCodec(ImmutablePerson.class);
 
@@ -166,6 +175,7 @@ public class TestJsonCodec
 
     @Test
     public void testImmutableListJsonCodec()
+            throws IOException
     {
         JsonCodec<List<ImmutablePerson>> jsonCodec = listJsonCodec(ImmutablePerson.class);
 
@@ -174,6 +184,7 @@ public class TestJsonCodec
 
     @Test
     public void testImmutableListJsonCodecFromJsonCodec()
+            throws IOException
     {
         JsonCodec<List<ImmutablePerson>> jsonCodec = listJsonCodec(jsonCodec(ImmutablePerson.class));
 
@@ -182,6 +193,7 @@ public class TestJsonCodec
 
     @Test
     public void testImmutableTypeTokenList()
+            throws IOException
     {
         JsonCodec<List<ImmutablePerson>> jsonCodec = jsonCodec(new TypeToken<List<ImmutablePerson>>() {});
 
@@ -190,6 +202,7 @@ public class TestJsonCodec
 
     @Test
     public void testImmutableMapJsonCodec()
+            throws IOException
     {
         JsonCodec<Map<String, ImmutablePerson>> jsonCodec = mapJsonCodec(String.class, ImmutablePerson.class);
 
@@ -198,6 +211,7 @@ public class TestJsonCodec
 
     @Test
     public void testImmutableMapJsonCodecFromJsonCodec()
+            throws IOException
     {
         JsonCodec<Map<String, ImmutablePerson>> jsonCodec = mapJsonCodec(String.class, jsonCodec(ImmutablePerson.class));
 
@@ -206,6 +220,7 @@ public class TestJsonCodec
 
     @Test
     public void testImmutableTypeTokenMap()
+            throws IOException
     {
         JsonCodec<Map<String, ImmutablePerson>> jsonCodec = jsonCodec(new TypeToken<Map<String, ImmutablePerson>>() {});
 
@@ -226,6 +241,7 @@ public class TestJsonCodec
 
     @Test
     public void testToJsonExceedingDefaultStringLimit()
+            throws IOException
     {
         JsonCodec<ImmutablePerson> jsonCodec = jsonCodec(ImmutablePerson.class);
         ImmutablePerson person = new ImmutablePerson(Strings.repeat("a", DEFAULT_MAX_STRING_LEN + 1), false);
@@ -292,7 +308,7 @@ public class TestJsonCodec
 
         assertThatThrownBy(() -> codec.fromJson(new StringReader(jsonWithTrailingContent)))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Invalid JSON characters for [simple type, class io.airlift.json.ImmutablePerson]")
+                .hasMessage("Invalid JSON bytes for [simple type, class io.airlift.json.ImmutablePerson]")
                 .hasStackTraceContaining("Unrecognized token 'trailer': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')");
 
         String jsonWithTrailingJsonContent = json + " \"valid json value\"";

--- a/json/src/test/java/io/airlift/json/TestJsonModule.java
+++ b/json/src/test/java/io/airlift/json/TestJsonModule.java
@@ -76,6 +76,7 @@ public class TestJsonModule
 
     @Test
     public void testJsonCodecFactoryBinding()
+            throws IOException
     {
         Injector injector = Guice.createInjector(new JsonModule());
         JsonCodecFactory codecFactory = injector.getInstance(JsonCodecFactory.class);

--- a/json/src/test/java/io/airlift/json/Vehicle.java
+++ b/json/src/test/java/io/airlift/json/Vehicle.java
@@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.List;
 import java.util.Map;
@@ -23,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public interface Vehicle
 {
     static void validateVehicleJsonCodec(JsonCodec<Vehicle> jsonCodec)
+            throws IOException
     {
         Vehicle expected = new Car("bmw");
 
@@ -52,6 +54,7 @@ public interface Vehicle
     }
 
     static void validateVehicleListJsonCodec(JsonCodec<List<Vehicle>> jsonCodec)
+            throws IOException
     {
         ImmutableList<Vehicle> expected = ImmutableList.of(
                 new Car("bmw"),
@@ -69,6 +72,7 @@ public interface Vehicle
     }
 
     static void validateVehicleMapJsonCodec(JsonCodec<Map<String, Vehicle>> jsonCodec)
+            throws IOException
     {
         ImmutableMap<String, Vehicle> expected = ImmutableMap.<String, Vehicle>builder()
                 .put("bmw", new Car("bmw"))


### PR DESCRIPTION
This allow the caller to capture exceptions coming from remote systems like FileNotFound and whatnot.

We've added streaming decoding in a previous release to avoid materializing Slices to byte array or Strings which always copies data.

<!-- Thank you for submitting pull request to Airlift -->

# Airlift contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [x] All automated tests are passing.
 - [x] Pull request was categorized using one of the existing labels.
