### PR TITLE
Fix double calling of PostConstruct/PreDestroy methods

### DIFF
--- a/bootstrap/src/main/java/io/airlift/bootstrap/ConcurrentWeakIdentitySet.java
+++ b/bootstrap/src/main/java/io/airlift/bootstrap/ConcurrentWeakIdentitySet.java
@@ -1,0 +1,66 @@
+package io.airlift.bootstrap;
+
+import com.google.common.collect.Sets;
+
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
+import java.util.Set;
+
+import static java.lang.System.identityHashCode;
+
+class ConcurrentWeakIdentitySet
+{
+    private final Set<Wrapper> set = Sets.newConcurrentHashSet();
+    private final ReferenceQueue<Object> queue = new ReferenceQueue<>();
+
+    // copied/modified from WeakHashMap implementation
+    private static class Wrapper
+            extends WeakReference<Object>
+    {
+        private final int id;
+
+        private Wrapper(Object o, ReferenceQueue<Object> queue)
+        {
+            super(o, queue);
+
+            // Asserting that "id" refers to an object's address in memory and that no
+            // two objects can have the same identityHashCode.
+            // This may not be true for all VM implementations.
+            id = identityHashCode(o);
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            return (this == o) || ((o instanceof Wrapper wrapper) && (wrapper.id == id));
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return id;
+        }
+    }
+
+    int size()
+    {
+        removeStaleEntries();
+
+        return set.size();
+    }
+
+    boolean add(Object o)
+    {
+        removeStaleEntries();
+
+        return set.add(new Wrapper(o, queue));
+    }
+
+    private void removeStaleEntries()
+    {
+        // copied/modified from WeakHashMap implementation
+        for (Object o; (o = queue.poll()) != null; ) {
+            set.remove((Wrapper) o);
+        }
+    }
+}

--- a/bootstrap/src/test/java/io/airlift/bootstrap/ControllerWithInstance.java
+++ b/bootstrap/src/test/java/io/airlift/bootstrap/ControllerWithInstance.java
@@ -1,0 +1,16 @@
+package io.airlift.bootstrap;
+
+import com.google.inject.Inject;
+
+import static java.util.Objects.requireNonNull;
+
+public class ControllerWithInstance
+{
+    // InstanceWithLifecycle must be injected into another object
+    // to exhibit the double start issue with optional binding
+    @Inject
+    public ControllerWithInstance(InstanceWithLifecycle instance)
+    {
+        requireNonNull(instance, "instance is null");
+    }
+}

--- a/bootstrap/src/test/java/io/airlift/bootstrap/InstanceWithLifecycle.java
+++ b/bootstrap/src/test/java/io/airlift/bootstrap/InstanceWithLifecycle.java
@@ -1,0 +1,6 @@
+package io.airlift.bootstrap;
+
+public interface InstanceWithLifecycle
+{
+    boolean isStarted();
+}

--- a/bootstrap/src/test/java/io/airlift/bootstrap/InstanceWithLifecycleImpl.java
+++ b/bootstrap/src/test/java/io/airlift/bootstrap/InstanceWithLifecycleImpl.java
@@ -1,0 +1,34 @@
+package io.airlift.bootstrap;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class InstanceWithLifecycleImpl
+        implements InstanceWithLifecycle
+{
+    private final AtomicBoolean started = new AtomicBoolean(false);
+
+    @Override
+    public boolean isStarted()
+    {
+        return started.get();
+    }
+
+    @PostConstruct
+    public void startMeUp()
+    {
+        if (!started.compareAndSet(false, true)) {
+            throw new IllegalStateException("Already started");
+        }
+    }
+
+    @PreDestroy
+    public void shutMeDown()
+    {
+        if (!started.compareAndSet(true, false)) {
+            throw new IllegalStateException("Not started");
+        }
+    }
+}

--- a/bootstrap/src/test/java/io/airlift/bootstrap/TestConcurrentWeakIdentitySet.java
+++ b/bootstrap/src/test/java/io/airlift/bootstrap/TestConcurrentWeakIdentitySet.java
@@ -1,0 +1,40 @@
+package io.airlift.bootstrap;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestConcurrentWeakIdentitySet
+{
+    @Test
+    public void testClearedReferences()
+    {
+        int iterations = 100000;
+
+        ConcurrentWeakIdentitySet weakIdentitySet = new ConcurrentWeakIdentitySet();
+        for (int i = 0; i < iterations; ++i) {
+            weakIdentitySet.add(new byte[1_000_000]);
+        }
+
+        // probably doesn't do anything but can't hurt
+        System.gc();
+
+        assertThat(weakIdentitySet.size()).isLessThan(iterations);
+    }
+
+    @Test
+    public void testIdentity()
+    {
+        record Tester(String id) {}
+
+        ConcurrentWeakIdentitySet weakIdentitySet = new ConcurrentWeakIdentitySet();
+
+        assertThat(weakIdentitySet.add("test")).isTrue();
+        assertThat(weakIdentitySet.add("test")).isFalse();
+
+        Tester one = new Tester("one");
+        assertThat(weakIdentitySet.add(one)).isTrue();
+        assertThat(weakIdentitySet.add(one)).isFalse();
+        assertThat(weakIdentitySet.add(new Tester("one"))).isTrue();
+    }
+}


### PR DESCRIPTION
Guice sometimes double-provisions objects. In particular when `OptionalBinder` is used. This causes the LifeCycleManager to call `@PostConstruct` and  `@PreDestroy` methods twice.

To fix, store objects that have either `@PostConstruct` or `@PreDestroy` in a concurrent identity-based map to prevent invoking these methods more than once.

# Airlift contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [x] All automated tests are passing.
 - [ ] Pull request was categorized using one of the existing labels.
