### PR TITLE
Add support for CompositeData metrics in OpenMetrics

### DIFF
--- a/openmetrics/src/main/java/io/airlift/openmetrics/types/CompositeMetric.java
+++ b/openmetrics/src/main/java/io/airlift/openmetrics/types/CompositeMetric.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.openmetrics.types;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+
+import javax.management.openmbean.CompositeData;
+import javax.management.openmbean.CompositeType;
+import javax.management.openmbean.TabularData;
+import javax.management.openmbean.TabularType;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.groupingBy;
+
+public record CompositeMetric(String metricName, Map<String, String> labels, String help, List<Metric> subMetrics)
+        implements Metric
+{
+    private static final Splitter SPLITTER = Splitter.on('\n')
+            .omitEmptyStrings()
+            .trimResults()
+            .limit(3);
+
+    public static CompositeMetric from(String metricName, Object value, Map<String, String> labels, String help)
+    {
+        requireNonNull(value, "value is null");
+        ImmutableList.Builder<Metric> subMetrics = ImmutableList.builder();
+        extractMetrics(value, metricName, labels, help, subMetrics);
+        return new CompositeMetric(metricName, labels, help, subMetrics.build());
+    }
+
+    private static void extractMetrics(Object value, String prefix, Map<String, String> labels, String help, ImmutableList.Builder<Metric> metrics)
+    {
+        switch (value) {
+            case Number number -> metrics.add(new Gauge(prefix, number.doubleValue(), labels, help));
+            case Boolean bool -> metrics.add(new Gauge(prefix, bool ? 1.0 : 0.0, labels, help));
+            case CompositeData compositeData -> {
+                CompositeType compositeType = compositeData.getCompositeType();
+                for (String itemName : compositeType.keySet()) {
+                    extractMetrics(compositeData.get(itemName), prefix + "_" + itemName, labels, help, metrics);
+                }
+            }
+            case TabularData tabularData when !tabularData.isEmpty() -> {
+                TabularType tabularType = tabularData.getTabularType();
+                Set<String> indexNames = ImmutableSet.copyOf(tabularType.getIndexNames());
+
+                for (Object entry : tabularData.values()) {
+                    if (entry instanceof CompositeData compositeData) {
+                        Map<String, String> rowLabels = new HashMap<>(labels);
+                        for (String indexName : indexNames) {
+                            if (compositeData.containsKey(indexName)) {
+                                rowLabels.put(indexName, compositeData.get(indexName).toString());
+                            }
+                        }
+                        for (String itemName : Sets.difference(compositeData.getCompositeType().keySet(), indexNames)) {
+                            extractMetrics(compositeData.get(itemName), prefix + "_" + itemName, rowLabels, help, metrics);
+                        }
+                    }
+                }
+            }
+            default -> throw new IllegalStateException("Unexpected value: " + value);
+        }
+    }
+
+    @Override
+    public String getMetricExposition()
+    {
+        if (subMetrics.isEmpty()) {
+            return "";
+        }
+
+        Map<String, List<Metric>> metricsByName = subMetrics.stream()
+                .collect(groupingBy(Metric::metricName));
+
+        StringBuilder exposition = new StringBuilder();
+
+        for (Map.Entry<String, List<Metric>> entry : metricsByName.entrySet()) {
+            List<Metric> metrics = entry.getValue();
+
+            if (metrics.isEmpty()) {
+                continue;
+            }
+            String typeLine = null;
+            String helpLine = null;
+            for (String line : SPLITTER.split(metrics.getFirst().getMetricExposition())) {
+                if (line.startsWith("# TYPE")) {
+                    typeLine = line;
+                }
+                else if (line.startsWith("# HELP")) {
+                    helpLine = line;
+                }
+            }
+            if (typeLine != null) {
+                exposition.append(typeLine).append('\n');
+            }
+            if (helpLine != null) {
+                exposition.append(helpLine).append('\n');
+            }
+            for (Metric metric : metrics) {
+                for (String line : SPLITTER.split(metric.getMetricExposition())) {
+                    if (!line.startsWith("#") && !line.isEmpty()) {
+                        exposition.append(line).append('\n');
+                    }
+                }
+            }
+        }
+        return exposition.toString();
+    }
+}

--- a/openmetrics/src/main/java/io/airlift/openmetrics/types/Metric.java
+++ b/openmetrics/src/main/java/io/airlift/openmetrics/types/Metric.java
@@ -44,6 +44,7 @@ public interface Metric
         return NAME_WITH_LABELS_LINE_FORMAT.formatted(
                 name,
                 labels.entrySet().stream()
+                        .sorted(Map.Entry.comparingByKey())
                         .map(e -> "%s=\"%s\"".formatted(e.getKey(), e.getValue()))
                         .collect(Collectors.joining(",")));
     }

--- a/openmetrics/src/test/java/io/airlift/openmetrics/TestMetricExpositions.java
+++ b/openmetrics/src/test/java/io/airlift/openmetrics/TestMetricExpositions.java
@@ -15,13 +15,25 @@ package io.airlift.openmetrics;
 
 import com.google.common.collect.ImmutableMap;
 import io.airlift.openmetrics.types.BigCounter;
+import io.airlift.openmetrics.types.CompositeMetric;
 import io.airlift.openmetrics.types.Counter;
 import io.airlift.openmetrics.types.Gauge;
 import io.airlift.openmetrics.types.Info;
 import io.airlift.openmetrics.types.Summary;
 import org.junit.jupiter.api.Test;
 
+import javax.management.openmbean.CompositeData;
+import javax.management.openmbean.CompositeDataSupport;
+import javax.management.openmbean.CompositeType;
+import javax.management.openmbean.OpenType;
+import javax.management.openmbean.SimpleType;
+import javax.management.openmbean.TabularData;
+import javax.management.openmbean.TabularDataSupport;
+import javax.management.openmbean.TabularType;
+
 import java.math.BigInteger;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -133,5 +145,125 @@ public class TestMetricExpositions
                 """;
 
         assertThat(new Summary("metric_name", 10L, 2.0, 3.0, ImmutableMap.of(0.5, 0.25), ImmutableMap.of("fruit", "apple"), "metric_help").getMetricExposition()).isEqualTo(expected);
+    }
+
+    @Test
+    public void testCompositeMetricExposition()
+    {
+        String expected = """
+                # TYPE metric_name_committed gauge
+                # HELP metric_name_committed metric_help
+                metric_name_committed 200.0
+                # TYPE metric_name_max gauge
+                # HELP metric_name_max metric_help
+                metric_name_max 1000.0
+                # TYPE metric_name_used gauge
+                # HELP metric_name_used metric_help
+                metric_name_used 100.0
+                """;
+
+        CompositeData compositeData = createMemoryUsageCompositeData(100L, 200L, 1000L);
+        CompositeMetric compositeMetric = CompositeMetric.from("metric_name", compositeData, ImmutableMap.of(), "metric_help");
+        assertThat(compositeMetric.getMetricExposition()).isEqualTo(expected);
+    }
+
+    @Test
+    public void testCompositeMetricExpositionLabels()
+    {
+        String expected = """
+                # TYPE metric_name_committed gauge
+                # HELP metric_name_committed metric_help
+                metric_name_committed{type="cavendish"} 200.0
+                # TYPE metric_name_max gauge
+                # HELP metric_name_max metric_help
+                metric_name_max{type="cavendish"} 1000.0
+                # TYPE metric_name_used gauge
+                # HELP metric_name_used metric_help
+                metric_name_used{type="cavendish"} 100.0
+                """;
+
+        CompositeData compositeData = createMemoryUsageCompositeData(100L, 200L, 1000L);
+        CompositeMetric compositeMetric = CompositeMetric.from("metric_name", compositeData, ImmutableMap.of("type", "cavendish"), "metric_help");
+        assertThat(compositeMetric.getMetricExposition()).isEqualTo(expected);
+    }
+
+    private CompositeData createMemoryUsageCompositeData(long used, long committed, long max)
+    {
+        try {
+            String[] itemNames = {"used", "committed", "max"};
+            OpenType<?>[] itemTypes = {SimpleType.LONG, SimpleType.LONG, SimpleType.LONG};
+            CompositeType compositeType = new CompositeType("MemoryUsage", "Memory Usage", itemNames, itemNames, itemTypes);
+
+            Map<String, Object> values = new HashMap<>();
+            values.put("used", used);
+            values.put("committed", committed);
+            values.put("max", max);
+
+            return new CompositeDataSupport(compositeType, values);
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void testTabularDataExposition()
+    {
+        String expected = """
+                # TYPE metric_name_value gauge
+                # HELP metric_name_value metric_help
+                metric_name_value{region="us-east",zone="1a"} 100.0
+                metric_name_value{region="us-west",zone="2b"} 200.0
+                """;
+
+        TabularData tabularData = createTestTabularData();
+        CompositeMetric compositeMetric = CompositeMetric.from("metric_name", tabularData, ImmutableMap.of(), "metric_help");
+        assertThat(compositeMetric.getMetricExposition()).isEqualTo(expected);
+    }
+
+    @Test
+    public void testTabularDataExpositionLabels()
+    {
+        String expected = """
+                # TYPE metric_name_value gauge
+                # HELP metric_name_value metric_help
+                metric_name_value{region="us-east",type="cavendish",zone="1a"} 100.0
+                metric_name_value{region="us-west",type="cavendish",zone="2b"} 200.0
+                """;
+
+        TabularData tabularData = createTestTabularData();
+        CompositeMetric compositeMetric = CompositeMetric.from("metric_name", tabularData, ImmutableMap.of("type", "cavendish"), "metric_help");
+        assertThat(compositeMetric.getMetricExposition()).isEqualTo(expected);
+    }
+
+    private TabularData createTestTabularData()
+    {
+        try {
+            String[] itemNames = {"region", "zone", "value"};
+            OpenType<?>[] itemTypes = {SimpleType.STRING, SimpleType.STRING, SimpleType.LONG};
+            CompositeType compositeType = new CompositeType("TestData", "Test Data", itemNames, itemNames, itemTypes);
+
+            String[] indexNames = {"region", "zone"};
+            TabularType tabularType = new TabularType("TestTable", "Test Table", compositeType, indexNames);
+
+            TabularDataSupport tabularData = new TabularDataSupport(tabularType);
+
+            Map<String, Object> row1 = new HashMap<>();
+            row1.put("region", "us-east");
+            row1.put("zone", "1a");
+            row1.put("value", 100L);
+            tabularData.put(new CompositeDataSupport(compositeType, row1));
+
+            Map<String, Object> row2 = new HashMap<>();
+            row2.put("region", "us-west");
+            row2.put("zone", "2b");
+            row2.put("value", 200L);
+            tabularData.put(new CompositeDataSupport(compositeType, row2));
+
+            return tabularData;
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting pull request to Airlift -->

## Background
Currently, the OpenMetrics implementation only supports simple numeric metrics through JMX, while the JMX Exporter can handle complex metrics like `HeapMemoryUsage`. This discrepancy exists because `HeapMemoryUsage` is a `CompositeData` type that contains multiple numeric values (used, max, committed), but our OpenMetrics implementation wasn't handling these composite types.

## Problem
Metrics like `HeapMemoryUsage` are important for monitoring JVM performance, but they weren't being exposed through OpenMetrics. This meant users couldn't access these metrics through the OpenMetrics endpoint, even though they were available through JMX.

## Solution
We've added support for `CompositeData` metrics by implementing a new `CompositeMetric` record that:
1. Takes a `CompositeData` object and converts it into multiple metrics
2. Creates a separate metric for each numeric field in the `CompositeData`
3. Maintains proper metric naming by appending the field name to the base metric name
4. Preserves the help text and labels for each metric

## Implementation Details
- Created a new `CompositeMetric` record that implements the `Metric` interface
- Modified `MetricsResource.getMetric()` to handle `CompositeData` attributes
- Each numeric field in `CompositeData` is converted to a `Gauge` metric
- Metric names are constructed by appending the field name to the base metric name
- The implementation follows the same patterns as other metric types (Gauge, Counter, Summary)

## Example
For a `HeapMemoryUsage` metric, the output now looks like:
```
# TYPE JMX_java_lang_TYPE_Memory_ATTRIBUTE_HeapMemoryUsage_committed gauge
# HELP JMX_java_lang_TYPE_Memory_ATTRIBUTE_HeapMemoryUsage_committed HeapMemoryUsage
JMX_java_lang_TYPE_Memory_ATTRIBUTE_HeapMemoryUsage_committed 5.70425344E8
# TYPE JMX_java_lang_TYPE_Memory_ATTRIBUTE_HeapMemoryUsage_init gauge
# HELP JMX_java_lang_TYPE_Memory_ATTRIBUTE_HeapMemoryUsage_init HeapMemoryUsage
JMX_java_lang_TYPE_Memory_ATTRIBUTE_HeapMemoryUsage_init 5.3921972224E10
# TYPE JMX_java_lang_TYPE_Memory_ATTRIBUTE_HeapMemoryUsage_max gauge
# HELP JMX_java_lang_TYPE_Memory_ATTRIBUTE_HeapMemoryUsage_max HeapMemoryUsage
JMX_java_lang_TYPE_Memory_ATTRIBUTE_HeapMemoryUsage_max 5.3921972224E10
# TYPE JMX_java_lang_TYPE_Memory_ATTRIBUTE_HeapMemoryUsage_used gauge
# HELP JMX_java_lang_TYPE_Memory_ATTRIBUTE_HeapMemoryUsage_used HeapMemoryUsage
JMX_java_lang_TYPE_Memory_ATTRIBUTE_HeapMemoryUsage_used 1.98519016E8
```

## Testing
- Added test cases for `CompositeData` handling
- Verified that `HeapMemoryUsage` and similar metrics are now properly exposed
- Ensured the output format matches OpenMetrics standards

## Impact
This change allows users to access important JVM metrics through the OpenMetrics endpoint, making it easier to monitor application performance and resource usage.



# Airlift contribution check list

 - [ ] Git commit messages follow https://cbea.ms/git-commit/.
 - [ ] All automated tests are passing.
 - [ ] Pull request was categorized using one of the existing labels.
