### PR TITLE
MCP Server support - Part 2 (sessions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Airlift takes the best-of-breed libraries from the Java ecosystem and glues them
 - TBD - Tracing
 - TBD - Maven BOM
 - TBD - Jackson/JSON
+- [JSON-RPC support](json-rpc/README.md)
+- [MCP server support](mcp/README.md)
 
 ## Recipes
 

--- a/json-rpc/README.md
+++ b/json-rpc/README.md
@@ -1,0 +1,75 @@
+[◀︎ Airlift](../README.md)
+
+# JSON-RPC support
+
+This module provides support for creating JSON-RPC endpoints in Airlift.
+The endpoints are defined in a similar way to JAX-RS endpoints, by
+annotating methods. These JSON-RPC endpoints integrate into JAX-RS via the
+`InternalRpcFilter` which adjusts the incoming request URI, headers, etc. such
+that JAX-RS sends the request directly to the annotated method. All usual
+JAX-RS behavior works as expected, `@Context` parameters, object payloads,
+etc. The method can return a Java object, `void` or a JAX-RS `Response`.
+
+JSON-RPC endpoints are exposed via a single URL defined by the base-path, which
+by default is `jsonrpc` (note: it can contain any number of `/`). So, HTTP POST 
+requests are sent to: `http(s)://host(:port)/basePath`
+
+## Defining JSON-RPC endpoints
+
+JSON-RPC endpoints can be defined declaratively via an annotation or
+programmatically.
+
+### Declarative definition
+
+Use the `@JsonRpc` annotation to declare a JSON-RPC endpoint. E.g.
+
+```java
+// define a JSON-RPC endpoint with a "method" of "readRecord"
+// no-arg version of @JsonRpc uses the Java method name
+
+@JsonRpc
+public Response readRecord(@Context Identity myIdentity, RecordRequest request)
+{
+    // ...
+}
+```
+
+```java
+// define a JSON-RPC endpoint with a "method" of "read"
+
+@JsonRpc("read")
+public RecordResponse readRecord(@Context Identity myIdentity, RecordRequest request)
+{
+    // ...
+}
+```
+
+### Programmatic definition
+
+```java
+JsonRpcMethod method = new JsonRpcMethod(MyClass.class, MyClass.class.getMethod(...), "methodName", "POST");
+```
+
+## Errors
+
+Rather than throw generic exceptions or error responses, use
+`JsonRpcErrorDetail.exception(...)` to generate a JSON-RPC exception to throw.
+This ensures that a proper JSON-RPC error is generated.
+
+## Installing the JSON-RPC Guice module
+
+```java
+Builder<?> builder = JsonRpcModule.builder();
+
+// default base path is "jsonrpc" - use this method to change it
+// it can contain any number of /
+builder.withBasePath("..")
+
+// add all @JsonRpc methods in the specified class    
+JsonRpcMethod.addAllInClass(builder, MyClass.class);
+
+// add any programmatic instances, if any
+builder.add(...);
+
+Module module = builder.builder();
+```

--- a/json-rpc/pom.xml
+++ b/json-rpc/pom.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.airlift</groupId>
+        <artifactId>airlift</artifactId>
+        <version>343-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>json-rpc</artifactId>
+    <packaging>jar</packaging>
+    <description>Airlift - JSON-RPC server support</description>
+
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jaxrs</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+            <classifier>classes</classifier>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-common</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-server</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>json</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>node</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>bootstrap</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>http-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>http-server</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-http</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/json-rpc/src/main/java/io/airlift/jsonrpc/JsonRpc.java
+++ b/json-rpc/src/main/java/io/airlift/jsonrpc/JsonRpc.java
@@ -1,0 +1,16 @@
+package io.airlift.jsonrpc;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface JsonRpc
+{
+    String JSON_RPC_VERSION = "2.0";
+
+    String value() default "";
+}

--- a/json-rpc/src/main/java/io/airlift/jsonrpc/JsonRpcMethod.java
+++ b/json-rpc/src/main/java/io/airlift/jsonrpc/JsonRpcMethod.java
@@ -1,0 +1,64 @@
+package io.airlift.jsonrpc;
+
+import jakarta.ws.rs.HttpMethod;
+import jakarta.ws.rs.Path;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static jakarta.ws.rs.HttpMethod.POST;
+import static java.util.Objects.requireNonNull;
+
+public record JsonRpcMethod(Class<?> clazz, Method javaMethod, String rpcMethod, String httpMethod)
+{
+    public JsonRpcMethod
+    {
+        requireNonNull(clazz, "clazz is null");
+        requireNonNull(javaMethod, "javaMethod is null");
+        requireNonNull(rpcMethod, "rpcMethod is null");
+        requireNonNull(httpMethod, "httpMethod is null");
+    }
+
+    public static <T extends JsonRpcModule.Builder<?>> T addAllInClass(T builder, Class<?> clazz)
+    {
+        inClass(clazz).forEach(builder::add);
+        return builder;
+    }
+
+    public static List<JsonRpcMethod> inClass(Class<?> clazz)
+    {
+        return Stream.of(clazz.getMethods())
+                .flatMap(method -> {
+                    JsonRpc jsonRpc = method.getAnnotation(JsonRpc.class);
+                    if (jsonRpc != null) {
+                        String value = jsonRpc.value();
+                        String rpcMethod = value.isEmpty() ? httpPath(method).orElseThrow(() -> missingPathException(clazz, method)) : value;
+                        String httpMethod = httpMethod(method).orElse(POST);
+                        return Stream.of(new JsonRpcMethod(clazz, method, rpcMethod, httpMethod));
+                    }
+                    return Stream.empty();
+                })
+                .collect(toImmutableList());
+    }
+
+    private static Optional<String> httpPath(Method method)
+    {
+        return Optional.ofNullable(method.getAnnotation(Path.class)).map(Path::value);
+    }
+
+    private static Optional<String> httpMethod(Method method)
+    {
+        return Stream.of(method.getAnnotations())
+                .flatMap(annotation -> Optional.ofNullable(annotation.annotationType().getAnnotation(HttpMethod.class)).map(HttpMethod::value).stream())
+                .findFirst();
+    }
+
+    private static RuntimeException missingPathException(Class<?> clazz, Method method)
+    {
+        return new IllegalStateException("%s's %s annotation does not have a method attribute and the method does not have a %s annotation"
+                .formatted(clazz.getName() + "#" + method.getName(), JsonRpc.class.getSimpleName(), Path.class.getSimpleName()));
+    }
+}

--- a/json-rpc/src/main/java/io/airlift/jsonrpc/JsonRpcModule.java
+++ b/json-rpc/src/main/java/io/airlift/jsonrpc/JsonRpcModule.java
@@ -1,0 +1,26 @@
+package io.airlift.jsonrpc;
+
+import com.google.inject.Module;
+import com.google.inject.binder.LinkedBindingBuilder;
+import io.airlift.jsonrpc.binding.InternalRpcModule;
+
+import java.util.function.Consumer;
+
+public interface JsonRpcModule
+{
+    static Builder<?> builder()
+    {
+        return InternalRpcModule.builder();
+    }
+
+    interface Builder<T extends Builder<T>>
+    {
+        T withBasePath(String basePath);
+
+        T add(JsonRpcMethod jsonRpcMethod);
+
+        T withRequestFilter(Consumer<LinkedBindingBuilder<JsonRpcRequestFilter>> binding);
+
+        Module build();
+    }
+}

--- a/json-rpc/src/main/java/io/airlift/jsonrpc/JsonRpcRequestFilter.java
+++ b/json-rpc/src/main/java/io/airlift/jsonrpc/JsonRpcRequestFilter.java
@@ -3,8 +3,10 @@ package io.airlift.jsonrpc;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Request;
 
+import java.util.Optional;
+
 public interface JsonRpcRequestFilter
 {
-    void filter(Request request, String rpcMethod)
+    void filter(Request request, Optional<String> rpcMethod)
             throws WebApplicationException;
 }

--- a/json-rpc/src/main/java/io/airlift/jsonrpc/JsonRpcRequestFilter.java
+++ b/json-rpc/src/main/java/io/airlift/jsonrpc/JsonRpcRequestFilter.java
@@ -1,0 +1,10 @@
+package io.airlift.jsonrpc;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Request;
+
+public interface JsonRpcRequestFilter
+{
+    void filter(Request request, String rpcMethod)
+            throws WebApplicationException;
+}

--- a/json-rpc/src/main/java/io/airlift/jsonrpc/JsonRpcResult.java
+++ b/json-rpc/src/main/java/io/airlift/jsonrpc/JsonRpcResult.java
@@ -1,0 +1,18 @@
+package io.airlift.jsonrpc;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface JsonRpcResult
+{
+    /*
+        Your annotated method should have a {@code JsonRpcResponse} parameter
+     */
+
+    String value() default "";
+}

--- a/json-rpc/src/main/java/io/airlift/jsonrpc/binding/BindingBridge.java
+++ b/json-rpc/src/main/java/io/airlift/jsonrpc/binding/BindingBridge.java
@@ -1,0 +1,32 @@
+package io.airlift.jsonrpc.binding;
+
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Singleton;
+import org.glassfish.jersey.internal.inject.AbstractBinder;
+
+import static java.util.Objects.requireNonNull;
+
+class BindingBridge
+        extends AbstractBinder
+{
+    private final RpcMetadata metadata;
+    private final Injector injector;
+
+    @Inject
+    BindingBridge(RpcMetadata metadata, Injector injector)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.injector = requireNonNull(injector, "injector is null");
+    }
+
+    @Override
+    protected void configure()
+    {
+        metadata.methodMap()
+                .values()
+                .stream()
+                .map(RpcMetadata.MethodMetadata::clazz)
+                .forEach(clazz -> bind(injector.getInstance(clazz)).to(clazz).in(Singleton.class));
+    }
+}

--- a/json-rpc/src/main/java/io/airlift/jsonrpc/binding/InternalRequest.java
+++ b/json-rpc/src/main/java/io/airlift/jsonrpc/binding/InternalRequest.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
-record InternalRequest(@Nullable Object id, String method, Optional<JsonNode> params, Optional<InputStream> payload)
+record InternalRequest(@Nullable Object id, Optional<String> method, Optional<JsonNode> params, Optional<InputStream> payload)
 {
     InternalRequest
     {

--- a/json-rpc/src/main/java/io/airlift/jsonrpc/binding/InternalRequest.java
+++ b/json-rpc/src/main/java/io/airlift/jsonrpc/binding/InternalRequest.java
@@ -1,0 +1,19 @@
+package io.airlift.jsonrpc.binding;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.annotation.Nullable;
+
+import java.io.InputStream;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+record InternalRequest(@Nullable Object id, String method, Optional<JsonNode> params, Optional<InputStream> payload)
+{
+    InternalRequest
+    {
+        requireNonNull(method, "method is null");
+        requireNonNull(params, "params is null");
+        requireNonNull(payload, "payload is null");
+    }
+}

--- a/json-rpc/src/main/java/io/airlift/jsonrpc/binding/InternalRpcFilter.java
+++ b/json-rpc/src/main/java/io/airlift/jsonrpc/binding/InternalRpcFilter.java
@@ -1,0 +1,133 @@
+package io.airlift.jsonrpc.binding;
+
+import com.google.inject.Inject;
+import io.airlift.jsonrpc.JsonRpcRequestFilter;
+import io.airlift.jsonrpc.binding.RpcMetadata.MethodMetadata;
+import io.airlift.jsonrpc.model.JsonRpcErrorCode;
+import io.airlift.jsonrpc.model.JsonRpcErrorDetail;
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.container.PreMatching;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriBuilder;
+
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.net.URI;
+import java.util.Optional;
+
+import static io.airlift.jsonrpc.model.JsonRpcErrorCode.METHOD_NOT_FOUND;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
+import static jakarta.ws.rs.core.Response.Status.OK;
+import static java.util.Objects.requireNonNull;
+
+@Priority(0)
+@PreMatching
+public class InternalRpcFilter
+        implements ContainerRequestFilter, ContainerResponseFilter
+{
+    private final InternalRpcHelper rpcHelper;
+    private final Optional<JsonRpcRequestFilter> rpcRequestFilter;
+
+    @Inject
+    InternalRpcFilter(InternalRpcHelper rpcHelper, Optional<JsonRpcRequestFilter> rpcRequestFilter)
+    {
+        this.rpcHelper = requireNonNull(rpcHelper, "jsonRpcObjects is null");
+        this.rpcRequestFilter = requireNonNull(rpcRequestFilter, "rpcRequestFilter is null");
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext)
+    {
+        if (!rpcHelper.isPotentialJsonRpc(requestContext)) {
+            return;
+        }
+
+        RpcMetadata rpcMetadata = rpcHelper.jsonRpcMetadata();
+        InternalRequest internalRequest = rpcHelper.buildRequest(requestContext.getEntityStream());
+
+        MethodMetadata methodMetadata = rpcMetadata.methodMap().get(internalRequest.method());
+        if (methodMetadata == null) {
+            Object error = rpcHelper.rpcError(internalRequest.id(), METHOD_NOT_FOUND, "No method found for JSON-RPC request: " + internalRequest.method(), Optional.empty());
+            requestContext.abortWith(Response.status(OK).type(APPLICATION_JSON_TYPE).entity(error).build());
+            return;
+        }
+
+        rpcRequestFilter.ifPresent(filter -> filter.filter(requestContext.getRequest(), internalRequest.method()));
+
+        requestContext.setProperty(InternalRpcFilter.class.getName(), internalRequest);
+
+        URI methodUri = UriBuilder.fromUri(requestContext.getUriInfo().getRequestUri())
+                .replacePath(methodMetadata.methodPath())
+                .build();
+        requestContext.setRequestUri(methodUri);
+        requestContext.setMethod(methodMetadata.httpMethod());
+        requestContext.setEntityStream(internalRequest.payload().orElseGet(EmptyInputStream::new));
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+    {
+        jsonRpcRequest(requestContext).ifPresent(internalRequest -> finalizeJsonRpcResponse(responseContext, internalRequest));
+    }
+
+    public static Optional<Object> requestId(ContainerRequestContext requestContext)
+    {
+        return jsonRpcRequest(requestContext).map(InternalRequest::id);
+    }
+
+    static Optional<InternalRequest> jsonRpcRequest(ContainerRequestContext requestContext)
+    {
+        return Optional.ofNullable((InternalRequest) requestContext.getProperty(InternalRpcFilter.class.getName()));
+    }
+
+    private void finalizeJsonRpcResponse(ContainerResponseContext responseContext, InternalRequest internalRequest)
+    {
+        switch (responseContext.getStatusInfo().getFamily()) {
+            case INFORMATIONAL, REDIRECTION -> {}   // do nothing
+
+            case SUCCESSFUL -> {
+                if (responseContext.hasEntity()) {
+                    setResponse(responseContext, rpcHelper.rpcResponse(internalRequest.id(), responseContext.getEntity()));
+                    responseContext.setStatus(OK.getStatusCode());
+                }
+            }
+
+            case CLIENT_ERROR, SERVER_ERROR, OTHER -> {
+                if (responseContext.hasEntity() && (responseContext.getEntity() instanceof JsonRpcErrorDetail(int errorCode, String message, Optional<Object> data))) {
+                    setResponse(responseContext, rpcHelper.rpcError(internalRequest.id(), errorCode, message, data));
+                }
+                else {
+                    JsonRpcErrorCode.fromCode(responseContext.getStatusInfo().getStatusCode()).ifPresentOrElse(
+                            errorCode -> setResponse(responseContext, rpcHelper.rpcError(internalRequest.id(), errorCode, responseContext.getStatusInfo().getReasonPhrase(), Optional.empty())),
+                            () -> setResponse(responseContext, rpcHelper.rpcError(internalRequest.id(), responseContext.getStatusInfo().getStatusCode(), responseContext.getStatusInfo().getReasonPhrase(), Optional.empty())));
+                }
+
+                responseContext.setStatus(OK.getStatusCode());
+            }
+        }
+    }
+
+    private static void setResponse(ContainerResponseContext responseContext, Object response)
+    {
+        responseContext.setEntity(response, new Annotation[0], APPLICATION_JSON_TYPE);
+    }
+
+    private static class EmptyInputStream
+            extends InputStream
+    {
+        @Override
+        public int available()
+        {
+            return 0;
+        }
+
+        public int read()
+        {
+            return -1;
+        }
+    }
+}

--- a/json-rpc/src/main/java/io/airlift/jsonrpc/binding/InternalRpcHelper.java
+++ b/json-rpc/src/main/java/io/airlift/jsonrpc/binding/InternalRpcHelper.java
@@ -1,0 +1,138 @@
+package io.airlift.jsonrpc.binding;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import io.airlift.jsonrpc.JsonRpc;
+import io.airlift.jsonrpc.model.JsonRpcErrorCode;
+import jakarta.annotation.Nullable;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.Response;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static io.airlift.jsonrpc.model.JsonRpcErrorCode.INVALID_PARAMS;
+import static io.airlift.jsonrpc.model.JsonRpcErrorCode.INVALID_REQUEST;
+import static java.util.Objects.requireNonNull;
+
+class InternalRpcHelper
+{
+    private final ObjectMapper objectMapper;
+    private final Provider<RpcMetadata> jsonRpcMetadata;
+
+    @Inject
+    InternalRpcHelper(ObjectMapper objectMapper, Provider<RpcMetadata> jsonRpcMetadata)
+    {
+        this.objectMapper = requireNonNull(objectMapper, "objectMapper is null");
+        this.jsonRpcMetadata = requireNonNull(jsonRpcMetadata, "jsonRpcMetadata is null");
+    }
+
+    boolean isPotentialJsonRpc(ContainerRequestContext requestContext)
+    {
+        if (requestContext.getRequest().getMethod().equalsIgnoreCase("POST")) {
+            String rpcPath = requestContext.getUriInfo().getBaseUri().resolve(jsonRpcMetadata.get().basePath()).getRawPath();
+            String requestPath = requestContext.getUriInfo().getRequestUri().getRawPath();
+            return requestPath.equals(rpcPath);
+        }
+        return false;
+    }
+
+    RpcMetadata jsonRpcMetadata()
+    {
+        return jsonRpcMetadata.get();
+    }
+
+    Object rpcError(@Nullable Object id, JsonRpcErrorCode errorCode, String message, Optional<Object> data)
+    {
+        return rpcError(id, errorCode.code(), message, data);
+    }
+
+    Object rpcError(@Nullable Object id, int errorCode, String message, Optional<Object> data)
+    {
+        ObjectNode error = objectMapper.createObjectNode()
+                .put("code", errorCode)
+                .put("message", message);
+        data.ifPresent(d -> error.putPOJO("data", d));
+        return objectMapper.createObjectNode()
+                .put("jsonrpc", JsonRpc.JSON_RPC_VERSION)
+                .putPOJO("id", id)
+                .set("error", error);
+    }
+
+    Object rpcResponse(@Nullable Object id, @Nullable Object result)
+    {
+        return objectMapper.createObjectNode()
+                .put("jsonrpc", JsonRpc.JSON_RPC_VERSION)
+                .putPOJO("id", id)
+                .putPOJO("result", result);
+    }
+
+    WebApplicationException rpcException(@Nullable Object id, JsonRpcErrorCode errorCode, String message, Optional<Object> data)
+    {
+        Object error = rpcError(id, errorCode, message, data);
+        return new WebApplicationException(message, Response.ok(error).build());
+    }
+
+    InternalRequest buildRequest(InputStream inputStream)
+    {
+        JsonNode tree = parseStream(inputStream);
+        JsonNode idNode = tree.get("id");
+        Object id;
+        if (idNode == null) {
+            id = null;
+        }
+        else if (idNode.isNumber()) {
+            id = idNode.asLong();
+        }
+        else {
+            id = idNode.asText();
+        }
+
+        JsonNode jsonrpcNode = tree.get("jsonrpc");
+        if (jsonrpcNode == null) {
+            throw rpcException(id, INVALID_REQUEST, "Missing \"jsonrpc\" field", Optional.empty());
+        }
+        String jsonrpcVersion = jsonrpcNode.asText();
+        if (!JsonRpc.JSON_RPC_VERSION.equals(jsonrpcVersion)) {
+            throw rpcException(id, INVALID_REQUEST, "Invalid \"jsonrpc\": " + jsonrpcVersion, Optional.empty());
+        }
+
+        JsonNode methodNode = tree.get("method");
+        if (methodNode == null) {
+            throw rpcException(id, INVALID_REQUEST, "Missing \"method\" field", Optional.empty());
+        }
+        String method = methodNode.asText();
+
+        Optional<JsonNode> params = Optional.ofNullable(tree.get("params"));
+        Optional<InputStream> paramsInputStream = params.map(paramNode -> {
+            // NOTE: this should be relatively efficient for most requests. However, very large
+            // requests imply the overhead of the ByteArrayInputStream. JSON-RPC isn't usually
+            // used for very large requests.
+            try {
+                return new ByteArrayInputStream(objectMapper.writeValueAsBytes(paramNode));
+            }
+            catch (JsonProcessingException e) {
+                throw rpcException(id, INVALID_PARAMS, "Could not parse \"params\": " + e.getMessage(), Optional.empty());
+            }
+        });
+        return new InternalRequest(id, method, params, paramsInputStream);
+    }
+
+    private JsonNode parseStream(InputStream inputStream)
+    {
+        try {
+            return objectMapper.readTree(inputStream);
+        }
+        catch (IOException e) {
+            throw rpcException(null, INVALID_REQUEST, firstNonNull(e.getMessage(), "Invalid JSON request"), Optional.empty());
+        }
+    }
+}

--- a/json-rpc/src/main/java/io/airlift/jsonrpc/binding/InternalRpcModule.java
+++ b/json-rpc/src/main/java/io/airlift/jsonrpc/binding/InternalRpcModule.java
@@ -1,0 +1,102 @@
+package io.airlift.jsonrpc.binding;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.binder.LinkedBindingBuilder;
+import com.google.inject.multibindings.OptionalBinder;
+import io.airlift.jaxrs.JaxrsBinder;
+import io.airlift.jsonrpc.JsonRpcMethod;
+import io.airlift.jsonrpc.JsonRpcModule;
+import io.airlift.jsonrpc.JsonRpcRequestFilter;
+import io.airlift.jsonrpc.binding.RpcMetadata.MethodMetadata;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import static com.google.inject.Scopes.SINGLETON;
+import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
+import static io.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
+import static java.util.Objects.requireNonNull;
+
+public class InternalRpcModule
+        implements Module, JsonRpcModule
+{
+    private final String basePath;
+    private final Set<JsonRpcMethod> methods;
+    private final Optional<Consumer<LinkedBindingBuilder<JsonRpcRequestFilter>>> requestFilterBinding;
+
+    private InternalRpcModule(String basePath, Set<JsonRpcMethod> methods, Optional<Consumer<LinkedBindingBuilder<JsonRpcRequestFilter>>> requestFilterBinding)
+    {
+        this.basePath = requireNonNull(basePath, "basePath is null");
+        this.methods = ImmutableSet.copyOf(methods);
+        this.requestFilterBinding = requireNonNull(requestFilterBinding, "requestFilterBinding is null");
+    }
+
+    @Override
+    public void configure(Binder binder)
+    {
+        binder.bind(InternalRpcHelper.class).in(SINGLETON);
+
+        Map<String, MethodMetadata> methodMap = new HashMap<>();
+        RpcResourceBuilder resourceBuilder = new RpcResourceBuilder(basePath, methodMap);
+
+        methods.forEach(method -> {
+            binder.bind(method.clazz()).in(SINGLETON);
+            resourceBuilder.add(method.clazz(), method.javaMethod(), method.rpcMethod(), method.httpMethod());
+        });
+
+        JaxrsBinder jaxrsBinder = jaxrsBinder(binder);
+        jaxrsBinder.bind(InternalRpcFilter.class);
+        jaxrsBinder.bindInstance(resourceBuilder.build());
+        jaxrsBinder.bind(BindingBridge.class);
+
+        binder.bind(RpcMetadata.class).toInstance(new RpcMetadata(basePath, methodMap));
+
+        OptionalBinder<JsonRpcRequestFilter> requestFilterBinder = newOptionalBinder(binder, JsonRpcRequestFilter.class);
+        requestFilterBinding.ifPresent(binding -> binding.accept(requestFilterBinder.setBinding()));
+    }
+
+    public static Builder<?> builder()
+    {
+        return new InternalBuilder();
+    }
+
+    private static class InternalBuilder
+            implements Builder<InternalBuilder>
+    {
+        private final ImmutableSet.Builder<JsonRpcMethod> methods = ImmutableSet.builder();
+        private Optional<Consumer<LinkedBindingBuilder<JsonRpcRequestFilter>>> requestFilterBinding = Optional.empty();
+        private String basePath = "jsonrpc";
+
+        @Override
+        public InternalBuilder withBasePath(String basePath)
+        {
+            this.basePath = requireNonNull(basePath, "basePath is null");
+            return this;
+        }
+
+        @Override
+        public InternalBuilder add(JsonRpcMethod jsonRpcMethod)
+        {
+            methods.add(jsonRpcMethod);
+            return this;
+        }
+
+        @Override
+        public InternalBuilder withRequestFilter(Consumer<LinkedBindingBuilder<JsonRpcRequestFilter>> binding)
+        {
+            requestFilterBinding = Optional.of(binding);
+            return this;
+        }
+
+        @Override
+        public Module build()
+        {
+            return new InternalRpcModule(basePath, methods.build(), requestFilterBinding);
+        }
+    }
+}

--- a/json-rpc/src/main/java/io/airlift/jsonrpc/binding/RpcMetadata.java
+++ b/json-rpc/src/main/java/io/airlift/jsonrpc/binding/RpcMetadata.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Starburst Data, Inc. All rights reserved.
+ *
+ * THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF STARBURST DATA.
+ * The copyright notice above does not evidence any
+ * actual or intended publication of such source code.
+ *
+ * Redistribution of this material is strictly prohibited.
+ */
+package io.airlift.jsonrpc.binding;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+record RpcMetadata(String basePath, Map<String, MethodMetadata> methodMap)
+{
+    record MethodMetadata(Class<?> clazz, String httpMethod, String methodPath, String source)
+    {
+        public MethodMetadata
+        {
+            requireNonNull(clazz, "clazz is null");
+            requireNonNull(httpMethod, "httpMethod is null");
+            requireNonNull(methodPath, "methodPath is null");
+            requireNonNull(source, "source is null");
+        }
+    }
+
+    RpcMetadata
+    {
+        requireNonNull(basePath, "basePath is null");
+        methodMap = ImmutableMap.copyOf(methodMap);
+    }
+}

--- a/json-rpc/src/main/java/io/airlift/jsonrpc/binding/RpcMetadata.java
+++ b/json-rpc/src/main/java/io/airlift/jsonrpc/binding/RpcMetadata.java
@@ -12,12 +12,13 @@ package io.airlift.jsonrpc.binding;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
+import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
-record RpcMetadata(String basePath, Map<String, MethodMetadata> methodMap)
+record RpcMetadata(String basePath, Map<String, MethodMetadata> methodMap, Optional<MethodMetadata> rpcResultMethod)
 {
-    record MethodMetadata(Class<?> clazz, String httpMethod, String methodPath, String source)
+    record MethodMetadata(Class<?> clazz, String httpMethod, String methodPath, String source, boolean isRpcResult)
     {
         public MethodMetadata
         {
@@ -32,5 +33,6 @@ record RpcMetadata(String basePath, Map<String, MethodMetadata> methodMap)
     {
         requireNonNull(basePath, "basePath is null");
         methodMap = ImmutableMap.copyOf(methodMap);
+        requireNonNull(rpcResultMethod, "rpcResultMethod is null");
     }
 }

--- a/json-rpc/src/main/java/io/airlift/jsonrpc/binding/RpcResourceBuilder.java
+++ b/json-rpc/src/main/java/io/airlift/jsonrpc/binding/RpcResourceBuilder.java
@@ -1,0 +1,74 @@
+package io.airlift.jsonrpc.binding;
+
+import io.airlift.jsonrpc.binding.RpcMetadata.MethodMetadata;
+import jakarta.ws.rs.Produces;
+import org.glassfish.jersey.server.model.Resource;
+import org.glassfish.jersey.server.model.ResourceMethod;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.Optional;
+
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
+import static java.util.Objects.requireNonNull;
+
+class RpcResourceBuilder
+{
+    private final Resource.Builder builder;
+    private final String path;
+    private final Map<String, MethodMetadata> methodMap;
+
+    RpcResourceBuilder(String path, Map<String, MethodMetadata> methodMap)
+    {
+        this.path = normalize(requireNonNull(path, "path is null"));
+        this.methodMap = requireNonNull(methodMap, "methodMap is null");    // don't copy - we want to modify the argument
+        builder = Resource.builder(path);
+    }
+
+    void add(Class<?> clazz, Method javaMethod, String rpcMethod, String httpMethod)
+    {
+        rpcMethod = normalize(rpcMethod);
+
+        String source = toSource(clazz, javaMethod);
+
+        MethodMetadata previous = methodMap.get(rpcMethod);
+        if (previous != null) {
+            throw new IllegalStateException("Duplicate JSON-RPC method. Method: %s, Found at: %s, Duplicate at: %s".formatted(rpcMethod, source, previous.source()));
+        }
+
+        String methodPath = path + "/" + rpcMethod;
+        methodMap.put(rpcMethod, new MethodMetadata(clazz, httpMethod, methodPath, source));
+
+        String[] produces = Optional.ofNullable(javaMethod.getAnnotation(Produces.class))
+                .map(Produces::value)
+                .orElseGet(() -> new String[] {APPLICATION_JSON});
+
+        Resource.Builder childBuilder = builder.addChildResource(rpcMethod);
+        ResourceMethod.Builder methodBuilder = childBuilder.addMethod(httpMethod);
+        methodBuilder.produces(produces);
+        methodBuilder.consumes(APPLICATION_JSON_TYPE);
+        methodBuilder.handledBy(clazz, javaMethod);
+    }
+
+    Resource build()
+    {
+        return builder.build();
+    }
+
+    private static String toSource(Class<?> clazz, Method javaMethod)
+    {
+        return clazz.getName() + "#" + javaMethod.getName();
+    }
+
+    private String normalize(String path)
+    {
+        if (path.startsWith("/")) {
+            path = path.substring(1);
+        }
+        if (path.endsWith("/")) {
+            path = path.substring(0, path.length() - 1);
+        }
+        return path;
+    }
+}

--- a/json-rpc/src/main/java/io/airlift/jsonrpc/binding/RpcResourceBuilder.java
+++ b/json-rpc/src/main/java/io/airlift/jsonrpc/binding/RpcResourceBuilder.java
@@ -26,7 +26,7 @@ class RpcResourceBuilder
         builder = Resource.builder(path);
     }
 
-    void add(Class<?> clazz, Method javaMethod, String rpcMethod, String httpMethod)
+    void add(Class<?> clazz, Method javaMethod, String rpcMethod, String httpMethod, boolean isRpcResult)
     {
         rpcMethod = normalize(rpcMethod);
 
@@ -38,7 +38,7 @@ class RpcResourceBuilder
         }
 
         String methodPath = path + "/" + rpcMethod;
-        methodMap.put(rpcMethod, new MethodMetadata(clazz, httpMethod, methodPath, source));
+        methodMap.put(rpcMethod, new MethodMetadata(clazz, httpMethod, methodPath, source, isRpcResult));
 
         String[] produces = Optional.ofNullable(javaMethod.getAnnotation(Produces.class))
                 .map(Produces::value)

--- a/json-rpc/src/main/java/io/airlift/jsonrpc/model/JsonRpcErrorCode.java
+++ b/json-rpc/src/main/java/io/airlift/jsonrpc/model/JsonRpcErrorCode.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Starburst Data, Inc. All rights reserved.
+ *
+ * THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF STARBURST DATA.
+ * The copyright notice above does not evidence any
+ * actual or intended publication of such source code.
+ *
+ * Redistribution of this material is strictly prohibited.
+ */
+package io.airlift.jsonrpc.model;
+
+import java.util.Optional;
+
+public enum JsonRpcErrorCode
+{
+    // SDK error codes
+    CONNECTION_CLOSED(-32000),
+    REQUEST_TIMEOUT(-32001),
+
+    // Standard JSON-RPC error codes
+    PARSE_ERROR(-32700),
+    INVALID_REQUEST(-32600),
+    METHOD_NOT_FOUND(-32601),
+    INVALID_PARAMS(-32602),
+    INTERNAL_ERROR(-32603);
+
+    private final int code;
+
+    public int code()
+    {
+        return code;
+    }
+
+    public static Optional<JsonRpcErrorCode> fromCode(int code)
+    {
+        for (JsonRpcErrorCode errorCode : values()) {
+            if (errorCode.code == code) {
+                return Optional.of(errorCode);
+            }
+        }
+        return Optional.empty();
+    }
+
+    JsonRpcErrorCode(int code)
+    {
+        this.code = code;
+    }
+}

--- a/json-rpc/src/main/java/io/airlift/jsonrpc/model/JsonRpcErrorDetail.java
+++ b/json-rpc/src/main/java/io/airlift/jsonrpc/model/JsonRpcErrorDetail.java
@@ -1,0 +1,40 @@
+package io.airlift.jsonrpc.model;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+
+import java.util.Optional;
+
+import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
+import static java.util.Objects.requireNonNull;
+
+public record JsonRpcErrorDetail(int code, String message, Optional<Object> data)
+{
+    public JsonRpcErrorDetail
+    {
+        requireNonNull(message, "message is null");
+        requireNonNull(data, "data is null");
+    }
+
+    public JsonRpcErrorDetail(JsonRpcErrorCode errorCode, String message)
+    {
+        this(errorCode.code(), message, Optional.empty());
+    }
+
+    public JsonRpcErrorDetail(JsonRpcErrorCode errorCode, String message, Object data)
+    {
+        this(errorCode.code(), message, Optional.of(data));
+    }
+
+    public static WebApplicationException exception(JsonRpcErrorCode errorCode, String message)
+    {
+        JsonRpcErrorDetail detail = new JsonRpcErrorDetail(errorCode.code(), message, Optional.empty());
+        return new WebApplicationException(Response.status(BAD_REQUEST).entity(detail).build());
+    }
+
+    public static WebApplicationException exception(JsonRpcErrorCode errorCode, String message, Object data)
+    {
+        JsonRpcErrorDetail detail = new JsonRpcErrorDetail(errorCode.code(), message, Optional.of(data));
+        return new WebApplicationException(Response.status(BAD_REQUEST).entity(detail).build());
+    }
+}

--- a/json-rpc/src/main/java/io/airlift/jsonrpc/model/JsonRpcRequest.java
+++ b/json-rpc/src/main/java/io/airlift/jsonrpc/model/JsonRpcRequest.java
@@ -1,0 +1,39 @@
+package io.airlift.jsonrpc.model;
+
+import jakarta.annotation.Nullable;
+
+import java.util.Optional;
+
+import static io.airlift.jsonrpc.JsonRpc.JSON_RPC_VERSION;
+import static java.util.Objects.requireNonNull;
+
+// see https://www.jsonrpc.org/specification#request_object
+public record JsonRpcRequest<T>(String jsonrpc, @Nullable Object id, String method, Optional<T> params)
+{
+    public JsonRpcRequest
+    {
+        requireNonNull(jsonrpc, "jsonrpc is null");
+        requireNonNull(method, "method is null");
+        requireNonNull(params, "params is null");
+    }
+
+    public static <T> JsonRpcRequest<T> buildRequest(@Nullable Object id, String method, T params)
+    {
+        return new JsonRpcRequest<>(JSON_RPC_VERSION, id, method, Optional.of(params));
+    }
+
+    public static <T> JsonRpcRequest<T> buildRequest(@Nullable Object id, String method)
+    {
+        return new JsonRpcRequest<>(JSON_RPC_VERSION, id, method, Optional.empty());
+    }
+
+    public static <T> JsonRpcRequest<T> buildNotification(String method, T params)
+    {
+        return new JsonRpcRequest<>(JSON_RPC_VERSION, null, method, Optional.of(params));
+    }
+
+    public static <T> JsonRpcRequest<T> buildNotification(String method)
+    {
+        return new JsonRpcRequest<>(JSON_RPC_VERSION, null, method, Optional.empty());
+    }
+}

--- a/json-rpc/src/main/java/io/airlift/jsonrpc/model/JsonRpcResponse.java
+++ b/json-rpc/src/main/java/io/airlift/jsonrpc/model/JsonRpcResponse.java
@@ -20,6 +20,11 @@ public record JsonRpcResponse<T>(String jsonrpc, @Nullable Object id, Optional<J
         requireNonNull(result, "result is null");
     }
 
+    public JsonRpcResponse(@Nullable Object id, Optional<JsonRpcErrorDetail> error, Optional<T> result)
+    {
+        this(JSON_RPC_VERSION, id, error, result);
+    }
+
     public static <T> JsonRpcResponse<T> buildResponse(Request request, T result)
     {
         Object requestId = (request instanceof ContainerRequest containerRequest) ? requestId(containerRequest).orElse(null) : null;

--- a/json-rpc/src/main/java/io/airlift/jsonrpc/model/JsonRpcResponse.java
+++ b/json-rpc/src/main/java/io/airlift/jsonrpc/model/JsonRpcResponse.java
@@ -1,0 +1,34 @@
+package io.airlift.jsonrpc.model;
+
+import jakarta.annotation.Nullable;
+import jakarta.ws.rs.core.Request;
+import org.glassfish.jersey.server.ContainerRequest;
+
+import java.util.Optional;
+
+import static io.airlift.jsonrpc.JsonRpc.JSON_RPC_VERSION;
+import static io.airlift.jsonrpc.binding.InternalRpcFilter.requestId;
+import static java.util.Objects.requireNonNull;
+
+// see https://www.jsonrpc.org/specification#response_object
+public record JsonRpcResponse<T>(String jsonrpc, @Nullable Object id, Optional<JsonRpcErrorDetail> error, Optional<T> result)
+{
+    public JsonRpcResponse
+    {
+        requireNonNull(jsonrpc, "jsonrpc is null");
+        requireNonNull(error, "error is null");
+        requireNonNull(result, "result is null");
+    }
+
+    public static <T> JsonRpcResponse<T> buildResponse(Request request, T result)
+    {
+        Object requestId = (request instanceof ContainerRequest containerRequest) ? requestId(containerRequest).orElse(null) : null;
+        return new JsonRpcResponse<>(JSON_RPC_VERSION, requestId, Optional.empty(), Optional.of(result));
+    }
+
+    public static <T> JsonRpcResponse<T> buildErrorResponse(Request request, JsonRpcErrorDetail error)
+    {
+        Object requestId = (request instanceof ContainerRequest containerRequest) ? requestId(containerRequest).orElse(null) : null;
+        return new JsonRpcResponse<>(JSON_RPC_VERSION, requestId, Optional.of(error), Optional.empty());
+    }
+}

--- a/json-rpc/src/test/java/io/airlift/ForTesting.java
+++ b/json-rpc/src/test/java/io/airlift/ForTesting.java
@@ -1,0 +1,16 @@
+package io.airlift;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@BindingAnnotation
+public @interface ForTesting {}

--- a/json-rpc/src/test/java/io/airlift/TestBase.java
+++ b/json-rpc/src/test/java/io/airlift/TestBase.java
@@ -16,6 +16,7 @@ import io.airlift.json.JsonCodec;
 import io.airlift.json.JsonModule;
 import io.airlift.jsonrpc.JsonRpcModule.Builder;
 import io.airlift.jsonrpc.model.JsonRpcRequest;
+import io.airlift.jsonrpc.model.JsonRpcResponse;
 import io.airlift.node.NodeModule;
 import jakarta.annotation.Nullable;
 
@@ -72,6 +73,16 @@ public abstract class TestBase
     protected Request buildNotification(String method)
     {
         return internalBuildRequest(null, method, new TypeToken<>() {}, Optional.empty());
+    }
+
+    protected <T> Request buildResponse(Object id, TypeToken<JsonRpcResponse<T>> type, Optional<T> maybeResult)
+    {
+        JsonRpcResponse<T> jsonRpcResponse = new JsonRpcResponse<>(id, Optional.empty(), maybeResult);
+        Request.Builder builder = Request.Builder.preparePost()
+                .setUri(uri())
+                .setHeader("Content-Type", "application/json")
+                .setBodyGenerator(jsonBodyGenerator(JsonCodec.jsonCodec(type), jsonRpcResponse));
+        return builder.build();
     }
 
     private <T> Request internalBuildRequest(@Nullable Object id, String method, TypeToken<JsonRpcRequest<T>> type, Optional<T> maybeParams)

--- a/json-rpc/src/test/java/io/airlift/TestBase.java
+++ b/json-rpc/src/test/java/io/airlift/TestBase.java
@@ -1,5 +1,7 @@
 package io.airlift;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.reflect.TypeToken;
@@ -20,8 +22,17 @@ import io.airlift.jsonrpc.model.JsonRpcResponse;
 import io.airlift.node.NodeModule;
 import jakarta.annotation.Nullable;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
 import java.net.URI;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static io.airlift.http.client.HttpClientBinder.httpClientBinder;
@@ -32,6 +43,7 @@ public abstract class TestBase
     protected final Injector injector;
     protected final HttpClient httpClient;
     protected final URI baseUri;
+    protected final ObjectMapper objectMapper;
 
     protected TestBase(Builder<?> rpcModuleBuilder, Module... additionalModules)
     {
@@ -53,6 +65,7 @@ public abstract class TestBase
 
         httpClient = injector.getInstance(Key.get(HttpClient.class, ForTesting.class));
         baseUri = injector.getInstance(HttpServerInfo.class).getHttpUri();
+        objectMapper = injector.getInstance(ObjectMapper.class);
     }
 
     protected URI uri()
@@ -83,6 +96,67 @@ public abstract class TestBase
                 .setHeader("Content-Type", "application/json")
                 .setBodyGenerator(jsonBodyGenerator(JsonCodec.jsonCodec(type), jsonRpcResponse));
         return builder.build();
+    }
+
+    protected Iterable<Map<String, String>> readEvents(InputStream inputStream)
+    {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
+        return () -> new Iterator<>()
+        {
+            private boolean isDone;
+            private Map<String, String> current = ImmutableMap.of();
+
+            {
+                readNext();
+            }
+
+            @Override
+            public boolean hasNext()
+            {
+                return !current.isEmpty();
+            }
+
+            @Override
+            public Map<String, String> next()
+            {
+                Map<String, String> result = current;
+                readNext();
+                return result;
+            }
+
+            private void readNext()
+            {
+                current = new HashMap<>();
+                if (isDone) {
+                    return;
+                }
+
+                try {
+                    while (true) {
+                        String line = reader.readLine();
+
+                        if (line == null) {
+                            isDone = true;
+                            break;
+                        }
+
+                        if (line.isEmpty()) {
+                            break;
+                        }
+
+                        List<String> parts = Splitter.on(':').limit(2).trimResults().splitToList(line);
+                        switch (parts.size()) {
+                            case 1 -> current.put(parts.getFirst(), "");
+                            case 2 -> current.put(parts.getFirst(), parts.getLast());
+                            default -> {}   // do nothing
+                        }
+                    }
+                }
+                catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            }
+        };
     }
 
     private <T> Request internalBuildRequest(@Nullable Object id, String method, TypeToken<JsonRpcRequest<T>> type, Optional<T> maybeParams)

--- a/json-rpc/src/test/java/io/airlift/TestBase.java
+++ b/json-rpc/src/test/java/io/airlift/TestBase.java
@@ -1,0 +1,87 @@
+package io.airlift;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.Module;
+import io.airlift.bootstrap.Bootstrap;
+import io.airlift.http.client.HttpClient;
+import io.airlift.http.client.Request;
+import io.airlift.http.server.HttpServerInfo;
+import io.airlift.http.server.testing.TestingHttpServerModule;
+import io.airlift.jaxrs.JaxrsModule;
+import io.airlift.json.JsonCodec;
+import io.airlift.json.JsonModule;
+import io.airlift.jsonrpc.JsonRpcModule.Builder;
+import io.airlift.jsonrpc.model.JsonRpcRequest;
+import io.airlift.node.NodeModule;
+import jakarta.annotation.Nullable;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Optional;
+
+import static io.airlift.http.client.HttpClientBinder.httpClientBinder;
+import static io.airlift.http.client.JsonBodyGenerator.jsonBodyGenerator;
+
+public abstract class TestBase
+{
+    protected final Injector injector;
+    protected final HttpClient httpClient;
+    protected final URI baseUri;
+
+    protected TestBase(Builder<?> rpcModuleBuilder, Module... additionalModules)
+    {
+        ImmutableList.Builder<Module> modules = ImmutableList.<Module>builder()
+                .add(rpcModuleBuilder.withBasePath("test").build())
+                .add(new NodeModule())
+                .add(new TestingHttpServerModule())
+                .add(new JsonModule())
+                .add(new JaxrsModule())
+                .add(binder -> httpClientBinder(binder).bindHttpClient("test", ForTesting.class));
+        modules.addAll(Arrays.asList(additionalModules));
+
+        ImmutableMap.Builder<String, String> serverProperties = ImmutableMap.<String, String>builder()
+                .put("node.environment", "testing");
+
+        Bootstrap app = new Bootstrap(modules.build());
+        app.setRequiredConfigurationProperties(serverProperties.build());
+        injector = app.quiet().doNotInitializeLogging().initialize();
+
+        httpClient = injector.getInstance(Key.get(HttpClient.class, ForTesting.class));
+        baseUri = injector.getInstance(HttpServerInfo.class).getHttpUri();
+    }
+
+    protected URI uri()
+    {
+        return baseUri.resolve("test");
+    }
+
+    protected <T> Request buildRequest(@Nullable Object id, String method, TypeToken<JsonRpcRequest<T>> type, T params)
+    {
+        return internalBuildRequest(id, method, type, Optional.ofNullable(params));
+    }
+
+    protected Request buildRequest(@Nullable Object id, String method)
+    {
+        return internalBuildRequest(id, method, new TypeToken<>() {}, Optional.empty());
+    }
+
+    protected Request buildNotification(String method)
+    {
+        return internalBuildRequest(null, method, new TypeToken<>() {}, Optional.empty());
+    }
+
+    private <T> Request internalBuildRequest(@Nullable Object id, String method, TypeToken<JsonRpcRequest<T>> type, Optional<T> maybeParams)
+    {
+        JsonRpcRequest<T> jsonRpcRequest = maybeParams.map(params -> (id == null) ? JsonRpcRequest.<T>buildNotification(method) : JsonRpcRequest.buildRequest(id, method, params))
+                .orElseGet(() -> JsonRpcRequest.buildRequest(id, method));
+        Request.Builder builder = Request.Builder.preparePost()
+                .setUri(uri())
+                .setHeader("Content-Type", "application/json")
+                .setBodyGenerator(jsonBodyGenerator(JsonCodec.jsonCodec(type), jsonRpcRequest));
+        return builder.build();
+    }
+}

--- a/json-rpc/src/test/java/io/airlift/jsonrpc/ErrorDetail.java
+++ b/json-rpc/src/test/java/io/airlift/jsonrpc/ErrorDetail.java
@@ -1,0 +1,11 @@
+package io.airlift.jsonrpc;
+
+import static java.util.Objects.requireNonNull;
+
+public record ErrorDetail(String detail)
+{
+    public ErrorDetail
+    {
+        requireNonNull(detail, "detail is null");
+    }
+}

--- a/json-rpc/src/test/java/io/airlift/jsonrpc/Person.java
+++ b/json-rpc/src/test/java/io/airlift/jsonrpc/Person.java
@@ -1,0 +1,11 @@
+package io.airlift.jsonrpc;
+
+import static java.util.Objects.requireNonNull;
+
+public record Person(String name, int age)
+{
+    public Person
+    {
+        requireNonNull(name, "name is null");
+    }
+}

--- a/json-rpc/src/test/java/io/airlift/jsonrpc/PersonResource.java
+++ b/json-rpc/src/test/java/io/airlift/jsonrpc/PersonResource.java
@@ -1,0 +1,47 @@
+package io.airlift.jsonrpc;
+
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.WebApplicationException;
+
+import java.util.Optional;
+
+import static io.airlift.jsonrpc.model.JsonRpcErrorCode.CONNECTION_CLOSED;
+import static io.airlift.jsonrpc.model.JsonRpcErrorDetail.exception;
+import static jakarta.ws.rs.core.Response.Status.NOT_FOUND;
+
+public class PersonResource
+{
+    private volatile Optional<Person> person = Optional.empty();
+
+    @JsonRpc("person/get")
+    public Person getPerson()
+    {
+        return person.orElseThrow(() -> new WebApplicationException(NOT_FOUND));
+    }
+
+    @JsonRpc("person/put")
+    public void setPerson(Person person)
+    {
+        if (person == null) {
+            throw new WebApplicationException("Person cannot be null", NOT_FOUND);
+        }
+        this.person = Optional.of(person);
+    }
+
+    @JsonRpc("person/delete")
+    public Person deletePerson()
+    {
+        Person deletedPerson = person.orElseThrow(() -> new WebApplicationException(NOT_FOUND));
+        person = Optional.empty();
+        return deletedPerson;
+    }
+
+    @Path("person/throws")
+    @DELETE
+    @JsonRpc
+    public void throwsError()
+    {
+        throw exception(CONNECTION_CLOSED, "Test throws");
+    }
+}

--- a/json-rpc/src/test/java/io/airlift/jsonrpc/PersonResource.java
+++ b/json-rpc/src/test/java/io/airlift/jsonrpc/PersonResource.java
@@ -1,5 +1,6 @@
 package io.airlift.jsonrpc;
 
+import io.airlift.jsonrpc.model.JsonRpcResponse;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.WebApplicationException;
@@ -8,6 +9,7 @@ import java.util.Optional;
 
 import static io.airlift.jsonrpc.model.JsonRpcErrorCode.CONNECTION_CLOSED;
 import static io.airlift.jsonrpc.model.JsonRpcErrorDetail.exception;
+import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
 import static jakarta.ws.rs.core.Response.Status.NOT_FOUND;
 
 public class PersonResource
@@ -43,5 +45,13 @@ public class PersonResource
     public void throwsError()
     {
         throw exception(CONNECTION_CLOSED, "Test throws");
+    }
+
+    @JsonRpcResult("result")
+    public void handleResponse(JsonRpcResponse<ErrorDetail> result)
+    {
+        if (!result.result().orElseThrow().detail().equals("test")) {
+            throw new WebApplicationException("Unexpected error detail", BAD_REQUEST);
+        }
     }
 }

--- a/json-rpc/src/test/java/io/airlift/jsonrpc/TestJsonRpc.java
+++ b/json-rpc/src/test/java/io/airlift/jsonrpc/TestJsonRpc.java
@@ -8,6 +8,7 @@ import io.airlift.jsonrpc.model.JsonRpcErrorDetail;
 import io.airlift.jsonrpc.model.JsonRpcResponse;
 import org.junit.jupiter.api.Test;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import static io.airlift.http.client.JsonResponseHandler.createJsonResponseHandler;
@@ -63,5 +64,13 @@ public class TestJsonRpc
         assertThat(response.result()).isEmpty();
         assertThat(response.error()).map(JsonRpcErrorDetail::code).contains(CONNECTION_CLOSED.code());
         assertThat(response.error()).map(JsonRpcErrorDetail::message).contains("Test throws");
+    }
+
+    @Test
+    public void testSendResult()
+    {
+        Request request = buildResponse(1234, new TypeToken<>() {}, Optional.of(new ErrorDetail("test")));
+        StatusResponse response = httpClient.execute(request, createStatusResponseHandler());
+        assertThat(response.getStatusCode()).isEqualTo(204);
     }
 }

--- a/json-rpc/src/test/java/io/airlift/jsonrpc/TestJsonRpc.java
+++ b/json-rpc/src/test/java/io/airlift/jsonrpc/TestJsonRpc.java
@@ -1,0 +1,67 @@
+package io.airlift.jsonrpc;
+
+import com.google.common.reflect.TypeToken;
+import io.airlift.TestBase;
+import io.airlift.http.client.Request;
+import io.airlift.http.client.StatusResponseHandler.StatusResponse;
+import io.airlift.jsonrpc.model.JsonRpcErrorDetail;
+import io.airlift.jsonrpc.model.JsonRpcResponse;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static io.airlift.http.client.JsonResponseHandler.createJsonResponseHandler;
+import static io.airlift.http.client.StatusResponseHandler.createStatusResponseHandler;
+import static io.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
+import static io.airlift.json.JsonCodec.jsonCodec;
+import static io.airlift.jsonrpc.model.JsonRpcErrorCode.CONNECTION_CLOSED;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestJsonRpc
+        extends TestBase
+{
+    public TestJsonRpc()
+    {
+        super(JsonRpcMethod.addAllInClass(JsonRpcModule.builder(), PersonResource.class), binder -> jaxrsBinder(binder).bind(PersonResource.class));
+    }
+
+    @Test
+    public void testSetPerson()
+    {
+        Person person = new Person("John", 24);
+        String id = UUID.randomUUID().toString();
+
+        Request request = buildRequest(id, "person/put", new TypeToken<>() {}, person);
+        StatusResponse putResponse = httpClient.execute(request, createStatusResponseHandler());
+        assertThat(putResponse.getStatusCode()).isEqualTo(204);
+
+        request = buildRequest(id, "person/get");
+        JsonRpcResponse<Person> personResponse = httpClient.execute(request, createJsonResponseHandler(jsonCodec(new TypeToken<>() {})));
+        assertThat(personResponse.id()).isEqualTo(id);
+        assertThat(personResponse.result()).contains(person);
+        assertThat(personResponse.error()).isEmpty();
+
+        request = buildRequest(id, "person/delete");
+        JsonRpcResponse<Person> deleteResponse = httpClient.execute(request, createJsonResponseHandler(jsonCodec(new TypeToken<>() {})));
+        assertThat(deleteResponse.id()).isEqualTo(id);
+        assertThat(deleteResponse.result()).contains(person);
+        assertThat(deleteResponse.error()).isEmpty();
+
+        request = buildRequest(id, "person/get");
+        personResponse = httpClient.execute(request, createJsonResponseHandler(jsonCodec(new TypeToken<>() {})));
+        assertThat(personResponse.id()).isEqualTo(id);
+        assertThat(personResponse.result()).isEmpty();
+        assertThat(personResponse.error()).map(JsonRpcErrorDetail::code).contains(404);
+    }
+
+    @Test
+    public void testException()
+    {
+        Request request = buildRequest(2468, "person/throws");
+        JsonRpcResponse<Object> response = httpClient.execute(request, createJsonResponseHandler(jsonCodec(new TypeToken<>() {})));
+        assertThat(response.id()).isEqualTo(2468);
+        assertThat(response.result()).isEmpty();
+        assertThat(response.error()).map(JsonRpcErrorDetail::code).contains(CONNECTION_CLOSED.code());
+        assertThat(response.error()).map(JsonRpcErrorDetail::message).contains("Test throws");
+    }
+}

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -22,6 +22,7 @@ variations of MCP servers defined by the standard. This module supports:
 - `_meta` field [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/basic#meta)
 - `context` field [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/changelog) in `CompletionRequest`
 - Structured content [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content)
+- Pagination [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/basic/utilities/pagination)
 
 If a session controller implementation is provided (see [the doc](docs/sessions.md)), this module also supports:
 
@@ -30,16 +31,13 @@ If a session controller implementation is provided (see [the doc](docs/sessions.
 - Subscriptions [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle#initialization)
 - Server-sent logging [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/server/utilities/logging)
 - Cancellation [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/basic/utilities/cancellation)
+- Pagination [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/basic/utilities/pagination)
 - Server-to-client features:
   - Elicitation [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/client/elicitation)
   - Roots [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/client/roots)
   - Sampling [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/client/sampling)
   - Note: it is the implementer's responsibility to support these features. This module merely provides
   the structure to implement them.
-
-It does not support:
-
-- Pagination (no benefit) [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/basic/utilities/pagination)
 
 Additionally, this module is agnostic regarding authentication and authorization.
 It is assumed that authz will be handled by the application adding MCP server

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -23,17 +23,23 @@ variations of MCP servers defined by the standard. This module supports:
 - `context` field [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/changelog) in `CompletionRequest`
 - Structured content [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content)
 
-It does not support:
+If a session controller implementation is provided (see [the doc](docs/sessions.md)), this module also supports:
 
 - Sessions [(see spec)](https://modelcontextprotocol.io/docs/concepts/transports#session-management)
-- Cancellation [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/basic/utilities/cancellation)
 - List changed events [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle#initialization)
 - Subscriptions [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle#initialization)
 - Server-sent logging [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/server/utilities/logging)
+- Cancellation [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/basic/utilities/cancellation)
+- Server-to-client features:
+  - Elicitation [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/client/elicitation)
+  - Roots [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/client/roots)
+  - Sampling [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/client/sampling)
+  - Note: it is the implementer's responsibility to support these features. This module merely provides
+  the structure to implement them.
+
+It does not support:
+
 - Pagination (no benefit) [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/basic/utilities/pagination)
-- Elicitation [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/client/elicitation)
-- Roots [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/client/roots)
-- Sampling [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/client/sampling)
 
 Additionally, this module is agnostic regarding authentication and authorization.
 It is assumed that authz will be handled by the application adding MCP server
@@ -51,6 +57,7 @@ For a quick start, see the [quick start guide](docs/quick-start.md).
 - [Prompts](docs/prompts.md)
 - [Resources and resource templates](docs/resources.md)
 - [Completions](docs/completions.md)
+- [Sessions](docs/sessions.md)
 - [Installation and configuration](docs/install.md)
 - [Miscellaneous](docs/misc.md)
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,59 @@
+[◀︎ Airlift](../README.md)
+
+# MCP server support
+
+## Introduction
+
+For a quick start, see the [quick start guide](docs/quick-start.md).
+
+This module provides support for creating [MCP servers](https://modelcontextprotocol.io). There are several
+variations of MCP servers defined by the standard. This module supports:
+
+- Protocol version 2025-06-18 [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/changelog#major-changes)
+- Stateless MCP servers [(see spec)](https://github.com/modelcontextprotocol/modelcontextprotocol/discussions?discussions_q=stateless)
+- Streamable HTTP transport [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#streamable-http)
+- Resources and resource templates [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/server/resources)
+- Prompts [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/server/prompts)
+- Tools [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/server/tools)
+- Completions [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/server/utilities/completion)
+- Progress notifications [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/basic/utilities/progress)
+- Ping [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/basic/utilities/ping)
+- Limited server-sent notifications during processing (e.g. for progress: [see spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/utilities/progress))
+- `_meta` field [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/basic#meta)
+- `context` field [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/changelog) in `CompletionRequest`
+- Structured content [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content)
+
+It does not support:
+
+- Sessions [(see spec)](https://modelcontextprotocol.io/docs/concepts/transports#session-management)
+- Cancellation [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/basic/utilities/cancellation)
+- List changed events [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle#initialization)
+- Subscriptions [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle#initialization)
+- Server-sent logging [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/server/utilities/logging)
+- Pagination (no benefit) [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/basic/utilities/pagination)
+- Elicitation [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/client/elicitation)
+- Roots [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/client/roots)
+- Sampling [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/client/sampling)
+
+Additionally, this module is agnostic regarding authentication and authorization.
+It is assumed that authz will be handled by the application adding MCP server
+support. However, all prompts, tools, etc. methods can receive the active
+HTTP request which should allow most authz implementations.
+
+## Quick start
+
+For a quick start, see the [quick start guide](docs/quick-start.md).
+
+## Details
+
+- [Quick start guide](docs/quick-start.md)
+- [Tools](docs/tools.md)
+- [Prompts](docs/prompts.md)
+- [Resources and resource templates](docs/resources.md)
+- [Completions](docs/completions.md)
+- [Installation and configuration](docs/install.md)
+- [Miscellaneous](docs/misc.md)
+
+## Tester/Demo
+
+Run the [tester/demo](docs/misc.md#testerdemo) to see the MCP server in action.

--- a/mcp/docs/completions.md
+++ b/mcp/docs/completions.md
@@ -1,0 +1,46 @@
+[◀︎ Airlift](../README.md) • [◀︎ MCP server support](../README.md)
+
+# MCP server support - completions
+
+From the [spec](https://modelcontextprotocol.io/specification/2025-06-18/server/utilities/completion):
+
+> The Model Context Protocol (MCP) provides a standardized way for servers 
+> to offer argument autocompletion suggestions for prompts and resource URIs. 
+> This enables rich, IDE-like experiences where users receive contextual 
+> suggestions while entering argument values.
+
+Completions can be created declaratively using the `@McpCompletion` annotation or
+programmatically.
+
+## Declarative MCP "completions"
+
+Completions can be defined using the `@McpCompletion` annotation. The annotation can be
+applied to methods in a class that conform to the following rules:
+
+- Parameters can be:
+    - [CompletionRequest](../src/main/java/io/airlift/mcp/model/CompletionRequest.java)
+    - `jakarta.ws.rs.core.Request`
+    - [McpNotifier](misc.md#notifications-to-clients)
+- Returns either:
+    - `List<String>`
+  - [Optional&lt;Completion&gt;](../src/main/java/io/airlift/mcp/model/Completion.java)
+
+[Register](install.md) the method's class with [the McpModule](install.md).
+
+
+## Programmatic MCP "completions"
+
+1. Define a `CompletionHandler`:
+
+```java
+public interface CompletionHandler
+{
+    Optional<Completion> completeCompletion(Request request, McpNotifier notifier, CompletionRequest completionRequest);
+}
+```
+
+2. Register the completion with the [McpServer](../src/main/java/io/airlift/mcp/McpServer.java) (which can be `@Inject`ed):
+
+```java
+mcpServer.completions().add("name", new CompletionEntry("name", handler));
+```

--- a/mcp/docs/completions.md
+++ b/mcp/docs/completions.md
@@ -22,6 +22,7 @@ applied to methods in a class that conform to the following rules:
     - `jakarta.ws.rs.core.Request`
     - SessionId ([see doc on sessions](sessions.md))
     - [McpNotifier](misc.md#notifications-to-clients)
+    - JAX-RS `@Context` parameters
 - Returns either:
     - `List<String>`
   - [Optional&lt;Completion&gt;](../src/main/java/io/airlift/mcp/model/Completion.java)
@@ -36,7 +37,7 @@ applied to methods in a class that conform to the following rules:
 ```java
 public interface CompletionHandler
 {
-    Optional<Completion> completeCompletion(Request request, McpNotifier notifier, CompletionRequest completionRequest);
+    Optional<Completion> completeCompletion(RequestContext requestContext, McpNotifier notifier, CompletionRequest completionRequest);
 }
 ```
 

--- a/mcp/docs/completions.md
+++ b/mcp/docs/completions.md
@@ -20,6 +20,7 @@ applied to methods in a class that conform to the following rules:
 - Parameters can be:
     - [CompletionRequest](../src/main/java/io/airlift/mcp/model/CompletionRequest.java)
     - `jakarta.ws.rs.core.Request`
+    - SessionId ([see doc on sessions](sessions.md))
     - [McpNotifier](misc.md#notifications-to-clients)
 - Returns either:
     - `List<String>`
@@ -44,3 +45,8 @@ public interface CompletionHandler
 ```java
 mcpServer.completions().add("name", new CompletionEntry("name", handler));
 ```
+
+## Note on cancellation
+
+Use the `cancellationRequested()` method of the `McpNotifier` to check if
+the request/operation has been requested to be cancelled.

--- a/mcp/docs/install.md
+++ b/mcp/docs/install.md
@@ -1,0 +1,24 @@
+[◀︎ Airlift](../README.md) • [◀︎ MCP server support](../README.md)
+
+# MCP server support - installation and configuration
+
+## Installation and configuration
+
+- Create an MCP module and install into your application via [McpModule](../src/main/java/io/airlift/mcp/McpModule.java).
+- Optionally, change any of the default values:
+  - `withBasePath()` to change the default URI path of `mcp`
+  - Add classes with MCP annotations via `addAllInClass()`
+  - Change the server name, version or instructions via `withServerInfo()`
+- Build the module via `build()` and install it into your application
+
+## McpHandlers instance
+
+The [McpHandlers](../src/main/java/io/airlift/mcp/McpHandlers.java)
+is available via injection. It can be used to register additional tools, prompts, resources, etc.
+or to remove existing ones.
+
+## McpServer instance
+
+The [McpServer](../src/main/java/io/airlift/mcp/McpServer.java)
+is available via injection. It contains all the protocol methods for MCP
+servers.

--- a/mcp/docs/misc.md
+++ b/mcp/docs/misc.md
@@ -1,0 +1,93 @@
+[◀︎ Airlift](../README.md) • [◀︎ MCP server support](../README.md)
+
+# MCP server support - miscellaneous
+
+## Notifications to clients
+
+While processing MCP requests, servers may need to notify clients about progress, etc.
+Most MCP methods can add an `McpNotifier` parameter to their method signature. While
+processing the request, the server can call methods on this notifier to send
+messages to the client:
+
+```java
+public interface McpNotifier
+{
+    void notifyProgress(String message, Optional<Double> progress, Optional<Double> total);
+
+    void sendNotification(String notificationType, Object data);
+    
+    // ...
+}
+```
+
+Example:
+```java
+@McpTool    // or prompt, etc
+public String myTool(McpNotifier notifier, ...)
+{
+    notifier.sendProgress("Starting processing", Optional.of(8.0), Optional.of(55.0));
+    
+    return "something";
+}
+```
+
+## Current request
+
+MCP methods can take the current JAX-RS request as a parameter. This allows
+servers to access request-specific information, such as headers, etc.
+
+```java
+@McpTool    // or prompt, etc
+public String myTool(Request request, ...)
+{
+    ...
+}
+```
+
+## Supported types
+
+For most method parameters or method return types, the MCP server supports the following types:
+
+- `String`
+- `boolean`, `Boolean`
+- `short`, `Short`, `int`, `Integer`, `long`, `Long`
+- `float`, `Float`, `double`, `Double`
+- `BigInteger`, `BigDecimal`
+- `Map<String, String>`
+- Collections of the above types
+- `Optional` of the above types
+
+In addition, Java `record`s are supported that use the above types (including
+records of with fields that are records). Note: recursive definitions are not supported.
+
+Your method can also return the type defined by MCP handler. E.g.
+tools and prompts can return `Content` or tools can return `CallToolResult`, etc.
+
+## Documentation
+
+Most fields, parameters, etc. can be annotated with `@McpDescription` to provide
+documentation for MCP clients.
+
+## JsonSchemaBuilder
+
+Use the `JsonSchemaBuilder` to create JSON schema for your method parameters, return types, etc.
+
+## Tester/Demo
+
+Run [LocalServers](../src/test/java/io/airlift/LocalServer.java) to showcase an example testing MCP server.
+
+e.g.
+
+```shell
+./mvnw -DskipTests install
+./mvnw -DskipTests -pl mcp -Dexec.classpathScope=test -Dexec.mainClass=io.airlift.LocalServer -Dexec.arguments=8888 exec:java
+```
+
+In a separate terminal, run the MCP tester:
+
+```shell
+npx @modelcontextprotocol/inspector
+```
+
+A browser should open with the MCP Inspector tool. Set the "Transport Type" to
+"Streamable HTTP". Change the URL to `http://localhost:8888/mcp` and click "Connect".

--- a/mcp/docs/prompts.md
+++ b/mcp/docs/prompts.md
@@ -1,0 +1,52 @@
+[◀︎ Airlift](../README.md) • [◀︎ MCP server support](../README.md)
+
+# MCP server support - prompts
+
+From the [spec](https://modelcontextprotocol.io/specification/2025-06-18/server/prompts):
+
+> The Model Context Protocol (MCP) provides a standardized way for servers to 
+> expose prompt templates to clients. Prompts allow servers to provide 
+> structured messages and instructions for interacting with language models. 
+> Clients can discover available prompts, retrieve their contents, and provide 
+> arguments to customize them.
+
+Prompts can be created declaratively using the `@McpPrompt` annotation or
+programmatically.
+
+## Declarative MCP "prompts"
+
+Prompts can be defined using the `@McpPrompt` annotation. The prompt name is either
+the `name` attribute of the annotation or the method name. The other attributes
+of the annotation are used to describe the prompt. The annotation can be
+applied to methods in a class that conform to the following rules:
+
+- Parameters can be:
+    - `String` for the prompt arguments
+    - `jakarta.ws.rs.core.Request`
+    - [GetPromptRequest](../src/main/java/io/airlift/mcp/model/GetPromptRequest.java)
+    - [McpNotifier](misc.md#notifications-to-clients)
+- Returns either:
+    - `String`
+    - one of the [Content](../src/main/java/io/airlift/mcp/model/Content.java) subtypes
+    - [GetPromptResult](../src/main/java/io/airlift/mcp/model/GetPromptResult.java)
+
+[Register](install.md) the method's class with [the McpModule](install.md).
+
+## Programmatic MCP "prompts"
+
+1. Define a `PromptHandler`:
+
+```java
+public interface PromptHandler
+{
+    GetPromptResult getPrompt(Request request, McpNotifier notifier, GetPromptRequest getPromptRequest);
+}
+```
+
+2. Create a [Prompt](../src/main/java/io/airlift/mcp/model/Prompt.java) instance
+
+3. Register the prompt with the [McpServer](../src/main/java/io/airlift/mcp/McpServer.java) (which can be `@Inject`ed):
+
+```java
+mcpServer.prompts().add("name", new PromptEntry(prompt, handler));
+```

--- a/mcp/docs/prompts.md
+++ b/mcp/docs/prompts.md
@@ -26,6 +26,7 @@ applied to methods in a class that conform to the following rules:
     - SessionId ([see doc on sessions](sessions.md))
     - [GetPromptRequest](../src/main/java/io/airlift/mcp/model/GetPromptRequest.java)
     - [McpNotifier](misc.md#notifications-to-clients)
+    - JAX-RS `@Context` parameters
 - Returns either:
     - `String`
     - one of the [Content](../src/main/java/io/airlift/mcp/model/Content.java) subtypes
@@ -40,7 +41,7 @@ applied to methods in a class that conform to the following rules:
 ```java
 public interface PromptHandler
 {
-    GetPromptResult getPrompt(Request request, McpNotifier notifier, GetPromptRequest getPromptRequest);
+    GetPromptResult getPrompt(RequestContext requestContext, McpNotifier notifier, GetPromptRequest getPromptRequest);
 }
 ```
 

--- a/mcp/docs/prompts.md
+++ b/mcp/docs/prompts.md
@@ -23,6 +23,7 @@ applied to methods in a class that conform to the following rules:
 - Parameters can be:
     - `String` for the prompt arguments
     - `jakarta.ws.rs.core.Request`
+    - SessionId ([see doc on sessions](sessions.md))
     - [GetPromptRequest](../src/main/java/io/airlift/mcp/model/GetPromptRequest.java)
     - [McpNotifier](misc.md#notifications-to-clients)
 - Returns either:
@@ -50,3 +51,8 @@ public interface PromptHandler
 ```java
 mcpServer.prompts().add("name", new PromptEntry(prompt, handler));
 ```
+
+## Note on cancellation
+
+Use the `cancellationRequested()` method of the `McpNotifier` to check if
+the request/operation has been requested to be cancelled.

--- a/mcp/docs/quick-start.md
+++ b/mcp/docs/quick-start.md
@@ -1,0 +1,59 @@
+[◀︎ Airlift](../README.md) • [◀︎ MCP server support](../README.md)
+
+# MCP server support - quick start
+
+## Create tools, prompts, resources as needed
+
+#### Tools
+
+```java
+// in some class...
+
+@McpTool(name = "add", description = "Adds two numbers")
+public int addTwoNumbers(
+        @McpDescription("first number to add") int a,
+        @McpDescription("second number to add") int b)
+{
+    return a + b;
+}
+```
+
+#### Prompts
+
+```java
+// in some class...
+
+@McpPrompt(name = "greeting", description = "Generate a greeting message")
+public String greeting(@McpDescription("Name of the person to greet") String name)
+{
+    return "Hello, " + name + "!";
+}
+```
+
+#### Resources, completions, etc.
+
+For resources, completions, etc. please see the [MCP Server documentation](../README.md#details).
+
+## Add the MCP server Guice module
+
+```java
+Module module = McpModule.builder()
+    .addAllInClass(MyClassWithToolsPromptsEtc.class)
+    .addAllInClass(MyOtherClassWithToolsPromptsEtc.class)
+    .build();
+
+// in your main module, etc.
+binder.install(module);
+```
+
+## Test your MCP server
+
+_Run your application locally via standard Airlift Bootstrap and make note of the server port._
+
+Start the MCP testing tool:
+```shell
+npx @modelcontextprotocol/inspector
+```
+
+A browser should open with the MCP Inspector tool. Set the "Transport Type" to 
+"Streamable HTTP". Change the URL to `http://localhost:<server-port>/mcp` and click "Connect".

--- a/mcp/docs/resources.md
+++ b/mcp/docs/resources.md
@@ -1,0 +1,68 @@
+[◀︎ Airlift](../README.md) • [◀︎ MCP server support](../README.md)
+
+# MCP server support - resources and resource templates
+
+From the [spec](https://modelcontextprotocol.io/specification/2025-06-18/server/resources):
+
+> The Model Context Protocol (MCP) provides a standardized way for servers to 
+> expose resources to clients. Resources allow servers to share data that 
+> provides context to language models, such as files, database schemas, or 
+> application-specific information. Each resource is uniquely identified by 
+> a URI.
+
+Resources and resource templates can be created declaratively using `@McpResources` annotations or programmatically.
+
+## Declarative MCP "resources"
+
+Resources and resource templates can be defined using the `@McpResource` and
+`@McpResourceTemplate` annotations. The annotation can be
+applied to methods in a class that conform to the following rules:
+
+- Parameters can be:
+    - `jakarta.ws.rs.core.Request`
+    - [McpNotifier](misc.md#notifications-to-clients)
+    - For resources:
+      - [Resource](../src/main/java/io/airlift/mcp/model/Resource.java) - the source resource being read
+    - For resource templates:
+      - [ResourceTemplate](../src/main/java/io/airlift/mcp/model/ResourceTemplate.java) - the source resource being read
+    - [ReadResourceRequest](../src/main/java/io/airlift/mcp/model/ReadResourceRequest.java)
+- Returns either:
+    - [ResourceContents](../src/main/java/io/airlift/mcp/model/ResourceContents.java)
+    - [List&lt;ResourceContents&gt;](../src/main/java/io/airlift/mcp/model/ResourceContents.java)
+
+[Register](install.md) the method's class with [the McpModule](install.md).
+
+## Programmatic MCP "resources"
+
+1. Define a handler for reading resources or resource templates:
+
+```java
+import io.airlift.mcp.McpNotifier;
+
+public interface ResourceHandler
+{
+  List<ResourceContents> readResource(Request request, McpNotifier notifier, Resource sourceResource, ReadResourceRequest readResourceRequest);
+}
+
+public interface ResourceTemplateHandler
+{
+  record PathTemplateValues(Map<String, String> values)
+  {
+    public PathTemplateValues
+    {
+      values = ImmutableMap.copyOf(values);
+    }
+  }
+
+  List<ResourceContents> readResource(Request request, McpNotifier notifier, ResourceTemplate sourceResourceTemplate, ReadResourceRequest readResourceRequest, PathTemplateValues pathTemplateValues);
+}
+```
+
+2. Create a [Resource](../src/main/java/io/airlift/mcp/model/Resource.java) or [ResourceTemplate](../src/main/java/io/airlift/mcp/model/ResourceTemplate.java) instance
+
+3. Register the resource/template with the [McpServer](../src/main/java/io/airlift/mcp/McpServer.java) (which can be `@Inject`ed):
+
+```java
+mcpServer.resources().add("name", new ResourceEntry(resource, handler));
+mcpServer.resourceTemplates().add("name", new ResourceTemplateEntry(resourceTemplate, handler));
+```

--- a/mcp/docs/resources.md
+++ b/mcp/docs/resources.md
@@ -20,6 +20,7 @@ applied to methods in a class that conform to the following rules:
 
 - Parameters can be:
     - `jakarta.ws.rs.core.Request`
+    - SessionId ([see doc on sessions](sessions.md))
     - [McpNotifier](misc.md#notifications-to-clients)
     - For resources:
       - [Resource](../src/main/java/io/airlift/mcp/model/Resource.java) - the source resource being read
@@ -66,3 +67,8 @@ public interface ResourceTemplateHandler
 mcpServer.resources().add("name", new ResourceEntry(resource, handler));
 mcpServer.resourceTemplates().add("name", new ResourceTemplateEntry(resourceTemplate, handler));
 ```
+
+## Note on cancellation
+
+Use the `cancellationRequested()` method of the `McpNotifier` to check if
+the request/operation has been requested to be cancelled.

--- a/mcp/docs/resources.md
+++ b/mcp/docs/resources.md
@@ -27,6 +27,7 @@ applied to methods in a class that conform to the following rules:
     - For resource templates:
       - [ResourceTemplate](../src/main/java/io/airlift/mcp/model/ResourceTemplate.java) - the source resource being read
     - [ReadResourceRequest](../src/main/java/io/airlift/mcp/model/ReadResourceRequest.java)
+    - JAX-RS `@Context` parameters
 - Returns either:
     - [ResourceContents](../src/main/java/io/airlift/mcp/model/ResourceContents.java)
     - [List&lt;ResourceContents&gt;](../src/main/java/io/airlift/mcp/model/ResourceContents.java)

--- a/mcp/docs/sessions.md
+++ b/mcp/docs/sessions.md
@@ -1,0 +1,15 @@
+[◀︎ Airlift](../README.md) • [◀︎ MCP server support](../README.md)
+
+# MCP server support - sessions
+
+From the [spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#session-management):
+
+> An MCP “session” consists of logically related interactions between a client and a server, beginning 
+> with the initialization phase.
+
+Session support in MCP assumes that the server is stateful. Therefore, session support for MCP
+in Airlift is optional. You must bind an instance of [SessionController](../src/main/java/io/airlift/mcp/session/SessionController.java)
+to enable session support. Your `SessionController` instance should be backed by a persistent store such as
+a database so that session state is persistent and consistent across server restarts or horizontal scaling.
+
+See the [SessionController](../src/main/java/io/airlift/mcp/session/SessionController.java)'s JavaDoc for details on usage.

--- a/mcp/docs/tools.md
+++ b/mcp/docs/tools.md
@@ -26,6 +26,7 @@ applied to methods in a class that conform to the following rules:
   - SessionId ([see doc on sessions](sessions.md))
   - [McpNotifier](misc.md#notifications-to-clients)
   - [CallToolRequest](../src/main/java/io/airlift/mcp/model/CallToolRequest.java)
+  - JAX-RS `@Context` parameters
 - Returns either:
   - `void`
   - the [supported types](misc.md#supported-types)
@@ -41,7 +42,7 @@ applied to methods in a class that conform to the following rules:
 ```java
 public interface ToolHandler
 {
-    CallToolResult callTool(Request request, McpNotifier notifier, CallToolRequest toolRequest);
+    CallToolResult callTool(RequestContext requestContext, McpNotifier notifier, CallToolRequest toolRequest);
 }
 ```
 

--- a/mcp/docs/tools.md
+++ b/mcp/docs/tools.md
@@ -23,6 +23,7 @@ applied to methods in a class that conform to the following rules:
 - Parameters can be:
   - types that conform to the [supported types](misc.md#supported-types)
   - `jakarta.ws.rs.core.Request`
+  - SessionId ([see doc on sessions](sessions.md))
   - [McpNotifier](misc.md#notifications-to-clients)
   - [CallToolRequest](../src/main/java/io/airlift/mcp/model/CallToolRequest.java)
 - Returns either:
@@ -51,3 +52,8 @@ public interface ToolHandler
 ```java
 mcpServer.tools().add("name", new ToolEntry(tool, handler));
 ```
+
+## Note on cancellation
+
+Use the `cancellationRequested()` method of the `McpNotifier` to check if 
+the request/operation has been requested to be cancelled.

--- a/mcp/docs/tools.md
+++ b/mcp/docs/tools.md
@@ -1,0 +1,53 @@
+[◀︎ Airlift](../README.md) • [◀︎ MCP server support](../README.md)
+
+# MCP server support - tools
+
+From the [spec](https://modelcontextprotocol.io/specification/2025-06-18/server/tools):
+
+> The Model Context Protocol (MCP) allows servers to expose tools that can be 
+> invoked by language models. Tools enable models to interact with external 
+> systems, such as querying databases, calling APIs, or performing computations. 
+> Each tool is uniquely identified by a name and includes metadata describing 
+> its schema.
+
+Tools can be created declaratively using the `@McpTool` annotation or 
+programmatically.
+
+## Declarative MCP "tools"
+
+Tools can be defined using the `@McpTool` annotation. The tool name is either
+the `name` attribute of the annotation or the method name. The other attributes
+of the annotation are used to describe the tool. The annotation can be
+applied to methods in a class that conform to the following rules:
+
+- Parameters can be:
+  - types that conform to the [supported types](misc.md#supported-types)
+  - `jakarta.ws.rs.core.Request`
+  - [McpNotifier](misc.md#notifications-to-clients)
+  - [CallToolRequest](../src/main/java/io/airlift/mcp/model/CallToolRequest.java)
+- Returns either:
+  - `void`
+  - the [supported types](misc.md#supported-types)
+  - one of the [Content](../src/main/java/io/airlift/mcp/model/Content.java) subtypes
+  - [CallToolResult](../src/main/java/io/airlift/mcp/model/CallToolResult.java)
+
+[Register](install.md) the method's class with [the McpModule](install.md).
+
+## Programmatic MCP "tools"
+
+1. Define a `ToolHandler`:
+
+```java
+public interface ToolHandler
+{
+    CallToolResult callTool(Request request, McpNotifier notifier, CallToolRequest toolRequest);
+}
+```
+
+2. Create a [Tool](../src/main/java/io/airlift/mcp/model/Tool.java) instance
+
+3. Register the tool with the [McpServer](../src/main/java/io/airlift/mcp/McpServer.java) (which can be `@Inject`ed):
+
+```java
+mcpServer.tools().add("name", new ToolEntry(tool, handler));
+```

--- a/mcp/pom.xml
+++ b/mcp/pom.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.airlift</groupId>
+        <artifactId>airlift</artifactId>
+        <version>343-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>mcp</artifactId>
+    <packaging>jar</packaging>
+    <description>Airlift - MCP server support</description>
+
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>json-rpc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>log</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+            <classifier>classes</classifier>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-common</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-server</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jaxrs</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>node</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>bootstrap</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>http-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>http-server</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>json-rpc</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-http</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/mcp/pom.xml
+++ b/mcp/pom.xml
@@ -19,6 +19,11 @@
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>jaxrs</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>json</artifactId>
         </dependency>
 
@@ -72,12 +77,6 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
             <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>jaxrs</artifactId>
-            <scope>runtime</scope>
         </dependency>
 
         <dependency>

--- a/mcp/src/main/java/io/airlift/mcp/McpCompletion.java
+++ b/mcp/src/main/java/io/airlift/mcp/McpCompletion.java
@@ -1,0 +1,14 @@
+package io.airlift.mcp;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface McpCompletion
+{
+    String name();
+}

--- a/mcp/src/main/java/io/airlift/mcp/McpDescription.java
+++ b/mcp/src/main/java/io/airlift/mcp/McpDescription.java
@@ -1,0 +1,19 @@
+package io.airlift.mcp;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.RECORD_COMPONENT;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({METHOD, PARAMETER, RECORD_COMPONENT})
+@BindingAnnotation
+public @interface McpDescription
+{
+    String value();
+}

--- a/mcp/src/main/java/io/airlift/mcp/McpException.java
+++ b/mcp/src/main/java/io/airlift/mcp/McpException.java
@@ -1,0 +1,55 @@
+package io.airlift.mcp;
+
+import io.airlift.jsonrpc.model.JsonRpcErrorCode;
+import io.airlift.jsonrpc.model.JsonRpcErrorDetail;
+
+import java.util.Optional;
+
+import static io.airlift.jsonrpc.model.JsonRpcErrorCode.INVALID_REQUEST;
+import static java.util.Objects.requireNonNull;
+
+public class McpException
+        extends RuntimeException
+{
+    private final JsonRpcErrorDetail errorDetail;
+
+    public McpException(JsonRpcErrorDetail errorDetail)
+    {
+        this.errorDetail = requireNonNull(errorDetail, "errorDetail is null");
+    }
+
+    public JsonRpcErrorDetail errorDetail()
+    {
+        return errorDetail;
+    }
+
+    public static McpException exception(JsonRpcErrorCode errorCode, String message)
+    {
+        JsonRpcErrorDetail detail = new JsonRpcErrorDetail(errorCode.code(), message, Optional.empty());
+        return new McpException(detail);
+    }
+
+    public static McpException exception(JsonRpcErrorCode errorCode, String message, Object data)
+    {
+        JsonRpcErrorDetail detail = new JsonRpcErrorDetail(errorCode.code(), message, Optional.of(data));
+        return new McpException(detail);
+    }
+
+    public static McpException exception(String message)
+    {
+        JsonRpcErrorDetail detail = new JsonRpcErrorDetail(INVALID_REQUEST, message, Optional.empty());
+        return new McpException(detail);
+    }
+
+    public static McpException exception(int code, String message)
+    {
+        JsonRpcErrorDetail detail = new JsonRpcErrorDetail(code, message, Optional.empty());
+        return new McpException(detail);
+    }
+
+    public static McpException exception(int code, String message, Optional<Object> data)
+    {
+        JsonRpcErrorDetail detail = new JsonRpcErrorDetail(code, message, data);
+        return new McpException(detail);
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/McpModule.java
+++ b/mcp/src/main/java/io/airlift/mcp/McpModule.java
@@ -3,6 +3,7 @@ package io.airlift.mcp;
 import com.google.inject.binder.LinkedBindingBuilder;
 import io.airlift.jsonrpc.JsonRpcModule;
 import io.airlift.mcp.internal.InternalMcpModule;
+import io.airlift.mcp.model.PaginationMetadata;
 import io.airlift.mcp.session.SessionController;
 import io.airlift.mcp.session.SessionMetadata;
 
@@ -18,6 +19,8 @@ public interface McpModule
         Builder addAllInClass(Class<?> clazz);
 
         Builder withSessionHandling(SessionMetadata sessionMetadata, Consumer<LinkedBindingBuilder<SessionController>> binding);
+
+        Builder withPaginationMetadata(PaginationMetadata paginationMetadata);
     }
 
     static Builder builder()

--- a/mcp/src/main/java/io/airlift/mcp/McpModule.java
+++ b/mcp/src/main/java/io/airlift/mcp/McpModule.java
@@ -1,0 +1,20 @@
+package io.airlift.mcp;
+
+import io.airlift.jsonrpc.JsonRpcModule;
+import io.airlift.mcp.internal.InternalMcpModule;
+
+public interface McpModule
+{
+    interface Builder
+            extends JsonRpcModule.Builder<Builder>
+    {
+        Builder withServerInfo(String serverName, String serverVersion, String instructions);
+
+        Builder addAllInClass(Class<?> clazz);
+    }
+
+    static Builder builder()
+    {
+        return InternalMcpModule.builder();
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/McpModule.java
+++ b/mcp/src/main/java/io/airlift/mcp/McpModule.java
@@ -1,7 +1,12 @@
 package io.airlift.mcp;
 
+import com.google.inject.binder.LinkedBindingBuilder;
 import io.airlift.jsonrpc.JsonRpcModule;
 import io.airlift.mcp.internal.InternalMcpModule;
+import io.airlift.mcp.session.SessionController;
+import io.airlift.mcp.session.SessionMetadata;
+
+import java.util.function.Consumer;
 
 public interface McpModule
 {
@@ -11,6 +16,8 @@ public interface McpModule
         Builder withServerInfo(String serverName, String serverVersion, String instructions);
 
         Builder addAllInClass(Class<?> clazz);
+
+        Builder withSessionHandling(SessionMetadata sessionMetadata, Consumer<LinkedBindingBuilder<SessionController>> binding);
     }
 
     static Builder builder()

--- a/mcp/src/main/java/io/airlift/mcp/McpNotifier.java
+++ b/mcp/src/main/java/io/airlift/mcp/McpNotifier.java
@@ -1,0 +1,12 @@
+package io.airlift.mcp;
+
+import java.util.Optional;
+
+public interface McpNotifier
+{
+    void notifyProgress(String message, Optional<Double> progress, Optional<Double> total);
+
+    <T> void sendNotification(String notificationType, T data);
+
+    void sendNotification(String notificationType);
+}

--- a/mcp/src/main/java/io/airlift/mcp/McpNotifier.java
+++ b/mcp/src/main/java/io/airlift/mcp/McpNotifier.java
@@ -1,6 +1,11 @@
 package io.airlift.mcp;
 
+import io.airlift.jsonrpc.model.JsonRpcRequest;
+import io.airlift.mcp.model.LoggingLevel;
+import io.airlift.mcp.session.SessionMetadata;
+
 import java.util.Optional;
+import java.util.function.Consumer;
 
 public interface McpNotifier
 {
@@ -9,4 +14,37 @@ public interface McpNotifier
     <T> void sendNotification(String notificationType, T data);
 
     void sendNotification(String notificationType);
+
+    /**
+     * Note: sendRequest() requires that session support is enabled in the MCP server
+     * via {@link McpModule.Builder#withSessionHandling(SessionMetadata, Consumer)}
+     * in order to get a response from a request. If session support is not enabled,
+     * the request will still be sent but no responses will be processed.
+     */
+    <T> void sendRequest(JsonRpcRequest<T> request);
+
+    /**
+     * Note: sendLog() requires that session support is enabled in the MCP server
+     * via {@link McpModule.Builder#withSessionHandling(SessionMetadata, Consumer)}.
+     * If session support is not enabled, this method does nothing. The server
+     * will check the currently set logging level for the session or the default
+     * before sending the log message.
+     */
+    <T> void sendLog(LoggingLevel level, String logger, T data);
+
+    /**
+     * Note: sendLog() requires that session support is enabled in the MCP server
+     * via {@link McpModule.Builder#withSessionHandling(SessionMetadata, Consumer)}
+     * If session support is not enabled, this method does nothing. The server
+     * will check the currently set logging level for the session or the default
+     * before sending the log message.
+     */
+    void sendLog(LoggingLevel level, String logger);
+
+    /**
+     * Returns {@code true} if the client has requested cancellation of the
+     * current request. Your operation should clean up and exit as soon as possible.
+     * If session support is not enabled, this method always returns {@code false}.
+     */
+    boolean cancellationRequested();
 }

--- a/mcp/src/main/java/io/airlift/mcp/McpPrompt.java
+++ b/mcp/src/main/java/io/airlift/mcp/McpPrompt.java
@@ -1,0 +1,20 @@
+package io.airlift.mcp;
+
+import io.airlift.mcp.model.Role;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface McpPrompt
+{
+    String name();
+
+    Role role() default Role.user;
+
+    String description() default "";
+}

--- a/mcp/src/main/java/io/airlift/mcp/McpResource.java
+++ b/mcp/src/main/java/io/airlift/mcp/McpResource.java
@@ -1,0 +1,28 @@
+package io.airlift.mcp;
+
+import io.airlift.mcp.model.Role;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface McpResource
+{
+    String name();
+
+    String uri();
+
+    String mimeType();
+
+    String description() default "";
+
+    long size() default -1;
+
+    Role[] audience() default {};
+
+    double priority() default Double.NaN;
+}

--- a/mcp/src/main/java/io/airlift/mcp/McpResourceTemplate.java
+++ b/mcp/src/main/java/io/airlift/mcp/McpResourceTemplate.java
@@ -1,0 +1,28 @@
+package io.airlift.mcp;
+
+import io.airlift.mcp.model.Role;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface McpResourceTemplate
+{
+    String name();
+
+    String uriTemplate();
+
+    String mimeType();
+
+    String description() default "";
+
+    long size() default -1;
+
+    Role[] audience() default {};
+
+    double priority() default Double.NaN;
+}

--- a/mcp/src/main/java/io/airlift/mcp/McpResources.java
+++ b/mcp/src/main/java/io/airlift/mcp/McpResources.java
@@ -1,0 +1,13 @@
+package io.airlift.mcp;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface McpResources
+{
+}

--- a/mcp/src/main/java/io/airlift/mcp/McpServer.java
+++ b/mcp/src/main/java/io/airlift/mcp/McpServer.java
@@ -1,0 +1,249 @@
+package io.airlift.mcp;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Streams;
+import com.google.inject.Inject;
+import io.airlift.jsonrpc.model.JsonRpcErrorDetail;
+import io.airlift.mcp.handler.CompletionEntry;
+import io.airlift.mcp.handler.Handlers;
+import io.airlift.mcp.handler.PromptEntry;
+import io.airlift.mcp.handler.ResourceEntry;
+import io.airlift.mcp.handler.ResourceTemplateEntry;
+import io.airlift.mcp.handler.ResourceTemplateHandler.PathTemplateValues;
+import io.airlift.mcp.handler.ToolEntry;
+import io.airlift.mcp.model.CallToolRequest;
+import io.airlift.mcp.model.CallToolResult;
+import io.airlift.mcp.model.Completion;
+import io.airlift.mcp.model.CompletionRequest;
+import io.airlift.mcp.model.CompletionResult;
+import io.airlift.mcp.model.GetPromptRequest;
+import io.airlift.mcp.model.GetPromptResult;
+import io.airlift.mcp.model.Implementation;
+import io.airlift.mcp.model.InitializeRequest;
+import io.airlift.mcp.model.InitializeResult;
+import io.airlift.mcp.model.InitializeResult.ServerCapabilities;
+import io.airlift.mcp.model.ListChanged;
+import io.airlift.mcp.model.ListPromptsResult;
+import io.airlift.mcp.model.ListResourceTemplatesResult;
+import io.airlift.mcp.model.ListResourcesResult;
+import io.airlift.mcp.model.ListToolsResponse;
+import io.airlift.mcp.model.Prompt;
+import io.airlift.mcp.model.ReadResourceRequest;
+import io.airlift.mcp.model.ReadResourceResult;
+import io.airlift.mcp.model.Resource;
+import io.airlift.mcp.model.ResourceContents;
+import io.airlift.mcp.model.ResourceTemplate;
+import io.airlift.mcp.model.ServerInfo;
+import io.airlift.mcp.model.SubscribeListChanged;
+import io.airlift.mcp.model.Tool;
+import jakarta.ws.rs.core.Request;
+import org.glassfish.jersey.uri.UriTemplate;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static com.google.common.base.Throwables.getRootCause;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.jsonrpc.model.JsonRpcErrorCode.INTERNAL_ERROR;
+import static io.airlift.jsonrpc.model.JsonRpcErrorCode.INVALID_PARAMS;
+import static io.airlift.mcp.model.Constants.PROTOCOL_VERSION;
+import static java.util.Objects.requireNonNull;
+
+public class McpServer
+{
+    private final ServerInfo serverInfo;
+    private final Handlers<ToolEntry> tools = new Handlers<>();
+    private final Handlers<PromptEntry> prompts = new Handlers<>();
+    private final Handlers<ResourceEntry> resources = new Handlers<>();
+    private final Handlers<ResourceTemplateEntry> resourceTemplates = new Handlers<>();
+    private final Handlers<CompletionEntry> completions = new Handlers<>();
+
+    @Inject
+    public McpServer(
+            ServerInfo serverInfo,
+            Map<String, ToolEntry> boundTools,
+            Map<String, PromptEntry> boundPrompts,
+            Map<String, ResourceEntry> boundResources,
+            Map<String, ResourceTemplateEntry> boundResourceTemplates,
+            Map<String, CompletionEntry> boundCompletions)
+    {
+        this.serverInfo = requireNonNull(serverInfo, "serverInfo is null");
+
+        boundTools.forEach(tools::add);
+        boundPrompts.forEach(prompts::add);
+        boundResources.forEach(resources::add);
+        boundResourceTemplates.forEach(resourceTemplates::add);
+        boundCompletions.forEach(completions::add);
+    }
+
+    public Handlers<ToolEntry> tools()
+    {
+        return tools;
+    }
+
+    public Handlers<PromptEntry> prompts()
+    {
+        return prompts;
+    }
+
+    public Handlers<ResourceEntry> resources()
+    {
+        return resources;
+    }
+
+    public Handlers<ResourceTemplateEntry> resourceTemplates()
+    {
+        return resourceTemplates;
+    }
+
+    public Handlers<CompletionEntry> completions()
+    {
+        return completions;
+    }
+
+    public InitializeResult initialize(InitializeRequest initializeRequest)
+    {
+        if (!initializeRequest.protocolVersion().equals(PROTOCOL_VERSION)) {
+            Map<String, Object> data = ImmutableMap.of("supported", new String[] {PROTOCOL_VERSION}, "requested", initializeRequest.protocolVersion());
+            throw JsonRpcErrorDetail.exception(INVALID_PARAMS, "Unsupported protocol version", data);
+        }
+
+        ServerCapabilities serverCapabilities = new ServerCapabilities(
+                completions.isEmpty() ? Optional.empty() : Optional.of(new InitializeResult.CompletionCapabilities()),
+                Optional.empty(),
+                prompts.isEmpty() ? Optional.empty() : Optional.of(new ListChanged(true)),
+                (resources.isEmpty() && resourceTemplates.isEmpty()) ? Optional.empty() : Optional.of(new SubscribeListChanged(false, false)),
+                tools.isEmpty() ? Optional.empty() : Optional.of(new ListChanged(false)));
+
+        return new InitializeResult(PROTOCOL_VERSION, serverCapabilities, new Implementation(serverInfo.serverName(), serverInfo.serverVersion()), serverInfo.instructions());
+    }
+
+    public ListToolsResponse listTools()
+    {
+        List<Tool> toolsList = tools.entries().map(ToolEntry::tool).collect(toImmutableList());
+        return new ListToolsResponse(toolsList);
+    }
+
+    public CallToolResult callTool(Request request, McpNotifier notifier, CallToolRequest callToolRequest)
+            throws McpException
+    {
+        return tools.entry(callToolRequest.name())
+                .map(toolEntry -> {
+                    try {
+                        return toolEntry.toolHandler().callTool(request, notifier, callToolRequest);
+                    }
+                    catch (Exception e) {
+                        throw handleException(e);
+                    }
+                })
+                .orElseThrow(() -> McpException.exception(INVALID_PARAMS, "Tool not found", ImmutableMap.of("name", callToolRequest.name())));
+    }
+
+    public ListPromptsResult listPrompts()
+    {
+        List<Prompt> pomptsList = prompts.entries().map(PromptEntry::prompt).collect(toImmutableList());
+        return new ListPromptsResult(pomptsList);
+    }
+
+    public GetPromptResult getPrompt(Request request, McpNotifier notifier, GetPromptRequest getPromptRequest)
+            throws McpException
+    {
+        return prompts.entry(getPromptRequest.name())
+                .map(promptEntry -> {
+                    try {
+                        return promptEntry.promptHandler().getPrompt(request, notifier, getPromptRequest);
+                    }
+                    catch (Exception e) {
+                        throw handleException(e);
+                    }
+                })
+                .orElseThrow(() -> McpException.exception(INVALID_PARAMS, "Prompt not found", ImmutableMap.of("name", getPromptRequest.name())));
+    }
+
+    public ListResourcesResult listResources()
+    {
+        List<Resource> resourcesList = resources.entries().map(ResourceEntry::resource).collect(toImmutableList());
+        return new ListResourcesResult(resourcesList);
+    }
+
+    public ListResourceTemplatesResult listResourceTemplates()
+    {
+        List<ResourceTemplate> resourceTemplatesList = resourceTemplates.entries().map(ResourceTemplateEntry::resourceTemplate).collect(toImmutableList());
+        return new ListResourceTemplatesResult(resourceTemplatesList);
+    }
+
+    public ReadResourceResult readResources(Request request, McpNotifier notifier, ReadResourceRequest readResourceRequest)
+            throws McpException
+    {
+        try {
+            Stream<ResourceContents> resourceContentsStream = resources.entries()
+                    .filter(resourceEntry -> resourceEntry.resource().uri().equals(readResourceRequest.uri()))
+                    .flatMap(resourceEntry -> resourceEntry.handler().readResource(request, notifier, resourceEntry.resource(), readResourceRequest).stream());
+
+            Stream<ResourceContents> resourceTemplateContentsStream = resourceTemplates.entries()
+                    .flatMap(resourceTemplateEntry -> {
+                        UriTemplate uriTemplate = new UriTemplate(resourceTemplateEntry.resourceTemplate().uriTemplate());
+                        Map<String, String> templateVariableToValue = new HashMap<>();
+                        if (uriTemplate.match(readResourceRequest.uri(), templateVariableToValue)) {
+                            return resourceTemplateEntry.handler().readResource(request, notifier, resourceTemplateEntry.resourceTemplate(), readResourceRequest, new PathTemplateValues(templateVariableToValue)).stream();
+                        }
+                        return Stream.of();
+                    });
+
+            List<ResourceContents> resourceContentsList = Streams.concat(resourceContentsStream, resourceTemplateContentsStream)
+                    .collect(toImmutableList());
+            return new ReadResourceResult(resourceContentsList);
+        }
+        catch (Exception e) {
+            throw handleException(e);
+        }
+    }
+
+    public CompletionResult completeCompletion(Request request, McpNotifier notifier, CompletionRequest completionRequest)
+            throws McpException
+    {
+        try {
+            Completion completion = completions.entries()
+                    .map(CompletionEntry::completionHandler)
+                    .flatMap(completionHandler -> completionHandler.completeCompletion(request, notifier, completionRequest).stream())
+                    .reduce(new Completion(ImmutableList.of()), this::mergeCompletions);
+            return new CompletionResult(completion);
+        }
+        catch (Exception e) {
+            throw handleException(e);
+        }
+    }
+
+    private Completion mergeCompletions(Completion c1, Completion c2)
+    {
+        List<String> combined = ImmutableList.<String>builder().addAll(c1.values()).addAll(c2.values()).build();
+        Optional<Integer> combinedTotal = (c1.total().isPresent() || c2.total().isPresent())
+                ? Optional.of(c1.total().orElse(0) + c2.total().orElse(0))
+                : Optional.empty();
+        boolean combinedHasMore = c1.hasMore() || c2.hasMore();
+        return new Completion(combined, combinedTotal, combinedHasMore);
+    }
+
+    private static McpException handleException(Exception exception)
+    {
+        return new McpException(fromException(exception));
+    }
+
+    private static JsonRpcErrorDetail fromException(Exception exception)
+    {
+        if (getRootCause(exception) instanceof McpException mcpException) {
+            return mcpException.errorDetail();
+        }
+
+        StringWriter stringWriter = new StringWriter();
+        exception.printStackTrace(new PrintWriter(stringWriter));
+
+        return new JsonRpcErrorDetail(INTERNAL_ERROR, stringWriter.toString());
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/McpTool.java
+++ b/mcp/src/main/java/io/airlift/mcp/McpTool.java
@@ -1,0 +1,31 @@
+package io.airlift.mcp;
+
+import io.airlift.mcp.model.OptionalBoolean;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static io.airlift.mcp.model.OptionalBoolean.UNDEFINED;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface McpTool
+{
+    String name();
+
+    String description() default "";
+
+    String title() default "";
+
+    OptionalBoolean readOnlyHint() default UNDEFINED;
+
+    OptionalBoolean destructiveHint() default UNDEFINED;
+
+    OptionalBoolean idempotentHint() default UNDEFINED;
+
+    OptionalBoolean openWorldHint() default UNDEFINED;
+
+    OptionalBoolean returnDirect() default UNDEFINED;
+}

--- a/mcp/src/main/java/io/airlift/mcp/handler/CompletionEntry.java
+++ b/mcp/src/main/java/io/airlift/mcp/handler/CompletionEntry.java
@@ -1,0 +1,12 @@
+package io.airlift.mcp.handler;
+
+import static java.util.Objects.requireNonNull;
+
+public record CompletionEntry(String completionName, CompletionHandler completionHandler)
+{
+    public CompletionEntry
+    {
+        requireNonNull(completionName, "completionName is null");
+        requireNonNull(completionHandler, "completionHandler is null");
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/handler/CompletionHandler.java
+++ b/mcp/src/main/java/io/airlift/mcp/handler/CompletionHandler.java
@@ -3,11 +3,12 @@ package io.airlift.mcp.handler;
 import io.airlift.mcp.McpNotifier;
 import io.airlift.mcp.model.Completion;
 import io.airlift.mcp.model.CompletionRequest;
+import io.airlift.mcp.session.SessionId;
 import jakarta.ws.rs.core.Request;
 
 import java.util.Optional;
 
 public interface CompletionHandler
 {
-    Optional<Completion> completeCompletion(Request request, McpNotifier notifier, CompletionRequest completionRequest);
+    Optional<Completion> completeCompletion(Request request, SessionId sessionId, McpNotifier notifier, CompletionRequest completionRequest);
 }

--- a/mcp/src/main/java/io/airlift/mcp/handler/CompletionHandler.java
+++ b/mcp/src/main/java/io/airlift/mcp/handler/CompletionHandler.java
@@ -1,0 +1,13 @@
+package io.airlift.mcp.handler;
+
+import io.airlift.mcp.McpNotifier;
+import io.airlift.mcp.model.Completion;
+import io.airlift.mcp.model.CompletionRequest;
+import jakarta.ws.rs.core.Request;
+
+import java.util.Optional;
+
+public interface CompletionHandler
+{
+    Optional<Completion> completeCompletion(Request request, McpNotifier notifier, CompletionRequest completionRequest);
+}

--- a/mcp/src/main/java/io/airlift/mcp/handler/CompletionHandler.java
+++ b/mcp/src/main/java/io/airlift/mcp/handler/CompletionHandler.java
@@ -3,12 +3,10 @@ package io.airlift.mcp.handler;
 import io.airlift.mcp.McpNotifier;
 import io.airlift.mcp.model.Completion;
 import io.airlift.mcp.model.CompletionRequest;
-import io.airlift.mcp.session.SessionId;
-import jakarta.ws.rs.core.Request;
 
 import java.util.Optional;
 
 public interface CompletionHandler
 {
-    Optional<Completion> completeCompletion(Request request, SessionId sessionId, McpNotifier notifier, CompletionRequest completionRequest);
+    Optional<Completion> completeCompletion(RequestContext requestContext, McpNotifier notifier, CompletionRequest completionRequest);
 }

--- a/mcp/src/main/java/io/airlift/mcp/handler/Handlers.java
+++ b/mcp/src/main/java/io/airlift/mcp/handler/Handlers.java
@@ -40,4 +40,9 @@ public class Handlers<T>
     {
         return entries.values().stream();
     }
+
+    public Stream<T> entriesAfter(String name)
+    {
+        return entries.tailMap(name, false).values().stream();
+    }
 }

--- a/mcp/src/main/java/io/airlift/mcp/handler/Handlers.java
+++ b/mcp/src/main/java/io/airlift/mcp/handler/Handlers.java
@@ -1,0 +1,43 @@
+package io.airlift.mcp.handler;
+
+import java.util.Optional;
+import java.util.concurrent.ConcurrentNavigableMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.stream.Stream;
+
+public class Handlers<T>
+{
+    private final ConcurrentNavigableMap<String, T> entries = new ConcurrentSkipListMap<>();
+
+    public void add(String name, T entry)
+    {
+        if (entries.put(name, entry) != null) {
+            throw new IllegalArgumentException("Entry with name \"%s\" already exists".formatted(name));
+        }
+    }
+
+    public boolean remove(String name)
+    {
+        return (entries.remove(name) != null);
+    }
+
+    public Optional<T> entry(String name)
+    {
+        return Optional.ofNullable(entries.get(name));
+    }
+
+    public int size()
+    {
+        return entries.size();
+    }
+
+    public boolean isEmpty()
+    {
+        return entries.isEmpty();
+    }
+
+    public Stream<T> entries()
+    {
+        return entries.values().stream();
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/handler/PromptEntry.java
+++ b/mcp/src/main/java/io/airlift/mcp/handler/PromptEntry.java
@@ -1,0 +1,14 @@
+package io.airlift.mcp.handler;
+
+import io.airlift.mcp.model.Prompt;
+
+import static java.util.Objects.requireNonNull;
+
+public record PromptEntry(Prompt prompt, PromptHandler promptHandler)
+{
+    public PromptEntry
+    {
+        requireNonNull(prompt, "prompt is null");
+        requireNonNull(promptHandler, "promptHandler is null");
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/handler/PromptHandler.java
+++ b/mcp/src/main/java/io/airlift/mcp/handler/PromptHandler.java
@@ -1,0 +1,11 @@
+package io.airlift.mcp.handler;
+
+import io.airlift.mcp.McpNotifier;
+import io.airlift.mcp.model.GetPromptRequest;
+import io.airlift.mcp.model.GetPromptResult;
+import jakarta.ws.rs.core.Request;
+
+public interface PromptHandler
+{
+    GetPromptResult getPrompt(Request request, McpNotifier notifier, GetPromptRequest getPromptRequest);
+}

--- a/mcp/src/main/java/io/airlift/mcp/handler/PromptHandler.java
+++ b/mcp/src/main/java/io/airlift/mcp/handler/PromptHandler.java
@@ -3,10 +3,8 @@ package io.airlift.mcp.handler;
 import io.airlift.mcp.McpNotifier;
 import io.airlift.mcp.model.GetPromptRequest;
 import io.airlift.mcp.model.GetPromptResult;
-import io.airlift.mcp.session.SessionId;
-import jakarta.ws.rs.core.Request;
 
 public interface PromptHandler
 {
-    GetPromptResult getPrompt(Request request, SessionId sessionId, McpNotifier notifier, GetPromptRequest getPromptRequest);
+    GetPromptResult getPrompt(RequestContext requestContext, McpNotifier notifier, GetPromptRequest getPromptRequest);
 }

--- a/mcp/src/main/java/io/airlift/mcp/handler/PromptHandler.java
+++ b/mcp/src/main/java/io/airlift/mcp/handler/PromptHandler.java
@@ -3,9 +3,10 @@ package io.airlift.mcp.handler;
 import io.airlift.mcp.McpNotifier;
 import io.airlift.mcp.model.GetPromptRequest;
 import io.airlift.mcp.model.GetPromptResult;
+import io.airlift.mcp.session.SessionId;
 import jakarta.ws.rs.core.Request;
 
 public interface PromptHandler
 {
-    GetPromptResult getPrompt(Request request, McpNotifier notifier, GetPromptRequest getPromptRequest);
+    GetPromptResult getPrompt(Request request, SessionId sessionId, McpNotifier notifier, GetPromptRequest getPromptRequest);
 }

--- a/mcp/src/main/java/io/airlift/mcp/handler/RequestContext.java
+++ b/mcp/src/main/java/io/airlift/mcp/handler/RequestContext.java
@@ -1,5 +1,6 @@
 package io.airlift.mcp.handler;
 
+import io.airlift.mcp.model.Pagination;
 import io.airlift.mcp.session.SessionId;
 import jakarta.ws.rs.core.Request;
 import jakarta.ws.rs.ext.Providers;
@@ -7,7 +8,7 @@ import org.glassfish.jersey.spi.ContextResolvers;
 
 import static java.util.Objects.requireNonNull;
 
-public record RequestContext(Request request, SessionId sessionId, Providers providers, ContextResolvers contextResolvers)
+public record RequestContext(Request request, SessionId sessionId, Providers providers, ContextResolvers contextResolvers, Pagination pagination)
 {
     public RequestContext
     {
@@ -15,5 +16,6 @@ public record RequestContext(Request request, SessionId sessionId, Providers pro
         requireNonNull(sessionId, "sessionId is null");
         requireNonNull(providers, "providers is null");
         requireNonNull(contextResolvers, "contextResolvers is null");
+        requireNonNull(pagination, "pagination is null");
     }
 }

--- a/mcp/src/main/java/io/airlift/mcp/handler/RequestContext.java
+++ b/mcp/src/main/java/io/airlift/mcp/handler/RequestContext.java
@@ -1,0 +1,19 @@
+package io.airlift.mcp.handler;
+
+import io.airlift.mcp.session.SessionId;
+import jakarta.ws.rs.core.Request;
+import jakarta.ws.rs.ext.Providers;
+import org.glassfish.jersey.spi.ContextResolvers;
+
+import static java.util.Objects.requireNonNull;
+
+public record RequestContext(Request request, SessionId sessionId, Providers providers, ContextResolvers contextResolvers)
+{
+    public RequestContext
+    {
+        requireNonNull(request, "request is null");
+        requireNonNull(sessionId, "sessionId is null");
+        requireNonNull(providers, "providers is null");
+        requireNonNull(contextResolvers, "contextResolvers is null");
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/handler/ResourceEntry.java
+++ b/mcp/src/main/java/io/airlift/mcp/handler/ResourceEntry.java
@@ -1,0 +1,14 @@
+package io.airlift.mcp.handler;
+
+import io.airlift.mcp.model.Resource;
+
+import static java.util.Objects.requireNonNull;
+
+public record ResourceEntry(Resource resource, ResourceHandler handler)
+{
+    public ResourceEntry
+    {
+        requireNonNull(resource, "resource is null");
+        requireNonNull(handler, "handler is null");
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/handler/ResourceHandler.java
+++ b/mcp/src/main/java/io/airlift/mcp/handler/ResourceHandler.java
@@ -1,0 +1,14 @@
+package io.airlift.mcp.handler;
+
+import io.airlift.mcp.McpNotifier;
+import io.airlift.mcp.model.ReadResourceRequest;
+import io.airlift.mcp.model.Resource;
+import io.airlift.mcp.model.ResourceContents;
+import jakarta.ws.rs.core.Request;
+
+import java.util.List;
+
+public interface ResourceHandler
+{
+    List<ResourceContents> readResource(Request request, McpNotifier notifier, Resource sourceResource, ReadResourceRequest readResourceRequest);
+}

--- a/mcp/src/main/java/io/airlift/mcp/handler/ResourceHandler.java
+++ b/mcp/src/main/java/io/airlift/mcp/handler/ResourceHandler.java
@@ -4,11 +4,12 @@ import io.airlift.mcp.McpNotifier;
 import io.airlift.mcp.model.ReadResourceRequest;
 import io.airlift.mcp.model.Resource;
 import io.airlift.mcp.model.ResourceContents;
+import io.airlift.mcp.session.SessionId;
 import jakarta.ws.rs.core.Request;
 
 import java.util.List;
 
 public interface ResourceHandler
 {
-    List<ResourceContents> readResource(Request request, McpNotifier notifier, Resource sourceResource, ReadResourceRequest readResourceRequest);
+    List<ResourceContents> readResource(Request request, SessionId sessionId, McpNotifier notifier, Resource sourceResource, ReadResourceRequest readResourceRequest);
 }

--- a/mcp/src/main/java/io/airlift/mcp/handler/ResourceHandler.java
+++ b/mcp/src/main/java/io/airlift/mcp/handler/ResourceHandler.java
@@ -4,12 +4,10 @@ import io.airlift.mcp.McpNotifier;
 import io.airlift.mcp.model.ReadResourceRequest;
 import io.airlift.mcp.model.Resource;
 import io.airlift.mcp.model.ResourceContents;
-import io.airlift.mcp.session.SessionId;
-import jakarta.ws.rs.core.Request;
 
 import java.util.List;
 
 public interface ResourceHandler
 {
-    List<ResourceContents> readResource(Request request, SessionId sessionId, McpNotifier notifier, Resource sourceResource, ReadResourceRequest readResourceRequest);
+    List<ResourceContents> readResource(RequestContext requestContext, McpNotifier notifier, Resource sourceResource, ReadResourceRequest readResourceRequest);
 }

--- a/mcp/src/main/java/io/airlift/mcp/handler/ResourceTemplateEntry.java
+++ b/mcp/src/main/java/io/airlift/mcp/handler/ResourceTemplateEntry.java
@@ -1,0 +1,14 @@
+package io.airlift.mcp.handler;
+
+import io.airlift.mcp.model.ResourceTemplate;
+
+import static java.util.Objects.requireNonNull;
+
+public record ResourceTemplateEntry(ResourceTemplate resourceTemplate, ResourceTemplateHandler handler)
+{
+    public ResourceTemplateEntry
+    {
+        requireNonNull(resourceTemplate, "resourceTemplate is null");
+        requireNonNull(handler, "handler is null");
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/handler/ResourceTemplateHandler.java
+++ b/mcp/src/main/java/io/airlift/mcp/handler/ResourceTemplateHandler.java
@@ -5,8 +5,6 @@ import io.airlift.mcp.McpNotifier;
 import io.airlift.mcp.model.ReadResourceRequest;
 import io.airlift.mcp.model.ResourceContents;
 import io.airlift.mcp.model.ResourceTemplate;
-import io.airlift.mcp.session.SessionId;
-import jakarta.ws.rs.core.Request;
 
 import java.util.List;
 import java.util.Map;
@@ -21,5 +19,5 @@ public interface ResourceTemplateHandler
         }
     }
 
-    List<ResourceContents> readResource(Request request, SessionId sessionId, McpNotifier notifier, ResourceTemplate sourceResourceTemplate, ReadResourceRequest readResourceRequest, PathTemplateValues pathTemplateValues);
+    List<ResourceContents> readResource(RequestContext requestContext, McpNotifier notifier, ResourceTemplate sourceResourceTemplate, ReadResourceRequest readResourceRequest, PathTemplateValues pathTemplateValues);
 }

--- a/mcp/src/main/java/io/airlift/mcp/handler/ResourceTemplateHandler.java
+++ b/mcp/src/main/java/io/airlift/mcp/handler/ResourceTemplateHandler.java
@@ -1,0 +1,24 @@
+package io.airlift.mcp.handler;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.mcp.McpNotifier;
+import io.airlift.mcp.model.ReadResourceRequest;
+import io.airlift.mcp.model.ResourceContents;
+import io.airlift.mcp.model.ResourceTemplate;
+import jakarta.ws.rs.core.Request;
+
+import java.util.List;
+import java.util.Map;
+
+public interface ResourceTemplateHandler
+{
+    record PathTemplateValues(Map<String, String> values)
+    {
+        public PathTemplateValues
+        {
+            values = ImmutableMap.copyOf(values);
+        }
+    }
+
+    List<ResourceContents> readResource(Request request, McpNotifier notifier, ResourceTemplate sourceResourceTemplate, ReadResourceRequest readResourceRequest, PathTemplateValues pathTemplateValues);
+}

--- a/mcp/src/main/java/io/airlift/mcp/handler/ResourceTemplateHandler.java
+++ b/mcp/src/main/java/io/airlift/mcp/handler/ResourceTemplateHandler.java
@@ -5,6 +5,7 @@ import io.airlift.mcp.McpNotifier;
 import io.airlift.mcp.model.ReadResourceRequest;
 import io.airlift.mcp.model.ResourceContents;
 import io.airlift.mcp.model.ResourceTemplate;
+import io.airlift.mcp.session.SessionId;
 import jakarta.ws.rs.core.Request;
 
 import java.util.List;
@@ -20,5 +21,5 @@ public interface ResourceTemplateHandler
         }
     }
 
-    List<ResourceContents> readResource(Request request, McpNotifier notifier, ResourceTemplate sourceResourceTemplate, ReadResourceRequest readResourceRequest, PathTemplateValues pathTemplateValues);
+    List<ResourceContents> readResource(Request request, SessionId sessionId, McpNotifier notifier, ResourceTemplate sourceResourceTemplate, ReadResourceRequest readResourceRequest, PathTemplateValues pathTemplateValues);
 }

--- a/mcp/src/main/java/io/airlift/mcp/handler/ToolEntry.java
+++ b/mcp/src/main/java/io/airlift/mcp/handler/ToolEntry.java
@@ -1,0 +1,14 @@
+package io.airlift.mcp.handler;
+
+import io.airlift.mcp.model.Tool;
+
+import static java.util.Objects.requireNonNull;
+
+public record ToolEntry(Tool tool, ToolHandler toolHandler)
+{
+    public ToolEntry
+    {
+        requireNonNull(tool, "tool is null");
+        requireNonNull(toolHandler, "toolHandler is null");
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/handler/ToolHandler.java
+++ b/mcp/src/main/java/io/airlift/mcp/handler/ToolHandler.java
@@ -3,10 +3,8 @@ package io.airlift.mcp.handler;
 import io.airlift.mcp.McpNotifier;
 import io.airlift.mcp.model.CallToolRequest;
 import io.airlift.mcp.model.CallToolResult;
-import io.airlift.mcp.session.SessionId;
-import jakarta.ws.rs.core.Request;
 
 public interface ToolHandler
 {
-    CallToolResult callTool(Request request, SessionId sessionId, McpNotifier notifier, CallToolRequest toolRequest);
+    CallToolResult callTool(RequestContext requestContext, McpNotifier notifier, CallToolRequest toolRequest);
 }

--- a/mcp/src/main/java/io/airlift/mcp/handler/ToolHandler.java
+++ b/mcp/src/main/java/io/airlift/mcp/handler/ToolHandler.java
@@ -1,0 +1,11 @@
+package io.airlift.mcp.handler;
+
+import io.airlift.mcp.McpNotifier;
+import io.airlift.mcp.model.CallToolRequest;
+import io.airlift.mcp.model.CallToolResult;
+import jakarta.ws.rs.core.Request;
+
+public interface ToolHandler
+{
+    CallToolResult callTool(Request request, McpNotifier notifier, CallToolRequest toolRequest);
+}

--- a/mcp/src/main/java/io/airlift/mcp/handler/ToolHandler.java
+++ b/mcp/src/main/java/io/airlift/mcp/handler/ToolHandler.java
@@ -3,9 +3,10 @@ package io.airlift.mcp.handler;
 import io.airlift.mcp.McpNotifier;
 import io.airlift.mcp.model.CallToolRequest;
 import io.airlift.mcp.model.CallToolResult;
+import io.airlift.mcp.session.SessionId;
 import jakarta.ws.rs.core.Request;
 
 public interface ToolHandler
 {
-    CallToolResult callTool(Request request, McpNotifier notifier, CallToolRequest toolRequest);
+    CallToolResult callTool(Request request, SessionId sessionId, McpNotifier notifier, CallToolRequest toolRequest);
 }

--- a/mcp/src/main/java/io/airlift/mcp/internal/BufferDefeatingStreamingOutput.java
+++ b/mcp/src/main/java/io/airlift/mcp/internal/BufferDefeatingStreamingOutput.java
@@ -1,0 +1,54 @@
+package io.airlift.mcp.internal;
+
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.StreamingOutput;
+import org.glassfish.jersey.server.ChunkedOutput;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import static java.util.Objects.requireNonNull;
+
+/*
+    Jersey buffers output until it exceeds a max, and then it switches
+    to chunked output. However, their ChunkedOutput requires threading.
+    StreamingOutput is much better. This class looks to Jersey like
+    it's both a StreamingOutput and a ChunkedOutput so you get
+    the nice StreamingOutput behavior without the buffering.
+ */
+class BufferDefeatingStreamingOutput
+        extends ChunkedOutput<String>
+        implements StreamingOutput
+{
+    private final StreamingOutput delegate;
+
+    BufferDefeatingStreamingOutput(StreamingOutput delegate)
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+    }
+
+    @Override
+    public void write(String chunk)
+    {
+        throw new UnsupportedOperationException("Use StreamingOutput.write(OutputStream) instead");
+    }
+
+    @Override
+    public void write(OutputStream output)
+            throws IOException, WebApplicationException
+    {
+        try {
+            delegate.write(output);
+        }
+        finally {
+            // if we don't close the chunked output stream, Jersey will hang
+            close();
+        }
+    }
+
+    @Override
+    protected void flushQueue()
+    {
+        // do nothing
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/internal/InternalMcpModule.java
+++ b/mcp/src/main/java/io/airlift/mcp/internal/InternalMcpModule.java
@@ -1,0 +1,210 @@
+package io.airlift.mcp.internal;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.binder.LinkedBindingBuilder;
+import com.google.inject.multibindings.MapBinder;
+import io.airlift.json.JsonSubType;
+import io.airlift.json.JsonSubTypeBinder;
+import io.airlift.jsonrpc.JsonRpcMethod;
+import io.airlift.jsonrpc.JsonRpcModule;
+import io.airlift.jsonrpc.JsonRpcRequestFilter;
+import io.airlift.mcp.McpCompletion;
+import io.airlift.mcp.McpModule;
+import io.airlift.mcp.McpPrompt;
+import io.airlift.mcp.McpResource;
+import io.airlift.mcp.McpResourceTemplate;
+import io.airlift.mcp.McpServer;
+import io.airlift.mcp.McpTool;
+import io.airlift.mcp.handler.CompletionEntry;
+import io.airlift.mcp.handler.PromptEntry;
+import io.airlift.mcp.handler.ResourceEntry;
+import io.airlift.mcp.handler.ResourceTemplateEntry;
+import io.airlift.mcp.handler.ToolEntry;
+import io.airlift.mcp.model.CompletionReference;
+import io.airlift.mcp.model.Content;
+import io.airlift.mcp.model.Content.AudioContent;
+import io.airlift.mcp.model.Content.EmbeddedResource;
+import io.airlift.mcp.model.Content.ImageContent;
+import io.airlift.mcp.model.Content.ResourceLink;
+import io.airlift.mcp.model.Content.TextContent;
+import io.airlift.mcp.model.ServerInfo;
+import io.airlift.mcp.reflection.CompletionHandlerProvider;
+import io.airlift.mcp.reflection.PromptHandlerProvider;
+import io.airlift.mcp.reflection.ResourceHandlerProvider;
+import io.airlift.mcp.reflection.ResourceTemplateHandlerProvider;
+import io.airlift.mcp.reflection.ToolHandlerProvider;
+
+import java.util.function.Consumer;
+
+import static com.google.inject.Scopes.SINGLETON;
+import static com.google.inject.multibindings.MapBinder.newMapBinder;
+import static io.airlift.json.JsonSubTypeBinder.jsonSubTypeBinder;
+import static io.airlift.mcp.reflection.ReflectionHelper.forAllInClass;
+
+public class InternalMcpModule
+{
+    private InternalMcpModule() {}
+
+    public static McpModule.Builder builder()
+    {
+        return new McpModule.Builder()
+        {
+            private final JsonRpcModule.Builder<?> jsonRpcBuilder = JsonRpcModule.builder().withBasePath("mcp");
+            private final ImmutableSet.Builder<Class<?>> instances = ImmutableSet.builder();
+            private final ImmutableMap.Builder<String, ToolHandlerProvider> tools = ImmutableMap.builder();
+            private final ImmutableMap.Builder<String, PromptHandlerProvider> prompts = ImmutableMap.builder();
+            private final ImmutableMap.Builder<String, CompletionHandlerProvider> completions = ImmutableMap.builder();
+            private final ImmutableMap.Builder<String, ResourceHandlerProvider> resources = ImmutableMap.builder();
+            private final ImmutableMap.Builder<String, ResourceTemplateHandlerProvider> resourceTemplates = ImmutableMap.builder();
+            private ServerInfo serverInfo = new ServerInfo("MCP", "1.0.0", "");
+
+            @Override
+            public McpModule.Builder withServerInfo(String serverName, String serverVersion, String instructions)
+            {
+                this.serverInfo = new ServerInfo(serverName, serverVersion, instructions);
+                return this;
+            }
+
+            @Override
+            public McpModule.Builder withBasePath(String basePath)
+            {
+                jsonRpcBuilder.withBasePath(basePath);
+                return this;
+            }
+
+            @Override
+            public McpModule.Builder add(JsonRpcMethod jsonRpcMethod)
+            {
+                jsonRpcBuilder.add(jsonRpcMethod);
+                return this;
+            }
+
+            @Override
+            public McpModule.Builder addAllInClass(Class<?> clazz)
+            {
+                instances.add(clazz);
+
+                addToolsInClass(clazz);
+                addPromptsInClass(clazz);
+                addCompletionsInClass(clazz);
+                addResourcesInClass(clazz);
+                addResourceTemplatesInClass(clazz);
+
+                return this;
+            }
+
+            @Override
+            public McpModule.Builder withRequestFilter(Consumer<LinkedBindingBuilder<JsonRpcRequestFilter>> binding)
+            {
+                jsonRpcBuilder.withRequestFilter(binding);
+                return this;
+            }
+
+            @Override
+            public Module build()
+            {
+                JsonRpcMethod.addAllInClass(jsonRpcBuilder, InternalRpcMethods.class);
+
+                return binder -> {
+                    binder.bind(McpServer.class).in(SINGLETON);
+                    binder.bind(ServerInfo.class).toInstance(serverInfo);
+                    binder.install(jsonRpcBuilder.build());
+
+                    instances.build().forEach(instance -> binder.bind(instance).in(SINGLETON));
+
+                    bindTools(binder);
+                    bindPrompts(binder);
+                    bindResources(binder);
+                    bindResourceTemplates(binder);
+                    bindCompletions(binder);
+                    bindJsonSubTypes(binder);
+                };
+            }
+
+            private void bindJsonSubTypes(Binder binder)
+            {
+                JsonSubTypeBinder jsonSubTypeBinder = jsonSubTypeBinder(binder);
+
+                JsonSubType contentJsonSubType = JsonSubType.builder()
+                        .forBase(Content.class, "type")
+                        .add(TextContent.class, "text")
+                        .add(ImageContent.class, "image")
+                        .add(AudioContent.class, "audio")
+                        .add(EmbeddedResource.class, "resource")
+                        .add(ResourceLink.class, "resource_link")
+                        .build();
+                jsonSubTypeBinder.bindJsonSubType(contentJsonSubType);
+
+                JsonSubType completionSubType = JsonSubType.builder()
+                        .forBase(CompletionReference.class, "type")
+                        .add(CompletionReference.Prompt.class, CompletionReference.Prompt.TYPE)
+                        .add(CompletionReference.Resource.class, CompletionReference.Resource.TYPE)
+                        .build();
+                jsonSubTypeBinder.bindJsonSubType(completionSubType);
+            }
+
+            private void bindCompletions(Binder binder)
+            {
+                MapBinder<String, CompletionEntry> completionBinder = newMapBinder(binder, String.class, CompletionEntry.class);
+                completions.build().forEach((completion, completionHandlerProvider) -> completionBinder.addBinding(completion).toProvider(completionHandlerProvider));
+            }
+
+            private void bindPrompts(Binder binder)
+            {
+                MapBinder<String, PromptEntry> promptBinder = newMapBinder(binder, String.class, PromptEntry.class);
+                prompts.build().forEach((prompt, promptHandlerProvider) -> promptBinder.addBinding(prompt).toProvider(promptHandlerProvider));
+            }
+
+            private void bindTools(Binder binder)
+            {
+                MapBinder<String, ToolEntry> toolBinder = newMapBinder(binder, String.class, ToolEntry.class);
+                tools.build().forEach((tool, toolHandlerProvider) -> toolBinder.addBinding(tool).toProvider(toolHandlerProvider));
+            }
+
+            private void bindResources(Binder binder)
+            {
+                MapBinder<String, ResourceEntry> resourceBinder = newMapBinder(binder, String.class, ResourceEntry.class);
+                resources.build().forEach((resource, resourceHandlerProvider) -> resourceBinder.addBinding(resource).toProvider(resourceHandlerProvider));
+            }
+
+            private void bindResourceTemplates(Binder binder)
+            {
+                MapBinder<String, ResourceTemplateEntry> resourceTemplateBinder = newMapBinder(binder, String.class, ResourceTemplateEntry.class);
+                resourceTemplates.build().forEach((resource, resourceHandlerProvider) -> resourceTemplateBinder.addBinding(resource).toProvider(resourceHandlerProvider));
+            }
+
+            private void addResourcesInClass(Class<?> clazz)
+            {
+                forAllInClass(clazz, McpResource.class, (mcpResource, method, parameters) ->
+                        resources.put(mcpResource.name(), new ResourceHandlerProvider(mcpResource, clazz, method, parameters)));
+            }
+
+            private void addResourceTemplatesInClass(Class<?> clazz)
+            {
+                forAllInClass(clazz, McpResourceTemplate.class, (mcpResourceTemplate, method, parameters) ->
+                        resourceTemplates.put(mcpResourceTemplate.name(), new ResourceTemplateHandlerProvider(mcpResourceTemplate, clazz, method, parameters)));
+            }
+
+            private void addCompletionsInClass(Class<?> clazz)
+            {
+                forAllInClass(clazz, McpCompletion.class, (mcpCompletion, method, parameters) ->
+                        completions.put(mcpCompletion.name(), new CompletionHandlerProvider(mcpCompletion, clazz, method, parameters)));
+            }
+
+            private void addPromptsInClass(Class<?> clazz)
+            {
+                forAllInClass(clazz, McpPrompt.class, (mcpPrompt, method, parameters) ->
+                        prompts.put(mcpPrompt.name(), new PromptHandlerProvider(mcpPrompt, clazz, method, parameters, mcpPrompt.role())));
+            }
+
+            private void addToolsInClass(Class<?> clazz)
+            {
+                forAllInClass(clazz, McpTool.class, (mcpTool, method, parameters) ->
+                        tools.put(mcpTool.name(), new ToolHandlerProvider(mcpTool, clazz, method, parameters)));
+            }
+        };
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/internal/InternalMcpModule.java
+++ b/mcp/src/main/java/io/airlift/mcp/internal/InternalMcpModule.java
@@ -32,6 +32,7 @@ import io.airlift.mcp.model.Content.EmbeddedResource;
 import io.airlift.mcp.model.Content.ImageContent;
 import io.airlift.mcp.model.Content.ResourceLink;
 import io.airlift.mcp.model.Content.TextContent;
+import io.airlift.mcp.model.PaginationMetadata;
 import io.airlift.mcp.model.ServerInfo;
 import io.airlift.mcp.reflection.CompletionHandlerProvider;
 import io.airlift.mcp.reflection.JerseyContextEmulation;
@@ -74,6 +75,7 @@ public class InternalMcpModule
             private String mcpPath = DEFAULT_MCP_PATH;
             private SessionMetadata sessionMetadata = SessionMetadata.DEFAULT;
             private ServerInfo serverInfo = new ServerInfo("MCP", "1.0.0", "");
+            private PaginationMetadata paginationMetadata = PaginationMetadata.DEFAULT;
 
             @Override
             public McpModule.Builder withServerInfo(String serverName, String serverVersion, String instructions)
@@ -127,6 +129,13 @@ public class InternalMcpModule
             }
 
             @Override
+            public McpModule.Builder withPaginationMetadata(PaginationMetadata paginationMetadata)
+            {
+                this.paginationMetadata = requireNonNull(paginationMetadata, "paginationMetadata is null");
+                return this;
+            }
+
+            @Override
             public Module build()
             {
                 JsonRpcMethod.addAllInClass(jsonRpcBuilder, InternalRpcMethods.class);
@@ -136,6 +145,7 @@ public class InternalMcpModule
                     binder.bind(JerseyContextEmulation.class).in(SINGLETON);
                     binder.bind(ServerInfo.class).toInstance(serverInfo);
                     binder.install(jsonRpcBuilder.build());
+                    binder.bind(PaginationMetadata.class).toInstance(paginationMetadata);
 
                     instances.build().forEach(instance -> binder.bind(instance).in(SINGLETON));
 

--- a/mcp/src/main/java/io/airlift/mcp/internal/InternalMcpModule.java
+++ b/mcp/src/main/java/io/airlift/mcp/internal/InternalMcpModule.java
@@ -34,6 +34,7 @@ import io.airlift.mcp.model.Content.ResourceLink;
 import io.airlift.mcp.model.Content.TextContent;
 import io.airlift.mcp.model.ServerInfo;
 import io.airlift.mcp.reflection.CompletionHandlerProvider;
+import io.airlift.mcp.reflection.JerseyContextEmulation;
 import io.airlift.mcp.reflection.PromptHandlerProvider;
 import io.airlift.mcp.reflection.ResourceHandlerProvider;
 import io.airlift.mcp.reflection.ResourceTemplateHandlerProvider;
@@ -132,6 +133,7 @@ public class InternalMcpModule
 
                 return binder -> {
                     binder.bind(McpServer.class).in(SINGLETON);
+                    binder.bind(JerseyContextEmulation.class).in(SINGLETON);
                     binder.bind(ServerInfo.class).toInstance(serverInfo);
                     binder.install(jsonRpcBuilder.build());
 

--- a/mcp/src/main/java/io/airlift/mcp/internal/InternalNotifier.java
+++ b/mcp/src/main/java/io/airlift/mcp/internal/InternalNotifier.java
@@ -4,9 +4,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.airlift.jsonrpc.model.JsonRpcErrorDetail;
 import io.airlift.jsonrpc.model.JsonRpcRequest;
 import io.airlift.jsonrpc.model.JsonRpcResponse;
+import io.airlift.log.Logger;
 import io.airlift.mcp.McpNotifier;
+import io.airlift.mcp.model.LoggingLevel;
+import io.airlift.mcp.model.LoggingMessageNotification;
 import io.airlift.mcp.model.Meta;
 import io.airlift.mcp.model.ProgressNotification;
+import io.airlift.mcp.session.RequestState;
+import io.airlift.mcp.session.SessionController;
+import io.airlift.mcp.session.SessionId;
 import jakarta.ws.rs.core.Request;
 
 import java.io.IOException;
@@ -17,9 +23,13 @@ import java.io.Writer;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static io.airlift.jsonrpc.model.JsonRpcRequest.buildNotification;
 import static io.airlift.jsonrpc.model.JsonRpcResponse.buildErrorResponse;
 import static io.airlift.jsonrpc.model.JsonRpcResponse.buildResponse;
+import static io.airlift.mcp.internal.InternalRpcMethods.currentRequestId;
+import static io.airlift.mcp.internal.InternalSessionResource.SERVER_TO_CLIENT_ID_SIGNIFIER;
+import static io.airlift.mcp.model.Constants.NOTIFICATION_MESSAGE;
 import static io.airlift.mcp.model.Constants.NOTIFICATION_PROGRESS;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
@@ -27,15 +37,21 @@ import static java.util.Objects.requireNonNull;
 class InternalNotifier
         implements McpNotifier
 {
+    private static final Logger log = Logger.get(InternalNotifier.class);
+
     private final Request request;
+    private final Optional<SessionController> sessionController;
+    private final SessionId sessionId;
     private final ObjectMapper objectMapper;
     private final String progressToken;
     private final AtomicLong eventId;
     private final Writer writer;
 
-    InternalNotifier(Request request, ObjectMapper objectMapper, Meta meta, OutputStream output)
+    InternalNotifier(Request request, Optional<SessionController> sessionController, SessionId sessionId, ObjectMapper objectMapper, Meta meta, OutputStream output)
     {
         this.request = requireNonNull(request, "request is null");
+        this.sessionController = requireNonNull(sessionController, "sessionController is null");
+        this.sessionId = requireNonNull(sessionId, "sessionId is null");
         this.objectMapper = requireNonNull(objectMapper, "objectMapper is null");
         this.eventId = new AtomicLong();
         this.writer = new OutputStreamWriter(output, UTF_8);
@@ -67,6 +83,47 @@ class InternalNotifier
         writeEvent(notification);
     }
 
+    @Override
+    public <T> void sendLog(LoggingLevel level, String logger, T data)
+    {
+        writeLog(level, logger, Optional.of(data));
+    }
+
+    @Override
+    public void sendLog(LoggingLevel level, String logger)
+    {
+        writeLog(level, logger, Optional.empty());
+    }
+
+    @Override
+    public <T> void sendRequest(JsonRpcRequest<T> request)
+    {
+        // NOTE: sendRequest is for session-based client-to-server requests where a response is expected
+        // writeRequest is context-free. It merely writes any request.
+
+        Object givenId = firstNonNull(request.id(), "");
+        String appliedId = SERVER_TO_CLIENT_ID_SIGNIFIER + givenId;
+
+        JsonRpcRequest<?> appliedRequest = request.params()
+                .map(params -> JsonRpcRequest.buildRequest(appliedId, request.method(), params))
+                .orElseGet(() -> JsonRpcRequest.buildRequest(appliedId, request.method()));
+
+        writeEvent(appliedRequest);
+    }
+
+    @Override
+    public boolean cancellationRequested()
+    {
+        RequestState requestState = sessionController.flatMap(controller -> currentRequestId(request).map(requestId -> controller.requestState(sessionId, String.valueOf(requestId))))
+                .orElse(RequestState.ENDED);
+        return requestState == RequestState.CANCELLATION_REQUESTED;
+    }
+
+    <T> void writeRequest(JsonRpcRequest<T> request)
+    {
+        writeEvent(request);
+    }
+
     void writeResult(Object data)
     {
         JsonRpcResponse<Object> response = buildResponse(request, data);
@@ -79,10 +136,31 @@ class InternalNotifier
         writeEvent(response);
     }
 
+    long nextEventId()
+    {
+        return eventId.getAndIncrement();
+    }
+
+    private void writeLog(LoggingLevel level, String logger, Optional<Object> maybeData)
+    {
+        sessionController.ifPresentOrElse(controller -> {
+            try {
+                LoggingLevel sessionLoggingLevel = controller.loggingLevel(sessionId);
+                if (sessionLoggingLevel.ordinal() <= level.ordinal()) {
+                    LoggingMessageNotification loggingMessageNotification = new LoggingMessageNotification(level, logger, maybeData);
+                    sendNotification(NOTIFICATION_MESSAGE, loggingMessageNotification);
+                }
+            }
+            catch (Exception e) {
+                log.error(e, "Failed to read session state for session %s while logging: %s", sessionId, logger);
+            }
+        }, () -> log.debug("Sessions are not supported by this server, logging will not be recorded: %s", logger));
+    }
+
     private void writeEvent(Object data)
     {
         try {
-            writer.write("id: event-%s%n".formatted(eventId.getAndIncrement()));
+            writer.write("id: event-%s%n".formatted(nextEventId()));
             writer.write("data: %s%n".formatted(encode(objectMapper.writeValueAsString(data))));
             writer.write('\n');
             writer.flush();

--- a/mcp/src/main/java/io/airlift/mcp/internal/InternalNotifier.java
+++ b/mcp/src/main/java/io/airlift/mcp/internal/InternalNotifier.java
@@ -1,0 +1,100 @@
+package io.airlift.mcp.internal;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.airlift.jsonrpc.model.JsonRpcErrorDetail;
+import io.airlift.jsonrpc.model.JsonRpcRequest;
+import io.airlift.jsonrpc.model.JsonRpcResponse;
+import io.airlift.mcp.McpNotifier;
+import io.airlift.mcp.model.Meta;
+import io.airlift.mcp.model.ProgressNotification;
+import jakarta.ws.rs.core.Request;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.UncheckedIOException;
+import java.io.Writer;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static io.airlift.jsonrpc.model.JsonRpcRequest.buildNotification;
+import static io.airlift.jsonrpc.model.JsonRpcResponse.buildErrorResponse;
+import static io.airlift.jsonrpc.model.JsonRpcResponse.buildResponse;
+import static io.airlift.mcp.model.Constants.NOTIFICATION_PROGRESS;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+
+class InternalNotifier
+        implements McpNotifier
+{
+    private final Request request;
+    private final ObjectMapper objectMapper;
+    private final String progressToken;
+    private final AtomicLong eventId;
+    private final Writer writer;
+
+    InternalNotifier(Request request, ObjectMapper objectMapper, Meta meta, OutputStream output)
+    {
+        this.request = requireNonNull(request, "request is null");
+        this.objectMapper = requireNonNull(objectMapper, "objectMapper is null");
+        this.eventId = new AtomicLong();
+        this.writer = new OutputStreamWriter(output, UTF_8);
+
+        progressToken = meta.meta()
+                .flatMap(m -> Optional.ofNullable(m.get("progressToken")).map(String::valueOf))
+                .orElse("unknown");
+    }
+
+    @Override
+    public void notifyProgress(String message, Optional<Double> progress, Optional<Double> total)
+    {
+        ProgressNotification progressNotification = new ProgressNotification(progressToken, message, progress, total);
+        JsonRpcRequest<ProgressNotification> notification = buildNotification(NOTIFICATION_PROGRESS, progressNotification);
+        writeEvent(notification);
+    }
+
+    @Override
+    public <T> void sendNotification(String notificationType, T data)
+    {
+        JsonRpcRequest<?> notification = buildNotification(notificationType, data);
+        writeEvent(notification);
+    }
+
+    @Override
+    public void sendNotification(String notificationType)
+    {
+        JsonRpcRequest<?> notification = buildNotification(notificationType);
+        writeEvent(notification);
+    }
+
+    void writeResult(Object data)
+    {
+        JsonRpcResponse<Object> response = buildResponse(request, data);
+        writeEvent(response);
+    }
+
+    void writeError(JsonRpcErrorDetail errorDetail)
+    {
+        JsonRpcResponse<Object> response = buildErrorResponse(request, errorDetail);
+        writeEvent(response);
+    }
+
+    private void writeEvent(Object data)
+    {
+        try {
+            writer.write("id: event-%s%n".formatted(eventId.getAndIncrement()));
+            writer.write("data: %s%n".formatted(encode(objectMapper.writeValueAsString(data))));
+            writer.write('\n');
+            writer.flush();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private String encode(String str)
+    {
+        // Escape newlines and carriage returns for SSE compliance
+        return str.replace("\n", "\\n").replace("\r", "\\r");
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/internal/InternalRpcMethods.java
+++ b/mcp/src/main/java/io/airlift/mcp/internal/InternalRpcMethods.java
@@ -4,10 +4,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import io.airlift.jsonrpc.JsonRpc;
+import io.airlift.jsonrpc.JsonRpcResult;
+import io.airlift.jsonrpc.binding.InternalRpcFilter;
+import io.airlift.jsonrpc.model.JsonRpcResponse;
 import io.airlift.log.Logger;
 import io.airlift.mcp.McpException;
 import io.airlift.mcp.McpServer;
 import io.airlift.mcp.model.CallToolRequest;
+import io.airlift.mcp.model.CancellationRequest;
 import io.airlift.mcp.model.CompletionRequest;
 import io.airlift.mcp.model.GetPromptRequest;
 import io.airlift.mcp.model.InitializeRequest;
@@ -18,14 +22,25 @@ import io.airlift.mcp.model.ListResourcesResult;
 import io.airlift.mcp.model.ListToolsResponse;
 import io.airlift.mcp.model.Meta;
 import io.airlift.mcp.model.ReadResourceRequest;
+import io.airlift.mcp.model.RootsResponse;
+import io.airlift.mcp.model.SetLoggingLevelRequest;
+import io.airlift.mcp.model.SubscribeResourceRequest;
+import io.airlift.mcp.session.RequestState;
+import io.airlift.mcp.session.SessionController;
+import io.airlift.mcp.session.SessionId;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Request;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.StreamingOutput;
 
 import java.util.Map;
+import java.util.Optional;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static io.airlift.jsonrpc.model.JsonRpcErrorCode.INVALID_REQUEST;
+import static io.airlift.mcp.internal.InternalSessionResource.SERVER_TO_CLIENT_ID_SIGNIFIER;
 import static io.airlift.mcp.model.Constants.METHOD_CALL_TOOL;
 import static io.airlift.mcp.model.Constants.METHOD_COMPLETION_COMPLETE;
 import static io.airlift.mcp.model.Constants.METHOD_GET_PROMPT;
@@ -34,9 +49,18 @@ import static io.airlift.mcp.model.Constants.METHOD_PING;
 import static io.airlift.mcp.model.Constants.METHOD_PROMPTS_LIST;
 import static io.airlift.mcp.model.Constants.METHOD_READ_RESOURCES;
 import static io.airlift.mcp.model.Constants.METHOD_RESOURCES_LIST;
+import static io.airlift.mcp.model.Constants.METHOD_RESOURCES_SUBSCRIBE;
 import static io.airlift.mcp.model.Constants.METHOD_RESOURCES_TEMPLATES_LIST;
+import static io.airlift.mcp.model.Constants.METHOD_RESOURCES_UNSUBSCRIBE;
+import static io.airlift.mcp.model.Constants.METHOD_ROOTS_LIST;
+import static io.airlift.mcp.model.Constants.METHOD_SET_LOGGING_LEVEL;
 import static io.airlift.mcp.model.Constants.METHOD_TOOLS_LIST;
+import static io.airlift.mcp.model.Constants.NOTIFICATION_CANCELLED;
 import static io.airlift.mcp.model.Constants.NOTIFICATION_INITIALIZED;
+import static io.airlift.mcp.model.Constants.NOTIFICATION_ROOTS_CHANGED;
+import static io.airlift.mcp.model.Constants.SESSION_HEADER;
+import static io.airlift.mcp.session.SubscribeType.SUBSCRIBE;
+import static io.airlift.mcp.session.SubscribeType.UNSUBSCRIBE;
 import static jakarta.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static jakarta.ws.rs.core.MediaType.SERVER_SENT_EVENTS;
@@ -48,12 +72,14 @@ public class InternalRpcMethods
 
     private final McpServer mcpServer;
     private final ObjectMapper objectMapper;
+    private final Optional<SessionController> sessionController;
 
     @Inject
-    public InternalRpcMethods(McpServer mcpServer, ObjectMapper objectMapper)
+    public InternalRpcMethods(McpServer mcpServer, ObjectMapper objectMapper, Optional<SessionController> sessionController)
     {
         this.mcpServer = requireNonNull(mcpServer, "mcpServer is null");
         this.objectMapper = requireNonNull(objectMapper, "objectMapper is null");
+        this.sessionController = requireNonNull(sessionController, "sessionController is null");
     }
 
     @JsonRpc(METHOD_PING)
@@ -64,92 +90,190 @@ public class InternalRpcMethods
         return ImmutableMap.of();
     }
 
+    @SuppressWarnings("SwitchStatementWithTooFewBranches")
+    @JsonRpcResult("internal-results")
+    public Response resultHandler(@Context SessionId sessionId, JsonRpcResponse<Map<String, Object>> response)
+    {
+        log.debug("Received server-to-client response: %s", response);
+
+        sessionController.ifPresent(controller -> {
+            String resultId = String.valueOf(firstNonNull(response.id(), ""));
+
+            switch (resultId) {
+                case METHOD_ROOTS_LIST -> response.result().ifPresent(result -> {
+                    RootsResponse rootsResponse = objectMapper.convertValue(result, RootsResponse.class);
+                    controller.acceptRoots(sessionId, rootsResponse.roots());
+                });
+
+                default -> {
+                    if (resultId.startsWith(SERVER_TO_CLIENT_ID_SIGNIFIER)) {
+                        String unwrappedId = resultId.substring(SERVER_TO_CLIENT_ID_SIGNIFIER.length());
+                        JsonRpcResponse<Map<String, Object>> appliedResult = new JsonRpcResponse<>(unwrappedId, response.error(), response.result());
+                        controller.acceptServerToClientResponse(sessionId, appliedResult);
+                    }
+                }
+            }
+        });
+
+        return Response.accepted().build();
+    }
+
     @JsonRpc(METHOD_INITIALIZE)
-    public InitializeResult initialize(@Context Request request, InitializeRequest initializeRequest)
+    public Response initialize(@Context Request request, InitializeRequest initializeRequest)
     {
         log.debug("Received initialize request: %s", initializeRequest);
 
-        return mcpServer.initialize(initializeRequest);
+        InitializeResult initializeResult = mcpServer.initialize(initializeRequest);
+        Response.ResponseBuilder responseBuilder = Response.ok(initializeResult);
+        sessionController.ifPresent(controller -> {
+            SessionId sessionId = controller.createSession(initializeRequest);
+            log.debug("Creating session for initialize request: %s, sessionId: %s", initializeRequest, sessionId);
+
+            responseBuilder.header(SESSION_HEADER, sessionId.asString());
+        });
+        return responseBuilder.build();
     }
 
     @JsonRpc(NOTIFICATION_INITIALIZED)
-    public Response notificationsInitialized()
+    public Response notificationInitialized(@Context SessionId sessionId)
     {
-        log.debug("Received notification that notifications have been initialized");
+        log.debug("Received notification that notifications have been initialized. SessionId: %s", sessionId);
+
+        return Response.accepted().build();
+    }
+
+    @JsonRpc(NOTIFICATION_CANCELLED)
+    public Response notificationCancelled(@Context Request request, @Context SessionId sessionId, CancellationRequest cancellationRequest)
+    {
+        log.debug("Received request cancellation notification. SessionId: %s, RequestId: %s", sessionId, cancellationRequest.requestId());
+
+        sessionController.ifPresent(controller -> controller.acceptRequestState(sessionId, String.valueOf(cancellationRequest.requestId()), RequestState.CANCELLATION_REQUESTED));
+
+        return Response.accepted().build();
+    }
+
+    @JsonRpc(NOTIFICATION_ROOTS_CHANGED)
+    public Response notificationRootsChanged(@Context SessionId sessionId)
+    {
+        log.debug("Received notification that roosts have changed. SessionId: %s", sessionId);
+
+        sessionController.ifPresent(controller -> controller.acceptRootsChanged(sessionId));
 
         return Response.accepted().build();
     }
 
     @JsonRpc(METHOD_TOOLS_LIST)
-    public ListToolsResponse listTools()
+    public ListToolsResponse listTools(@Context SessionId sessionId)
     {
-        log.debug("Received list tools request");
+        log.debug("Received list tools request. SessionId: %s", sessionId);
 
         return mcpServer.listTools();
     }
 
     @JsonRpc(METHOD_CALL_TOOL)
     @Produces({SERVER_SENT_EVENTS, APPLICATION_JSON})
-    public Response callTool(@Context Request request, CallToolRequest callToolRequest)
+    public Response callTool(@Context Request request, @Context SessionId sessionId, CallToolRequest callToolRequest)
     {
-        log.debug("Received call tool request: %s", callToolRequest);
+        log.debug("Received call tool request: %s, sessionId: %s", callToolRequest, sessionId);
 
-        return asStreamingOutput(request, callToolRequest,
-                notifier -> mcpServer.callTool(request, notifier, callToolRequest));
+        return asStreamingOutput(request, sessionId, callToolRequest,
+                notifier -> mcpServer.callTool(request, sessionId, notifier, callToolRequest));
     }
 
     @JsonRpc(METHOD_PROMPTS_LIST)
-    public ListPromptsResult listPrompts()
+    public ListPromptsResult listPrompts(@Context SessionId sessionId)
     {
-        log.debug("Received list prompts request");
+        log.debug("Received list prompts request. SessionId: %s", sessionId);
 
         return mcpServer.listPrompts();
     }
 
     @JsonRpc(METHOD_GET_PROMPT)
     @Produces({SERVER_SENT_EVENTS, APPLICATION_JSON})
-    public Response getPrompt(@Context Request request, GetPromptRequest getPromptRequest)
+    public Response getPrompt(@Context Request request, @Context SessionId sessionId, GetPromptRequest getPromptRequest)
     {
-        log.debug("Received get prompt request: %s", getPromptRequest);
+        log.debug("Received get prompt request: %s, sessionId: %s", getPromptRequest, sessionId);
 
-        return asStreamingOutput(request, getPromptRequest,
-                notifier -> mcpServer.getPrompt(request, notifier, getPromptRequest));
+        return asStreamingOutput(request, sessionId, getPromptRequest,
+                notifier -> mcpServer.getPrompt(request, sessionId, notifier, getPromptRequest));
     }
 
     @JsonRpc(METHOD_RESOURCES_LIST)
-    public ListResourcesResult listResources()
+    public ListResourcesResult listResources(@Context SessionId sessionId)
     {
-        log.debug("Received list resources request");
+        log.debug("Received list resources request. SessionId: %s", sessionId);
 
         return mcpServer.listResources();
     }
 
     @JsonRpc(METHOD_RESOURCES_TEMPLATES_LIST)
-    public ListResourceTemplatesResult listResourceTemplates(@Context Request request)
+    public ListResourceTemplatesResult listResourceTemplates(@Context Request request, @Context SessionId sessionId)
     {
-        log.debug("Received list resources templates request");
+        log.debug("Received list resources templates request. SessionId: %s", sessionId);
 
         return mcpServer.listResourceTemplates();
     }
 
     @JsonRpc(METHOD_READ_RESOURCES)
     @Produces({SERVER_SENT_EVENTS, APPLICATION_JSON})
-    public Response readResources(@Context Request request, ReadResourceRequest readResourceRequest)
+    public Response readResources(@Context Request request, @Context SessionId sessionId, ReadResourceRequest readResourceRequest)
     {
-        log.debug("Received read resources request: %s", readResourceRequest);
+        log.debug("Received read resources request: %s, sessionId: %s", readResourceRequest, sessionId);
 
-        return asStreamingOutput(request, readResourceRequest,
-                notifier -> mcpServer.readResources(request, notifier, readResourceRequest));
+        return asStreamingOutput(request, sessionId, readResourceRequest,
+                notifier -> mcpServer.readResources(request, sessionId, notifier, readResourceRequest));
     }
 
     @JsonRpc(METHOD_COMPLETION_COMPLETE)
     @Produces({SERVER_SENT_EVENTS, APPLICATION_JSON})
-    public Response completeCompletion(@Context Request request, CompletionRequest completionRequest)
+    public Response completeCompletion(@Context Request request, @Context SessionId sessionId, CompletionRequest completionRequest)
     {
-        log.debug("Received completion request: %s", completionRequest);
+        log.debug("Received completion request: %s, sessionId: %s", completionRequest, sessionId);
 
-        return asStreamingOutput(request, completionRequest,
-                notifier -> mcpServer.completeCompletion(request, notifier, completionRequest));
+        return asStreamingOutput(request, sessionId, completionRequest,
+                notifier -> mcpServer.completeCompletion(request, sessionId, notifier, completionRequest));
+    }
+
+    @JsonRpc(METHOD_SET_LOGGING_LEVEL)
+    public Map<String, String> setLoggingLevel(@Context Request request, @Context SessionId sessionId, SetLoggingLevelRequest loggingLevelRequest)
+    {
+        log.debug("Received set logging level request: %s, sessionId: %s", loggingLevelRequest, sessionId);
+
+        requireSessionController().setLoggingLevel(sessionId, loggingLevelRequest.level());
+
+        return ImmutableMap.of();
+    }
+
+    @JsonRpc(METHOD_RESOURCES_SUBSCRIBE)
+    public Map<String, String> subscribeToResource(@Context Request request, @Context SessionId sessionId, SubscribeResourceRequest subscribeResourceRequest)
+    {
+        log.debug("Received subscribe to resource request: %s, sessionId: %s", subscribeResourceRequest, sessionId);
+
+        requireSessionController().changeResourceSubscription(sessionId, subscribeResourceRequest.uri(), SUBSCRIBE);
+
+        return ImmutableMap.of();
+    }
+
+    @JsonRpc(METHOD_RESOURCES_UNSUBSCRIBE)
+    public Map<String, String> unsubscribeToResource(@Context Request request, @Context SessionId sessionId, SubscribeResourceRequest subscribeResourceRequest)
+    {
+        log.debug("Received unsubscribe to resource request: %s, sessionId: %s", subscribeResourceRequest, sessionId);
+
+        requireSessionController().changeResourceSubscription(sessionId, subscribeResourceRequest.uri(), UNSUBSCRIBE);
+
+        return ImmutableMap.of();
+    }
+
+    static Optional<Object> currentRequestId(Request request)
+    {
+        return (request instanceof ContainerRequestContext containerRequestContext)
+                ? InternalRpcFilter.requestId(containerRequestContext)
+                : Optional.empty();
+    }
+
+    private SessionController requireSessionController()
+    {
+        return sessionController.orElseThrow(() -> McpException.exception(INVALID_REQUEST, "Sessions are not supported"));
     }
 
     private interface ResultSupplier
@@ -158,11 +282,15 @@ public class InternalRpcMethods
                 throws McpException;
     }
 
-    private Response asStreamingOutput(Request request, Meta meta, ResultSupplier resultSupplier)
+    private Response asStreamingOutput(Request request, SessionId sessionId, Meta meta, ResultSupplier resultSupplier)
     {
+        Optional<String> requestId = currentRequestId(request).map(String::valueOf);
+
         StreamingOutput streamingOutput = output -> {
             try (output) {
-                InternalNotifier internalNotifier = new InternalNotifier(request, objectMapper, meta, output);
+                sessionController.ifPresent(controller -> requestId.ifPresent(id -> controller.acceptRequestState(sessionId, id, RequestState.STARTED)));
+
+                InternalNotifier internalNotifier = new InternalNotifier(request, sessionController, sessionId, objectMapper, meta, output);
                 try {
                     Object result = resultSupplier.apply(internalNotifier);
                     internalNotifier.writeResult(result);
@@ -173,6 +301,9 @@ public class InternalRpcMethods
                     log.debug(e, "Error processing request");
 
                     internalNotifier.writeError(e.errorDetail());
+                }
+                finally {
+                    sessionController.ifPresent(controller -> requestId.ifPresent(id -> controller.acceptRequestState(sessionId, id, RequestState.ENDED)));
                 }
             }
         };

--- a/mcp/src/main/java/io/airlift/mcp/internal/InternalRpcMethods.java
+++ b/mcp/src/main/java/io/airlift/mcp/internal/InternalRpcMethods.java
@@ -10,6 +10,7 @@ import io.airlift.jsonrpc.model.JsonRpcResponse;
 import io.airlift.log.Logger;
 import io.airlift.mcp.McpException;
 import io.airlift.mcp.McpServer;
+import io.airlift.mcp.handler.RequestContext;
 import io.airlift.mcp.model.CallToolRequest;
 import io.airlift.mcp.model.CancellationRequest;
 import io.airlift.mcp.model.CompletionRequest;
@@ -34,6 +35,8 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Request;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.StreamingOutput;
+import jakarta.ws.rs.ext.Providers;
+import org.glassfish.jersey.spi.ContextResolvers;
 
 import java.util.Map;
 import java.util.Optional;
@@ -172,12 +175,12 @@ public class InternalRpcMethods
 
     @JsonRpc(METHOD_CALL_TOOL)
     @Produces({SERVER_SENT_EVENTS, APPLICATION_JSON})
-    public Response callTool(@Context Request request, @Context SessionId sessionId, CallToolRequest callToolRequest)
+    public Response callTool(@Context Request request, @Context SessionId sessionId, @Context Providers providers, @Context ContextResolvers contextResolvers, CallToolRequest callToolRequest)
     {
         log.debug("Received call tool request: %s, sessionId: %s", callToolRequest, sessionId);
 
         return asStreamingOutput(request, sessionId, callToolRequest,
-                notifier -> mcpServer.callTool(request, sessionId, notifier, callToolRequest));
+                notifier -> mcpServer.callTool(new RequestContext(request, sessionId, providers, contextResolvers), notifier, callToolRequest));
     }
 
     @JsonRpc(METHOD_PROMPTS_LIST)
@@ -190,12 +193,12 @@ public class InternalRpcMethods
 
     @JsonRpc(METHOD_GET_PROMPT)
     @Produces({SERVER_SENT_EVENTS, APPLICATION_JSON})
-    public Response getPrompt(@Context Request request, @Context SessionId sessionId, GetPromptRequest getPromptRequest)
+    public Response getPrompt(@Context Request request, @Context SessionId sessionId, @Context Providers providers, @Context ContextResolvers contextResolvers, GetPromptRequest getPromptRequest)
     {
         log.debug("Received get prompt request: %s, sessionId: %s", getPromptRequest, sessionId);
 
         return asStreamingOutput(request, sessionId, getPromptRequest,
-                notifier -> mcpServer.getPrompt(request, sessionId, notifier, getPromptRequest));
+                notifier -> mcpServer.getPrompt(new RequestContext(request, sessionId, providers, contextResolvers), notifier, getPromptRequest));
     }
 
     @JsonRpc(METHOD_RESOURCES_LIST)
@@ -216,22 +219,22 @@ public class InternalRpcMethods
 
     @JsonRpc(METHOD_READ_RESOURCES)
     @Produces({SERVER_SENT_EVENTS, APPLICATION_JSON})
-    public Response readResources(@Context Request request, @Context SessionId sessionId, ReadResourceRequest readResourceRequest)
+    public Response readResources(@Context Request request, @Context SessionId sessionId, @Context Providers providers, @Context ContextResolvers contextResolvers, ReadResourceRequest readResourceRequest)
     {
         log.debug("Received read resources request: %s, sessionId: %s", readResourceRequest, sessionId);
 
         return asStreamingOutput(request, sessionId, readResourceRequest,
-                notifier -> mcpServer.readResources(request, sessionId, notifier, readResourceRequest));
+                notifier -> mcpServer.readResources(new RequestContext(request, sessionId, providers, contextResolvers), notifier, readResourceRequest));
     }
 
     @JsonRpc(METHOD_COMPLETION_COMPLETE)
     @Produces({SERVER_SENT_EVENTS, APPLICATION_JSON})
-    public Response completeCompletion(@Context Request request, @Context SessionId sessionId, CompletionRequest completionRequest)
+    public Response completeCompletion(@Context Request request, @Context SessionId sessionId, @Context Providers providers, @Context ContextResolvers contextResolvers, CompletionRequest completionRequest)
     {
         log.debug("Received completion request: %s, sessionId: %s", completionRequest, sessionId);
 
         return asStreamingOutput(request, sessionId, completionRequest,
-                notifier -> mcpServer.completeCompletion(request, sessionId, notifier, completionRequest));
+                notifier -> mcpServer.completeCompletion(new RequestContext(request, sessionId, providers, contextResolvers), notifier, completionRequest));
     }
 
     @JsonRpc(METHOD_SET_LOGGING_LEVEL)

--- a/mcp/src/main/java/io/airlift/mcp/internal/InternalRpcMethods.java
+++ b/mcp/src/main/java/io/airlift/mcp/internal/InternalRpcMethods.java
@@ -17,11 +17,16 @@ import io.airlift.mcp.model.CompletionRequest;
 import io.airlift.mcp.model.GetPromptRequest;
 import io.airlift.mcp.model.InitializeRequest;
 import io.airlift.mcp.model.InitializeResult;
+import io.airlift.mcp.model.ListPromptsRequest;
 import io.airlift.mcp.model.ListPromptsResult;
+import io.airlift.mcp.model.ListResourceTemplatesRequest;
 import io.airlift.mcp.model.ListResourceTemplatesResult;
+import io.airlift.mcp.model.ListResourcesRequest;
 import io.airlift.mcp.model.ListResourcesResult;
+import io.airlift.mcp.model.ListToolsRequest;
 import io.airlift.mcp.model.ListToolsResponse;
 import io.airlift.mcp.model.Meta;
+import io.airlift.mcp.model.Pagination;
 import io.airlift.mcp.model.ReadResourceRequest;
 import io.airlift.mcp.model.RootsResponse;
 import io.airlift.mcp.model.SetLoggingLevelRequest;
@@ -166,11 +171,13 @@ public class InternalRpcMethods
     }
 
     @JsonRpc(METHOD_TOOLS_LIST)
-    public ListToolsResponse listTools(@Context SessionId sessionId)
+    public ListToolsResponse listTools(@Context SessionId sessionId, Optional<ListToolsRequest> listToolsRequest)
     {
-        log.debug("Received list tools request. SessionId: %s", sessionId);
+        Pagination pagination = listToolsRequest.map(Pagination.class::cast).orElse(Pagination.NONE);
 
-        return mcpServer.listTools();
+        log.debug("Received list tools request. SessionId: %s, Cursor: %s", sessionId, pagination);
+
+        return mcpServer.listTools(pagination);
     }
 
     @JsonRpc(METHOD_CALL_TOOL)
@@ -180,15 +187,17 @@ public class InternalRpcMethods
         log.debug("Received call tool request: %s, sessionId: %s", callToolRequest, sessionId);
 
         return asStreamingOutput(request, sessionId, callToolRequest,
-                notifier -> mcpServer.callTool(new RequestContext(request, sessionId, providers, contextResolvers), notifier, callToolRequest));
+                notifier -> mcpServer.callTool(new RequestContext(request, sessionId, providers, contextResolvers, Pagination.NONE), notifier, callToolRequest));
     }
 
     @JsonRpc(METHOD_PROMPTS_LIST)
-    public ListPromptsResult listPrompts(@Context SessionId sessionId)
+    public ListPromptsResult listPrompts(@Context SessionId sessionId, Optional<ListPromptsRequest> listPromptsRequest)
     {
-        log.debug("Received list prompts request. SessionId: %s", sessionId);
+        Pagination pagination = listPromptsRequest.map(Pagination.class::cast).orElse(Pagination.NONE);
 
-        return mcpServer.listPrompts();
+        log.debug("Received list prompts request. SessionId: %s, Cursor: %s", sessionId, pagination);
+
+        return mcpServer.listPrompts(pagination);
     }
 
     @JsonRpc(METHOD_GET_PROMPT)
@@ -198,23 +207,27 @@ public class InternalRpcMethods
         log.debug("Received get prompt request: %s, sessionId: %s", getPromptRequest, sessionId);
 
         return asStreamingOutput(request, sessionId, getPromptRequest,
-                notifier -> mcpServer.getPrompt(new RequestContext(request, sessionId, providers, contextResolvers), notifier, getPromptRequest));
+                notifier -> mcpServer.getPrompt(new RequestContext(request, sessionId, providers, contextResolvers, Pagination.NONE), notifier, getPromptRequest));
     }
 
     @JsonRpc(METHOD_RESOURCES_LIST)
-    public ListResourcesResult listResources(@Context SessionId sessionId)
+    public ListResourcesResult listResources(@Context SessionId sessionId, Optional<ListResourcesRequest> listResourcesRequest)
     {
-        log.debug("Received list resources request. SessionId: %s", sessionId);
+        Pagination pagination = listResourcesRequest.map(Pagination.class::cast).orElse(Pagination.NONE);
 
-        return mcpServer.listResources();
+        log.debug("Received list resources request. SessionId: %s, Cursor: %s", sessionId, pagination);
+
+        return mcpServer.listResources(pagination);
     }
 
     @JsonRpc(METHOD_RESOURCES_TEMPLATES_LIST)
-    public ListResourceTemplatesResult listResourceTemplates(@Context Request request, @Context SessionId sessionId)
+    public ListResourceTemplatesResult listResourceTemplates(@Context Request request, @Context SessionId sessionId, Optional<ListResourceTemplatesRequest> listResourceTemplatesRequest)
     {
-        log.debug("Received list resources templates request. SessionId: %s", sessionId);
+        Pagination pagination = listResourceTemplatesRequest.map(Pagination.class::cast).orElse(Pagination.NONE);
 
-        return mcpServer.listResourceTemplates();
+        log.debug("Received list resources templates request. SessionId: %s, Cursor: %s", sessionId, pagination);
+
+        return mcpServer.listResourceTemplates(pagination);
     }
 
     @JsonRpc(METHOD_READ_RESOURCES)
@@ -224,7 +237,7 @@ public class InternalRpcMethods
         log.debug("Received read resources request: %s, sessionId: %s", readResourceRequest, sessionId);
 
         return asStreamingOutput(request, sessionId, readResourceRequest,
-                notifier -> mcpServer.readResources(new RequestContext(request, sessionId, providers, contextResolvers), notifier, readResourceRequest));
+                notifier -> mcpServer.readResources(new RequestContext(request, sessionId, providers, contextResolvers, Pagination.NONE), notifier, readResourceRequest));
     }
 
     @JsonRpc(METHOD_COMPLETION_COMPLETE)
@@ -234,7 +247,7 @@ public class InternalRpcMethods
         log.debug("Received completion request: %s, sessionId: %s", completionRequest, sessionId);
 
         return asStreamingOutput(request, sessionId, completionRequest,
-                notifier -> mcpServer.completeCompletion(new RequestContext(request, sessionId, providers, contextResolvers), notifier, completionRequest));
+                notifier -> mcpServer.completeCompletion(new RequestContext(request, sessionId, providers, contextResolvers, Pagination.NONE), notifier, completionRequest));
     }
 
     @JsonRpc(METHOD_SET_LOGGING_LEVEL)

--- a/mcp/src/main/java/io/airlift/mcp/internal/InternalRpcMethods.java
+++ b/mcp/src/main/java/io/airlift/mcp/internal/InternalRpcMethods.java
@@ -1,0 +1,185 @@
+package io.airlift.mcp.internal;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import io.airlift.jsonrpc.JsonRpc;
+import io.airlift.log.Logger;
+import io.airlift.mcp.McpException;
+import io.airlift.mcp.McpServer;
+import io.airlift.mcp.model.CallToolRequest;
+import io.airlift.mcp.model.CompletionRequest;
+import io.airlift.mcp.model.GetPromptRequest;
+import io.airlift.mcp.model.InitializeRequest;
+import io.airlift.mcp.model.InitializeResult;
+import io.airlift.mcp.model.ListPromptsResult;
+import io.airlift.mcp.model.ListResourceTemplatesResult;
+import io.airlift.mcp.model.ListResourcesResult;
+import io.airlift.mcp.model.ListToolsResponse;
+import io.airlift.mcp.model.Meta;
+import io.airlift.mcp.model.ReadResourceRequest;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Request;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.StreamingOutput;
+
+import java.util.Map;
+
+import static io.airlift.mcp.model.Constants.METHOD_CALL_TOOL;
+import static io.airlift.mcp.model.Constants.METHOD_COMPLETION_COMPLETE;
+import static io.airlift.mcp.model.Constants.METHOD_GET_PROMPT;
+import static io.airlift.mcp.model.Constants.METHOD_INITIALIZE;
+import static io.airlift.mcp.model.Constants.METHOD_PING;
+import static io.airlift.mcp.model.Constants.METHOD_PROMPTS_LIST;
+import static io.airlift.mcp.model.Constants.METHOD_READ_RESOURCES;
+import static io.airlift.mcp.model.Constants.METHOD_RESOURCES_LIST;
+import static io.airlift.mcp.model.Constants.METHOD_RESOURCES_TEMPLATES_LIST;
+import static io.airlift.mcp.model.Constants.METHOD_TOOLS_LIST;
+import static io.airlift.mcp.model.Constants.NOTIFICATION_INITIALIZED;
+import static jakarta.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static jakarta.ws.rs.core.MediaType.SERVER_SENT_EVENTS;
+import static java.util.Objects.requireNonNull;
+
+public class InternalRpcMethods
+{
+    private static final Logger log = Logger.get(InternalRpcMethods.class);
+
+    private final McpServer mcpServer;
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public InternalRpcMethods(McpServer mcpServer, ObjectMapper objectMapper)
+    {
+        this.mcpServer = requireNonNull(mcpServer, "mcpServer is null");
+        this.objectMapper = requireNonNull(objectMapper, "objectMapper is null");
+    }
+
+    @JsonRpc(METHOD_PING)
+    public Map<String, String> ping()
+    {
+        log.debug("Received ping request");
+
+        return ImmutableMap.of();
+    }
+
+    @JsonRpc(METHOD_INITIALIZE)
+    public InitializeResult initialize(@Context Request request, InitializeRequest initializeRequest)
+    {
+        log.debug("Received initialize request: %s", initializeRequest);
+
+        return mcpServer.initialize(initializeRequest);
+    }
+
+    @JsonRpc(NOTIFICATION_INITIALIZED)
+    public Response notificationsInitialized()
+    {
+        log.debug("Received notification that notifications have been initialized");
+
+        return Response.accepted().build();
+    }
+
+    @JsonRpc(METHOD_TOOLS_LIST)
+    public ListToolsResponse listTools()
+    {
+        log.debug("Received list tools request");
+
+        return mcpServer.listTools();
+    }
+
+    @JsonRpc(METHOD_CALL_TOOL)
+    @Produces({SERVER_SENT_EVENTS, APPLICATION_JSON})
+    public Response callTool(@Context Request request, CallToolRequest callToolRequest)
+    {
+        log.debug("Received call tool request: %s", callToolRequest);
+
+        return asStreamingOutput(request, callToolRequest,
+                notifier -> mcpServer.callTool(request, notifier, callToolRequest));
+    }
+
+    @JsonRpc(METHOD_PROMPTS_LIST)
+    public ListPromptsResult listPrompts()
+    {
+        log.debug("Received list prompts request");
+
+        return mcpServer.listPrompts();
+    }
+
+    @JsonRpc(METHOD_GET_PROMPT)
+    @Produces({SERVER_SENT_EVENTS, APPLICATION_JSON})
+    public Response getPrompt(@Context Request request, GetPromptRequest getPromptRequest)
+    {
+        log.debug("Received get prompt request: %s", getPromptRequest);
+
+        return asStreamingOutput(request, getPromptRequest,
+                notifier -> mcpServer.getPrompt(request, notifier, getPromptRequest));
+    }
+
+    @JsonRpc(METHOD_RESOURCES_LIST)
+    public ListResourcesResult listResources()
+    {
+        log.debug("Received list resources request");
+
+        return mcpServer.listResources();
+    }
+
+    @JsonRpc(METHOD_RESOURCES_TEMPLATES_LIST)
+    public ListResourceTemplatesResult listResourceTemplates(@Context Request request)
+    {
+        log.debug("Received list resources templates request");
+
+        return mcpServer.listResourceTemplates();
+    }
+
+    @JsonRpc(METHOD_READ_RESOURCES)
+    @Produces({SERVER_SENT_EVENTS, APPLICATION_JSON})
+    public Response readResources(@Context Request request, ReadResourceRequest readResourceRequest)
+    {
+        log.debug("Received read resources request: %s", readResourceRequest);
+
+        return asStreamingOutput(request, readResourceRequest,
+                notifier -> mcpServer.readResources(request, notifier, readResourceRequest));
+    }
+
+    @JsonRpc(METHOD_COMPLETION_COMPLETE)
+    @Produces({SERVER_SENT_EVENTS, APPLICATION_JSON})
+    public Response completeCompletion(@Context Request request, CompletionRequest completionRequest)
+    {
+        log.debug("Received completion request: %s", completionRequest);
+
+        return asStreamingOutput(request, completionRequest,
+                notifier -> mcpServer.completeCompletion(request, notifier, completionRequest));
+    }
+
+    private interface ResultSupplier
+    {
+        Object apply(InternalNotifier internalNotifier)
+                throws McpException;
+    }
+
+    private Response asStreamingOutput(Request request, Meta meta, ResultSupplier resultSupplier)
+    {
+        StreamingOutput streamingOutput = output -> {
+            try (output) {
+                InternalNotifier internalNotifier = new InternalNotifier(request, objectMapper, meta, output);
+                try {
+                    Object result = resultSupplier.apply(internalNotifier);
+                    internalNotifier.writeResult(result);
+                }
+                catch (McpException e) {
+                    // debug on purpose. This exception will result in an error result.
+                    // Normally, there's no need to log this, but it can be useful for debugging.
+                    log.debug(e, "Error processing request");
+
+                    internalNotifier.writeError(e.errorDetail());
+                }
+            }
+        };
+
+        BufferDefeatingStreamingOutput wrapped = new BufferDefeatingStreamingOutput(streamingOutput);
+        return Response.ok(wrapped)
+                .header(CONTENT_TYPE, SERVER_SENT_EVENTS)
+                .build();
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/internal/InternalSessionResource.java
+++ b/mcp/src/main/java/io/airlift/mcp/internal/InternalSessionResource.java
@@ -1,0 +1,173 @@
+package io.airlift.mcp.internal;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Stopwatch;
+import com.google.common.base.Throwables;
+import com.google.inject.Inject;
+import io.airlift.jsonrpc.model.JsonRpcRequest;
+import io.airlift.log.Logger;
+import io.airlift.mcp.McpException;
+import io.airlift.mcp.model.ResourcesUpdatedNotification;
+import io.airlift.mcp.session.ListType;
+import io.airlift.mcp.session.SessionController;
+import io.airlift.mcp.session.SessionId;
+import io.airlift.mcp.session.SessionMetadata;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Request;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.StreamingOutput;
+
+import java.io.EOFException;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
+import static io.airlift.mcp.model.Constants.METHOD_PING;
+import static io.airlift.mcp.model.Constants.METHOD_ROOTS_LIST;
+import static io.airlift.mcp.model.Constants.NOTIFICATION_MESSAGE;
+import static io.airlift.mcp.model.Constants.NOTIFICATION_PROMPTS_LIST_CHANGED;
+import static io.airlift.mcp.model.Constants.NOTIFICATION_RESOURCES_LIST_CHANGED;
+import static io.airlift.mcp.model.Constants.NOTIFICATION_RESOURCES_UPDATED;
+import static io.airlift.mcp.model.Constants.NOTIFICATION_TOOLS_LIST_CHANGED;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static jakarta.ws.rs.core.MediaType.SERVER_SENT_EVENTS;
+import static java.util.Objects.requireNonNull;
+
+public class InternalSessionResource
+{
+    private static final Logger log = Logger.get(InternalSessionResource.class);
+
+    public static final String SERVER_TO_CLIENT_ID_SIGNIFIER = "X-SERVER-TO-CLIENT-";
+
+    private final SessionController sessionController;
+    private final SessionMetadata sessionMetadata;
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public InternalSessionResource(SessionController sessionController, SessionMetadata sessionMetadata, ObjectMapper objectMapper)
+    {
+        this.sessionController = requireNonNull(sessionController, "sessionController is null");
+        this.sessionMetadata = requireNonNull(sessionMetadata, "sessionMetadata is null");
+        this.objectMapper = requireNonNull(objectMapper, "objectMapper is null");
+    }
+
+    @GET
+    @Produces({SERVER_SENT_EVENTS, APPLICATION_JSON})
+    public Response sessionStreamHandler(@Context Request request, @Context SessionId sessionId)
+    {
+        log.debug("Streaming session events for session %s", sessionId);
+
+        StreamingOutput streamingOutput = out -> {
+            try (out) {
+                InternalNotifier internalNotifier = new InternalNotifier(request, Optional.of(sessionController), sessionId, objectMapper, Optional::empty, out);
+                sessionStreamingLoop(internalNotifier, sessionId);
+            }
+        };
+        BufferDefeatingStreamingOutput wrapper = new BufferDefeatingStreamingOutput(streamingOutput);
+        return Response.ok(wrapper)
+                .header(CONTENT_TYPE, SERVER_SENT_EVENTS)
+                .build();
+    }
+
+    @DELETE
+    public Response deleteSession(@Context SessionId sessionId)
+    {
+        log.debug("Deleting session %s", sessionId);
+
+        sessionController.deleteSession(sessionId);
+
+        return Response.accepted().build();
+    }
+
+    @SuppressWarnings("BusyWait")
+    private void sessionStreamingLoop(InternalNotifier internalNotifier, SessionId sessionId)
+    {
+        try {
+            Stopwatch stopwatch = Stopwatch.createStarted();
+
+            boolean supportsRoots = sessionController.clientCapabilities(sessionId)
+                    .map(clientCapabilities -> clientCapabilities.roots().isPresent())
+                    .orElse(false);
+            if (supportsRoots) {
+                log.debug("Sending \"roots/list\" for new streaming of session %s", sessionId);
+
+                sendRootsListRequest(internalNotifier);
+            }
+
+            while (true) {
+                if (sessionController.parseAndValidate(sessionId.asString()).isEmpty()) {
+                    log.debug("Session has expired. Exiting event loop for: %s", sessionId);
+                    break;
+                }
+
+                if (stopwatch.elapsed().compareTo(sessionMetadata.maxEventsLoopDuration()) > 0) {
+                    log.debug("Max event loop duration %s exceeded for session %s. Exiting event loop.", sessionMetadata.maxEventsLoopDuration(), sessionId);
+                    break;
+                }
+
+                Thread.sleep(sessionMetadata.sessionUpdateCadence().toMillis());
+
+                Set<ListType> changedLists = sessionController.takeChangedLists(sessionId);
+                changedLists.forEach(listType -> {
+                    switch (listType) {
+                        case TOOLS -> internalNotifier.sendNotification(NOTIFICATION_TOOLS_LIST_CHANGED);
+                        case PROMPTS -> internalNotifier.sendNotification(NOTIFICATION_PROMPTS_LIST_CHANGED);
+                        case RESOURCES -> internalNotifier.sendNotification(NOTIFICATION_RESOURCES_LIST_CHANGED);
+                        case ROOTS -> sendRootsListRequest(internalNotifier);
+                    }
+                });
+
+                List<String> resourceUpdates = sessionController.takeResourceUpdates(sessionId);
+                resourceUpdates.forEach(resource -> {
+                    ResourcesUpdatedNotification notification = new ResourcesUpdatedNotification(resource);
+                    internalNotifier.sendNotification(NOTIFICATION_RESOURCES_UPDATED, notification);
+                });
+
+                List<JsonRpcRequest<?>> serverToClientRequests = sessionController.takeServerToClientRequests(sessionId);
+                serverToClientRequests.forEach(internalNotifier::sendRequest);
+
+                if (changedLists.isEmpty() && resourceUpdates.isEmpty() && serverToClientRequests.isEmpty()) {
+                    JsonRpcRequest<Object> rpcRequest = JsonRpcRequest.buildRequest(internalNotifier.nextEventId(), METHOD_PING);
+                    internalNotifier.writeRequest(rpcRequest);
+                }
+            }
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.debug("Interrupted while waiting for session %s", sessionId);
+        }
+        catch (Exception e) {
+            //noinspection SimplifyStreamApiCallChains
+            boolean handled = Throwables.getCausalChain(e)
+                    .stream()
+                    .filter(t -> {
+                        if (t instanceof EOFException) {
+                            log.debug("Client disconnected from session stream. Exiting event loop for: %s", sessionId);
+                            return true;
+                        }
+
+                        if (t instanceof McpException mcpException) {
+                            internalNotifier.sendNotification(NOTIFICATION_MESSAGE, mcpException.errorDetail());
+                            return true;
+                        }
+
+                        return false;
+                    })
+                    .findFirst()
+                    .isPresent();
+            if (!handled) {
+                log.error("Exception while dispatching request %s", sessionId, e);
+            }
+        }
+    }
+
+    private static void sendRootsListRequest(InternalNotifier internalNotifier)
+    {
+        JsonRpcRequest<Object> request = JsonRpcRequest.buildRequest(METHOD_ROOTS_LIST, METHOD_ROOTS_LIST);
+        internalNotifier.writeRequest(request);
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/internal/SessionIdValueProvider.java
+++ b/mcp/src/main/java/io/airlift/mcp/internal/SessionIdValueProvider.java
@@ -1,0 +1,67 @@
+package io.airlift.mcp.internal;
+
+import com.google.inject.Inject;
+import io.airlift.mcp.session.SessionController;
+import io.airlift.mcp.session.SessionId;
+import jakarta.ws.rs.WebApplicationException;
+import org.glassfish.jersey.server.ContainerRequest;
+import org.glassfish.jersey.server.model.Parameter;
+import org.glassfish.jersey.server.spi.internal.ValueParamProvider;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+import static io.airlift.mcp.model.Constants.SESSION_HEADER;
+import static jakarta.ws.rs.core.Response.Status.NOT_FOUND;
+import static java.util.Objects.requireNonNull;
+import static org.glassfish.jersey.server.spi.internal.ValueParamProvider.Priority.HIGH;
+
+public class SessionIdValueProvider
+        implements ValueParamProvider
+{
+    private static final SessionId NO_SESSION = () -> "0";
+
+    private final Optional<SessionController> sessionController;
+
+    @Inject
+    public SessionIdValueProvider(Optional<SessionController> sessionController)
+    {
+        this.sessionController = requireNonNull(sessionController, "sessionController is null");
+    }
+
+    @Override
+    public Function<ContainerRequest, ?> getValueProvider(Parameter parameter)
+    {
+        if (SessionId.class.isAssignableFrom(parameter.getRawType())) {
+            return this::handler;
+        }
+        return null;
+    }
+
+    @Override
+    public PriorityType getPriority()
+    {
+        return HIGH;
+    }
+
+    private SessionId handler(ContainerRequest request)
+    {
+        return sessionController.map(controller -> sessionIdHandler(request, controller))
+                .orElse(NO_SESSION);
+    }
+
+    private SessionId sessionIdHandler(ContainerRequest request, SessionController sessionController)
+    {
+        String value = request.getHeaderString(SESSION_HEADER);
+        if (value == null) {
+            // see https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#session-management
+            throw new WebApplicationException("Invalid session", NOT_FOUND);
+        }
+
+        return sessionController.parseAndValidate(value)
+                .orElseThrow(() -> {
+                    // see https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#session-management
+                    return new WebApplicationException("Invalid session", NOT_FOUND);
+                });
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/Annotations.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/Annotations.java
@@ -1,0 +1,17 @@
+package io.airlift.mcp.model;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public record Annotations(List<Role> audience, Optional<Double> priority)
+{
+    public Annotations
+    {
+        audience = ImmutableList.copyOf(audience);
+        requireNonNull(priority, "priority is null");
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/CallToolRequest.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/CallToolRequest.java
@@ -1,0 +1,23 @@
+package io.airlift.mcp.model;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public record CallToolRequest(String name, Map<String, Object> arguments, Optional<Map<String, Object>> meta)
+        implements Meta
+{
+    public CallToolRequest
+    {
+        requireNonNull(name, "name is null");
+        arguments = ImmutableMap.copyOf(arguments);
+    }
+
+    public CallToolRequest(String name, Map<String, Object> arguments)
+    {
+        this(name, arguments, Optional.empty());
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/CallToolResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/CallToolResult.java
@@ -1,0 +1,27 @@
+package io.airlift.mcp.model;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public record CallToolResult(List<Content> content, Optional<StructuredContent<?>> structuredContent, boolean isError)
+{
+    public CallToolResult
+    {
+        requireNonNull(content, "content is null");
+        requireNonNull(structuredContent, "structuredContent is null");
+    }
+
+    public CallToolResult(Content content)
+    {
+        this(ImmutableList.of(content), Optional.empty(), false);
+    }
+
+    public CallToolResult(List<Content> content)
+    {
+        this(content, Optional.empty(), false);
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/CancellationRequest.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/CancellationRequest.java
@@ -1,0 +1,19 @@
+package io.airlift.mcp.model;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public record CancellationRequest(Object requestId, Optional<String> reason)
+{
+    public CancellationRequest
+    {
+        requireNonNull(requestId, "requestId is null");
+        requireNonNull(reason, "reason is null");
+    }
+
+    public CancellationRequest(Object requestId)
+    {
+        this(requestId, Optional.empty());
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/Completion.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/Completion.java
@@ -1,0 +1,22 @@
+package io.airlift.mcp.model;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public record Completion(List<String> values, Optional<Integer> total, boolean hasMore)
+{
+    public Completion
+    {
+        values = ImmutableList.copyOf(values);
+        requireNonNull(total, "total is null");
+    }
+
+    public Completion(List<String> values)
+    {
+        this(values, Optional.empty(), false);
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/CompletionReference.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/CompletionReference.java
@@ -1,0 +1,45 @@
+package io.airlift.mcp.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static java.util.Objects.requireNonNull;
+
+public sealed interface CompletionReference
+{
+    @JsonProperty
+    String type();
+
+    record Prompt(String name)
+            implements CompletionReference
+    {
+        public static final String TYPE = "ref/prompt";
+
+        public Prompt
+        {
+            requireNonNull(name, "name is null");
+        }
+
+        @Override
+        public String type()
+        {
+            return TYPE;
+        }
+    }
+
+    record Resource(String uri)
+            implements CompletionReference
+    {
+        public static final String TYPE = "ref/resource";
+
+        public Resource
+        {
+            requireNonNull(uri, "uri is null");
+        }
+
+        @Override
+        public String type()
+        {
+            return TYPE;
+        }
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/CompletionRequest.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/CompletionRequest.java
@@ -1,0 +1,41 @@
+package io.airlift.mcp.model;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public record CompletionRequest(CompletionReference ref, Argument argument, Optional<Context> context, Optional<Map<String, Object>> meta)
+        implements Meta
+{
+    public record Argument(String name, String value)
+    {
+        public Argument
+        {
+            requireNonNull(name, "value is null");
+            requireNonNull(value, "value is null");
+        }
+    }
+
+    public record Context(Map<String, Object> arguments)
+    {
+        public Context
+        {
+            arguments = ImmutableMap.copyOf(arguments);
+        }
+    }
+
+    public CompletionRequest
+    {
+        requireNonNull(ref, "ref is null");
+        requireNonNull(argument, "argument is null");
+        requireNonNull(context, "context is null");
+    }
+
+    public CompletionRequest(CompletionReference ref, Argument argument, Optional<Context> context)
+    {
+        this(ref, argument, context, Optional.empty());
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/CompletionResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/CompletionResult.java
@@ -1,0 +1,11 @@
+package io.airlift.mcp.model;
+
+import static java.util.Objects.requireNonNull;
+
+public record CompletionResult(Completion completion)
+{
+    public CompletionResult
+    {
+        requireNonNull(completion, "completion is null");
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/Constants.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/Constants.java
@@ -1,0 +1,21 @@
+package io.airlift.mcp.model;
+
+public interface Constants
+{
+    String PROTOCOL_VERSION = "2025-06-18";
+
+    String METHOD_CALL_TOOL = "tools/call";
+    String METHOD_GET_PROMPT = "prompts/get";
+    String METHOD_READ_RESOURCES = "resources/read";
+    String METHOD_PING = "ping";
+    String METHOD_INITIALIZE = "initialize";
+    String METHOD_TOOLS_LIST = "tools/list";
+    String METHOD_PROMPTS_LIST = "prompts/list";
+    String METHOD_RESOURCES_LIST = "resources/list";
+    String METHOD_RESOURCES_TEMPLATES_LIST = "resources/templates/list";
+    String METHOD_COMPLETION_COMPLETE = "completion/complete";
+
+    String NOTIFICATION_PROGRESS = "notifications/progress";
+    String NOTIFICATION_MESSAGE = "notifications/message";
+    String NOTIFICATION_INITIALIZED = "notifications/initialized";
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/Constants.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/Constants.java
@@ -13,9 +13,21 @@ public interface Constants
     String METHOD_PROMPTS_LIST = "prompts/list";
     String METHOD_RESOURCES_LIST = "resources/list";
     String METHOD_RESOURCES_TEMPLATES_LIST = "resources/templates/list";
+    String METHOD_RESOURCES_SUBSCRIBE = "resources/subscribe";
+    String METHOD_RESOURCES_UNSUBSCRIBE = "resources/unsubscribe";
     String METHOD_COMPLETION_COMPLETE = "completion/complete";
+    String METHOD_SET_LOGGING_LEVEL = "logging/setLevel";
+    String METHOD_ROOTS_LIST = "roots/list";
 
     String NOTIFICATION_PROGRESS = "notifications/progress";
     String NOTIFICATION_MESSAGE = "notifications/message";
     String NOTIFICATION_INITIALIZED = "notifications/initialized";
+    String NOTIFICATION_TOOLS_LIST_CHANGED = "notifications/tools/list_changed";
+    String NOTIFICATION_PROMPTS_LIST_CHANGED = "notifications/prompts/list_changed";
+    String NOTIFICATION_RESOURCES_LIST_CHANGED = "notifications/resources/list_changed";
+    String NOTIFICATION_RESOURCES_UPDATED = "notifications/resources/updated";
+    String NOTIFICATION_ROOTS_CHANGED = "notifications/roots/list_changed";
+    String NOTIFICATION_CANCELLED = "notifications/cancelled";
+
+    String SESSION_HEADER = "Mcp-Session-Id";
 }

--- a/mcp/src/main/java/io/airlift/mcp/model/Content.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/Content.java
@@ -1,0 +1,84 @@
+package io.airlift.mcp.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public sealed interface Content
+{
+    record TextContent(String text, Optional<Annotations> annotations)
+            implements Content
+    {
+        @JsonCreator
+        public TextContent
+        {
+            requireNonNull(text, "text is null");
+            requireNonNull(annotations, "annotations is null");
+        }
+
+        public TextContent(String text)
+        {
+            this(text, Optional.empty());
+        }
+    }
+
+    record ImageContent(String data, String mimeType, Optional<Annotations> annotations)
+            implements Content
+    {
+        @JsonCreator
+        public ImageContent
+        {
+            requireNonNull(data, "data is null");
+            requireNonNull(mimeType, "mimeType is null");
+            requireNonNull(annotations, "annotations is null");
+        }
+
+        public ImageContent(String data, String mimeType)
+        {
+            this(data, mimeType, Optional.empty());
+        }
+    }
+
+    record AudioContent(String data, String mimeType, Optional<Annotations> annotations)
+            implements Content
+    {
+        @JsonCreator
+        public AudioContent
+        {
+            requireNonNull(data, "data is null");
+            requireNonNull(mimeType, "mimeType is null");
+            requireNonNull(annotations, "annotations is null");
+        }
+
+        public AudioContent(String data, String mimeType)
+        {
+            this(data, mimeType, Optional.empty());
+        }
+    }
+
+    record EmbeddedResource(ResourceContents resource, Optional<Annotations> annotations)
+            implements Content
+    {
+        public EmbeddedResource
+        {
+            requireNonNull(resource, "resource is null");
+            requireNonNull(annotations, "annotations is null");
+        }
+    }
+
+    record ResourceLink(String name, String uri, Optional<String> description, String mimeType, Optional<Long> size, Optional<Annotations> annotations)
+            implements Content
+    {
+        public ResourceLink
+        {
+            requireNonNull(name, "name is null");
+            requireNonNull(uri, "uri is null");
+            requireNonNull(description, "description is null");
+            requireNonNull(mimeType, "mimeType is null");
+            requireNonNull(size, "size is null");
+            requireNonNull(annotations, "annotations is null");
+        }
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/ContextInclusionStrategy.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ContextInclusionStrategy.java
@@ -1,0 +1,8 @@
+package io.airlift.mcp.model;
+
+public enum ContextInclusionStrategy
+{
+    none,
+    this_server,
+    all_servers,
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/CreateMessageRequest.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/CreateMessageRequest.java
@@ -1,0 +1,39 @@
+package io.airlift.mcp.model;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public record CreateMessageRequest(
+        List<SamplingMessage> messages,
+        ModelPreferences modelPreferences,
+        String systemPrompt,
+        Optional<ContextInclusionStrategy> includeContext,
+        Optional<Double> temperature,
+        int maxTokens,
+        Optional<List<String>> stopSequences,
+        Optional<Map<String, Object>> metadata,
+        Optional<Map<String, Object>> meta)
+        implements Meta
+{
+    public CreateMessageRequest
+    {
+        messages = ImmutableList.copyOf(messages);
+        requireNonNull(modelPreferences, "modelPreferences is null");
+        requireNonNull(systemPrompt, "systemPrompt is null");
+        requireNonNull(includeContext, "includeContext is null");
+        requireNonNull(temperature, "temperature is null");
+        requireNonNull(stopSequences, "stopSequences is null");
+        requireNonNull(metadata, "metadata is null");
+        requireNonNull(meta, "meta is null");
+    }
+
+    public CreateMessageRequest(List<SamplingMessage> messages, ModelPreferences modelPreferences, String systemPrompt, int maxTokens)
+    {
+        this(messages, modelPreferences, systemPrompt, Optional.empty(), Optional.empty(), maxTokens, Optional.empty(), Optional.empty(), Optional.empty());
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/CreateMessageResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/CreateMessageResult.java
@@ -1,0 +1,16 @@
+package io.airlift.mcp.model;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public record CreateMessageResult(Role role, Content content, String model, Optional<StopReason> stopReason)
+{
+    public CreateMessageResult
+    {
+        requireNonNull(role, "role is null");
+        requireNonNull(content, "content is null");
+        requireNonNull(model, "model is null");
+        requireNonNull(stopReason, "stopReason is null");
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/GetPromptRequest.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/GetPromptRequest.java
@@ -1,0 +1,23 @@
+package io.airlift.mcp.model;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public record GetPromptRequest(String name, Map<String, Object> arguments, Optional<Map<String, Object>> meta)
+        implements Meta
+{
+    public GetPromptRequest
+    {
+        requireNonNull(name, "name is null");
+        arguments = ImmutableMap.copyOf(arguments);
+    }
+
+    public GetPromptRequest(String name, Map<String, Object> arguments)
+    {
+        this(name, arguments, Optional.empty());
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/GetPromptResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/GetPromptResult.java
@@ -1,0 +1,26 @@
+package io.airlift.mcp.model;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public record GetPromptResult(Optional<String> description, List<PromptMessage> messages)
+{
+    public record PromptMessage(Role role, Content content)
+    {
+        public PromptMessage
+        {
+            requireNonNull(role, "role is null");
+            requireNonNull(content, "content is null");
+        }
+    }
+
+    public GetPromptResult
+    {
+        requireNonNull(description, "description is null");
+        messages = ImmutableList.copyOf(messages);
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/Implementation.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/Implementation.java
@@ -1,0 +1,12 @@
+package io.airlift.mcp.model;
+
+import static java.util.Objects.requireNonNull;
+
+public record Implementation(String name, String version)
+{
+    public Implementation
+    {
+        requireNonNull(name, "name is null");
+        requireNonNull(version, "version is null");
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/InitializeRequest.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/InitializeRequest.java
@@ -1,0 +1,40 @@
+package io.airlift.mcp.model;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public record InitializeRequest(
+        String protocolVersion,
+        ClientCapabilities capabilities,
+        Implementation clientInfo,
+        Optional<Map<String, Object>> meta)
+        implements Meta
+{
+    public record ClientCapabilities(Optional<ListChanged> roots, Optional<Sampling> sampling, Optional<Elicitation> elicitation)
+    {
+        public ClientCapabilities
+        {
+            requireNonNull(roots, "roots is null");
+            requireNonNull(sampling, "sampling is null");
+            requireNonNull(elicitation, "elicitation is null");
+        }
+    }
+
+    public InitializeRequest
+    {
+        requireNonNull(protocolVersion, "protocolVersion is null");
+        requireNonNull(capabilities, "capabilities is null");
+        requireNonNull(clientInfo, "clientInfo is null");
+    }
+
+    public InitializeRequest(String protocolVersion, ClientCapabilities capabilities, Implementation clientInfo)
+    {
+        this(protocolVersion, capabilities, clientInfo, Optional.empty());
+    }
+
+    public record Sampling() {}
+
+    public record Elicitation() {}
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/InitializeResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/InitializeResult.java
@@ -1,0 +1,33 @@
+package io.airlift.mcp.model;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public record InitializeResult(
+        String protocolVersion,
+        ServerCapabilities capabilities,
+        Implementation serverInfo,
+        String instructions)
+{
+    public record ServerCapabilities(Optional<CompletionCapabilities> completions, Optional<LoggingCapabilities> logging, Optional<ListChanged> prompts, Optional<SubscribeListChanged> resources, Optional<ListChanged> tools)
+    {
+        public ServerCapabilities
+        {
+            requireNonNull(completions, "completions is null");
+            requireNonNull(logging, "logging is null");
+            requireNonNull(prompts, "prompts is null");
+            requireNonNull(resources, "resources is null");
+            requireNonNull(tools, "tools is null");
+        }
+
+        public ServerCapabilities()
+        {
+            this(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+        }
+    }
+
+    public record CompletionCapabilities() {}
+
+    public record LoggingCapabilities() {}
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/JsonSchemaBuilder.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/JsonSchemaBuilder.java
@@ -1,0 +1,226 @@
+package io.airlift.mcp.model;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.TypeLiteral;
+import io.airlift.json.ObjectMapperProvider;
+import io.airlift.mcp.McpDescription;
+import io.airlift.mcp.reflection.MethodParameter;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.RecordComponent;
+import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.stream.Stream;
+
+import static io.airlift.mcp.reflection.ReflectionHelper.listArgument;
+import static io.airlift.mcp.reflection.ReflectionHelper.optionalArgument;
+import static java.util.Objects.requireNonNull;
+
+public class JsonSchemaBuilder
+{
+    private static final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+
+    private static final Map<Class<?>, String> primitiveTypes = ImmutableMap.<Class<?>, String>builder()
+            .put(String.class, "string")
+            .put(Integer.class, "integer")
+            .put(int.class, "integer")
+            .put(Boolean.class, "boolean")
+            .put(boolean.class, "boolean")
+            .put(BigInteger.class, "number")
+            .put(BigDecimal.class, "number")
+            .put(Short.class, "number")
+            .put(short.class, "number")
+            .put(Long.class, "number")
+            .put(long.class, "number")
+            .put(Double.class, "number")
+            .put(double.class, "number")
+            .put(Float.class, "number")
+            .put(float.class, "number")
+            .build();
+
+    private final String exceptionContext;
+    private final List<Class<?>> parents;
+
+    public JsonSchemaBuilder(String exceptionContext)
+    {
+        this.exceptionContext = requireNonNull(exceptionContext, "exceptionContext is null");
+        this.parents = new ArrayList<>();
+    }
+
+    public ObjectNode build(Optional<String> description, List<MethodParameter> parameters)
+    {
+        return buildObject(description, (properties, required) -> parameters.stream()
+                .flatMap(methodParameter -> (methodParameter instanceof MethodParameter.ObjectParameter objectParameter) ? Stream.of(objectParameter) : Stream.empty())
+                .forEach(objectParameter -> {
+                    ObjectNode typeNode;
+                    if (objectParameter.rawType().isRecord()) {
+                        typeNode = buildObject(objectParameter.description(), (objectProperties, objectRequried) ->
+                                buildRecord(objectParameter.rawType(), objectProperties, objectRequried));
+                    }
+                    else {
+                        typeNode = objectMapper.createObjectNode();
+                        typeNode.put("type", primitiveType(objectParameter.rawType()));
+                        description.ifPresent(value -> typeNode.put("description", value));
+                    }
+
+                    properties.set(objectParameter.name(), typeNode);
+
+                    if (objectParameter.required()) {
+                        required.add(objectParameter.name());
+                    }
+                }));
+    }
+
+    public ObjectNode build(Optional<String> description, Class<?> recordType)
+    {
+        return buildObject(description, (objectProperties, objectRequried) ->
+                buildRecord(recordType, objectProperties, objectRequried));
+    }
+
+    private void buildRecord(Class<?> recordType, ObjectNode properties, ArrayNode required)
+    {
+        if (parents.contains(recordType)) {
+            throw exception("Recursive type detected. Chain: " + parents);
+        }
+        parents.add(recordType);
+
+        try {
+            RecordComponent[] recordComponents = recordType.getRecordComponents();
+            for (RecordComponent recordComponent : recordComponents) {
+                Class<?> rawType;
+                Type genericType;
+                String name = recordComponent.getName();
+
+                if (Optional.class.isAssignableFrom(recordComponent.getType())) {
+                    genericType = optionalArgument(recordComponent.getGenericType())
+                            .orElseThrow(() -> exception("Optional record component isn't fully declared: " + name));
+                    rawType = TypeLiteral.get(genericType).getRawType();
+                }
+                else {
+                    required.add(name);
+                    rawType = recordComponent.getType();
+                    genericType = recordComponent.getGenericType();
+                }
+
+                Optional<String> description = Optional.ofNullable(recordComponent.getAnnotation(McpDescription.class)).map(McpDescription::value);
+                ObjectNode typeNode = typeToNode(name, description, genericType, rawType);
+
+                properties.set(name, typeNode);
+            }
+        }
+        finally {
+            parents.removeLast();
+        }
+    }
+
+    public static boolean isPrimitiveType(Type type)
+    {
+        if (type instanceof Class<?> rawType) {
+            return primitiveTypes.containsKey(rawType);
+        }
+        return false;
+    }
+
+    public static boolean isSupportedType(Type type)
+    {
+        if (type instanceof Class<?> rawType) {
+            return primitiveTypes.containsKey(rawType)
+                    || rawType.isRecord()
+                    || (Map.class.isAssignableFrom(rawType) && isSupportedMap(type))
+                    || (Collection.class.isAssignableFrom(rawType) && listArgument(type).map(JsonSchemaBuilder::isSupportedType).orElse(false));
+        }
+        return false;
+    }
+
+    private static boolean isSupportedMap(Type genericType)
+    {
+        return (genericType instanceof ParameterizedType parameterizedType) && parameterizedType.getActualTypeArguments()[0].equals(String.class) && parameterizedType.getActualTypeArguments()[1].equals(String.class);
+    }
+
+    private ObjectNode typeToNode(String name, Optional<String> description, Type genericType, Class<?> rawType)
+    {
+        ObjectNode typeNode;
+        if (rawType.isRecord()) {
+            typeNode = buildObject(description, (objectProperties, objectRequired) ->
+                    buildRecord(rawType, objectProperties, objectRequired));
+        }
+        else if (Map.class.isAssignableFrom(rawType)) {
+            if (!isSupportedMap(genericType)) {
+                throw exception("Map types for JSON schema must be Map<String, String>");
+            }
+            typeNode = buildMap(description);
+        }
+        else if (Collection.class.isAssignableFrom(rawType)) {
+            Type collectionType = listArgument(genericType)
+                    .orElseThrow(() -> exception("Collection record component isn't fully declared: " + name));
+            typeNode = buildArray(description, collectionType);
+        }
+        else {
+            typeNode = objectMapper.createObjectNode();
+            typeNode.put("type", primitiveType(rawType));
+            description.ifPresent(value -> typeNode.put("description", value));
+        }
+        return typeNode;
+    }
+
+    private ObjectNode buildArray(Optional<String> description, Type genericType)
+    {
+        Class<?> rawType = TypeLiteral.get(genericType).getRawType();
+        ObjectNode objectNode = typeToNode("[]", Optional.empty(), genericType, rawType);
+
+        ObjectNode typeNode = objectMapper.createObjectNode();
+        typeNode.put("type", "array");
+        typeNode.set("items", objectNode);
+        description.ifPresent(value -> typeNode.put("description", value));
+        return typeNode;
+    }
+
+    private ObjectNode buildMap(Optional<String> description)
+    {
+        ObjectNode additionalPropertiesNode = objectMapper.createObjectNode();
+        additionalPropertiesNode.put("type", "string");
+
+        ObjectNode typeNode = objectMapper.createObjectNode();
+        typeNode.put("type", "object");
+        typeNode.set("additionalProperties", additionalPropertiesNode);
+        description.ifPresent(value -> typeNode.put("description", value));
+
+        return typeNode;
+    }
+
+    private ObjectNode buildObject(Optional<String> description, BiConsumer<ObjectNode, ArrayNode> propertiesConsumer)
+    {
+        ArrayNode requiredNode = objectMapper.createArrayNode();
+        ObjectNode propertiesNode = objectMapper.createObjectNode();
+        propertiesConsumer.accept(propertiesNode, requiredNode);
+
+        ObjectNode objectNode = objectMapper.createObjectNode();
+        objectNode.put("$schema", "https://json-schema.org/draft/2020-12/schema");
+        description.ifPresent(value -> objectNode.put("description", value));
+        objectNode.put("type", "object");
+        objectNode.set("properties", propertiesNode);
+        objectNode.set("required", requiredNode);
+        return objectNode;
+    }
+
+    private String primitiveType(Class<?> rawType)
+    {
+        return Optional.ofNullable(primitiveTypes.get(rawType))
+                .orElseThrow(() -> exception("Unsupported primitive type: " + rawType));
+    }
+
+    private RuntimeException exception(String message)
+    {
+        return new IllegalArgumentException(message + " at " + exceptionContext);
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/ListChanged.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ListChanged.java
@@ -1,0 +1,5 @@
+package io.airlift.mcp.model;
+
+public record ListChanged(boolean listChanged)
+{
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/ListPromptsRequest.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ListPromptsRequest.java
@@ -1,0 +1,14 @@
+package io.airlift.mcp.model;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public record ListPromptsRequest(Optional<String> cursor)
+        implements Pagination
+{
+    public ListPromptsRequest
+    {
+        requireNonNull(cursor, "nextCursor is null");
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/ListPromptsResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ListPromptsResult.java
@@ -3,11 +3,16 @@ package io.airlift.mcp.model;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
+import java.util.Optional;
 
-public record ListPromptsResult(List<Prompt> prompts)
+import static java.util.Objects.requireNonNull;
+
+public record ListPromptsResult(List<Prompt> prompts, Optional<String> nextCursor)
+        implements Paginated
 {
     public ListPromptsResult
     {
         prompts = ImmutableList.copyOf(prompts);
+        requireNonNull(nextCursor, "nextCursor is null");
     }
 }

--- a/mcp/src/main/java/io/airlift/mcp/model/ListPromptsResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ListPromptsResult.java
@@ -1,0 +1,13 @@
+package io.airlift.mcp.model;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+public record ListPromptsResult(List<Prompt> prompts)
+{
+    public ListPromptsResult
+    {
+        prompts = ImmutableList.copyOf(prompts);
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/ListResourceTemplatesRequest.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ListResourceTemplatesRequest.java
@@ -1,0 +1,14 @@
+package io.airlift.mcp.model;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public record ListResourceTemplatesRequest(Optional<String> cursor)
+        implements Pagination
+{
+    public ListResourceTemplatesRequest
+    {
+        requireNonNull(cursor, "nextCursor is null");
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/ListResourceTemplatesResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ListResourceTemplatesResult.java
@@ -1,11 +1,16 @@
 package io.airlift.mcp.model;
 
 import java.util.List;
+import java.util.Optional;
 
-public record ListResourceTemplatesResult(List<ResourceTemplate> resourceTemplates)
+import static java.util.Objects.requireNonNull;
+
+public record ListResourceTemplatesResult(List<ResourceTemplate> resourceTemplates, Optional<String> nextCursor)
+        implements Paginated
 {
     public ListResourceTemplatesResult
     {
         resourceTemplates = List.copyOf(resourceTemplates);
+        requireNonNull(nextCursor, "nextCursor is null");
     }
 }

--- a/mcp/src/main/java/io/airlift/mcp/model/ListResourceTemplatesResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ListResourceTemplatesResult.java
@@ -1,0 +1,11 @@
+package io.airlift.mcp.model;
+
+import java.util.List;
+
+public record ListResourceTemplatesResult(List<ResourceTemplate> resourceTemplates)
+{
+    public ListResourceTemplatesResult
+    {
+        resourceTemplates = List.copyOf(resourceTemplates);
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/ListResourcesRequest.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ListResourcesRequest.java
@@ -1,0 +1,14 @@
+package io.airlift.mcp.model;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public record ListResourcesRequest(Optional<String> cursor)
+        implements Pagination
+{
+    public ListResourcesRequest
+    {
+        requireNonNull(cursor, "nextCursor is null");
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/ListResourcesResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ListResourcesResult.java
@@ -3,11 +3,16 @@ package io.airlift.mcp.model;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
+import java.util.Optional;
 
-public record ListResourcesResult(List<Resource> resources)
+import static java.util.Objects.requireNonNull;
+
+public record ListResourcesResult(List<Resource> resources, Optional<String> nextCursor)
+        implements Paginated
 {
     public ListResourcesResult
     {
         resources = ImmutableList.copyOf(resources);
+        requireNonNull(nextCursor, "nextCursor is null");
     }
 }

--- a/mcp/src/main/java/io/airlift/mcp/model/ListResourcesResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ListResourcesResult.java
@@ -1,0 +1,13 @@
+package io.airlift.mcp.model;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+public record ListResourcesResult(List<Resource> resources)
+{
+    public ListResourcesResult
+    {
+        resources = ImmutableList.copyOf(resources);
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/ListToolsRequest.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ListToolsRequest.java
@@ -1,0 +1,14 @@
+package io.airlift.mcp.model;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public record ListToolsRequest(Optional<String> cursor)
+        implements Pagination
+{
+    public ListToolsRequest
+    {
+        requireNonNull(cursor, "nextCursor is null");
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/ListToolsResponse.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ListToolsResponse.java
@@ -1,0 +1,13 @@
+package io.airlift.mcp.model;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+public record ListToolsResponse(List<Tool> tools)
+{
+    public ListToolsResponse
+    {
+        tools = ImmutableList.copyOf(tools);
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/ListToolsResponse.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ListToolsResponse.java
@@ -3,11 +3,16 @@ package io.airlift.mcp.model;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
+import java.util.Optional;
 
-public record ListToolsResponse(List<Tool> tools)
+import static java.util.Objects.requireNonNull;
+
+public record ListToolsResponse(List<Tool> tools, Optional<String> nextCursor)
+        implements Paginated
 {
     public ListToolsResponse
     {
         tools = ImmutableList.copyOf(tools);
+        requireNonNull(nextCursor, "nextCursor is null");
     }
 }

--- a/mcp/src/main/java/io/airlift/mcp/model/LoggingLevel.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/LoggingLevel.java
@@ -1,0 +1,13 @@
+package io.airlift.mcp.model;
+
+public enum LoggingLevel
+{
+    debug,
+    info,
+    notice,
+    warning,
+    error,
+    critical,
+    alert,
+    emergency,
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/LoggingMessageNotification.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/LoggingMessageNotification.java
@@ -1,0 +1,15 @@
+package io.airlift.mcp.model;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public record LoggingMessageNotification(LoggingLevel level, String logger, Optional<Object> data)
+{
+    public LoggingMessageNotification
+    {
+        requireNonNull(level, "level is null");
+        requireNonNull(logger, "logger is null");
+        requireNonNull(data, "data is null");
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/Meta.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/Meta.java
@@ -1,0 +1,12 @@
+package io.airlift.mcp.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+import java.util.Optional;
+
+public interface Meta
+{
+    @JsonProperty("_meta")
+    Optional<Map<String, Object>> meta();
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/ModelHint.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ModelHint.java
@@ -1,0 +1,11 @@
+package io.airlift.mcp.model;
+
+import static java.util.Objects.requireNonNull;
+
+public record ModelHint(String name)
+{
+    public ModelHint
+    {
+        requireNonNull(name, "name is null");
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/ModelPreferences.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ModelPreferences.java
@@ -1,0 +1,29 @@
+package io.airlift.mcp.model;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public record ModelPreferences(List<ModelHint> hints, Optional<Double> costPriority, Optional<Double> speedPriority, Optional<Double> intelligencePriority)
+{
+    public ModelPreferences
+    {
+        hints = ImmutableList.copyOf(hints);
+        requireNonNull(costPriority, "costPriority is null");
+        requireNonNull(speedPriority, "speedPriority is null");
+        requireNonNull(intelligencePriority, "intelligencePriority is null");
+    }
+
+    public ModelPreferences(List<ModelHint> hints)
+    {
+        this(hints, Optional.empty(), Optional.empty(), Optional.empty());
+    }
+
+    public ModelPreferences(ModelHint hint)
+    {
+        this(ImmutableList.of(hint), Optional.empty(), Optional.empty(), Optional.empty());
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/OptionalBoolean.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/OptionalBoolean.java
@@ -1,0 +1,19 @@
+package io.airlift.mcp.model;
+
+import java.util.Optional;
+
+public enum OptionalBoolean
+{
+    UNDEFINED,
+    TRUE,
+    FALSE;
+
+    public Optional<Boolean> map()
+    {
+        return switch (this) {
+            case UNDEFINED -> Optional.empty();
+            case TRUE -> Optional.of(true);
+            case FALSE -> Optional.of(false);
+        };
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/Paginated.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/Paginated.java
@@ -1,0 +1,11 @@
+package io.airlift.mcp.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Optional;
+
+public interface Paginated
+{
+    @JsonProperty
+    Optional<String> nextCursor();
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/Pagination.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/Pagination.java
@@ -1,0 +1,13 @@
+package io.airlift.mcp.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Optional;
+
+public interface Pagination
+{
+    Pagination NONE = Optional::empty;
+
+    @JsonProperty
+    Optional<String> cursor();
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/PaginationMetadata.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/PaginationMetadata.java
@@ -1,0 +1,18 @@
+package io.airlift.mcp.model;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public record PaginationMetadata(int pageSize)
+{
+    public static final PaginationMetadata DEFAULT = new PaginationMetadata(100);
+
+    public PaginationMetadata
+    {
+        checkArgument(pageSize > 0, "pageSize must be greater than 0");
+    }
+
+    public static PaginationMetadata noPagination()
+    {
+        return new PaginationMetadata(Integer.MAX_VALUE);
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/ProgressNotification.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ProgressNotification.java
@@ -1,0 +1,16 @@
+package io.airlift.mcp.model;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public record ProgressNotification(String progressToken, String message, Optional<Double> progress, Optional<Double> total)
+{
+    public ProgressNotification
+    {
+        requireNonNull(progressToken, "progressToken is null");
+        requireNonNull(message, "message is null");
+        requireNonNull(progress, "progress is null");
+        requireNonNull(total, "total is null");
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/Prompt.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/Prompt.java
@@ -1,0 +1,28 @@
+package io.airlift.mcp.model;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public record Prompt(String name, Optional<String> description, Role role, List<Argument> arguments)
+{
+    public record Argument(String name, Optional<String> description, boolean required)
+    {
+        public Argument
+        {
+            requireNonNull(name, "name is null");
+            requireNonNull(description, "description is null");
+        }
+    }
+
+    public Prompt
+    {
+        requireNonNull(name, "name is null");
+        requireNonNull(description, "description is null");
+        requireNonNull(role, "role is null");
+        arguments = ImmutableList.copyOf(arguments);
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/ReadResourceRequest.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ReadResourceRequest.java
@@ -1,0 +1,21 @@
+package io.airlift.mcp.model;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public record ReadResourceRequest(String uri, Optional<Map<String, Object>> meta)
+        implements Meta
+{
+    public ReadResourceRequest
+    {
+        requireNonNull(uri, "uri is null");
+        requireNonNull(meta, "meta is null");
+    }
+
+    public ReadResourceRequest(String uri)
+    {
+        this(uri, Optional.empty());
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/ReadResourceResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ReadResourceResult.java
@@ -1,0 +1,13 @@
+package io.airlift.mcp.model;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+public record ReadResourceResult(List<ResourceContents> contents)
+{
+    public ReadResourceResult
+    {
+        contents = ImmutableList.copyOf(contents);
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/Resource.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/Resource.java
@@ -1,0 +1,32 @@
+package io.airlift.mcp.model;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public record Resource(String name, String uri, Optional<String> description, String mimeType, Optional<Long> size, Optional<Annotations> annotations)
+{
+    public record Annotations(List<Role> audience, Optional<Double> priority)
+    {
+        public static final Annotations EMPTY = new Annotations(ImmutableList.of(), Optional.empty());
+
+        public Annotations
+        {
+            audience = ImmutableList.copyOf(audience);
+            requireNonNull(priority, "priority is null");
+        }
+    }
+
+    public Resource
+    {
+        requireNonNull(name, "name is null");
+        requireNonNull(uri, "uri is null");
+        requireNonNull(description, "description is null");
+        requireNonNull(mimeType, "mimeType is null");
+        requireNonNull(size, "size is null");
+        requireNonNull(annotations, "annotations is null");
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/ResourceContents.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ResourceContents.java
@@ -1,0 +1,25 @@
+package io.airlift.mcp.model;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public record ResourceContents(String name, String uri, String mimeType, Optional<String> text, Optional<String> blob)
+{
+    public ResourceContents
+    {
+        requireNonNull(name, "name is null");
+        requireNonNull(uri, "uri is null");
+        requireNonNull(mimeType, "mimeType is null");
+        requireNonNull(text, "text is null");
+
+        if (text.isEmpty() == blob.isEmpty()) {
+            throw new IllegalArgumentException("Both text and blob cannot be empty or both cannot be present");
+        }
+    }
+
+    public ResourceContents(String name, String uri, String mimeType, String text)
+    {
+        this(name, uri, mimeType, Optional.of(text), Optional.empty());
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/ResourceTemplate.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ResourceTemplate.java
@@ -1,0 +1,29 @@
+package io.airlift.mcp.model;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public record ResourceTemplate(String name, String uriTemplate, Optional<String> description, String mimeType, Optional<Long> size, Optional<Resource.Annotations> annotations)
+{
+    public ResourceTemplate
+    {
+        requireNonNull(name, "name is null");
+        requireNonNull(uriTemplate, "uriTemplate is null");
+        requireNonNull(description, "description is null");
+        requireNonNull(mimeType, "mimeType is null");
+        requireNonNull(size, "size is null");
+        requireNonNull(annotations, "annotations is null");
+    }
+
+    public static ResourceTemplate map(Resource resource)
+    {
+        return new ResourceTemplate(
+                resource.name(),
+                resource.uri(),
+                resource.description(),
+                resource.mimeType(),
+                resource.size(),
+                resource.annotations());
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/ResourcesUpdatedNotification.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ResourcesUpdatedNotification.java
@@ -1,0 +1,11 @@
+package io.airlift.mcp.model;
+
+import static java.util.Objects.requireNonNull;
+
+public record ResourcesUpdatedNotification(String uri)
+{
+    public ResourcesUpdatedNotification
+    {
+        requireNonNull(uri, "uri is null");
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/Role.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/Role.java
@@ -1,0 +1,7 @@
+package io.airlift.mcp.model;
+
+public enum Role
+{
+    user,
+    assistant,
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/RootsResponse.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/RootsResponse.java
@@ -1,0 +1,24 @@
+package io.airlift.mcp.model;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public record RootsResponse(List<Root> roots)
+{
+    public record Root(String uri, String name)
+    {
+        public Root
+        {
+            requireNonNull(uri, "uri is null");
+            requireNonNull(name, "name is null");
+        }
+    }
+
+    public RootsResponse
+    {
+        roots = ImmutableList.copyOf(roots);
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/SamplingMessage.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/SamplingMessage.java
@@ -1,0 +1,12 @@
+package io.airlift.mcp.model;
+
+import static java.util.Objects.requireNonNull;
+
+public record SamplingMessage(Role role, Content content)
+{
+    public SamplingMessage
+    {
+        requireNonNull(role, "role is null");
+        requireNonNull(content, "content is null");
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/ServerInfo.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ServerInfo.java
@@ -1,0 +1,13 @@
+package io.airlift.mcp.model;
+
+import static java.util.Objects.requireNonNull;
+
+public record ServerInfo(String serverName, String serverVersion, String instructions)
+{
+    public ServerInfo
+    {
+        requireNonNull(serverName, "serverName is null");
+        requireNonNull(serverVersion, "serverVersion is null");
+        requireNonNull(instructions, "instructions is null");
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/SetLoggingLevelRequest.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/SetLoggingLevelRequest.java
@@ -1,0 +1,11 @@
+package io.airlift.mcp.model;
+
+import static java.util.Objects.requireNonNull;
+
+public record SetLoggingLevelRequest(LoggingLevel level)
+{
+    public SetLoggingLevelRequest
+    {
+        requireNonNull(level, "level is null");
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/StopReason.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/StopReason.java
@@ -1,0 +1,9 @@
+package io.airlift.mcp.model;
+
+public enum StopReason
+{
+    endTurn,
+    stopSequence,
+    maxTokens,
+    unknown,
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/StructuredContent.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/StructuredContent.java
@@ -1,0 +1,13 @@
+package io.airlift.mcp.model;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import static java.util.Objects.requireNonNull;
+
+public record StructuredContent<T>(@JsonValue T value)
+{
+    public StructuredContent
+    {
+        requireNonNull(value, "value is null");
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/SubscribeListChanged.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/SubscribeListChanged.java
@@ -1,0 +1,5 @@
+package io.airlift.mcp.model;
+
+public record SubscribeListChanged(boolean subscribe, boolean listChanged)
+{
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/SubscribeResourceRequest.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/SubscribeResourceRequest.java
@@ -1,0 +1,11 @@
+package io.airlift.mcp.model;
+
+import static java.util.Objects.requireNonNull;
+
+public record SubscribeResourceRequest(String uri)
+{
+    public SubscribeResourceRequest
+    {
+        requireNonNull(uri, "uri is null");
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/Tool.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/Tool.java
@@ -1,0 +1,38 @@
+package io.airlift.mcp.model;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public record Tool(String name, Optional<String> description, ObjectNode inputSchema, Optional<ObjectNode> outputSchema, ToolAnnotations annotations)
+{
+    public record ToolAnnotations(
+            Optional<String> title,
+            Optional<Boolean> readOnlyHint,
+            Optional<Boolean> destructiveHint,
+            Optional<Boolean> idempotentHint,
+            Optional<Boolean> openWorldHint,
+            Optional<Boolean> returnDirect)
+    {
+        public ToolAnnotations
+        {
+            requireNonNull(title, "title is null");
+            requireNonNull(readOnlyHint, "readOnlyHint is null");
+            requireNonNull(destructiveHint, "destructiveHint is null");
+            requireNonNull(idempotentHint, "idempotentHint is null");
+            requireNonNull(openWorldHint, "openWorldHint is null");
+            requireNonNull(returnDirect, "returnDirect is null");
+        }
+    }
+
+    public Tool
+    {
+        requireNonNull(name, "name is null");
+        requireNonNull(description, "description is null");
+        requireNonNull(inputSchema, "inputSchema is null");
+        requireNonNull(outputSchema, "outputSchema is null");
+        requireNonNull(annotations, "annotations is null");
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/reflection/CompletionHandlerProvider.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/CompletionHandlerProvider.java
@@ -1,0 +1,76 @@
+package io.airlift.mcp.reflection;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Provider;
+import io.airlift.jsonrpc.model.JsonRpcErrorCode;
+import io.airlift.mcp.McpCompletion;
+import io.airlift.mcp.handler.CompletionEntry;
+import io.airlift.mcp.handler.CompletionHandler;
+import io.airlift.mcp.model.Completion;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Optional;
+
+import static io.airlift.mcp.McpException.exception;
+import static io.airlift.mcp.reflection.Predicates.isCompletionRequest;
+import static io.airlift.mcp.reflection.Predicates.isHttpRequest;
+import static io.airlift.mcp.reflection.Predicates.isNotifier;
+import static io.airlift.mcp.reflection.Predicates.returnsOptionalCompletion;
+import static io.airlift.mcp.reflection.Predicates.returnsOptionalListOfString;
+import static io.airlift.mcp.reflection.ReflectionHelper.listArgument;
+import static io.airlift.mcp.reflection.ReflectionHelper.validate;
+import static java.util.Objects.requireNonNull;
+
+public class CompletionHandlerProvider
+        implements Provider<CompletionEntry>
+{
+    private final Class<?> clazz;
+    private final Method method;
+    private final List<MethodParameter> parameters;
+    private final boolean isStringListResult;
+    private final String name;
+    @Inject private Injector injector;
+    @Inject private ObjectMapper objectMapper;
+
+    public CompletionHandlerProvider(McpCompletion mcpCompletion, Class<?> clazz, Method method, List<MethodParameter> parameters)
+    {
+        this.clazz = requireNonNull(clazz, "clazz is null");
+        this.method = requireNonNull(method, "method is null");
+        this.parameters = ImmutableList.copyOf(parameters);
+        this.name = mcpCompletion.name();
+
+        validate(method, parameters, isHttpRequest.or(isNotifier).or(isCompletionRequest), returnsOptionalCompletion.or(returnsOptionalListOfString));
+
+        isStringListResult = listArgument(method.getGenericReturnType()).map(type -> type.equals(String.class)).orElse(false);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public CompletionEntry get()
+    {
+        Object instance = injector.getInstance(clazz);
+        MethodInvoker methodInvoker = new MethodInvoker(instance, method, parameters, objectMapper);
+
+        CompletionHandler completionHandler = (request, notifier, completionRequest) -> {
+            Object result = methodInvoker.builder(request)
+                    .withCompletionRequest(completionRequest)
+                    .withNotifier(notifier)
+                    .invoke();
+            if (result == null) {
+                throw exception(JsonRpcErrorCode.INTERNAL_ERROR, "Completion %s returned null".formatted(method.getName()));
+            }
+
+            if (isStringListResult) {
+                return Optional.of(new Completion((List<String>) result));
+            }
+
+            return (Optional<Completion>) result;
+        };
+
+        return new CompletionEntry(name, completionHandler);
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/reflection/JerseyContextEmulation.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/JerseyContextEmulation.java
@@ -1,0 +1,111 @@
+package io.airlift.mcp.reflection;
+
+import com.google.inject.Inject;
+import io.airlift.mcp.handler.RequestContext;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Request;
+import jakarta.ws.rs.core.SecurityContext;
+import jakarta.ws.rs.core.UriInfo;
+import jakarta.ws.rs.ext.ContextResolver;
+import jakarta.ws.rs.ext.Providers;
+import org.glassfish.jersey.server.ContainerRequest;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.server.model.Parameter;
+import org.glassfish.jersey.server.spi.internal.ValueParamProvider;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static jakarta.ws.rs.core.MediaType.WILDCARD_TYPE;
+import static java.util.Objects.requireNonNull;
+
+public class JerseyContextEmulation
+{
+    private final List<ValueParamProvider> valueParamProviders;
+    private final ResourceConfig application;
+
+    @Inject
+    public JerseyContextEmulation(ResourceConfig application)
+    {
+        valueParamProviders = application.getSingletons()
+                .stream()
+                .flatMap(instance -> (instance instanceof ValueParamProvider valueParamProvider) ? Stream.of(valueParamProvider) : Stream.empty())
+                .sorted(Comparator.<ValueParamProvider>comparingInt(valueParamProvider -> valueParamProvider.getPriority().getWeight()).reversed())
+                .collect(toImmutableList());
+        this.application = requireNonNull(application, "application is null");
+    }
+
+    public interface InternalContextResolver
+    {
+        Object resolve(RequestContext requestContext);
+    }
+
+    public Optional<InternalContextResolver> resolveContextInstance(Class<?> declaringClass, Class<?> rawType, Type type, Annotation[] annotations)
+    {
+        if (Request.class.isAssignableFrom(rawType)) {
+            return Optional.of((RequestContext::request));
+        }
+
+        if (Application.class.isAssignableFrom(rawType)) {
+            return Optional.of(_ -> application);
+        }
+
+        if (UriInfo.class.isAssignableFrom(rawType)) {
+            return Optional.of(requestContext -> requireContainerRequest(requestContext).getUriInfo());
+        }
+
+        if (HttpHeaders.class.isAssignableFrom(rawType)) {
+            return Optional.of(JerseyContextEmulation::requireContainerRequest);    // ContainerRequest implements HttpHeaders
+        }
+
+        if (SecurityContext.class.isAssignableFrom(rawType)) {
+            return Optional.of(requestContext -> requireContainerRequest(requestContext).getSecurityContext());
+        }
+
+        if (Providers.class.isAssignableFrom(rawType)) {
+            return Optional.of(RequestContext::providers);
+        }
+
+        Parameter parameter = Parameter.create(declaringClass, declaringClass, false, rawType, type, annotations);
+
+        Optional<? extends Function<ContainerRequest, ?>> provider = valueParamProviders.stream()
+                .flatMap(valueParamProvider -> Optional.ofNullable(valueParamProvider.getValueProvider(parameter)).stream())
+                .findFirst();
+
+        InternalContextResolver catchAllInternalContextResolver = provider.map(JerseyContextEmulation::paramProviderResolver)
+                .orElseGet(() -> jaxrsContextResolver(rawType, type));
+        return Optional.of(catchAllInternalContextResolver);
+    }
+
+    private static InternalContextResolver paramProviderResolver(Function<ContainerRequest, ?> proc)
+    {
+        return requestContext -> proc.apply(requireContainerRequest(requestContext));
+    }
+
+    private static InternalContextResolver jaxrsContextResolver(Class<?> rawType, Type type)
+    {
+        return requestContext -> {
+            ContextResolver<Object> jaxrsResolver = requestContext.contextResolvers().resolve(type, firstNonNull(requireContainerRequest(requestContext).getMediaType(), WILDCARD_TYPE));
+            if (jaxrsResolver != null) {
+                return jaxrsResolver.getContext(rawType);
+            }
+            return null;
+        };
+    }
+
+    private static ContainerRequest requireContainerRequest(RequestContext requestContext)
+    {
+        if (requestContext.request() instanceof ContainerRequest containerRequest) {
+            return containerRequest;
+        }
+        throw new IllegalArgumentException("request is not a ContainerRequest: " + requestContext.request().getClass().getName());
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/reflection/MethodInvoker.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/MethodInvoker.java
@@ -22,8 +22,10 @@ import io.airlift.mcp.reflection.MethodParameter.NotifierParameter;
 import io.airlift.mcp.reflection.MethodParameter.ObjectParameter;
 import io.airlift.mcp.reflection.MethodParameter.PathTemplateValuesParameter;
 import io.airlift.mcp.reflection.MethodParameter.ReadResourceRequestParameter;
+import io.airlift.mcp.reflection.MethodParameter.SessionIdParameter;
 import io.airlift.mcp.reflection.MethodParameter.SourceResourceParameter;
 import io.airlift.mcp.reflection.MethodParameter.SourceResourceTemplateParameter;
+import io.airlift.mcp.session.SessionId;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Request;
 
@@ -71,7 +73,7 @@ public class MethodInvoker
         Object invoke();
     }
 
-    public Builder builder(Request request)
+    public Builder builder(Request request, SessionId sessionId)
     {
         return new Builder()
         {
@@ -144,6 +146,7 @@ public class MethodInvoker
                     Object[] methodArguments = parameters.stream()
                             .map(parameter -> switch (parameter) {
                                 case HttpRequestParameter _ -> request;
+                                case SessionIdParameter _ -> sessionId;
                                 case NotifierParameter _ -> notifier.orElseThrow(() -> new IllegalArgumentException("Notifier is required"));
                                 case CompletionRequestParameter _ -> completion.orElseThrow(() -> new IllegalArgumentException("Completion is required"));
                                 case GetPromptRequestParameter _ -> getPromptRequest.orElseThrow(() -> new IllegalArgumentException("GetPromptRequest is required"));

--- a/mcp/src/main/java/io/airlift/mcp/reflection/MethodInvoker.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/MethodInvoker.java
@@ -1,0 +1,188 @@
+package io.airlift.mcp.reflection;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import io.airlift.mcp.McpException;
+import io.airlift.mcp.McpNotifier;
+import io.airlift.mcp.handler.ResourceTemplateHandler.PathTemplateValues;
+import io.airlift.mcp.model.CallToolRequest;
+import io.airlift.mcp.model.CompletionRequest;
+import io.airlift.mcp.model.GetPromptRequest;
+import io.airlift.mcp.model.ReadResourceRequest;
+import io.airlift.mcp.model.Resource;
+import io.airlift.mcp.model.ResourceTemplate;
+import io.airlift.mcp.reflection.MethodParameter.CallToolRequestParameter;
+import io.airlift.mcp.reflection.MethodParameter.CompletionRequestParameter;
+import io.airlift.mcp.reflection.MethodParameter.GetPromptRequestParameter;
+import io.airlift.mcp.reflection.MethodParameter.HttpRequestParameter;
+import io.airlift.mcp.reflection.MethodParameter.NotifierParameter;
+import io.airlift.mcp.reflection.MethodParameter.ObjectParameter;
+import io.airlift.mcp.reflection.MethodParameter.PathTemplateValuesParameter;
+import io.airlift.mcp.reflection.MethodParameter.ReadResourceRequestParameter;
+import io.airlift.mcp.reflection.MethodParameter.SourceResourceParameter;
+import io.airlift.mcp.reflection.MethodParameter.SourceResourceTemplateParameter;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Request;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.airlift.jsonrpc.model.JsonRpcErrorCode.INVALID_REQUEST;
+import static io.airlift.mcp.McpException.exception;
+import static java.util.Objects.requireNonNull;
+
+public class MethodInvoker
+{
+    private final Object instance;
+    private final Method method;
+    private final List<MethodParameter> parameters;
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public MethodInvoker(Object instance, Method method, List<MethodParameter> parameters, ObjectMapper objectMapper)
+    {
+        this.instance = requireNonNull(instance, "instance is null");
+        this.method = requireNonNull(method, "method is null");
+        this.parameters = ImmutableList.copyOf(parameters);
+        this.objectMapper = requireNonNull(objectMapper, "objectMapper is null");
+    }
+
+    public interface Builder
+    {
+        Builder withArguments(Map<String, Object> arguments);
+
+        Builder withCompletionRequest(CompletionRequest completion);
+
+        Builder withGetPromptRequest(GetPromptRequest getPromptRequest);
+
+        Builder withCallToolRequest(CallToolRequest callToolRequest);
+
+        Builder withNotifier(McpNotifier notifier);
+
+        Builder withReadResourceRequest(Resource sourceResource, ReadResourceRequest readResourceRequest);
+
+        Builder withReadResourceTemplateRequest(ResourceTemplate sourceResourceTemplate, ReadResourceRequest readResourceRequest, PathTemplateValues pathTemplateValues);
+
+        Object invoke();
+    }
+
+    public Builder builder(Request request)
+    {
+        return new Builder()
+        {
+            private Map<String, Object> arguments = ImmutableMap.of();
+            private Optional<CompletionRequest> completion = Optional.empty();
+            private Optional<McpNotifier> notifier = Optional.empty();
+            private Optional<GetPromptRequest> getPromptRequest = Optional.empty();
+            private Optional<CallToolRequest> callToolRequest = Optional.empty();
+            private Optional<Resource> sourceResource = Optional.empty();
+            private Optional<ReadResourceRequest> readResourceRequest = Optional.empty();
+            private Optional<ResourceTemplate> sourceResourceTemplate = Optional.empty();
+            private Optional<PathTemplateValues> pathTemplateValues = Optional.empty();
+
+            @Override
+            public Builder withArguments(Map<String, Object> arguments)
+            {
+                this.arguments = ImmutableMap.copyOf(arguments);
+                return this;
+            }
+
+            @Override
+            public Builder withCompletionRequest(CompletionRequest completion)
+            {
+                this.completion = Optional.of(completion);
+                return this;
+            }
+
+            @Override
+            public Builder withGetPromptRequest(GetPromptRequest getPromptRequest)
+            {
+                this.getPromptRequest = Optional.of(getPromptRequest);
+                return this;
+            }
+
+            @Override
+            public Builder withCallToolRequest(CallToolRequest callToolRequest)
+            {
+                this.callToolRequest = Optional.of(callToolRequest);
+                return this;
+            }
+
+            @Override
+            public Builder withNotifier(McpNotifier notifier)
+            {
+                this.notifier = Optional.of(notifier);
+                return this;
+            }
+
+            @Override
+            public Builder withReadResourceRequest(Resource sourceResource, ReadResourceRequest readResourceRequest)
+            {
+                this.sourceResource = Optional.of(sourceResource);
+                this.readResourceRequest = Optional.of(readResourceRequest);
+                return this;
+            }
+
+            @Override
+            public Builder withReadResourceTemplateRequest(ResourceTemplate sourceResourceTemplate, ReadResourceRequest readResourceRequest, PathTemplateValues pathTemplateValues)
+            {
+                this.sourceResourceTemplate = Optional.of(sourceResourceTemplate);
+                this.readResourceRequest = Optional.of(readResourceRequest);
+                this.pathTemplateValues = Optional.of(pathTemplateValues);
+                return this;
+            }
+
+            @Override
+            public Object invoke()
+            {
+                try {
+                    Object[] methodArguments = parameters.stream()
+                            .map(parameter -> switch (parameter) {
+                                case HttpRequestParameter _ -> request;
+                                case NotifierParameter _ -> notifier.orElseThrow(() -> new IllegalArgumentException("Notifier is required"));
+                                case CompletionRequestParameter _ -> completion.orElseThrow(() -> new IllegalArgumentException("Completion is required"));
+                                case GetPromptRequestParameter _ -> getPromptRequest.orElseThrow(() -> new IllegalArgumentException("GetPromptRequest is required"));
+                                case CallToolRequestParameter _ -> callToolRequest.orElseThrow(() -> new IllegalArgumentException("CallToolRequest is required"));
+                                case SourceResourceParameter _ -> sourceResource.orElseThrow(() -> new IllegalArgumentException("SourceResource is required"));
+                                case ReadResourceRequestParameter _ -> readResourceRequest.orElseThrow(() -> new IllegalArgumentException("ReadResourceRequest is required"));
+                                case SourceResourceTemplateParameter _ -> sourceResourceTemplate.orElseThrow(() -> new IllegalArgumentException("SourceResourceTemplate is required"));
+                                case PathTemplateValuesParameter _ -> pathTemplateValues.orElseThrow(() -> new IllegalArgumentException("PathTemplateValues is required"));
+                                case ObjectParameter objectParameter -> valueForObjectParameter(arguments, objectParameter);
+                            })
+                            .toArray();
+
+                    return method.invoke(instance, methodArguments);
+                }
+                catch (McpException | WebApplicationException e) {
+                    throw e;
+                }
+                catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+    }
+
+    private Object valueForObjectParameter(Map<String, Object> arguments, ObjectParameter objectParameter)
+    {
+        Object value = arguments.get(objectParameter.name());
+        if (value == null) {
+            if (objectParameter.required()) {
+                throw exception(INVALID_REQUEST, "Missing required parameter: " + objectParameter.name());
+            }
+            return Optional.empty();
+        }
+
+        if (objectParameter.rawType().isRecord()) {
+            JavaType javaType = objectMapper.getTypeFactory().constructType(objectParameter.genericType());
+            return objectMapper.convertValue(value, javaType);
+        }
+
+        return value;
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/reflection/MethodParameter.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/MethodParameter.java
@@ -1,7 +1,11 @@
 package io.airlift.mcp.reflection;
 
+import io.airlift.mcp.reflection.JerseyContextEmulation.InternalContextResolver;
+
 import java.lang.reflect.Type;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 import static java.util.Objects.requireNonNull;
 
@@ -65,6 +69,15 @@ public sealed interface MethodParameter
             implements MethodParameter
     {
         public static final PathTemplateValuesParameter INSTANCE = new PathTemplateValuesParameter();
+    }
+
+    record JaxrsContextParameter(Function<JerseyContextEmulation, Supplier<InternalContextResolver>> contextResolverSupplier)
+            implements MethodParameter
+    {
+        public JaxrsContextParameter
+        {
+            requireNonNull(contextResolverSupplier, "contextResolverSupplier is null");
+        }
     }
 
     record ObjectParameter(

--- a/mcp/src/main/java/io/airlift/mcp/reflection/MethodParameter.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/MethodParameter.java
@@ -13,6 +13,12 @@ public sealed interface MethodParameter
         public static final HttpRequestParameter INSTANCE = new HttpRequestParameter();
     }
 
+    record SessionIdParameter()
+            implements MethodParameter
+    {
+        public static final SessionIdParameter INSTANCE = new SessionIdParameter();
+    }
+
     record CompletionRequestParameter()
             implements MethodParameter
     {

--- a/mcp/src/main/java/io/airlift/mcp/reflection/MethodParameter.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/MethodParameter.java
@@ -1,0 +1,80 @@
+package io.airlift.mcp.reflection;
+
+import java.lang.reflect.Type;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public sealed interface MethodParameter
+{
+    record HttpRequestParameter()
+            implements MethodParameter
+    {
+        public static final HttpRequestParameter INSTANCE = new HttpRequestParameter();
+    }
+
+    record CompletionRequestParameter()
+            implements MethodParameter
+    {
+        public static final CompletionRequestParameter INSTANCE = new CompletionRequestParameter();
+    }
+
+    record GetPromptRequestParameter()
+            implements MethodParameter
+    {
+        public static final GetPromptRequestParameter INSTANCE = new GetPromptRequestParameter();
+    }
+
+    record CallToolRequestParameter()
+            implements MethodParameter
+    {
+        public static final CallToolRequestParameter INSTANCE = new CallToolRequestParameter();
+    }
+
+    record NotifierParameter()
+            implements MethodParameter
+    {
+        public static final NotifierParameter INSTANCE = new NotifierParameter();
+    }
+
+    record SourceResourceParameter()
+            implements MethodParameter
+    {
+        public static final SourceResourceParameter INSTANCE = new SourceResourceParameter();
+    }
+
+    record SourceResourceTemplateParameter()
+            implements MethodParameter
+    {
+        public static final SourceResourceTemplateParameter INSTANCE = new SourceResourceTemplateParameter();
+    }
+
+    record ReadResourceRequestParameter()
+            implements MethodParameter
+    {
+        public static final ReadResourceRequestParameter INSTANCE = new ReadResourceRequestParameter();
+    }
+
+    record PathTemplateValuesParameter()
+            implements MethodParameter
+    {
+        public static final PathTemplateValuesParameter INSTANCE = new PathTemplateValuesParameter();
+    }
+
+    record ObjectParameter(
+            String name,
+            Class<?> rawType,
+            Type genericType,
+            Optional<String> description,
+            boolean required)
+            implements MethodParameter
+    {
+        public ObjectParameter
+        {
+            requireNonNull(name, "name is null");
+            requireNonNull(rawType, "rawType is null");
+            requireNonNull(genericType, "genericType is null");
+            requireNonNull(description, "description is null");
+        }
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/reflection/Predicates.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/Predicates.java
@@ -4,6 +4,7 @@ import io.airlift.mcp.model.Completion;
 import io.airlift.mcp.model.GetPromptResult;
 import io.airlift.mcp.model.ResourceContents;
 import io.airlift.mcp.reflection.MethodParameter.HttpRequestParameter;
+import io.airlift.mcp.reflection.MethodParameter.JaxrsContextParameter;
 import io.airlift.mcp.reflection.MethodParameter.SessionIdParameter;
 
 import java.lang.reflect.Method;
@@ -16,7 +17,6 @@ import static io.airlift.mcp.reflection.ReflectionHelper.optionalReturnArgument;
 
 public interface Predicates
 {
-    Predicate<MethodParameter> isHttpRequestOrSessonId = methodParameter -> (methodParameter instanceof HttpRequestParameter) || (methodParameter instanceof SessionIdParameter);
     Predicate<MethodParameter> isNotifier = methodParameter -> methodParameter instanceof MethodParameter.NotifierParameter;
     Predicate<MethodParameter> isCompletionRequest = methodParameter -> methodParameter instanceof MethodParameter.CompletionRequestParameter;
     Predicate<MethodParameter> isGetPromptRequest = methodParameter -> methodParameter instanceof MethodParameter.GetPromptRequestParameter;
@@ -28,6 +28,9 @@ public interface Predicates
     Predicate<MethodParameter> isObject = methodParameter -> (methodParameter instanceof MethodParameter.ObjectParameter);
     Predicate<MethodParameter> isString = methodParameter -> (methodParameter instanceof MethodParameter.ObjectParameter objectParameter)
             && objectParameter.rawType().equals(String.class);
+    Predicate<MethodParameter> isRequestParameter = methodParameter -> (methodParameter instanceof HttpRequestParameter)
+            || (methodParameter instanceof SessionIdParameter)
+            || (methodParameter instanceof JaxrsContextParameter);
 
     Predicate<Method> returnsAnything = _ -> true;
     Predicate<Method> returnsOptionalCompletion = method -> optionalReturnArgument(method).equals(Completion.class);

--- a/mcp/src/main/java/io/airlift/mcp/reflection/Predicates.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/Predicates.java
@@ -1,0 +1,43 @@
+package io.airlift.mcp.reflection;
+
+import io.airlift.mcp.model.Completion;
+import io.airlift.mcp.model.GetPromptResult;
+import io.airlift.mcp.model.ResourceContents;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.WildcardType;
+import java.util.function.Predicate;
+
+import static io.airlift.mcp.reflection.ReflectionHelper.listArgument;
+import static io.airlift.mcp.reflection.ReflectionHelper.optionalReturnArgument;
+
+public interface Predicates
+{
+    Predicate<MethodParameter> isHttpRequest = methodParameter -> methodParameter instanceof MethodParameter.HttpRequestParameter;
+    Predicate<MethodParameter> isNotifier = methodParameter -> methodParameter instanceof MethodParameter.NotifierParameter;
+    Predicate<MethodParameter> isCompletionRequest = methodParameter -> methodParameter instanceof MethodParameter.CompletionRequestParameter;
+    Predicate<MethodParameter> isGetPromptRequest = methodParameter -> methodParameter instanceof MethodParameter.GetPromptRequestParameter;
+    Predicate<MethodParameter> isCallToolRequest = methodParameter -> methodParameter instanceof MethodParameter.CallToolRequestParameter;
+    Predicate<MethodParameter> isReadResourceRequest = methodParameter -> methodParameter instanceof MethodParameter.ReadResourceRequestParameter;
+    Predicate<MethodParameter> isSourceResource = methodParameter -> methodParameter instanceof MethodParameter.SourceResourceParameter;
+    Predicate<MethodParameter> isSourceResourceTemplate = methodParameter -> methodParameter instanceof MethodParameter.SourceResourceTemplateParameter;
+    Predicate<MethodParameter> isPathTemplateValues = methodParameter -> methodParameter instanceof MethodParameter.PathTemplateValuesParameter;
+    Predicate<MethodParameter> isObject = methodParameter -> (methodParameter instanceof MethodParameter.ObjectParameter);
+    Predicate<MethodParameter> isString = methodParameter -> (methodParameter instanceof MethodParameter.ObjectParameter objectParameter)
+            && objectParameter.rawType().equals(String.class);
+
+    Predicate<Method> returnsAnything = _ -> true;
+    Predicate<Method> returnsOptionalCompletion = method -> optionalReturnArgument(method).equals(Completion.class);
+    Predicate<Method> returnsResourceContents = method -> method.getReturnType().equals(ResourceContents.class);
+    Predicate<Method> returnsResourceContentsList = method -> listArgument(method.getGenericReturnType())
+            .map(t -> t.equals(ResourceContents.class))
+            .orElse(false);
+    Predicate<Method> returnsString = method -> method.getReturnType().equals(String.class);
+    Predicate<Method> returnsGetPromptResult = method -> method.getReturnType().equals(GetPromptResult.class)
+            && (method.getGenericReturnType() instanceof ParameterizedType parameterizedType)
+            && (parameterizedType.getActualTypeArguments()[0] instanceof WildcardType);
+    Predicate<Method> returnsOptionalListOfString = method -> listArgument(optionalReturnArgument(method))
+            .map(t -> t.equals(String.class))
+            .orElse(false);
+}

--- a/mcp/src/main/java/io/airlift/mcp/reflection/Predicates.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/Predicates.java
@@ -3,6 +3,8 @@ package io.airlift.mcp.reflection;
 import io.airlift.mcp.model.Completion;
 import io.airlift.mcp.model.GetPromptResult;
 import io.airlift.mcp.model.ResourceContents;
+import io.airlift.mcp.reflection.MethodParameter.HttpRequestParameter;
+import io.airlift.mcp.reflection.MethodParameter.SessionIdParameter;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
@@ -14,7 +16,7 @@ import static io.airlift.mcp.reflection.ReflectionHelper.optionalReturnArgument;
 
 public interface Predicates
 {
-    Predicate<MethodParameter> isHttpRequest = methodParameter -> methodParameter instanceof MethodParameter.HttpRequestParameter;
+    Predicate<MethodParameter> isHttpRequestOrSessonId = methodParameter -> (methodParameter instanceof HttpRequestParameter) || (methodParameter instanceof SessionIdParameter);
     Predicate<MethodParameter> isNotifier = methodParameter -> methodParameter instanceof MethodParameter.NotifierParameter;
     Predicate<MethodParameter> isCompletionRequest = methodParameter -> methodParameter instanceof MethodParameter.CompletionRequestParameter;
     Predicate<MethodParameter> isGetPromptRequest = methodParameter -> methodParameter instanceof MethodParameter.GetPromptRequestParameter;

--- a/mcp/src/main/java/io/airlift/mcp/reflection/PromptHandlerProvider.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/PromptHandlerProvider.java
@@ -1,0 +1,101 @@
+package io.airlift.mcp.reflection;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Provider;
+import io.airlift.jsonrpc.model.JsonRpcErrorCode;
+import io.airlift.mcp.McpPrompt;
+import io.airlift.mcp.handler.PromptEntry;
+import io.airlift.mcp.handler.PromptHandler;
+import io.airlift.mcp.model.Content;
+import io.airlift.mcp.model.GetPromptResult;
+import io.airlift.mcp.model.GetPromptResult.PromptMessage;
+import io.airlift.mcp.model.Prompt;
+import io.airlift.mcp.model.Role;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.mcp.McpException.exception;
+import static io.airlift.mcp.reflection.Predicates.isGetPromptRequest;
+import static io.airlift.mcp.reflection.Predicates.isHttpRequest;
+import static io.airlift.mcp.reflection.Predicates.isNotifier;
+import static io.airlift.mcp.reflection.Predicates.isString;
+import static io.airlift.mcp.reflection.Predicates.returnsGetPromptResult;
+import static io.airlift.mcp.reflection.Predicates.returnsString;
+import static io.airlift.mcp.reflection.ReflectionHelper.mapToContent;
+import static io.airlift.mcp.reflection.ReflectionHelper.validate;
+import static java.util.Objects.requireNonNull;
+
+public class PromptHandlerProvider
+        implements Provider<PromptEntry>
+{
+    private final Prompt prompt;
+    private final Class<?> clazz;
+    private final Method method;
+    private final List<MethodParameter> parameters;
+    private final Role role;
+    private final boolean isGetPromptResult;
+    @Inject private Injector injector;
+    @Inject private ObjectMapper objectMapper;
+
+    public PromptHandlerProvider(McpPrompt mcpPrompt, Class<?> clazz, Method method, List<MethodParameter> parameters, Role role)
+    {
+        this.clazz = requireNonNull(clazz, "clazz is null");
+        this.method = requireNonNull(method, "method is null");
+        this.parameters = ImmutableList.copyOf(parameters);
+        this.role = requireNonNull(role, "role is null");
+
+        validate(method, parameters, isHttpRequest.or(isNotifier).or(isString).or(isGetPromptRequest), returnsString.or(returnsGetPromptResult));
+
+        prompt = buildPrompt(mcpPrompt, parameters);
+        isGetPromptResult = GetPromptResult.class.isAssignableFrom(method.getReturnType());
+    }
+
+    @Override
+    public PromptEntry get()
+    {
+        Object instance = injector.getInstance(clazz);
+        MethodInvoker methodInvoker = new MethodInvoker(instance, method, parameters, objectMapper);
+
+        PromptHandler promptHandler = (request, notifier, promptRequest) -> {
+            Object result = methodInvoker.builder(request)
+                    .withArguments(promptRequest.arguments())
+                    .withNotifier(notifier)
+                    .withGetPromptRequest(promptRequest)
+                    .invoke();
+            if (result == null) {
+                throw exception(JsonRpcErrorCode.INTERNAL_ERROR, "Prompt %s returned null".formatted(method.getName()));
+            }
+
+            if (isGetPromptResult) {
+                return (GetPromptResult) result;
+            }
+
+            Content content = mapToContent(result);
+            return new GetPromptResult(prompt.description(), ImmutableList.of(new PromptMessage(role, content)));
+        };
+
+        return new PromptEntry(prompt, promptHandler);
+    }
+
+    private static Prompt buildPrompt(McpPrompt prompt, List<MethodParameter> parameters)
+    {
+        Optional<String> description = prompt.description().isEmpty() ? Optional.empty() : Optional.of(prompt.description());
+        return new Prompt(prompt.name(), description, prompt.role(), toPromptArguments(parameters));
+    }
+
+    private static List<Prompt.Argument> toPromptArguments(List<MethodParameter> parameters)
+    {
+        return parameters
+                .stream()
+                .flatMap(methodParameter -> (methodParameter instanceof MethodParameter.ObjectParameter objectParameter) ? Stream.of(objectParameter) : Stream.empty())
+                .map(objectParameter -> new Prompt.Argument(objectParameter.name(), objectParameter.description(), objectParameter.required()))
+                .collect(toImmutableList());
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/reflection/ReflectionHelper.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/ReflectionHelper.java
@@ -19,8 +19,10 @@ import io.airlift.mcp.reflection.MethodParameter.NotifierParameter;
 import io.airlift.mcp.reflection.MethodParameter.ObjectParameter;
 import io.airlift.mcp.reflection.MethodParameter.PathTemplateValuesParameter;
 import io.airlift.mcp.reflection.MethodParameter.ReadResourceRequestParameter;
+import io.airlift.mcp.reflection.MethodParameter.SessionIdParameter;
 import io.airlift.mcp.reflection.MethodParameter.SourceResourceParameter;
 import io.airlift.mcp.reflection.MethodParameter.SourceResourceTemplateParameter;
+import io.airlift.mcp.session.SessionId;
 import jakarta.ws.rs.core.Request;
 
 import java.lang.annotation.Annotation;
@@ -66,11 +68,15 @@ public interface ReflectionHelper
                     Parameter parameter = method.getParameters()[index];
                     Type genericType = method.getGenericParameterTypes()[index];
 
-                    if (parameter.getType().equals(Request.class)) {
+                    if (Request.class.isAssignableFrom(parameter.getType())) {
                         return HttpRequestParameter.INSTANCE;
                     }
 
-                    if (parameter.getType().equals(McpNotifier.class)) {
+                    if (SessionId.class.isAssignableFrom(parameter.getType())) {
+                        return SessionIdParameter.INSTANCE;
+                    }
+
+                    if (McpNotifier.class.isAssignableFrom(parameter.getType())) {
                         return NotifierParameter.INSTANCE;
                     }
 

--- a/mcp/src/main/java/io/airlift/mcp/reflection/ReflectionHelper.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/ReflectionHelper.java
@@ -1,0 +1,195 @@
+package io.airlift.mcp.reflection;
+
+import io.airlift.mcp.McpDescription;
+import io.airlift.mcp.McpNotifier;
+import io.airlift.mcp.handler.ResourceTemplateHandler.PathTemplateValues;
+import io.airlift.mcp.model.CallToolRequest;
+import io.airlift.mcp.model.CompletionRequest;
+import io.airlift.mcp.model.Content;
+import io.airlift.mcp.model.Content.TextContent;
+import io.airlift.mcp.model.GetPromptRequest;
+import io.airlift.mcp.model.ReadResourceRequest;
+import io.airlift.mcp.model.Resource;
+import io.airlift.mcp.model.ResourceTemplate;
+import io.airlift.mcp.reflection.MethodParameter.CallToolRequestParameter;
+import io.airlift.mcp.reflection.MethodParameter.CompletionRequestParameter;
+import io.airlift.mcp.reflection.MethodParameter.GetPromptRequestParameter;
+import io.airlift.mcp.reflection.MethodParameter.HttpRequestParameter;
+import io.airlift.mcp.reflection.MethodParameter.NotifierParameter;
+import io.airlift.mcp.reflection.MethodParameter.ObjectParameter;
+import io.airlift.mcp.reflection.MethodParameter.PathTemplateValuesParameter;
+import io.airlift.mcp.reflection.MethodParameter.ReadResourceRequestParameter;
+import io.airlift.mcp.reflection.MethodParameter.SourceResourceParameter;
+import io.airlift.mcp.reflection.MethodParameter.SourceResourceTemplateParameter;
+import jakarta.ws.rs.core.Request;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.mcp.reflection.ReflectionHelper.parseParameters;
+
+public interface ReflectionHelper
+{
+    @SuppressWarnings("SwitchStatementWithTooFewBranches")
+    static void validate(Method method, List<MethodParameter> methodParameters, Predicate<MethodParameter> parameterPredicateChain, Predicate<Method> methodPredicateChain)
+    {
+        Function<MethodParameter, String> methodDebug = parameter -> switch (parameter) {
+            case ObjectParameter objectParameter -> objectParameter.name();
+            default -> parameter.getClass().getSimpleName();
+        };
+
+        methodParameters.forEach(methodParameter -> {
+            if (!parameterPredicateChain.test(methodParameter)) {
+                throw new IllegalArgumentException("Validation failure for %s. Parameter failed validation: %s.".formatted(method, methodDebug.apply(methodParameter)));
+            }
+        });
+
+        if (!methodPredicateChain.test(method)) {
+            throw new IllegalArgumentException("Method validation failure. Check that the return type is correct for: %s".formatted(method));
+        }
+    }
+
+    static List<MethodParameter> parseParameters(Method method)
+    {
+        return IntStream.range(0, method.getParameterCount())
+                .mapToObj(index -> {
+                    Parameter parameter = method.getParameters()[index];
+                    Type genericType = method.getGenericParameterTypes()[index];
+
+                    if (parameter.getType().equals(Request.class)) {
+                        return HttpRequestParameter.INSTANCE;
+                    }
+
+                    if (parameter.getType().equals(McpNotifier.class)) {
+                        return NotifierParameter.INSTANCE;
+                    }
+
+                    if (CompletionRequest.class.isAssignableFrom(parameter.getType())) {
+                        return CompletionRequestParameter.INSTANCE;
+                    }
+
+                    if (GetPromptRequest.class.isAssignableFrom(parameter.getType())) {
+                        return GetPromptRequestParameter.INSTANCE;
+                    }
+
+                    if (CallToolRequest.class.isAssignableFrom(parameter.getType())) {
+                        return CallToolRequestParameter.INSTANCE;
+                    }
+
+                    if (Resource.class.isAssignableFrom(parameter.getType())) {
+                        return SourceResourceParameter.INSTANCE;
+                    }
+
+                    if (ResourceTemplate.class.isAssignableFrom(parameter.getType())) {
+                        return SourceResourceTemplateParameter.INSTANCE;
+                    }
+
+                    if (ReadResourceRequest.class.isAssignableFrom(parameter.getType())) {
+                        return ReadResourceRequestParameter.INSTANCE;
+                    }
+
+                    if (PathTemplateValues.class.isAssignableFrom(parameter.getType())) {
+                        return PathTemplateValuesParameter.INSTANCE;
+                    }
+
+                    Optional<String> description = Optional.ofNullable(parameter.getAnnotation(McpDescription.class)).map(McpDescription::value);
+                    return new ObjectParameter(parameter.getName(), parameter.getType(), genericType, description, Optional.class.isAssignableFrom(parameter.getType()));
+                })
+                .collect(toImmutableList());
+    }
+
+    interface InClassConsumer<A extends Annotation>
+    {
+        void accept(A annotation, Method method, List<MethodParameter> parameters);
+    }
+
+    static <A extends Annotation> void forAllInClass(Class<?> clazz, Class<A> annotationClass, InClassConsumer<A> consumer)
+    {
+        Stream.of(clazz.getMethods())
+                .forEach(method -> {
+                    A annotation = method.getAnnotation(annotationClass);
+                    if (annotation == null) {
+                        return;
+                    }
+
+                    List<MethodParameter> parameters = parseParameters(method);
+                    consumer.accept(annotation, method, parameters);
+                });
+    }
+
+    static Content mapToContent(Object result)
+    {
+        return switch (result) {
+            case String str -> new TextContent(str);
+            case Number number -> new TextContent(number.toString());
+            case Content content -> content;
+            default -> new TextContent(String.valueOf(result));
+        };
+    }
+
+    static Type listReturnArgument(Method method)
+    {
+        return listArgument(method.getGenericReturnType())
+                .orElseThrow(() -> new IllegalArgumentException(String.format("Method %s does not return a List", method.getName())));
+    }
+
+    static Optional<Type> listArgument(Type type)
+    {
+        if (type instanceof ParameterizedType parameterizedType) {
+            if (parameterizedType.getRawType().equals(List.class)) {
+                Type[] actualTypeArguments = parameterizedType.getActualTypeArguments();
+                if (actualTypeArguments.length == 1) {
+                    return Optional.of(actualTypeArguments[0]);
+                }
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    static Type optionalReturnArgument(Method method)
+    {
+        return optionalArgument(method.getGenericReturnType())
+                .orElseThrow(() -> new IllegalArgumentException(String.format("Method %s does not return an Optional", method.getName())));
+    }
+
+    static Optional<Type> optionalArgument(Type type)
+    {
+        if (type instanceof ParameterizedType parameterizedType) {
+            if (parameterizedType.getRawType().equals(Optional.class)) {
+                Type[] actualTypeArguments = parameterizedType.getActualTypeArguments();
+                if (actualTypeArguments.length == 1) {
+                    return Optional.of(actualTypeArguments[0]);
+                }
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    static void validateOnlyContexts(Method method, List<MethodParameter> parameters, Class<?> returnType)
+    {
+        if (!parameters.stream().allMatch(parameter -> (parameter instanceof HttpRequestParameter) || (parameter instanceof NotifierParameter))) {
+            throw new IllegalArgumentException("Method " + method.getName() + " must only have HttpRequest or Notifier parameters");
+        }
+
+        Type genericReturnType = method.getGenericReturnType();
+        if ((genericReturnType instanceof ParameterizedType parameterizedType) && parameterizedType.getRawType().equals(List.class)) {
+            if (parameterizedType.getActualTypeArguments()[0].equals(returnType)) {
+                return;
+            }
+        }
+
+        throw new IllegalArgumentException(String.format("Method %s does not return %s", method.getName(), returnType.getSimpleName()));
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/reflection/ResourceHandlerProvider.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/ResourceHandlerProvider.java
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static io.airlift.mcp.McpException.exception;
-import static io.airlift.mcp.reflection.Predicates.isHttpRequest;
+import static io.airlift.mcp.reflection.Predicates.isHttpRequestOrSessonId;
 import static io.airlift.mcp.reflection.Predicates.isNotifier;
 import static io.airlift.mcp.reflection.Predicates.isReadResourceRequest;
 import static io.airlift.mcp.reflection.Predicates.isSourceResource;
@@ -45,7 +45,7 @@ public class ResourceHandlerProvider
         this.method = requireNonNull(method, "method is null");
         this.parameters = ImmutableList.copyOf(parameters);
 
-        validate(method, parameters, isHttpRequest.or(isNotifier).or(isReadResourceRequest).or(isSourceResource), returnsResourceContents.or(returnsResourceContentsList));
+        validate(method, parameters, isHttpRequestOrSessonId.or(isNotifier).or(isReadResourceRequest).or(isSourceResource), returnsResourceContents.or(returnsResourceContentsList));
         resultIsSingleContent = returnsResourceContents.test(method);
 
         resource = buildResource(
@@ -64,8 +64,8 @@ public class ResourceHandlerProvider
         Object instance = injector.getInstance(clazz);
         MethodInvoker methodInvoker = new MethodInvoker(instance, method, parameters, objectMapper);
 
-        ResourceHandler resourceHandler = (request, notifier, sourceResource, readResourceRequest) -> {
-            Object result = methodInvoker.builder(request)
+        ResourceHandler resourceHandler = (request, sessionId, notifier, sourceResource, readResourceRequest) -> {
+            Object result = methodInvoker.builder(request, sessionId)
                     .withNotifier(notifier)
                     .withReadResourceRequest(sourceResource, readResourceRequest)
                     .invoke();

--- a/mcp/src/main/java/io/airlift/mcp/reflection/ResourceHandlerProvider.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/ResourceHandlerProvider.java
@@ -1,0 +1,104 @@
+package io.airlift.mcp.reflection;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Provider;
+import io.airlift.jsonrpc.model.JsonRpcErrorCode;
+import io.airlift.mcp.McpResource;
+import io.airlift.mcp.handler.ResourceEntry;
+import io.airlift.mcp.handler.ResourceHandler;
+import io.airlift.mcp.model.Resource;
+import io.airlift.mcp.model.ResourceContents;
+import io.airlift.mcp.model.Role;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Optional;
+
+import static io.airlift.mcp.McpException.exception;
+import static io.airlift.mcp.reflection.Predicates.isHttpRequest;
+import static io.airlift.mcp.reflection.Predicates.isNotifier;
+import static io.airlift.mcp.reflection.Predicates.isReadResourceRequest;
+import static io.airlift.mcp.reflection.Predicates.isSourceResource;
+import static io.airlift.mcp.reflection.Predicates.returnsResourceContents;
+import static io.airlift.mcp.reflection.Predicates.returnsResourceContentsList;
+import static io.airlift.mcp.reflection.ReflectionHelper.validate;
+import static java.lang.Double.isNaN;
+import static java.util.Objects.requireNonNull;
+
+public class ResourceHandlerProvider
+        implements Provider<ResourceEntry>
+{
+    private final Resource resource;
+    private final Class<?> clazz;
+    private final Method method;
+    private final List<MethodParameter> parameters;
+    private final boolean resultIsSingleContent;
+    @Inject private Injector injector;
+    @Inject private ObjectMapper objectMapper;
+
+    public ResourceHandlerProvider(McpResource mcpResource, Class<?> clazz, Method method, List<MethodParameter> parameters)
+    {
+        this.clazz = requireNonNull(clazz, "clazz is null");
+        this.method = requireNonNull(method, "method is null");
+        this.parameters = ImmutableList.copyOf(parameters);
+
+        validate(method, parameters, isHttpRequest.or(isNotifier).or(isReadResourceRequest).or(isSourceResource), returnsResourceContents.or(returnsResourceContentsList));
+        resultIsSingleContent = returnsResourceContents.test(method);
+
+        resource = buildResource(
+                mcpResource.name(),
+                mcpResource.uri(),
+                mcpResource.mimeType(),
+                mcpResource.description(),
+                mcpResource.size(),
+                mcpResource.audience(),
+                mcpResource.priority());
+    }
+
+    @Override
+    public ResourceEntry get()
+    {
+        Object instance = injector.getInstance(clazz);
+        MethodInvoker methodInvoker = new MethodInvoker(instance, method, parameters, objectMapper);
+
+        ResourceHandler resourceHandler = (request, notifier, sourceResource, readResourceRequest) -> {
+            Object result = methodInvoker.builder(request)
+                    .withNotifier(notifier)
+                    .withReadResourceRequest(sourceResource, readResourceRequest)
+                    .invoke();
+            return mapResult(method, result, resultIsSingleContent);
+        };
+
+        return new ResourceEntry(resource, resourceHandler);
+    }
+
+    @SuppressWarnings("unchecked")
+    static List<ResourceContents> mapResult(Method method, Object result, boolean resultIsSingleContent)
+    {
+        if (result == null) {
+            throw exception(JsonRpcErrorCode.INTERNAL_ERROR, "ResourceHandler %s returned null".formatted(method.getName()));
+        }
+
+        if (resultIsSingleContent) {
+            return ImmutableList.of((ResourceContents) result);
+        }
+
+        return (List<ResourceContents>) result;
+    }
+
+    static Resource buildResource(String name, String uri, String mimeType, String descriptionOrEmpty, long size, Role[] audience, double priority)
+    {
+        Optional<String> description = descriptionOrEmpty.isEmpty() ? Optional.empty() : Optional.of(descriptionOrEmpty);
+
+        Resource.Annotations annotations = new Resource.Annotations(
+                ImmutableList.copyOf(audience),
+                isNaN(priority) ? Optional.empty() : Optional.of(priority));
+
+        Optional<Long> useSize = (size >= 0) ? Optional.of(size) : Optional.empty();
+        Optional<Resource.Annotations> useAnnotations = annotations.equals(Resource.Annotations.EMPTY) ? Optional.empty() : Optional.of(annotations);
+        return new Resource(name, uri, description, mimeType, useSize, useAnnotations);
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/reflection/ResourceTemplateHandlerProvider.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/ResourceTemplateHandlerProvider.java
@@ -1,0 +1,80 @@
+package io.airlift.mcp.reflection;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Provider;
+import io.airlift.mcp.McpResourceTemplate;
+import io.airlift.mcp.handler.ResourceTemplateEntry;
+import io.airlift.mcp.handler.ResourceTemplateHandler;
+import io.airlift.mcp.model.Resource;
+import io.airlift.mcp.model.ResourceTemplate;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static io.airlift.mcp.reflection.Predicates.isHttpRequest;
+import static io.airlift.mcp.reflection.Predicates.isNotifier;
+import static io.airlift.mcp.reflection.Predicates.isPathTemplateValues;
+import static io.airlift.mcp.reflection.Predicates.isReadResourceRequest;
+import static io.airlift.mcp.reflection.Predicates.isSourceResourceTemplate;
+import static io.airlift.mcp.reflection.Predicates.returnsResourceContents;
+import static io.airlift.mcp.reflection.Predicates.returnsResourceContentsList;
+import static io.airlift.mcp.reflection.ReflectionHelper.validate;
+import static io.airlift.mcp.reflection.ResourceHandlerProvider.mapResult;
+import static java.util.Objects.requireNonNull;
+
+public class ResourceTemplateHandlerProvider
+        implements Provider<ResourceTemplateEntry>
+{
+    private final ResourceTemplate resourceTemplate;
+    private final Class<?> clazz;
+    private final Method method;
+    private final List<MethodParameter> parameters;
+    private final boolean resultIsSingleContent;
+    @Inject private Injector injector;
+    @Inject private ObjectMapper objectMapper;
+
+    public ResourceTemplateHandlerProvider(McpResourceTemplate mcpResourceTemplate, Class<?> clazz, Method method, List<MethodParameter> parameters)
+    {
+        this.clazz = requireNonNull(clazz, "clazz is null");
+        this.method = requireNonNull(method, "method is null");
+        this.parameters = ImmutableList.copyOf(parameters);
+
+        validate(method, parameters, isHttpRequest.or(isNotifier).or(isReadResourceRequest).or(isSourceResourceTemplate).or(isPathTemplateValues), returnsResourceContents.or(returnsResourceContentsList));
+        resultIsSingleContent = returnsResourceContents.test(method);
+
+        resourceTemplate = buildResourceTemplate(mcpResourceTemplate);
+    }
+
+    @Override
+    public ResourceTemplateEntry get()
+    {
+        Object instance = injector.getInstance(clazz);
+        MethodInvoker methodInvoker = new MethodInvoker(instance, method, parameters, objectMapper);
+
+        ResourceTemplateHandler resourceTemplateHandler = (request, notifier, sourceResourceTemplate, readResourceRequest, pathTemplateValues) -> {
+            Object result = methodInvoker.builder(request)
+                    .withNotifier(notifier)
+                    .withReadResourceTemplateRequest(sourceResourceTemplate, readResourceRequest, pathTemplateValues)
+                    .invoke();
+            return mapResult(method, result, resultIsSingleContent);
+        };
+
+        return new ResourceTemplateEntry(resourceTemplate, resourceTemplateHandler);
+    }
+
+    private static ResourceTemplate buildResourceTemplate(McpResourceTemplate resourceTemplate)
+    {
+        Resource resource = ResourceHandlerProvider.buildResource(
+                resourceTemplate.name(),
+                resourceTemplate.uriTemplate(),
+                resourceTemplate.mimeType(),
+                resourceTemplate.description(),
+                resourceTemplate.size(),
+                resourceTemplate.audience(),
+                resourceTemplate.priority());
+        return new ResourceTemplate(resource.name(), resource.uri(), resource.description(), resource.mimeType(), resource.size(), resource.annotations());
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/reflection/ResourceTemplateHandlerProvider.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/ResourceTemplateHandlerProvider.java
@@ -14,7 +14,7 @@ import io.airlift.mcp.model.ResourceTemplate;
 import java.lang.reflect.Method;
 import java.util.List;
 
-import static io.airlift.mcp.reflection.Predicates.isHttpRequest;
+import static io.airlift.mcp.reflection.Predicates.isHttpRequestOrSessonId;
 import static io.airlift.mcp.reflection.Predicates.isNotifier;
 import static io.airlift.mcp.reflection.Predicates.isPathTemplateValues;
 import static io.airlift.mcp.reflection.Predicates.isReadResourceRequest;
@@ -42,7 +42,7 @@ public class ResourceTemplateHandlerProvider
         this.method = requireNonNull(method, "method is null");
         this.parameters = ImmutableList.copyOf(parameters);
 
-        validate(method, parameters, isHttpRequest.or(isNotifier).or(isReadResourceRequest).or(isSourceResourceTemplate).or(isPathTemplateValues), returnsResourceContents.or(returnsResourceContentsList));
+        validate(method, parameters, isHttpRequestOrSessonId.or(isNotifier).or(isReadResourceRequest).or(isSourceResourceTemplate).or(isPathTemplateValues), returnsResourceContents.or(returnsResourceContentsList));
         resultIsSingleContent = returnsResourceContents.test(method);
 
         resourceTemplate = buildResourceTemplate(mcpResourceTemplate);
@@ -54,8 +54,8 @@ public class ResourceTemplateHandlerProvider
         Object instance = injector.getInstance(clazz);
         MethodInvoker methodInvoker = new MethodInvoker(instance, method, parameters, objectMapper);
 
-        ResourceTemplateHandler resourceTemplateHandler = (request, notifier, sourceResourceTemplate, readResourceRequest, pathTemplateValues) -> {
-            Object result = methodInvoker.builder(request)
+        ResourceTemplateHandler resourceTemplateHandler = (request, sessionId, notifier, sourceResourceTemplate, readResourceRequest, pathTemplateValues) -> {
+            Object result = methodInvoker.builder(request, sessionId)
                     .withNotifier(notifier)
                     .withReadResourceTemplateRequest(sourceResourceTemplate, readResourceRequest, pathTemplateValues)
                     .invoke();

--- a/mcp/src/main/java/io/airlift/mcp/reflection/ToolHandlerProvider.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/ToolHandlerProvider.java
@@ -1,0 +1,134 @@
+package io.airlift.mcp.reflection;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Provider;
+import io.airlift.jsonrpc.model.JsonRpcErrorCode;
+import io.airlift.mcp.McpTool;
+import io.airlift.mcp.handler.ToolEntry;
+import io.airlift.mcp.handler.ToolHandler;
+import io.airlift.mcp.model.CallToolResult;
+import io.airlift.mcp.model.Content;
+import io.airlift.mcp.model.JsonSchemaBuilder;
+import io.airlift.mcp.model.StructuredContent;
+import io.airlift.mcp.model.Tool;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Optional;
+
+import static io.airlift.mcp.McpException.exception;
+import static io.airlift.mcp.model.JsonSchemaBuilder.isPrimitiveType;
+import static io.airlift.mcp.model.JsonSchemaBuilder.isSupportedType;
+import static io.airlift.mcp.reflection.Predicates.isCallToolRequest;
+import static io.airlift.mcp.reflection.Predicates.isHttpRequest;
+import static io.airlift.mcp.reflection.Predicates.isNotifier;
+import static io.airlift.mcp.reflection.Predicates.isObject;
+import static io.airlift.mcp.reflection.Predicates.returnsAnything;
+import static io.airlift.mcp.reflection.ReflectionHelper.mapToContent;
+import static io.airlift.mcp.reflection.ReflectionHelper.validate;
+import static java.util.Objects.requireNonNull;
+
+public class ToolHandlerProvider
+        implements Provider<ToolEntry>
+{
+    private final Tool tool;
+    private final Class<?> clazz;
+    private final Method method;
+    private final List<MethodParameter> parameters;
+    private final ReturnType returnType;
+    @Inject private Injector injector;
+    @Inject private ObjectMapper objectMapper;
+
+    public ToolHandlerProvider(McpTool mcpTool, Class<?> clazz, Method method, List<MethodParameter> parameters)
+    {
+        this.clazz = requireNonNull(clazz, "clazz is null");
+        this.method = requireNonNull(method, "method is null");
+        this.parameters = ImmutableList.copyOf(parameters);
+
+        validate(method, parameters, isHttpRequest.or(isNotifier).or(isObject).or(isCallToolRequest), returnsAnything);
+
+        tool = buildTool(mcpTool, method, parameters);
+
+        if (void.class.equals(method.getReturnType())) {
+            returnType = ReturnType.VOID;
+        }
+        else if (Content.class.isAssignableFrom(method.getReturnType()) || isPrimitiveType(method.getGenericReturnType())) {
+            returnType = ReturnType.CONTENT;
+        }
+        else if (CallToolResult.class.isAssignableFrom(method.getReturnType())) {
+            returnType = ReturnType.CALL_TOOL_RESULT;
+        }
+        else if (isSupportedType(method.getGenericReturnType())) {
+            returnType = ReturnType.STRUCTURED;
+        }
+        else {
+            throw new IllegalArgumentException("Method %s has unsupported return type: %s".formatted(method.getName(), method.getGenericReturnType()));
+        }
+    }
+
+    private enum ReturnType {
+        VOID,
+        CALL_TOOL_RESULT,
+        CONTENT,
+        STRUCTURED,
+    }
+
+    @Override
+    public ToolEntry get()
+    {
+        Object instance = injector.getInstance(clazz);
+        MethodInvoker methodInvoker = new MethodInvoker(instance, method, parameters, objectMapper);
+
+        ToolHandler toolHandler = (request, notifier, toolRequest) -> {
+            Object result = methodInvoker.builder(request)
+                    .withArguments(toolRequest.arguments())
+                    .withNotifier(notifier)
+                    .withCallToolRequest(toolRequest)
+                    .invoke();
+            if ((result == null) && (returnType != ReturnType.VOID)) {
+                throw exception(JsonRpcErrorCode.INTERNAL_ERROR, "Tool %s returned null".formatted(method.getName()));
+            }
+
+            return switch (returnType) {
+                case VOID -> new CallToolResult(ImmutableList.of());
+                case CONTENT -> new CallToolResult(mapToContent(result));
+                case STRUCTURED -> new CallToolResult(ImmutableList.of(mapToContent(result)), Optional.of(new StructuredContent<>(result)), false);
+                case CALL_TOOL_RESULT -> (CallToolResult) result;
+            };
+        };
+
+        return new ToolEntry(tool, toolHandler);
+    }
+
+    private static Tool buildTool(McpTool tool, Method method, List<MethodParameter> parameters)
+    {
+        Optional<String> description = tool.description().isEmpty() ? Optional.empty() : Optional.of(tool.description());
+        Optional<String> title = tool.title().isEmpty() ? Optional.empty() : Optional.of(tool.title());
+
+        Tool.ToolAnnotations toolAnnotations = new Tool.ToolAnnotations(
+                title,
+                tool.readOnlyHint().map(),
+                tool.destructiveHint().map(),
+                tool.idempotentHint().map(),
+                tool.openWorldHint().map(),
+                tool.returnDirect().map());
+
+        Optional<ObjectNode> outputSchema;
+        if (method.getReturnType().isRecord()) {
+            JsonSchemaBuilder jsonSchemaBuilder = new JsonSchemaBuilder("Tool (return): " + tool.name());
+            outputSchema = Optional.of(jsonSchemaBuilder.build(description, method.getReturnType()));
+        }
+        else {
+            outputSchema = Optional.empty();
+        }
+
+        JsonSchemaBuilder jsonSchemaBuilder = new JsonSchemaBuilder("Tool: " + tool.name());
+        ObjectNode jsonSchema = jsonSchemaBuilder.build(description, parameters);
+
+        return new Tool(tool.name(), description, jsonSchema, outputSchema, toolAnnotations);
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/session/ListType.java
+++ b/mcp/src/main/java/io/airlift/mcp/session/ListType.java
@@ -1,0 +1,9 @@
+package io.airlift.mcp.session;
+
+public enum ListType
+{
+    TOOLS,
+    PROMPTS,
+    RESOURCES,
+    ROOTS,
+}

--- a/mcp/src/main/java/io/airlift/mcp/session/NotificationType.java
+++ b/mcp/src/main/java/io/airlift/mcp/session/NotificationType.java
@@ -1,0 +1,10 @@
+package io.airlift.mcp.session;
+
+public enum NotificationType
+{
+    SERVER_TO_CLIENT_LOGGING,
+    TOOLS_LIST_CHANGED,
+    PROMPTS_LIST_CHANGED,
+    RESOURCES_LIST_CHANGED,
+    RESOURCE_UPDATED,
+}

--- a/mcp/src/main/java/io/airlift/mcp/session/RequestState.java
+++ b/mcp/src/main/java/io/airlift/mcp/session/RequestState.java
@@ -1,0 +1,8 @@
+package io.airlift.mcp.session;
+
+public enum RequestState
+{
+    STARTED,
+    CANCELLATION_REQUESTED,
+    ENDED,
+}

--- a/mcp/src/main/java/io/airlift/mcp/session/SessionController.java
+++ b/mcp/src/main/java/io/airlift/mcp/session/SessionController.java
@@ -1,0 +1,160 @@
+package io.airlift.mcp.session;
+
+import io.airlift.jsonrpc.model.JsonRpcRequest;
+import io.airlift.jsonrpc.model.JsonRpcResponse;
+import io.airlift.mcp.model.InitializeRequest;
+import io.airlift.mcp.model.InitializeRequest.ClientCapabilities;
+import io.airlift.mcp.model.LoggingLevel;
+import io.airlift.mcp.model.RootsResponse;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+public interface SessionController
+{
+    /**
+     * Create a new session based on the provided request.
+     */
+    SessionId createSession(InitializeRequest request);
+
+    /**
+     * Delete the session with the given ID (if it is valid). This method should clean up any resources
+     * associated with the session, such as tools, prompts, and other session-related entities.
+     * Note: it is the MCP client's responsibility to delete sessions, and it is optional
+     * behavior. Therefore, your controller should periodically clean up sessions.
+     */
+    void deleteSession(SessionId sessionId);
+
+    /**
+     * Parse and validate the provided session ID string. Return {@code Optional.empty()}
+     * if the session ID is invalid for any reason.
+     */
+    Optional<SessionId> parseAndValidate(String sessionId);
+
+    /**
+     * Return the client capabilities for the session. Return {@code Optional.empty()}
+     * if the session ID is invalid for any reason.
+     */
+    Optional<ClientCapabilities> clientCapabilities(SessionId sessionId);
+
+    /**
+     * The session controller is responsible for managing the lifecycle of tools, prompts,
+     * resources, and other session-related entities. The MCP Server will periodically
+     * call this method (per {@link SessionMetadata#sessionUpdateCadence()}) to
+     * take any changes or updates that have occurred since the last call for this session. The session controller
+     * should return a set of entity lists that have changed since the last call for this session, clearing the saved set
+     * so that a subsequent call will not return the same set of changed entities. Return an empty set
+     * if the session ID is invalid for any reason.
+     */
+    Set<ListType> takeChangedLists(SessionId sessionId);
+
+    /**
+     * The session controller is responsible for managing the lifecycle of tools, prompts,
+     * resources, and other session-related entities. The MCP Server will periodically
+     * call this method (per {@link SessionMetadata#sessionUpdateCadence()}) to
+     * take any changes or updates that have occurred since the last call for this session. The session controller
+     * should return a list of resource updates that have occurred, clearing the saved set
+     * so that a subsequent call will not return the same set of changed entities.
+     * Return an empty list if the session ID is invalid for any reason.
+     */
+    List<String> takeResourceUpdates(SessionId sessionId);
+
+    /**
+     * <p>
+     *     The session controller is responsible for managing the lifecycle of tools, prompts,
+     *     resources, and other session-related entities. The MCP Server will periodically
+     *     call this method (per {@link SessionMetadata#sessionUpdateCadence()})
+     * </p>
+     *
+     * <p>
+     *     Any server-to-client requests that should be sent to the client. IMPORTANT: the responses to the requests will be
+     *     sent in a different context as clients send responses as single HTTP POSTs to the server.
+     *     In a horizontally scaled environment, it may even be a different server receiving the response.
+     *     Clearing the saved set so that a subsequent call will not return the same set of requests.
+     *     Return an empty list if the session ID is invalid for any reason.
+     * </p>
+     *
+     * <p>
+     *     Use the request ID to correlate the request with the response. Note: your request ID should
+     *     be a {@code String}.
+     * </p>
+     *
+     * <p>
+     *     Use for server-to-client features such as sampling and elicitation.
+     * </p>
+     */
+    List<JsonRpcRequest<?>> takeServerToClientRequests(SessionId sessionId);
+
+    /**
+     * Returns the state of the given request. If the request is
+     * currently running on any server the state returned will be
+     * {@link RequestState#STARTED}. If the request is not running on any server
+     * or isn't known, the state returned will be {@link RequestState#ENDED}. If
+     * any client has requested that the request be cancelled, the state returned will be
+     * {@link RequestState#CANCELLATION_REQUESTED}.
+     */
+    RequestState requestState(SessionId sessionId, String requestId);
+
+    /**
+     * The session controller is responsible for managing the lifecycle of tools, prompts,
+     * resources, and other session-related entities. Called when a request state has changed.
+     */
+    void acceptRequestState(SessionId sessionId, String requestId, RequestState state);
+
+    /**
+     * The session controller is responsible for managing the lifecycle of tools, prompts,
+     * resources, and other session-related entities. Return the current list of
+     * roots in the session or an empty list if the session ID is invalid for any reason.
+     */
+    List<String> roots(SessionId sessionId);
+
+    /**
+     * The session controller is responsible for managing the lifecycle of tools, prompts, resources,
+     * and other session-related entities. This method is called to accept a new roots
+     * notification from the client. The controller
+     * must save this state in the session (if it is valid) so that a future call to {@link SessionController#roots(SessionId)}
+     * for {@code ChangedLists} returns {@link ListType#ROOTS} for the session.
+     */
+    void acceptRoots(SessionId sessionId, List<RootsResponse.Root> roots);
+
+    /**
+     * The session controller is responsible for managing the lifecycle of tools, prompts, resources,
+     * and other session-related entities. This method is called when the server receives
+     * initial or updated roots from the client.
+     */
+    void acceptRootsChanged(SessionId sessionId);
+
+    /**
+     * The session controller is responsible for managing the lifecycle of tools, prompts, resources,
+     * and other session-related entities. Can be used by tools or anywhere else in your code to queue a request to be sent to the client.The controller
+     * must save this state in the session (if it is valid) so that a future call to {@link #takeServerToClientRequests(SessionId)}
+     * for {@code ServerToClientRequests} returns this request for the session.
+     */
+    void acceptClientToServerRequest(SessionId sessionId, JsonRpcRequest<?> request);
+
+    /**
+     * The session controller is responsible for managing the lifecycle of tools, prompts, resources,
+     * and other session-related entities. Called when the client sends a response to a server-to-client request. IMPORTANT: the responses
+     * to the requests will be sent in a different context as clients send responses as single HTTP POSTs
+     * to the server. In a horizontally scaled environment, it may even be a different server receiving the response.
+     * Use the request ID to correlate the request with the response.
+     */
+    void acceptServerToClientResponse(SessionId sessionId, JsonRpcResponse<Map<String, Object>> response);
+
+    /**
+     * Change this session's subscription to the given URI (if the session/uri is valid)
+     */
+    void changeResourceSubscription(SessionId sessionId, String uri, SubscribeType subscribeType);
+
+    /**
+     * Return the logging level for the given session (if it is valid) or a default level if not set.
+     */
+    LoggingLevel loggingLevel(SessionId sessionId);
+
+    /**
+     * Set the logging level for the given session (if it is valid).
+     */
+    void setLoggingLevel(SessionId sessionId, LoggingLevel level);
+}

--- a/mcp/src/main/java/io/airlift/mcp/session/SessionId.java
+++ b/mcp/src/main/java/io/airlift/mcp/session/SessionId.java
@@ -1,0 +1,6 @@
+package io.airlift.mcp.session;
+
+public interface SessionId
+{
+    String asString();
+}

--- a/mcp/src/main/java/io/airlift/mcp/session/SessionMetadata.java
+++ b/mcp/src/main/java/io/airlift/mcp/session/SessionMetadata.java
@@ -1,0 +1,25 @@
+package io.airlift.mcp.session;
+
+import com.google.common.collect.ImmutableSet;
+
+import java.time.Duration;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public record SessionMetadata(Set<NotificationType> supportedNotifications, Duration sessionUpdateCadence, Duration maxEventsLoopDuration)
+{
+    public static final SessionMetadata DEFAULT = new SessionMetadata(
+            ImmutableSet.copyOf(NotificationType.values()),
+            Duration.ofSeconds(10),
+            Duration.ofMinutes(5));
+
+    public SessionMetadata
+    {
+        supportedNotifications = ImmutableSet.copyOf(supportedNotifications);
+        checkArgument(sessionUpdateCadence.isPositive(), "sessionUpdateCadence must be positive");
+        checkArgument(maxEventsLoopDuration.isPositive(), "maxEventsLoopDuration must be positive");
+
+        checkArgument(maxEventsLoopDuration.compareTo(sessionUpdateCadence) > 0, "maxEventsLoopDuration must be greater than sessionUpdateCadence");
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/session/SubscribeType.java
+++ b/mcp/src/main/java/io/airlift/mcp/session/SubscribeType.java
@@ -1,0 +1,7 @@
+package io.airlift.mcp.session;
+
+public enum SubscribeType
+{
+    SUBSCRIBE,
+    UNSUBSCRIBE,
+}

--- a/mcp/src/test/java/io/airlift/LocalServer.java
+++ b/mcp/src/test/java/io/airlift/LocalServer.java
@@ -16,6 +16,7 @@ import io.airlift.log.Logger;
 import io.airlift.mcp.McpModule;
 import io.airlift.mcp.TestingEndpoints;
 import io.airlift.mcp.TestingSessionController;
+import io.airlift.mcp.model.PaginationMetadata;
 import io.airlift.mcp.session.SessionMetadata;
 import io.airlift.node.NodeModule;
 
@@ -43,7 +44,8 @@ public class LocalServer
 
         McpModule.Builder builder = McpModule.builder()
                 .addAllInClass(TestingEndpoints.class)
-                .withSessionHandling(SessionMetadata.DEFAULT, binding -> binding.to(TestingSessionController.class).in(SINGLETON));
+                .withSessionHandling(SessionMetadata.DEFAULT, binding -> binding.to(TestingSessionController.class).in(SINGLETON))
+                .withPaginationMetadata(new PaginationMetadata(7)); // so that we can test pagination
         Module module = new Module()
         {
             @Override

--- a/mcp/src/test/java/io/airlift/LocalServer.java
+++ b/mcp/src/test/java/io/airlift/LocalServer.java
@@ -1,0 +1,58 @@
+package io.airlift;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import io.airlift.bootstrap.Bootstrap;
+import io.airlift.http.server.HttpServerInfo;
+import io.airlift.http.server.testing.TestingHttpServerModule;
+import io.airlift.jaxrs.JaxrsModule;
+import io.airlift.json.JsonModule;
+import io.airlift.log.Logger;
+import io.airlift.mcp.McpModule;
+import io.airlift.mcp.TestingEndpoints;
+import io.airlift.node.NodeModule;
+
+import java.util.Optional;
+
+import static io.airlift.http.client.HttpClientBinder.httpClientBinder;
+
+public class LocalServer
+{
+    private LocalServer() {}
+
+    private static final Logger log = Logger.get(LocalServer.class);
+
+    public static void main(String[] args)
+    {
+        Optional<Integer> port = switch (args.length) {
+            case 0 -> Optional.empty();
+            case 1 -> Optional.of(Integer.parseInt(args[0]));
+            default -> {
+                System.err.println("Usage: LocalServer [port]");
+                yield Optional.empty();
+            }
+        };
+        start(McpModule.builder().addAllInClass(TestingEndpoints.class), port);
+    }
+
+    public static void start(McpModule.Builder builder, Optional<Integer> port)
+    {
+        ImmutableList.Builder<com.google.inject.Module> modules = ImmutableList.<Module>builder()
+                .add(builder.build())
+                .add(new NodeModule())
+                .add(new TestingHttpServerModule(port.orElse(0)))
+                .add(new JsonModule())
+                .add(new JaxrsModule())
+                .add(binder -> httpClientBinder(binder).bindHttpClient("test", ForTesting.class));
+
+        ImmutableMap.Builder<String, String> serverProperties = ImmutableMap.<String, String>builder()
+                .put("node.environment", "testing");
+
+        Bootstrap app = new Bootstrap(modules.build());
+        Injector injector = app.setRequiredConfigurationProperties(serverProperties.build()).initialize();
+
+        log.info("Local server started at: %s/mcp", injector.getInstance(HttpServerInfo.class).getHttpUri());
+    }
+}

--- a/mcp/src/test/java/io/airlift/LocalServer.java
+++ b/mcp/src/test/java/io/airlift/LocalServer.java
@@ -2,8 +2,11 @@ package io.airlift;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.inject.Binder;
 import com.google.inject.Injector;
 import com.google.inject.Module;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
 import io.airlift.bootstrap.Bootstrap;
 import io.airlift.http.server.HttpServerInfo;
 import io.airlift.http.server.testing.TestingHttpServerModule;
@@ -12,10 +15,13 @@ import io.airlift.json.JsonModule;
 import io.airlift.log.Logger;
 import io.airlift.mcp.McpModule;
 import io.airlift.mcp.TestingEndpoints;
+import io.airlift.mcp.TestingSessionController;
+import io.airlift.mcp.session.SessionMetadata;
 import io.airlift.node.NodeModule;
 
 import java.util.Optional;
 
+import static com.google.inject.Scopes.SINGLETON;
 import static io.airlift.http.client.HttpClientBinder.httpClientBinder;
 
 public class LocalServer
@@ -34,13 +40,34 @@ public class LocalServer
                 yield Optional.empty();
             }
         };
-        start(McpModule.builder().addAllInClass(TestingEndpoints.class), port);
+
+        McpModule.Builder builder = McpModule.builder()
+                .addAllInClass(TestingEndpoints.class)
+                .withSessionHandling(SessionMetadata.DEFAULT, binding -> binding.to(TestingSessionController.class).in(SINGLETON));
+        Module module = new Module()
+        {
+            @Override
+            public void configure(Binder binder)
+            {
+                binder.bind(TestingSessionController.class).in(SINGLETON);
+            }
+
+            @SuppressWarnings("unused")
+            @Provides
+            @Singleton
+            public Optional<TestingSessionController> sessionController(TestingSessionController sessionController)
+            {
+                return Optional.of(sessionController);
+            }
+        };
+        start(builder, port, module);
     }
 
-    public static void start(McpModule.Builder builder, Optional<Integer> port)
+    public static void start(McpModule.Builder builder, Optional<Integer> port, Module additionalModule)
     {
         ImmutableList.Builder<com.google.inject.Module> modules = ImmutableList.<Module>builder()
                 .add(builder.build())
+                .add(additionalModule)
                 .add(new NodeModule())
                 .add(new TestingHttpServerModule(port.orElse(0)))
                 .add(new JsonModule())

--- a/mcp/src/test/java/io/airlift/mcp/Person.java
+++ b/mcp/src/test/java/io/airlift/mcp/Person.java
@@ -1,0 +1,25 @@
+package io.airlift.mcp;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public record Person(String name, int age, Address address, List<Address> alternateAddresses, Optional<String> code)
+{
+    public record Address(String street, String city, String state, String zip)
+    {
+        public Address
+        {
+            requireNonNull(street, "street is null");
+            requireNonNull(city, "city is null");
+            requireNonNull(state, "state is null");
+            requireNonNull(zip, "zip is null");
+        }
+    }
+
+    public Person
+    {
+        requireNonNull(name, "name is null");
+    }
+}

--- a/mcp/src/test/java/io/airlift/mcp/SimpleThing.java
+++ b/mcp/src/test/java/io/airlift/mcp/SimpleThing.java
@@ -1,0 +1,13 @@
+package io.airlift.mcp;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+public record SimpleThing(@McpDescription("Some values") List<String> values, @McpDescription("The average value") double averageValue)
+{
+    public SimpleThing
+    {
+        values = ImmutableList.copyOf(values);
+    }
+}

--- a/mcp/src/test/java/io/airlift/mcp/TestMcp.java
+++ b/mcp/src/test/java/io/airlift/mcp/TestMcp.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright Starburst Data, Inc. All rights reserved.
+ *
+ * THIS IS UNPUBLISHED PROPRIETARY SOURCE CODE OF STARBURST DATA.
+ * The copyright notice above does not evidence any
+ * actual or intended publication of such source code.
+ *
+ * Redistribution of this material is strictly prohibited.
+ */
+package io.airlift.mcp;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
+import io.airlift.TestBase;
+import io.airlift.http.client.Request;
+import io.airlift.http.client.StatusResponseHandler.StatusResponse;
+import io.airlift.http.client.StreamingResponse;
+import io.airlift.jsonrpc.model.JsonRpcResponse;
+import io.airlift.mcp.model.CallToolRequest;
+import io.airlift.mcp.model.CallToolResult;
+import io.airlift.mcp.model.CompletionReference;
+import io.airlift.mcp.model.CompletionRequest;
+import io.airlift.mcp.model.CompletionResult;
+import io.airlift.mcp.model.Content.TextContent;
+import io.airlift.mcp.model.GetPromptRequest;
+import io.airlift.mcp.model.GetPromptResult;
+import io.airlift.mcp.model.Implementation;
+import io.airlift.mcp.model.InitializeRequest;
+import io.airlift.mcp.model.InitializeRequest.ClientCapabilities;
+import io.airlift.mcp.model.ListPromptsResult;
+import io.airlift.mcp.model.ListResourceTemplatesResult;
+import io.airlift.mcp.model.ListResourcesResult;
+import io.airlift.mcp.model.ListToolsResponse;
+import io.airlift.mcp.model.Prompt;
+import io.airlift.mcp.model.ReadResourceRequest;
+import io.airlift.mcp.model.ReadResourceResult;
+import io.airlift.mcp.model.Resource;
+import io.airlift.mcp.model.ResourceContents;
+import io.airlift.mcp.model.ResourceTemplate;
+import io.airlift.mcp.model.Tool;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static io.airlift.http.client.FullJsonResponseHandler.createFullJsonResponseHandler;
+import static io.airlift.http.client.JsonResponseHandler.createJsonResponseHandler;
+import static io.airlift.http.client.StatusResponseHandler.createStatusResponseHandler;
+import static io.airlift.json.JsonCodec.jsonCodec;
+import static io.airlift.mcp.model.Constants.METHOD_CALL_TOOL;
+import static io.airlift.mcp.model.Constants.METHOD_GET_PROMPT;
+import static io.airlift.mcp.model.Constants.METHOD_READ_RESOURCES;
+import static io.airlift.mcp.model.Constants.PROTOCOL_VERSION;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class TestMcp
+        extends TestBase
+{
+    public TestMcp()
+    {
+        super(McpModule.builder().addAllInClass(TestingEndpoints.class));
+    }
+
+    @Test
+    public void testTools()
+            throws IOException
+    {
+        String requestId = UUID.randomUUID().toString();
+        initialize(requestId);
+
+        Request request = buildRequest(requestId, "tools/list", new TypeToken<>() {}, Optional.empty());
+        JsonRpcResponse<ListToolsResponse> toolsResponse = httpClient.execute(request, createJsonResponseHandler(jsonCodec(new TypeToken<>() {})));
+        assertThat(toolsResponse.result()).map(ListToolsResponse::tools).get()
+                .asInstanceOf(InstanceOfAssertFactories.list(Tool.class))
+                .extracting(Tool::name)
+                .containsExactlyInAnyOrder("add", "uppercase", "lookupPerson", "throws", "uppercaseSoon", "itsSimple");
+
+        request = buildRequest(requestId, METHOD_CALL_TOOL, new TypeToken<>() {}, Optional.of(new CallToolRequest("add", ImmutableMap.of("x", 6, "y", 24))));
+        try (StreamingResponse response = httpClient.executeStreaming(request)) {
+            for (Map<String, String> event : readEvents(response.getInputStream())) {
+                JsonRpcResponse<Object> jsonRpcResponse = parseData(event, new TypeReference<>() {});
+                CallToolResult callToolResult = jsonRpcResponse.result().map(o -> objectMapper.convertValue(o, CallToolResult.class)).orElseThrow();
+
+                assertThat(callToolResult.content())
+                        .hasSize(1)
+                        .first()
+                        .asInstanceOf(InstanceOfAssertFactories.type(TextContent.class))
+                        .extracting(TextContent::text)
+                        .isEqualTo("30");
+
+                break;
+            }
+        }
+    }
+
+    @Test
+    public void testPrompts()
+            throws IOException
+    {
+        String requestId = UUID.randomUUID().toString();
+        initialize(requestId);
+
+        Request request = buildRequest(requestId, "prompts/list", new TypeToken<>() {}, Optional.empty());
+        JsonRpcResponse<ListPromptsResult> promptsResponse = httpClient.execute(request, createJsonResponseHandler(jsonCodec(new TypeToken<>() {})));
+        assertThat(promptsResponse.result()).map(ListPromptsResult::prompts).get()
+                .asInstanceOf(InstanceOfAssertFactories.list(Prompt.class))
+                .extracting(Prompt::name)
+                .containsExactlyInAnyOrder("greeting", "progress");
+
+        request = buildRequest(requestId, METHOD_GET_PROMPT, new TypeToken<>() {}, Optional.of(new GetPromptRequest("greeting", ImmutableMap.of("name", "Galt"))));
+        try (StreamingResponse response = httpClient.executeStreaming(request)) {
+            for (Map<String, String> event : readEvents(response.getInputStream())) {
+                JsonRpcResponse<Object> jsonRpcResponse = parseData(event, new TypeReference<>() {});
+                GetPromptResult getPromptResult = jsonRpcResponse.result().map(o -> objectMapper.convertValue(o, GetPromptResult.class)).orElseThrow();
+
+                assertThat(getPromptResult.messages())
+                        .hasSize(1)
+                        .first()
+                        .extracting(GetPromptResult.PromptMessage::content)
+                        .asInstanceOf(InstanceOfAssertFactories.type(TextContent.class))
+                        .extracting(TextContent::text)
+                        .isEqualTo("Hello, Galt!");
+
+                break;
+            }
+        }
+    }
+
+    @Test
+    public void testResources()
+            throws IOException
+    {
+        String requestId = UUID.randomUUID().toString();
+        initialize(requestId);
+
+        Request request = buildRequest(requestId, "resources/list", new TypeToken<>() {}, Optional.empty());
+        JsonRpcResponse<ListResourcesResult> resourcesResponse = httpClient.execute(request, createJsonResponseHandler(jsonCodec(new TypeToken<>() {})));
+        ListResourcesResult listResourcesResult = resourcesResponse.result().orElseThrow();
+        assertThat(listResourcesResult.resources())
+                .extracting(Resource::name)
+                .containsExactlyInAnyOrder("example1", "example2");
+
+        request = buildRequest(requestId, METHOD_READ_RESOURCES, new TypeToken<>() {}, Optional.of(new ReadResourceRequest("file://example1.txt", Optional.empty())));
+        try (StreamingResponse response = httpClient.executeStreaming(request)) {
+            for (Map<String, String> event : readEvents(response.getInputStream())) {
+                JsonRpcResponse<Object> jsonRpcResponse = parseData(event, new TypeReference<>() {});
+                ReadResourceResult readResourceResult = jsonRpcResponse.result().map(o -> objectMapper.convertValue(o, ReadResourceResult.class)).orElseThrow();
+
+                assertThat(readResourceResult.contents())
+                        .hasSize(1)
+                        .first()
+                        .extracting(ResourceContents::text)
+                        .extracting(Optional::orElseThrow)
+                        .isEqualTo("This is the content of file://example1.txt");
+
+                break;
+            }
+        }
+    }
+
+    @Test
+    public void testResourceTemplates()
+            throws IOException
+    {
+        String requestId = UUID.randomUUID().toString();
+        initialize(requestId);
+
+        Request request = buildRequest(requestId, "resources/templates/list", new TypeToken<>() {}, Optional.empty());
+        JsonRpcResponse<ListResourceTemplatesResult> resourcesResponse = httpClient.execute(request, createJsonResponseHandler(jsonCodec(new TypeToken<>() {})));
+        ListResourceTemplatesResult templatesResult = resourcesResponse.result().orElseThrow();
+        assertThat(templatesResult.resourceTemplates())
+                .hasSize(1)
+                .extracting(ResourceTemplate::uriTemplate)
+                .containsExactly("file://{part}.txt");
+
+        request = buildRequest(requestId, METHOD_READ_RESOURCES, new TypeToken<>() {}, Optional.of(new ReadResourceRequest("file://one.txt", Optional.empty())));
+        try (StreamingResponse response = httpClient.executeStreaming(request)) {
+            for (Map<String, String> event : readEvents(response.getInputStream())) {
+                JsonRpcResponse<Object> jsonRpcResponse = parseData(event, new TypeReference<>() {});
+                ReadResourceResult resourceResult = jsonRpcResponse.result().map(o -> objectMapper.convertValue(o, ReadResourceResult.class)).orElseThrow();
+
+                assertThat(resourceResult.contents())
+                        .hasSize(1)
+                        .extracting(ResourceContents::text)
+                        .extracting(Optional::orElseThrow)
+                        .containsExactly("one");
+
+                break;
+            }
+        }
+    }
+
+    @Test
+    public void testCompletions()
+            throws IOException
+    {
+        String requestId = UUID.randomUUID().toString();
+        initialize(requestId);
+
+        CompletionRequest completionRequest = new CompletionRequest(new CompletionReference.Prompt("greeting"), new CompletionRequest.Argument("name", "hey"), Optional.empty());
+        Request request = buildRequest(requestId, "completion/complete", new TypeToken<>() {}, Optional.of(completionRequest));
+        try (StreamingResponse response = httpClient.executeStreaming(request)) {
+            for (Map<String, String> event : readEvents(response.getInputStream())) {
+                JsonRpcResponse<Object> jsonRpcResponse = parseData(event, new TypeReference<>() {});
+                CompletionResult completionResult = jsonRpcResponse.result().map(o -> objectMapper.convertValue(o, CompletionResult.class)).orElseThrow();
+
+                assertThat(completionResult.completion().values())
+                        .containsExactlyInAnyOrder("yo", "hey");
+
+                break;
+            }
+        }
+    }
+
+    private void initialize(String requestId)
+    {
+        InitializeRequest initializeRequest = new InitializeRequest(PROTOCOL_VERSION, new ClientCapabilities(Optional.empty(), Optional.empty(), Optional.empty()), new Implementation("hey", "1.0.0"));
+        Request request = buildRequest(requestId, "initialize", new TypeToken<>() {}, initializeRequest);
+        httpClient.execute(request, createFullJsonResponseHandler(jsonCodec(new TypeToken<>() {})));
+
+        request = buildRequest(requestId, "notifications/initialized", new TypeToken<>() {}, Optional.empty());
+        StatusResponse status = httpClient.execute(request, createStatusResponseHandler());
+        assertThat(status.getStatusCode()).isBetween(200, 299);
+    }
+
+    private <T> T parseData(Map<String, String> event, TypeReference<T> type)
+    {
+        String data = event.get("data");
+        if (data == null) {
+            return fail("No data in event: " + event);
+        }
+        try {
+            return objectMapper.readValue(data, type);
+        }
+        catch (Exception e) {
+            return fail(e);
+        }
+    }
+}

--- a/mcp/src/test/java/io/airlift/mcp/TestMcp.java
+++ b/mcp/src/test/java/io/airlift/mcp/TestMcp.java
@@ -17,6 +17,7 @@ import io.airlift.http.client.FullJsonResponseHandler.JsonResponse;
 import io.airlift.http.client.Request;
 import io.airlift.http.client.StatusResponseHandler.StatusResponse;
 import io.airlift.http.client.StreamingResponse;
+import io.airlift.jaxrs.JaxrsBinder;
 import io.airlift.jsonrpc.model.JsonRpcResponse;
 import io.airlift.mcp.model.CallToolRequest;
 import io.airlift.mcp.model.CallToolResult;
@@ -60,6 +61,7 @@ import static com.google.inject.Scopes.SINGLETON;
 import static io.airlift.http.client.FullJsonResponseHandler.createFullJsonResponseHandler;
 import static io.airlift.http.client.JsonResponseHandler.createJsonResponseHandler;
 import static io.airlift.http.client.StatusResponseHandler.createStatusResponseHandler;
+import static io.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
 import static io.airlift.json.JsonCodec.jsonCodec;
 import static io.airlift.mcp.model.Constants.METHOD_CALL_TOOL;
 import static io.airlift.mcp.model.Constants.METHOD_GET_PROMPT;
@@ -78,7 +80,13 @@ public class TestMcp
 {
     public TestMcp()
     {
-        super(moduleBuilder(), binder -> binder.bind(TestingSessionController.class).in(SINGLETON));
+        super(moduleBuilder(), binder -> {
+            binder.bind(TestingSessionController.class).in(SINGLETON);
+
+            JaxrsBinder jaxrsBinder = jaxrsBinder(binder);
+            jaxrsBinder.bind(TestingValueParam.class);
+            jaxrsBinder.bind(TestingContextResolver.class);
+        });
     }
 
     private static McpModule.Builder moduleBuilder()

--- a/mcp/src/test/java/io/airlift/mcp/TestingContext.java
+++ b/mcp/src/test/java/io/airlift/mcp/TestingContext.java
@@ -1,0 +1,18 @@
+package io.airlift.mcp;
+
+import java.time.Instant;
+
+import static java.util.Objects.requireNonNull;
+
+public record TestingContext(Instant now)
+{
+    public TestingContext
+    {
+        requireNonNull(now, "now is null");
+    }
+
+    public TestingContext()
+    {
+        this(Instant.now());
+    }
+}

--- a/mcp/src/test/java/io/airlift/mcp/TestingContextResolver.java
+++ b/mcp/src/test/java/io/airlift/mcp/TestingContextResolver.java
@@ -1,0 +1,15 @@
+package io.airlift.mcp;
+
+import jakarta.ws.rs.ext.ContextResolver;
+import jakarta.ws.rs.ext.Provider;
+
+@Provider
+public class TestingContextResolver
+        implements ContextResolver<TestingContext>
+{
+    @Override
+    public TestingContext getContext(Class<?> ignore)
+    {
+        return new TestingContext();
+    }
+}

--- a/mcp/src/test/java/io/airlift/mcp/TestingEndpoints.java
+++ b/mcp/src/test/java/io/airlift/mcp/TestingEndpoints.java
@@ -3,6 +3,7 @@ package io.airlift.mcp;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import io.airlift.jsonrpc.model.JsonRpcRequest;
+import io.airlift.log.Logger;
 import io.airlift.mcp.Person.Address;
 import io.airlift.mcp.handler.ResourceTemplateHandler.PathTemplateValues;
 import io.airlift.mcp.model.CallToolResult;
@@ -22,7 +23,10 @@ import io.airlift.mcp.model.Role;
 import io.airlift.mcp.model.SamplingMessage;
 import io.airlift.mcp.session.ListType;
 import io.airlift.mcp.session.SessionId;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
 
+import java.net.URI;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -34,6 +38,8 @@ import static java.util.Objects.requireNonNull;
 
 public class TestingEndpoints
 {
+    private static final Logger log = Logger.get(TestingEndpoints.class);
+
     private final TestingSessionController sessionController;
 
     @Inject
@@ -150,8 +156,10 @@ public class TestingEndpoints
     }
 
     @McpPrompt(name = "greeting", description = "Generate a greeting message")
-    public String greeting(@McpDescription("Name of the person to greet") String name)
+    public String greeting(@McpDescription("Name of the person to greet") String name, @Context URI requestUri, @Context HttpHeaders httpHeaders, @Context TestingContext testingContext)
     {
+        log.info("Received greeting request for name: %s, request URI: %s, content-type: %s, now: %s", name, requestUri, httpHeaders.getRequestHeaders().getFirst("Content-Type"), testingContext.now());
+
         return "Hello, " + name + "!";
     }
 

--- a/mcp/src/test/java/io/airlift/mcp/TestingEndpoints.java
+++ b/mcp/src/test/java/io/airlift/mcp/TestingEndpoints.java
@@ -1,22 +1,47 @@
 package io.airlift.mcp;
 
 import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import io.airlift.jsonrpc.model.JsonRpcRequest;
 import io.airlift.mcp.Person.Address;
 import io.airlift.mcp.handler.ResourceTemplateHandler.PathTemplateValues;
+import io.airlift.mcp.model.CallToolResult;
 import io.airlift.mcp.model.Completion;
 import io.airlift.mcp.model.CompletionReference;
 import io.airlift.mcp.model.CompletionRequest;
+import io.airlift.mcp.model.Content;
+import io.airlift.mcp.model.Content.TextContent;
+import io.airlift.mcp.model.CreateMessageRequest;
+import io.airlift.mcp.model.CreateMessageResult;
+import io.airlift.mcp.model.LoggingLevel;
+import io.airlift.mcp.model.ModelHint;
+import io.airlift.mcp.model.ModelPreferences;
 import io.airlift.mcp.model.ReadResourceRequest;
 import io.airlift.mcp.model.ResourceContents;
+import io.airlift.mcp.model.Role;
+import io.airlift.mcp.model.SamplingMessage;
+import io.airlift.mcp.session.ListType;
+import io.airlift.mcp.session.SessionId;
 
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.mcp.McpException.exception;
+import static java.util.Objects.requireNonNull;
 
 public class TestingEndpoints
 {
+    private final TestingSessionController sessionController;
+
+    @Inject
+    public TestingEndpoints(TestingSessionController sessionController)
+    {
+        this.sessionController = requireNonNull(sessionController, "sessionController is null");
+    }
+
     @McpTool(name = "add")
     public int add(@McpDescription("X marks the spot") int x, @McpDescription("Because we like you") int y)
     {
@@ -43,7 +68,7 @@ public class TestingEndpoints
     }
 
     @McpTool(name = "itsSimple", description = "It's just so simple")
-    public int itsSimple(@McpDescription("A simple thing") SimpleThing thing)
+    public int itsSimple(@McpDescription("A simple thing") SimpleThing ignore)
     {
         return 0;
     }
@@ -58,6 +83,60 @@ public class TestingEndpoints
     public ResourceContents example2Resource()
     {
         return new ResourceContents("foo2", "file://example2.txt", "text/plain", "This is the content of file://example2.txt");
+    }
+
+    @McpTool(name = "logging", description = "Do some logging (at the \"warning\" level")
+    public void doLogging(McpNotifier notifier)
+    {
+        notifier.sendLog(LoggingLevel.warning, "This is a warning message", new SimpleThing(ImmutableList.of("a", "b"), 123.456));
+    }
+
+    @McpTool(name = "showCurrentRoots", description = "List the current roots")
+    public CallToolResult showCurrentRoots(SessionId sessionId)
+    {
+        List<String> roots = sessionController.roots(sessionId);
+        List<Content> content = roots
+                .stream()
+                .map(TextContent::new)
+                .collect(toImmutableList());
+        return new CallToolResult(content);
+    }
+
+    @McpTool(name = "sendListChangedEvents", description = "Simulate sending list changed events")
+    public void sendListChangedNotification(SessionId sessionId)
+    {
+        sessionController.simulateListChanged(sessionId, ListType.RESOURCES);
+        sessionController.simulateListChanged(sessionId, ListType.PROMPTS);
+        sessionController.simulateListChanged(sessionId, ListType.TOOLS);
+    }
+
+    @McpTool(name = "takeCreateMessageResults", description = "Show the results of create message requests")
+    public CallToolResult takeCreateMessageResults(SessionId sessionId)
+    {
+        List<CreateMessageResult> createMessageResults = sessionController.takeCreateMessageResults(sessionId);
+        List<Content> content = createMessageResults.stream()
+                .map(CreateMessageResult::content)
+                .collect(toImmutableList());
+        return new CallToolResult(content);
+    }
+
+    @McpTool(name = "sendResourcesUpdatedNotification", description = "Simulate sending resource updated notifications")
+    public String sendResourcesUpdatedNotification(SessionId sessionId, String uri)
+    {
+        return sessionController.simulateResourcesUpdated(sessionId, uri)
+                ? "Resources updated notification sent for URI: " + uri
+                : "You are not subscribed to: " + uri;
+    }
+
+    @McpTool(name = "sendSamplingMessage", description = "Simulate sending a sampling message")
+    public void sendSamplingMessage(McpNotifier notifier, SessionId sessionId)
+    {
+        List<SamplingMessage> messages = ImmutableList.of(new SamplingMessage(Role.user, new TextContent("This is some content")));
+        ModelPreferences modelPreferences = new ModelPreferences(new ModelHint("Only a test"));
+        CreateMessageRequest createMessageRequest = new CreateMessageRequest(messages, modelPreferences, "This is only a test", 500);
+        JsonRpcRequest<CreateMessageRequest> request = JsonRpcRequest.buildRequest("sendSamplingMessage", "sampling/createMessage", createMessageRequest);
+        sessionController.acceptClientToServerRequest(sessionId, request);
+        notifier.sendRequest(request);
     }
 
     @McpResourceTemplate(name = "template1", uriTemplate = "file://{part}.txt", description = "This is a template resource.", mimeType = "text/plain")
@@ -81,6 +160,24 @@ public class TestingEndpoints
     {
         sendProgress(notifier);
         return "Hello, " + name + "!";
+    }
+
+    @McpPrompt(name = "testCancellation", description = "Loops forever until cancelled")
+    public String testCancellation(McpNotifier notifier)
+    {
+        while (!notifier.cancellationRequested()) {
+            try {
+                TimeUnit.MILLISECONDS.sleep(100);
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+            notifier.notifyProgress("Waiting for cancellation...", Optional.empty(), Optional.empty());
+        }
+
+        notifier.notifyProgress("Cancelled!", Optional.empty(), Optional.empty());
+        return "Cancelled!";
     }
 
     @McpTool(name = "throws", description = "Throws an exception")

--- a/mcp/src/test/java/io/airlift/mcp/TestingEndpoints.java
+++ b/mcp/src/test/java/io/airlift/mcp/TestingEndpoints.java
@@ -1,0 +1,121 @@
+package io.airlift.mcp;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.mcp.Person.Address;
+import io.airlift.mcp.handler.ResourceTemplateHandler.PathTemplateValues;
+import io.airlift.mcp.model.Completion;
+import io.airlift.mcp.model.CompletionReference;
+import io.airlift.mcp.model.CompletionRequest;
+import io.airlift.mcp.model.ReadResourceRequest;
+import io.airlift.mcp.model.ResourceContents;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+import static io.airlift.mcp.McpException.exception;
+
+public class TestingEndpoints
+{
+    @McpTool(name = "add")
+    public int add(@McpDescription("X marks the spot") int x, @McpDescription("Because we like you") int y)
+    {
+        return x + y;
+    }
+
+    @McpTool(name = "uppercase", description = "Convert a string to uppercase")
+    public String uppercase(String input)
+    {
+        return input.toUpperCase(Locale.ROOT);
+    }
+
+    @McpTool(name = "uppercaseSoon", description = "Convert a string to uppercase eventually")
+    public String uppercaseWithProgress(String input, McpNotifier notifier)
+    {
+        sendProgress(notifier);
+        return input.toUpperCase(Locale.ROOT);
+    }
+
+    @McpTool(name = "lookupPerson")
+    public Address lookupPerson(Person person)
+    {
+        return person.address();
+    }
+
+    @McpTool(name = "itsSimple", description = "It's just so simple")
+    public int itsSimple(@McpDescription("A simple thing") SimpleThing thing)
+    {
+        return 0;
+    }
+
+    @McpResource(name = "example1", uri = "file://example1.txt", description = "This is example1 resource.", mimeType = "text/plain")
+    public ResourceContents example1Resource()
+    {
+        return new ResourceContents("foo2", "file://example1.txt", "text/plain", "This is the content of file://example1.txt");
+    }
+
+    @McpResource(name = "example2", uri = "file://example2.txt", description = "This is example2 resource.", mimeType = "text/plain")
+    public ResourceContents example2Resource()
+    {
+        return new ResourceContents("foo2", "file://example2.txt", "text/plain", "This is the content of file://example2.txt");
+    }
+
+    @McpResourceTemplate(name = "template1", uriTemplate = "file://{part}.txt", description = "This is a template resource.", mimeType = "text/plain")
+    public List<ResourceContents> listResourceTemplates(ReadResourceRequest readResourceRequest, PathTemplateValues pathTemplateValues)
+    {
+        if (readResourceRequest.uri().equals("file://one.txt")) {
+            ResourceContents contents = new ResourceContents("foo2", readResourceRequest.uri(), "text/plain", pathTemplateValues.values().get("part"));
+            return ImmutableList.of(contents);
+        }
+        return ImmutableList.of();
+    }
+
+    @McpPrompt(name = "greeting", description = "Generate a greeting message")
+    public String greeting(@McpDescription("Name of the person to greet") String name)
+    {
+        return "Hello, " + name + "!";
+    }
+
+    @McpPrompt(name = "progress", description = "Generate a greeting message after some time")
+    public String greetingWithProgress(@McpDescription("Name of the person to greet") String name, McpNotifier notifier)
+    {
+        sendProgress(notifier);
+        return "Hello, " + name + "!";
+    }
+
+    @McpTool(name = "throws", description = "Throws an exception")
+    public String throwException()
+    {
+        throw exception("This didn't work");
+    }
+
+    @McpCompletion(name = "completePrompt")
+    public Optional<Completion> completePrompt(CompletionRequest prompt)
+    {
+        return switch (prompt.ref()) {
+            case CompletionReference.Prompt promptRef -> {
+                if (promptRef.name().equals("greeting")) {
+                    yield Optional.of(new Completion(ImmutableList.of("yo", "hey")));
+                }
+                yield Optional.empty();
+            }
+
+            case CompletionReference.Resource _ -> Optional.of(new Completion(ImmutableList.of("one", "two")));
+        };
+    }
+
+    private static void sendProgress(McpNotifier notifier)
+    {
+        final int qty = 1000;
+        for (int i = 0; i < qty; i++) {
+            try {
+                Thread.sleep(10);
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+            notifier.notifyProgress("Processing... ", Optional.of((double) i + 1), Optional.of((double) qty));
+        }
+    }
+}

--- a/mcp/src/test/java/io/airlift/mcp/TestingSessionController.java
+++ b/mcp/src/test/java/io/airlift/mcp/TestingSessionController.java
@@ -1,0 +1,237 @@
+package io.airlift.mcp;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import com.google.inject.Inject;
+import io.airlift.jsonrpc.model.JsonRpcRequest;
+import io.airlift.jsonrpc.model.JsonRpcResponse;
+import io.airlift.mcp.model.Content.TextContent;
+import io.airlift.mcp.model.CreateMessageResult;
+import io.airlift.mcp.model.InitializeRequest;
+import io.airlift.mcp.model.InitializeRequest.ClientCapabilities;
+import io.airlift.mcp.model.LoggingLevel;
+import io.airlift.mcp.model.Role;
+import io.airlift.mcp.model.RootsResponse.Root;
+import io.airlift.mcp.session.ListType;
+import io.airlift.mcp.session.RequestState;
+import io.airlift.mcp.session.SessionController;
+import io.airlift.mcp.session.SessionId;
+import io.airlift.mcp.session.SubscribeType;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static java.util.Objects.requireNonNull;
+
+public class TestingSessionController
+        implements SessionController
+{
+    private final Map<SessionId, Session> sessions = new ConcurrentHashMap<>();
+    private final ObjectMapper objectMapper;
+
+    private static class Session
+    {
+        final InitializeRequest request;
+        final Set<ListType> changedLists = Sets.newConcurrentHashSet();
+        final List<String> resourceUpdates = new CopyOnWriteArrayList<>();
+        final Set<String> subscribedResources = Sets.newConcurrentHashSet();
+        final List<JsonRpcRequest<?>> clientToServerRequests = new CopyOnWriteArrayList<>();
+        final List<String> roots = new CopyOnWriteArrayList<>();
+        final List<CreateMessageResult> createMessageResults = new CopyOnWriteArrayList<>();
+        final Map<Object, RequestState> requestStates = new ConcurrentHashMap<>();
+        volatile LoggingLevel loggingLevel = LoggingLevel.debug;
+
+        Session(InitializeRequest request)
+        {
+            this.request = requireNonNull(request, "request is null");
+        }
+    }
+
+    @Inject
+    public TestingSessionController(ObjectMapper objectMapper)
+    {
+        this.objectMapper = requireNonNull(objectMapper, "objectMapper is null");
+    }
+
+    @Override
+    public SessionId createSession(InitializeRequest request)
+    {
+        TestingSessionId sessionId = TestingSessionId.random();
+        sessions.put(sessionId, new Session(request));
+        return sessionId;
+    }
+
+    @Override
+    public Optional<ClientCapabilities> clientCapabilities(SessionId sessionId)
+    {
+        return Optional.ofNullable(sessions.get(sessionId))
+                .map(session -> session.request.capabilities());
+    }
+
+    @Override
+    public Optional<SessionId> parseAndValidate(String sessionId)
+    {
+        try {
+            TestingSessionId testingSessionId = TestingSessionId.parse(sessionId);
+            return sessions.containsKey(testingSessionId) ? Optional.of(testingSessionId) : Optional.empty();
+        }
+        catch (Exception _) {
+            // ignore
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public RequestState requestState(SessionId sessionId, String requestId)
+    {
+        return Optional.ofNullable(sessions.get(sessionId))
+                .map(session -> session.requestStates.getOrDefault(requestId, RequestState.ENDED))
+                .orElse(RequestState.ENDED);
+    }
+
+    @Override
+    public Set<ListType> takeChangedLists(SessionId sessionId)
+    {
+        return Optional.ofNullable(sessions.get(sessionId))
+                .map(session -> {
+                    Set<ListType> changedLists = ImmutableSet.copyOf(session.changedLists);
+                    session.changedLists.clear();
+                    return changedLists;
+                })
+                .orElseGet(ImmutableSet::of);
+    }
+
+    @Override
+    public List<String> takeResourceUpdates(SessionId sessionId)
+    {
+        return Optional.ofNullable(sessions.get(sessionId))
+                .map(session -> {
+                    List<String> resourceUpdates = ImmutableList.copyOf(session.resourceUpdates);
+                    session.resourceUpdates.clear();
+                    return resourceUpdates;
+                })
+                .orElseGet(ImmutableList::of);
+    }
+
+    @Override
+    public List<JsonRpcRequest<?>> takeServerToClientRequests(SessionId sessionId)
+    {
+        return Optional.ofNullable(sessions.get(sessionId))
+                .map(session -> {
+                    List<JsonRpcRequest<?>> clientToServerRequests = ImmutableList.copyOf(session.clientToServerRequests);
+                    session.clientToServerRequests.clear();
+                    return clientToServerRequests;
+                })
+                .orElseGet(ImmutableList::of);
+    }
+
+    @Override
+    public void changeResourceSubscription(SessionId sessionId, String uri, SubscribeType subscribeType)
+    {
+        switch (subscribeType) {
+            case SUBSCRIBE -> Optional.ofNullable(sessions.get(sessionId)).ifPresent(session -> session.subscribedResources.add(uri));
+
+            case UNSUBSCRIBE -> Optional.ofNullable(sessions.get(sessionId)).ifPresent(session -> session.subscribedResources.remove(uri));
+        }
+    }
+
+    @Override
+    public void setLoggingLevel(SessionId sessionId, LoggingLevel level)
+    {
+        Optional.ofNullable(sessions.get(sessionId)).ifPresent(session -> session.loggingLevel = level);
+    }
+
+    @Override
+    public LoggingLevel loggingLevel(SessionId sessionId)
+    {
+        return Optional.ofNullable(sessions.get(sessionId)).map(sessionn -> sessionn.loggingLevel).orElse(LoggingLevel.debug);
+    }
+
+    @Override
+    public void deleteSession(SessionId sessionId)
+    {
+        sessions.remove(sessionId);
+    }
+
+    List<CreateMessageResult> takeCreateMessageResults(SessionId sessionId)
+    {
+        return Optional.ofNullable(sessions.get(sessionId))
+                .map(session -> {
+                    List<CreateMessageResult> createMessageResults = ImmutableList.copyOf(session.createMessageResults);
+                    session.createMessageResults.clear();
+                    return createMessageResults;
+                })
+                .orElseGet(ImmutableList::of);
+    }
+
+    void simulateListChanged(SessionId sessionId, ListType listType)
+    {
+        Optional.ofNullable(sessions.get(sessionId)).ifPresent(session -> session.changedLists.add(listType));
+    }
+
+    boolean simulateResourcesUpdated(SessionId sessionId, String uri)
+    {
+        return Optional.ofNullable(sessions.get(sessionId))
+                .filter(session -> session.subscribedResources.contains(uri))
+                .map(session -> {
+                    session.resourceUpdates.add(uri);
+                    return true;
+                })
+                .orElse(false);
+    }
+
+    @Override
+    public List<String> roots(SessionId sessionId)
+    {
+        return Optional.ofNullable(sessions.get(sessionId))
+                .map(session -> session.roots)
+                .orElseGet(ImmutableList::of);
+    }
+
+    @Override
+    public void acceptRequestState(SessionId sessionId, String requestId, RequestState state)
+    {
+        Optional.ofNullable(sessions.get(sessionId))
+                .ifPresent(session -> session.requestStates.put(requestId, state));
+    }
+
+    @Override
+    public void acceptServerToClientResponse(SessionId sessionId, JsonRpcResponse<Map<String, Object>> response)
+    {
+        if (String.valueOf(response.id()).equals("sendSamplingMessage")) {
+            CreateMessageResult createMessageResult =
+                    response.error()
+                            .map(error -> new CreateMessageResult(Role.user, new TextContent(error.message()), "", Optional.empty()))
+                            .orElseGet(() -> objectMapper.convertValue(response.result().orElseThrow(), CreateMessageResult.class));
+            Optional.ofNullable(sessions.get(sessionId)).ifPresent(session -> session.createMessageResults.add(createMessageResult));
+        }
+    }
+
+    @Override
+    public void acceptRoots(SessionId sessionId, List<Root> roots)
+    {
+        Optional.ofNullable(sessions.get(sessionId))
+                .ifPresent(session -> {
+                    session.roots.clear();
+                    roots.forEach(root -> session.roots.add(root.uri()));
+                });
+    }
+
+    @Override
+    public void acceptRootsChanged(SessionId sessionId)
+    {
+        simulateListChanged(sessionId, ListType.ROOTS);
+    }
+
+    @Override
+    public void acceptClientToServerRequest(SessionId sessionId, JsonRpcRequest<?> request)
+    {
+        Optional.ofNullable(sessions.get(sessionId)).ifPresent(session -> session.clientToServerRequests.add(request));
+    }
+}

--- a/mcp/src/test/java/io/airlift/mcp/TestingSessionId.java
+++ b/mcp/src/test/java/io/airlift/mcp/TestingSessionId.java
@@ -1,0 +1,32 @@
+package io.airlift.mcp;
+
+import io.airlift.mcp.session.SessionId;
+
+import java.util.UUID;
+
+import static java.util.Objects.requireNonNull;
+
+public record TestingSessionId(UUID id)
+        implements SessionId
+{
+    public TestingSessionId
+    {
+        requireNonNull(id, "id is null");
+    }
+
+    public static TestingSessionId random()
+    {
+        return new TestingSessionId(UUID.randomUUID());
+    }
+
+    public static TestingSessionId parse(String id)
+    {
+        return new TestingSessionId(UUID.fromString(id));
+    }
+
+    @Override
+    public String asString()
+    {
+        return id.toString();
+    }
+}

--- a/mcp/src/test/java/io/airlift/mcp/TestingValueParam.java
+++ b/mcp/src/test/java/io/airlift/mcp/TestingValueParam.java
@@ -1,0 +1,27 @@
+package io.airlift.mcp;
+
+import org.glassfish.jersey.server.ContainerRequest;
+import org.glassfish.jersey.server.model.Parameter;
+import org.glassfish.jersey.server.spi.internal.ValueParamProvider;
+
+import java.net.URI;
+import java.util.function.Function;
+
+public class TestingValueParam
+        implements ValueParamProvider
+{
+    @Override
+    public Function<ContainerRequest, ?> getValueProvider(Parameter parameter)
+    {
+        if (parameter.getRawType().equals(URI.class)) {
+            return containerRequest -> containerRequest.getUriInfo().getRequestUri();
+        }
+        return null;
+    }
+
+    @Override
+    public PriorityType getPriority()
+    {
+        return Priority.HIGH;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
         <module>jmx</module>
         <module>jmx-http</module>
         <module>json</module>
+        <module>json-rpc</module>
         <module>log</module>
         <module>log-manager</module>
         <module>node</module>
@@ -183,6 +184,12 @@
             <dependency>
                 <groupId>io.airlift</groupId>
                 <artifactId>json</artifactId>
+                <version>${dep.airlift.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.airlift</groupId>
+                <artifactId>json-rpc</artifactId>
                 <version>${dep.airlift.version}</version>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
         <module>json-rpc</module>
         <module>log</module>
         <module>log-manager</module>
+        <module>mcp</module>
         <module>node</module>
         <module>openmetrics</module>
         <module>packaging</module>
@@ -195,6 +196,13 @@
 
             <dependency>
                 <groupId>io.airlift</groupId>
+                <artifactId>json-rpc</artifactId>
+                <version>${dep.airlift.version}</version>
+                <type>test-jar</type>
+            </dependency>
+
+            <dependency>
+                <groupId>io.airlift</groupId>
                 <artifactId>junit-extensions</artifactId>
                 <version>2</version>
             </dependency>
@@ -224,6 +232,12 @@
             <dependency>
                 <groupId>io.airlift</groupId>
                 <artifactId>log-manager</artifactId>
+                <version>${dep.airlift.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.airlift</groupId>
+                <artifactId>mcp</artifactId>
                 <version>${dep.airlift.version}</version>
             </dependency>
 


### PR DESCRIPTION
# Context for this PR

MCP's original protocol required long running bi-directional connections with persistent sessions. They've recently updated the protocol so that a subset of features can be implemented in a stateless manner. See: https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http

Even with this new protocol they've updated the specification to still allow the features that were used prior to this change. In order to support these features, MCP servers MUST support two connections per "session" and maintain sessions in some kind of persistent store (unless you are willing to run with a single server that is a single point of failure). MCP clients will make an HTTP GET call to receives events, notifications and "requests" from the server. This is a long-lived connection that returns a chunked, SSE-style event stream. MCP clients make single HTTP POST requests to the server to send MCP requests or responses from server requests.

This PR implements the full feature set. Just as in Part 1 (https://github.com/airlift/airlift/pull/1495) we could try to modify and/or wait for improvements in the reference SDK but it would be a lot of work.

This PR is Draft as this is a more speculative submission. However, it has been tested with the https://github.com/modelcontextprotocol/inspector tool.

# Airlift contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [x] All automated tests are passing.
 - [ ] Pull request was categorized using one of the existing labels.
