### PR TITLE
Need to set IdentityMapper for LocalServer

### DIFF
--- a/mcp/src/test/java/io/airlift/mcp/LocalServer.java
+++ b/mcp/src/test/java/io/airlift/mcp/LocalServer.java
@@ -33,8 +33,13 @@ public class LocalServer
             }
         };
 
+        Module mcpModule = McpModule.builder()
+                .withAllInClass(TestingEndpoints.class)
+                .withIdentityMapper(TestingIdentity.class, binding -> binding.toInstance(_ -> new TestingIdentity("Mr. Tester")))
+                .build();
+
         ImmutableList.Builder<Module> modules = ImmutableList.<Module>builder()
-                .add(McpModule.builder().withAllInClass(TestingEndpoints.class).build())
+                .add(mcpModule)
                 .add(binder -> binder.bind(TestingEndpoints.class).in(SINGLETON))
                 .add(new NodeModule())
                 .add(new TestingHttpServerModule(port.orElse(0)))


### PR DESCRIPTION
I forgot to do this when I added `IdentityMapper`. This only affects the tester, `LocalServer`

# Airlift contribution check list

 - [ ] Git commit messages follow https://cbea.ms/git-commit/.
 - [ ] All automated tests are passing.
 - [ ] Pull request was categorized using one of the existing labels.
