### PR TITLE
Add support for OTLP/HTTP trace exporter

### DIFF
--- a/tracing/src/main/java/io/airlift/tracing/OpenTelemetryExporterConfig.java
+++ b/tracing/src/main/java/io/airlift/tracing/OpenTelemetryExporterConfig.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.Pattern;
 public class OpenTelemetryExporterConfig
 {
     private String endpoint = "http://localhost:4317";
+    private Protocol protocol = Protocol.GRPC;
 
     @NotNull
     @Pattern(regexp = "^(http|https)://.*$", message = "must start with http:// or https://")
@@ -20,5 +21,33 @@ public class OpenTelemetryExporterConfig
     {
         this.endpoint = endpoint;
         return this;
+    }
+
+    @NotNull
+    public Protocol getProtocol()
+    {
+        return protocol;
+    }
+
+    @Config("tracing.exporter.protocol")
+    public OpenTelemetryExporterConfig setProtocol(Protocol protocol)
+    {
+        this.protocol = protocol;
+        return this;
+    }
+
+    public enum Protocol
+    {
+        GRPC,
+        HTTP_PROTOBUF;
+
+        public static Protocol fromString(String protocol)
+        {
+            return switch (protocol) {
+                case "grpc" -> GRPC;
+                case "http/protobuf" -> HTTP_PROTOBUF;
+                default -> throw new IllegalArgumentException("Invalid protocol: " + protocol);
+            };
+        }
     }
 }

--- a/tracing/src/test/java/io/airlift/tracing/TestOpenTelemetryExporterConfig.java
+++ b/tracing/src/test/java/io/airlift/tracing/TestOpenTelemetryExporterConfig.java
@@ -8,6 +8,8 @@ import java.util.Map;
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static io.airlift.tracing.OpenTelemetryExporterConfig.Protocol.GRPC;
+import static io.airlift.tracing.OpenTelemetryExporterConfig.Protocol.HTTP_PROTOBUF;
 
 public class TestOpenTelemetryExporterConfig
 {
@@ -15,7 +17,8 @@ public class TestOpenTelemetryExporterConfig
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(OpenTelemetryExporterConfig.class)
-                .setEndpoint("http://localhost:4317"));
+                .setEndpoint("http://localhost:4317")
+                .setProtocol(GRPC));
     }
 
     @Test
@@ -23,10 +26,12 @@ public class TestOpenTelemetryExporterConfig
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("tracing.exporter.endpoint", "http://example.com:1234")
+                .put("tracing.exporter.protocol", "http/protobuf")
                 .buildOrThrow();
 
         OpenTelemetryExporterConfig expected = new OpenTelemetryExporterConfig()
-                .setEndpoint("http://example.com:1234");
+                .setEndpoint("http://example.com:1234")
+                .setProtocol(HTTP_PROTOBUF);
 
         assertFullMapping(properties, expected);
     }

--- a/tracing/src/test/java/io/airlift/tracing/TestOpenTelemetryExporterModule.java
+++ b/tracing/src/test/java/io/airlift/tracing/TestOpenTelemetryExporterModule.java
@@ -1,0 +1,35 @@
+package io.airlift.tracing;
+
+import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
+import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import org.junit.jupiter.api.Test;
+
+import static io.airlift.tracing.OpenTelemetryExporterConfig.Protocol.GRPC;
+import static io.airlift.tracing.OpenTelemetryExporterConfig.Protocol.HTTP_PROTOBUF;
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class TestOpenTelemetryExporterModule
+{
+    @Test
+    void testGrpcExporterIsCreated()
+    {
+        OpenTelemetryExporterConfig config = new OpenTelemetryExporterConfig()
+                .setProtocol(GRPC)
+                .setEndpoint("http://localhost:4317");
+
+        SpanExporter exporter = OpenTelemetryExporterModule.createSpanExporter(config);
+        assertThat(exporter).isInstanceOf(OtlpGrpcSpanExporter.class);
+    }
+
+    @Test
+    void testHttpExporterIsCreated()
+    {
+        OpenTelemetryExporterConfig config = new OpenTelemetryExporterConfig()
+                .setProtocol(HTTP_PROTOBUF)
+                .setEndpoint("http://localhost:4317");
+
+        SpanExporter exporter = OpenTelemetryExporterModule.createSpanExporter(config);
+        assertThat(exporter).isInstanceOf(OtlpHttpSpanExporter.class);
+    }
+}


### PR DESCRIPTION
This change adds support for exporting OpenTelemetry traces using the OTLP/HTTP protocol, in addition to the existing gRPC-based exporter.

### Summary
- Introduced a new configuration option `tracing.exporter.protocol` (default: `grpc`)
- Supported values: `grpc`, `http/protobuf`
- If `http/protobuf` is configured, an `OtlpHttpSpanExporter` is used instead of the default `OtlpGrpcSpanExporter`
- Kept the default behavior unchanged for backward compatibility

### Motivation
Some observability platforms only support receiving OTLP over HTTP. This update makes Airlift’s tracing more flexible and easier to integrate with a wider range of tools.

<!-- Thank you for submitting pull request to Airlift -->

# Airlift contribution check list

 - [ ] Git commit messages follow https://cbea.ms/git-commit/.
 - [ ] All automated tests are passing.
 - [ ] Pull request was categorized using one of the existing labels.
