### PR TITLE
Add support for `Path` as configuration value type

### DIFF
--- a/concurrent/src/test/java/io/airlift/concurrent/TestAsyncSemaphore.java
+++ b/concurrent/src/test/java/io/airlift/concurrent/TestAsyncSemaphore.java
@@ -670,8 +670,7 @@ public class TestAsyncSemaphore
 
         public ListenableFuture<String> submit(Integer value)
         {
-            Supplier<ListenableFuture<String>> failure = failures.get(value);
-            if (failure != null) {
+            if (failures.get(value) instanceof Supplier<ListenableFuture<String>> failure) {
                 return failure.get();
             }
             SettableFuture<String> future = SettableFuture.create();

--- a/configuration/src/main/java/io/airlift/configuration/ConfigurationFactory.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigurationFactory.java
@@ -75,6 +75,7 @@ import static java.lang.String.format;
 import static java.util.Arrays.stream;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
+import static java.util.function.Function.identity;
 
 public class ConfigurationFactory
 {
@@ -617,8 +618,7 @@ public class ConfigurationFactory
 
         Map<String, Method> stringAcceptingMethods = stream(type.getRawType().getMethods())
                 .filter(ConfigurationFactory::acceptsSingleStringParameter)
-                .map(method -> Map.entry(method.getName(), method))
-                .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+                .collect(toImmutableMap(Method::getName, identity()));
 
         // Look for a static fromString(String) methods. This is used in preference
         // to the built-in valueOf() method for enums.

--- a/configuration/src/main/java/io/airlift/configuration/ConfigurationFactory.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigurationFactory.java
@@ -51,6 +51,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Executable;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -617,6 +618,7 @@ public class ConfigurationFactory
         }
 
         Map<String, Method> stringAcceptingMethods = stream(type.getRawType().getMethods())
+                .filter(method -> Modifier.isStatic(method.getModifiers()))
                 .filter(ConfigurationFactory::acceptsSingleStringParameter)
                 .collect(toImmutableMap(Method::getName, identity()));
 

--- a/configuration/src/main/java/io/airlift/configuration/ConfigurationFactory.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigurationFactory.java
@@ -622,8 +622,7 @@ public class ConfigurationFactory
 
         // Look for a static fromString(String) methods. This is used in preference
         // to the built-in valueOf() method for enums.
-        Method fromString = stringAcceptingMethods.get("fromString");
-        if (fromString != null) {
+        if (stringAcceptingMethods.get("fromString") instanceof Method fromString) {
             if (type.isSubtypeOf(fromString.getGenericReturnType())) {
                 try {
                     return fromString.invoke(null, value);
@@ -677,8 +676,7 @@ public class ConfigurationFactory
         }
 
         // Look for a static valueOf(String) method
-        Method valueOf = stringAcceptingMethods.get("valueOf");
-        if (valueOf != null) {
+        if (stringAcceptingMethods.get("valueOf") instanceof Method valueOf) {
             if (type.isSubtypeOf(valueOf.getGenericReturnType())) {
                 try {
                     return valueOf.invoke(null, value);

--- a/configuration/src/test/java/io/airlift/configuration/Config1.java
+++ b/configuration/src/test/java/io/airlift/configuration/Config1.java
@@ -18,6 +18,7 @@ package io.airlift.configuration;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -58,15 +59,21 @@ public class Config1
 
     MyEnum myEnumSecondOption;
 
+    Path pathOption;
+
     Set<MyEnum> myEnumSet = ImmutableSet.of();
 
     List<MyEnum> myEnumList = ImmutableList.of();
 
     List<Integer> myIntegerList = ImmutableList.of();
 
+    List<Path> myPathList = ImmutableList.of();
+
     ValueClass valueClassOption;
 
     Optional<ValueClass> optionalValueClassOption = Optional.empty();
+
+    Optional<Path> optionalPathOption = Optional.empty();
 
     public String getStringOption()
     {
@@ -272,6 +279,18 @@ public class Config1
         return this;
     }
 
+    public Path getPathOption()
+    {
+        return pathOption;
+    }
+
+    @Config("pathOption")
+    public Config1 setPathOption(Path pathOption)
+    {
+        this.pathOption = pathOption;
+        return this;
+    }
+
     public Set<MyEnum> getMyEnumSet()
     {
         return myEnumSet;
@@ -308,6 +327,18 @@ public class Config1
         return this;
     }
 
+    public List<Path> getMyPathList()
+    {
+        return myPathList;
+    }
+
+    @Config("myPathList")
+    public Config1 setMyPathList(List<Path> myPathList)
+    {
+        this.myPathList = myPathList;
+        return this;
+    }
+
     public ValueClass getValueClassOption()
     {
         return valueClassOption;
@@ -329,6 +360,18 @@ public class Config1
     public Config1 setOptionalValueClassOption(Optional<ValueClass> optionalValueClassOption)
     {
         this.optionalValueClassOption = optionalValueClassOption;
+        return this;
+    }
+
+    public Optional<Path> getOptionalPathOption()
+    {
+        return optionalPathOption;
+    }
+
+    @Config("optionalPathOption")
+    public Config1 setOptionalPathOption(Optional<Path> optionalPathOption)
+    {
+        this.optionalPathOption = optionalPathOption;
         return this;
     }
 }

--- a/configuration/src/test/java/io/airlift/configuration/TestConfig.java
+++ b/configuration/src/test/java/io/airlift/configuration/TestConfig.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -81,9 +82,12 @@ public class TestConfig
             .put("myEnumSet", "FOO,bar")
             .put("myEnumList", "BAR,foo")
             .put("myIntegerList", "10,12,14,16")
+            .put("myPathList", "/dev/null,/proc/self")
             .put("myEnumSecondOption", "bar") // lowercase
+            .put("pathOption", "/dev/null")
             .put("valueClassOption", "a value class")
             .put("optionalValueClassOption", "a value class")
+            .put("optionalPathOption", "/dev/null")
             .build();
 
     @Test
@@ -195,14 +199,18 @@ public class TestConfig
         assertThat(Double.MAX_VALUE).isEqualTo(config.getBoxedDoubleOption());
         assertThat(FOO).isEqualTo(config.getMyEnumOption());
         assertThat(BAR).isEqualTo(config.getMyEnumSecondOption());
+        assertThat(Paths.get("/dev/null")).isEqualTo(config.getPathOption());
         assertThat(config.getValueClassOption().getValue()).isEqualTo("a value class");
         assertThat(config.getMyEnumList()).isEqualTo(ImmutableList.of(BAR, FOO));
         assertThat(config.getMyEnumSet()).isEqualTo(ImmutableSet.of(BAR, FOO));
         assertThat(config.getMyIntegerList()).isEqualTo(ImmutableList.of(10, 12, 14, 16));
+        assertThat(config.getMyPathList()).isEqualTo(ImmutableList.of(Paths.get("/dev/null"), Paths.get("/proc/self")));
         assertThat(config.getOptionalValueClassOption())
                 .isPresent()
                 .hasValueSatisfying(value -> assertThat(value.getValue())
                         .isEqualTo("a value class"));
+        assertThat(config.getOptionalPathOption())
+                .contains(Paths.get("/dev/null"));
     }
 
     @Test

--- a/configuration/src/test/java/io/airlift/configuration/testing/TestConfigAssertions.java
+++ b/configuration/src/test/java/io/airlift/configuration/testing/TestConfigAssertions.java
@@ -486,13 +486,16 @@ public class TestConfigAssertions
                 .setLongOption(0)
                 .setMyEnumOption(null)
                 .setMyEnumSecondOption(null)
+                .setPathOption(null)
                 .setMyEnumList(ImmutableList.of())
                 .setMyEnumSet(ImmutableSet.of())
                 .setMyIntegerList(ImmutableList.of())
+                .setMyPathList(ImmutableList.of())
                 .setShortOption((short) 0)
                 .setStringOption(null)
                 .setValueClassOption(null)
-                .setOptionalValueClassOption(Optional.empty()));
+                .setOptionalValueClassOption(Optional.empty())
+                .setOptionalPathOption(Optional.empty()));
     }
 
     @Test

--- a/discovery/src/main/java/io/airlift/discovery/client/HttpServiceSelectorImpl.java
+++ b/discovery/src/main/java/io/airlift/discovery/client/HttpServiceSelectorImpl.java
@@ -59,8 +59,7 @@ public class HttpServiceSelectorImpl
         // favor https over http
         List<URI> httpsUri = new ArrayList<>();
         for (ServiceDescriptor serviceDescriptor : serviceDescriptors) {
-            String https = serviceDescriptor.getProperties().get("https");
-            if (https != null) {
+            if (serviceDescriptor.getProperties().get("https") instanceof String https) {
                 try {
                     httpsUri.add(new URI(https));
                 }
@@ -70,8 +69,7 @@ public class HttpServiceSelectorImpl
         }
         List<URI> httpUri = new ArrayList<>();
         for (ServiceDescriptor serviceDescriptor : serviceDescriptors) {
-            String http = serviceDescriptor.getProperties().get("http");
-            if (http != null) {
+            if (serviceDescriptor.getProperties().get("http") instanceof String http) {
                 try {
                     httpUri.add(new URI(http));
                 }

--- a/openmetrics/src/main/java/io/airlift/openmetrics/MetricsResource.java
+++ b/openmetrics/src/main/java/io/airlift/openmetrics/MetricsResource.java
@@ -265,8 +265,7 @@ public class MetricsResource
                 String metricAndAttribute = managedClass.isAttributeFlatten(attributeName) ? metricName : metricName + "_" + attributeName;
                 String attributeDescription = managedClass.getAttributeDescription(attributeName);
 
-                ManagedClass child = managedClass.getChildren().get(attributeName);
-                if (child != null) {
+                if (managedClass.getChildren().get(attributeName) instanceof ManagedClass child) {
                     // The managed class is directly translatable to an openmetrics type, don't recurse any further
                     Optional<Metric> metricFromTarget = getMetricFromTarget(child, metricAndAttribute, attributeDescription);
                     if (metricFromTarget.isPresent()) {


### PR DESCRIPTION
<!-- Thank you for submitting pull request to Airlift -->

Just like support for `File` is indirect via matching a `String`-accepting constructor, support for `Path` is indirect via matching a static `of` factory method (available on `Path` since Java 11). The quirk is that this is a vararg method, which takes "at least one" `String`: `of(String, String...)`. So we have to treat such methods as `String`-accepting as well.

# Airlift contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [x] All automated tests are passing.
 - [x] Pull request was categorized using one of the existing labels.
