### PR TITLE
Remove `@BindingAnnotation` from `@Config` and `@DefunctConfig` to fix errorprone

### DIFF
--- a/configuration/src/main/java/io/airlift/configuration/Config.java
+++ b/configuration/src/main/java/io/airlift/configuration/Config.java
@@ -15,8 +15,6 @@
  */
 package io.airlift.configuration;
 
-import com.google.inject.BindingAnnotation;
-
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -26,7 +24,6 @@ import java.lang.annotation.Target;
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
-@BindingAnnotation
 public @interface Config
 {
     String value();

--- a/configuration/src/main/java/io/airlift/configuration/DefunctConfig.java
+++ b/configuration/src/main/java/io/airlift/configuration/DefunctConfig.java
@@ -15,8 +15,6 @@
  */
 package io.airlift.configuration;
 
-import com.google.inject.BindingAnnotation;
-
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -26,7 +24,6 @@ import java.lang.annotation.Target;
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
-@BindingAnnotation
 public @interface DefunctConfig
 {
     String[] value();


### PR DESCRIPTION
I couldn’t find a functional reason for `@BindingAnnotation` to be on `@Config` or `@DefunctConfig`. Since it creates false-positive matches for the errorprone  bug pattern [`UnnecessaryQualifier`](https://errorprone.info/bugpattern/UnnecessaryQualifier), I think it’s best to just remove `@BindingAnnotation`.

fixes #1492 

# Airlift contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [x] All automated tests are passing.
 - [x] Pull request was categorized using one of the existing labels.
