### PR TITLE
io.modelcontextprotocol.sdk mcp 0.11.2

### DIFF
--- a/mcp/src/test/java/io/airlift/mcp/TestMcp.java
+++ b/mcp/src/test/java/io/airlift/mcp/TestMcp.java
@@ -55,7 +55,7 @@ import static io.airlift.http.client.HttpClientBinder.httpClientBinder;
 import static io.airlift.http.client.JsonResponseHandler.createJsonResponseHandler;
 import static io.airlift.http.client.Request.Builder.preparePost;
 import static io.airlift.json.JsonCodec.jsonCodec;
-import static io.airlift.mcp.model.JsonRpcErrorCode.INTERNAL_ERROR;
+import static io.airlift.mcp.model.JsonRpcErrorCode.INVALID_REQUEST;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.type;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
@@ -132,9 +132,8 @@ public class TestMcp
         JsonRpcRequest<?> jsonrpcRequest = JsonRpcRequest.buildRequest(1, "tools/call", callToolRequest);
         JsonRpcResponse<?> response = rpcCall(jsonrpcRequest);
 
-        // NOTE: should be "INVALID_REQUEST". Our PR will fix this: https://github.com/modelcontextprotocol/java-sdk/pull/465
         assertThat(response.error())
-                .contains(new JsonRpcErrorDetail(INTERNAL_ERROR, "this ain't good"));
+                .contains(new JsonRpcErrorDetail(INVALID_REQUEST, "this ain't good"));
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <dep.modernizer.version>2.7.0</dep.modernizer.version>
         <dep.jersey.version>3.1.11</dep.jersey.version>
         <dep.jjwt.version>0.12.6</dep.jjwt.version>
-        <dep.modelcontextprotocol.sdk.version>0.11.0</dep.modelcontextprotocol.sdk.version>
+        <dep.modelcontextprotocol.sdk.version>0.11.2</dep.modelcontextprotocol.sdk.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Change test to check INVALID_REQUEST

Our change has been merged to the MCP SDK so it now throws the correct exception.

# Airlift contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [x] All automated tests are passing.
 - [x] Pull request was categorized using one of the existing labels.
