### PR TITLE
Allow skipping some properties with assertFullMapping

### DIFF
--- a/configuration-testing/src/test/java/io/airlift/configuration/testing/TestConfigAssertions.java
+++ b/configuration-testing/src/test/java/io/airlift/configuration/testing/TestConfigAssertions.java
@@ -183,6 +183,23 @@ public class TestConfigAssertions
     }
 
     @Test
+    public void testExplicitPropertyMappingsWithSkipped()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("name", "Jenny")
+                .put("email", "jenny@compuserve.com")
+                .put("home-page", "http://example.com")
+                .build();
+
+        PersonConfig expected = new PersonConfig()
+                .setName("Jenny")
+                .setEmail("jenny@compuserve.com")
+                .setHomePage(URI.create("http://example.com"));
+
+        ConfigAssertions.assertFullMapping(properties, expected, ImmutableSet.of("phone"));
+    }
+
+    @Test
     public void testExplicitPropertyMappingsFailUnsupportedProperty()
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()


### PR DESCRIPTION
Sometimes configs disallows setting two properties together. One needs remain default for other to be set and vice versa. Currently such config were not testable using assertFullMapping as it complained that some properties remained default (or if we tried to set both properties to non-default values validation logic triggered).

This commit adds a way to explicitly point out that we want to test "almost" full mapping skipping some of the properties from validation and testing those separately.
