### PR TITLE
Allow NodeInfo annotations to be set via a comma separated key value string

### DIFF
--- a/node/src/main/java/io/airlift/node/NodeInfo.java
+++ b/node/src/main/java/io/airlift/node/NodeInfo.java
@@ -41,6 +41,7 @@ import java.util.function.Function;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Verify.verify;
 import static io.airlift.configuration.ConfigurationLoader.loadPropertiesFrom;
 import static io.airlift.configuration.ConfigurationUtils.replaceEnvironmentVariables;
 import static io.airlift.node.AddressToHostname.encodeAddressAsHostname;
@@ -82,6 +83,7 @@ public class NodeInfo
                 config.getConfigSpec(),
                 config.getInternalAddressSource(),
                 config.getAnnotationFile(),
+                config.getAnnotations(),
                 config.getPreferIpv6Address());
     }
 
@@ -96,6 +98,7 @@ public class NodeInfo
             String configSpec,
             AddressSource internalAddressSource,
             String annotationFile,
+            Map<String, String> annotations,
             boolean preferIpv6Address)
     {
         requireNonNull(environment, "environment is null");
@@ -147,6 +150,7 @@ public class NodeInfo
             this.externalAddress = this.internalAddress;
         }
 
+        verify(annotationFile == null || annotations == null, "Only one of annotationFile or annotations should be set, but not both");
         if (annotationFile != null) {
             try {
                 this.annotations = ImmutableMap.copyOf(replaceEnvironmentVariables(loadPropertiesFrom(annotationFile)));
@@ -154,6 +158,9 @@ public class NodeInfo
             catch (IOException e) {
                 throw new UncheckedIOException(e);
             }
+        }
+        else if (annotations != null) {
+            this.annotations = ImmutableMap.copyOf(annotations);
         }
         else {
             this.annotations = ImmutableMap.of();


### PR DESCRIPTION
Adds an easy way of creating NodeInfo in memory without needing a physical file for annotations. Useful when having more than one Metrics endpoint with different labels exposed.

<!-- Thank you for submitting pull request to Airlift -->

# Airlift contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [x] All automated tests are passing.
 - [ ] Pull request was categorized using one of the existing labels.
