### PR TITLE
Make command line log output colored if supported

### DIFF
--- a/log-manager/src/main/java/io/airlift/log/Format.java
+++ b/log-manager/src/main/java/io/airlift/log/Format.java
@@ -6,17 +6,22 @@ import java.util.logging.Formatter;
 public enum Format
 {
     JSON {
-        public Formatter createFormatter(Map<String, String> logAnnotations)
+        public Formatter createFormatter(Map<String, String> logAnnotations, boolean interactive)
         {
             return new JsonFormatter(logAnnotations);
         }
     },
     TEXT {
-        public Formatter createFormatter(Map<String, String> logAnnotations)
+        public Formatter createFormatter(Map<String, String> logAnnotations, boolean interactive)
         {
-            return new StaticFormatter(logAnnotations);
+            return new StaticFormatter(logAnnotations, interactive);
         }
     };
 
-    public abstract Formatter createFormatter(Map<String, String> logAnnotations);
+    public abstract Formatter createFormatter(Map<String, String> logAnnotations, boolean interactive);
+
+    public Formatter createFormatter(Map<String, String> logAnnotations)
+    {
+        return createFormatter(logAnnotations, false);
+    }
 }

--- a/log-manager/src/main/java/io/airlift/log/Logging.java
+++ b/log-manager/src/main/java/io/airlift/log/Logging.java
@@ -276,7 +276,7 @@ public class Logging
 
         if (config.getLogPath() != null) {
             if (config.getLogPath().startsWith("tcp://")) {
-                logToSocket(config.getLogPath(), config.getFormat().createFormatter(logAnnotations), mBeanExportCollector);
+                logToSocket(config.getLogPath(), config.getFormat().createFormatter(logAnnotations, false), mBeanExportCollector);
             }
             else {
                 logToFile(
@@ -284,7 +284,7 @@ public class Logging
                         config.getMaxSize(),
                         config.getMaxTotalSize(),
                         config.getCompression(),
-                        config.getFormat().createFormatter(logAnnotations),
+                        config.getFormat().createFormatter(logAnnotations, false),
                         mBeanExportCollector);
             }
         }
@@ -296,7 +296,7 @@ public class Logging
             // reinitialize console handler with provided configs and redirect standard streams to a reconfigured logger
             resetStdStreams();
             disableConsole();
-            enableConsole(config.getConsoleFormat().createFormatter(logAnnotations));
+            enableConsole(config.getConsoleFormat().createFormatter(logAnnotations, true));
             redirectStdStreams();
         }
 

--- a/log-manager/src/main/java/io/airlift/log/StaticFormatter.java
+++ b/log-manager/src/main/java/io/airlift/log/StaticFormatter.java
@@ -16,6 +16,13 @@ import java.util.Map;
 import java.util.logging.Formatter;
 import java.util.logging.LogRecord;
 
+import static io.airlift.log.TerminalColors.Color.BRIGHT_BLACK;
+import static io.airlift.log.TerminalColors.Color.CYAN;
+import static io.airlift.log.TerminalColors.Color.GREEN;
+import static io.airlift.log.TerminalColors.Color.PURPLE;
+import static io.airlift.log.TerminalColors.Color.WHITE;
+import static io.airlift.log.TerminalColors.colored;
+import static io.airlift.log.TerminalColors.coloredWriter;
 import static java.time.temporal.ChronoField.DAY_OF_MONTH;
 import static java.time.temporal.ChronoField.HOUR_OF_DAY;
 import static java.time.temporal.ChronoField.MILLI_OF_SECOND;
@@ -71,23 +78,24 @@ class StaticFormatter
     public String format(LogRecord record)
     {
         ZonedDateTime timestamp = ZonedDateTime.ofInstant(Instant.ofEpochMilli(record.getMillis()), SYSTEM_ZONE);
+        Level level = Level.fromJulLevel(record.getLevel());
 
         StringWriter stringWriter = new StringWriter()
-                .append(TIMESTAMP_FORMATTER.format(timestamp))
+                .append(colored(TIMESTAMP_FORMATTER.format(timestamp), BRIGHT_BLACK))
                 .append('\t')
-                .append(Level.fromJulLevel(record.getLevel()).name())
+                .append(colored(level.name(), level))
                 .append('\t')
-                .append(Thread.currentThread().getName())
+                .append(colored(Thread.currentThread().getName(), CYAN))
                 .append('\t')
-                .append(record.getLoggerName());
+                .append(colored(record.getLoggerName(), PURPLE));
 
         if (!logAnnotations.isEmpty()) {
             stringWriter.append('\t')
-                    .append(Joiner.on(",").withKeyValueSeparator("=").join(logAnnotations));
+                    .append(colored(Joiner.on(",").withKeyValueSeparator("=").join(logAnnotations), level));
         }
 
         stringWriter.append('\t')
-                .append(record.getMessage());
+                .append(colored(record.getMessage(), WHITE));
 
         if (record.getParameters() != null && record.getParameters().length != 0) {
             stringWriter.append(" parameters=").append(deepToString(record.getParameters()));
@@ -95,7 +103,7 @@ class StaticFormatter
 
         if (record.getThrown() != null) {
             stringWriter.append('\n');
-            record.getThrown().printStackTrace(new PrintWriter(stringWriter));
+            record.getThrown().printStackTrace(coloredWriter(new PrintWriter(stringWriter), GREEN));
             stringWriter.append('\n');
         }
 

--- a/log-manager/src/main/java/io/airlift/log/StaticFormatter.java
+++ b/log-manager/src/main/java/io/airlift/log/StaticFormatter.java
@@ -21,7 +21,6 @@ import static io.airlift.log.TerminalColors.Color.CYAN;
 import static io.airlift.log.TerminalColors.Color.GREEN;
 import static io.airlift.log.TerminalColors.Color.PURPLE;
 import static io.airlift.log.TerminalColors.Color.WHITE;
-import static io.airlift.log.TerminalColors.colored;
 import static io.airlift.log.TerminalColors.coloredWriter;
 import static java.time.temporal.ChronoField.DAY_OF_MONTH;
 import static java.time.temporal.ChronoField.HOUR_OF_DAY;
@@ -38,6 +37,7 @@ class StaticFormatter
 {
     private static final ZoneId SYSTEM_ZONE = ZoneId.systemDefault().normalized();
     private final Map<String, String> logAnnotations;
+    private final TerminalColors colors;
 
     private static final DateTimeFormatter TIMESTAMP_FORMATTER = new DateTimeFormatterBuilder()
             .parseCaseInsensitive()
@@ -59,12 +59,13 @@ class StaticFormatter
 
     public StaticFormatter()
     {
-        this(ImmutableMap.of());
+        this(ImmutableMap.of(), false);
     }
 
-    public StaticFormatter(Map<String, String> logAnnotations)
+    public StaticFormatter(Map<String, String> logAnnotations, boolean interactive)
     {
         this.logAnnotations = ImmutableMap.copyOf(requireNonNull(logAnnotations, "logAnnotations is null"));
+        this.colors = new TerminalColors(interactive);
     }
 
     @Override
@@ -81,21 +82,21 @@ class StaticFormatter
         Level level = Level.fromJulLevel(record.getLevel());
 
         StringWriter stringWriter = new StringWriter()
-                .append(colored(TIMESTAMP_FORMATTER.format(timestamp), BRIGHT_BLACK))
+                .append(colors.colored(TIMESTAMP_FORMATTER.format(timestamp), BRIGHT_BLACK))
                 .append('\t')
-                .append(colored(level.name(), level))
+                .append(colors.colored(level.name(), level))
                 .append('\t')
-                .append(colored(Thread.currentThread().getName(), CYAN))
+                .append(colors.colored(Thread.currentThread().getName(), CYAN))
                 .append('\t')
-                .append(colored(record.getLoggerName(), PURPLE));
+                .append(colors.colored(record.getLoggerName(), PURPLE));
 
         if (!logAnnotations.isEmpty()) {
             stringWriter.append('\t')
-                    .append(colored(Joiner.on(",").withKeyValueSeparator("=").join(logAnnotations), level));
+                    .append(colors.colored(Joiner.on(",").withKeyValueSeparator("=").join(logAnnotations), level));
         }
 
         stringWriter.append('\t')
-                .append(colored(record.getMessage(), WHITE));
+                .append(colors.colored(record.getMessage(), WHITE));
 
         if (record.getParameters() != null && record.getParameters().length != 0) {
             stringWriter.append(" parameters=").append(deepToString(record.getParameters()));

--- a/log-manager/src/main/java/io/airlift/log/TerminalColors.java
+++ b/log-manager/src/main/java/io/airlift/log/TerminalColors.java
@@ -1,0 +1,109 @@
+package io.airlift.log;
+
+import java.io.PrintWriter;
+
+import static io.airlift.log.TerminalColors.Color.BLUE;
+import static io.airlift.log.TerminalColors.Color.GREEN;
+import static io.airlift.log.TerminalColors.Color.RED;
+import static io.airlift.log.TerminalColors.Color.WHITE;
+import static io.airlift.log.TerminalColors.Color.YELLOW;
+
+public class TerminalColors
+{
+    private static final boolean isColorSupported = detectIsColorSupported();
+    private static final String ANSI_RESET = "\033[0m";
+
+    private TerminalColors() {}
+
+    public enum Color
+    {
+        WHITE("\033[37m"),
+        RED("\033[31m"),
+        GREEN("\033[32m"),
+        YELLOW("\033[33m"),
+        BLUE("\033[34m"),
+        PURPLE("\033[35m"),
+        CYAN("\033[36m"),
+        BRIGHT_BLACK("\033[90m"),;
+
+        private final String code;
+
+        Color(String code)
+        {
+            this.code = code;
+        }
+
+        public String getCode()
+        {
+            return code;
+        }
+    }
+
+    public static String colored(String text, Color color)
+    {
+        if (!isColorSupported) {
+            return text;
+        }
+        return color.getCode() + text + ANSI_RESET;
+    }
+
+    public static String colored(String text, Level level)
+    {
+        return switch (level) {
+            case OFF -> text;
+            case TRACE -> colored(text, WHITE);
+            case DEBUG -> colored(text, BLUE);
+            case INFO -> colored(text, GREEN);
+            case WARN -> colored(text, YELLOW);
+            case ERROR -> colored(text, RED);
+        };
+    }
+
+    public static PrintWriter coloredWriter(PrintWriter writer, Color color)
+    {
+        return new PrintWriter(writer)
+        {
+            @Override
+            public void write(char[] buffer, int off, int len)
+            {
+                writer.write(color.getCode());
+                writer.write(buffer, off, len);
+                writer.write(ANSI_RESET);
+            }
+
+            @Override
+            public void flush()
+            {
+                writer.flush();
+            }
+
+            @Override
+            public void close()
+            {
+                writer.close();
+            }
+        };
+    }
+
+    private static boolean detectIsColorSupported()
+    {
+        // Non-interactive terminal
+        if (System.console() == null) {
+            return false;
+        }
+
+        // No terminal at all
+        String term = System.getenv("TERM");
+        if (term == null) {
+            return false;
+        }
+
+        // Dumb terminal
+        if (term.equalsIgnoreCase("dumb")) {
+            return false;
+        }
+
+        // https://no-color.org/
+        return System.getenv("NO_COLOR") == null;
+    }
+}

--- a/log-manager/src/main/java/io/airlift/log/TerminalColors.java
+++ b/log-manager/src/main/java/io/airlift/log/TerminalColors.java
@@ -13,7 +13,12 @@ public class TerminalColors
     private static final boolean isColorSupported = detectIsColorSupported();
     private static final String ANSI_RESET = "\033[0m";
 
-    private TerminalColors() {}
+    private final boolean interactive;
+
+    public TerminalColors(boolean interactive)
+    {
+        this.interactive = interactive;
+    }
 
     public enum Color
     {
@@ -39,15 +44,18 @@ public class TerminalColors
         }
     }
 
-    public static String colored(String text, Color color)
+    public String colored(String text, Color color)
     {
         if (!isColorSupported) {
+            return text;
+        }
+        if (!interactive) {
             return text;
         }
         return color.getCode() + text + ANSI_RESET;
     }
 
-    public static String colored(String text, Level level)
+    public String colored(String text, Level level)
     {
         return switch (level) {
             case OFF -> text;


### PR DESCRIPTION
This assigns different colors to different log levels and is only supported if we are running in the interactive, non-dumb terminal with NO_COLORS unset.

<!-- Thank you for submitting pull request to Airlift -->

# Airlift contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [x] All automated tests are passing.
 - [x] Pull request was categorized using one of the existing labels.
