### PR TITLE
Re-introduce Jackson exception mapper

### DIFF
--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -56,6 +56,11 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>units</artifactId>
             <optional>true</optional>
         </dependency>
@@ -101,12 +106,6 @@
         </dependency>
 
         <!-- used by tests but also needed transitively -->
-        <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>json</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>node</artifactId>
@@ -183,6 +182,12 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/jaxrs/src/main/java/io/airlift/jaxrs/JaxrsBinder.java
+++ b/jaxrs/src/main/java/io/airlift/jaxrs/JaxrsBinder.java
@@ -4,9 +4,12 @@ import com.google.inject.Binder;
 import com.google.inject.Key;
 import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.Multibinder;
+import io.airlift.jaxrs.JsonParsingFeature.MappingEnabled;
 
 import static com.google.inject.Scopes.SINGLETON;
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
+import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
+import static io.airlift.jaxrs.JsonParsingFeature.MappingEnabled.DISABLED;
 import static java.util.Objects.requireNonNull;
 
 public class JaxrsBinder
@@ -41,6 +44,12 @@ public class JaxrsBinder
     {
         binder.bind(targetKey).in(SINGLETON);
         resourceBinder.addBinding().to(targetKey).in(SINGLETON);
+    }
+
+    public JaxrsBinder disableJsonExceptionMapper()
+    {
+        newOptionalBinder(binder, MappingEnabled.class).setBinding().toInstance(DISABLED);
+        return this;
     }
 
     public void bindInstance(Object instance)

--- a/jaxrs/src/main/java/io/airlift/jaxrs/JaxrsModule.java
+++ b/jaxrs/src/main/java/io/airlift/jaxrs/JaxrsModule.java
@@ -20,6 +20,7 @@ import com.google.inject.Binder;
 import com.google.inject.Key;
 import com.google.inject.Provides;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.airlift.jaxrs.JsonParsingFeature.MappingEnabled;
 import io.airlift.jaxrs.tracing.JaxrsTracingModule;
 import jakarta.servlet.Servlet;
 import org.glassfish.jersey.server.ResourceConfig;
@@ -29,7 +30,9 @@ import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
+import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
+import static io.airlift.jaxrs.JsonParsingFeature.MappingEnabled.ENABLED;
 import static org.glassfish.jersey.server.ServerProperties.RESPONSE_SET_STATUS_OVER_SEND_ERROR;
 
 public class JaxrsModule
@@ -49,7 +52,14 @@ public class JaxrsModule
         binder.disableCircularProxies();
         binder.bind(Servlet.class).to(Key.get(ServletContainer.class));
         newSetBinder(binder, Object.class, JaxrsResource.class).permitDuplicates();
-        jaxrsBinder(binder).bind(JsonMapper.class);
+
+        JaxrsBinder jaxrsBinder = jaxrsBinder(binder);
+        jaxrsBinder.bind(JsonMapper.class);
+        jaxrsBinder.bind(JsonParsingFeature.class);
+
+        newOptionalBinder(binder, MappingEnabled.class)
+                .setDefault()
+                .toInstance(ENABLED);
 
         if (getProperty("tracing.enabled").map(Boolean::parseBoolean).orElse(false)) {
             install(new JaxrsTracingModule());

--- a/jaxrs/src/main/java/io/airlift/jaxrs/JsonError.java
+++ b/jaxrs/src/main/java/io/airlift/jaxrs/JsonError.java
@@ -1,0 +1,27 @@
+package io.airlift.jaxrs;
+
+import com.google.common.base.CharMatcher;
+import io.airlift.json.JsonCodec;
+
+import static com.google.common.base.Verify.verify;
+import static io.airlift.json.JsonCodec.jsonCodec;
+import static java.util.Objects.requireNonNull;
+
+public record JsonError(String code, String message)
+{
+    private static final CharMatcher MATCHER = CharMatcher.inRange('A', 'Z')
+            .or(CharMatcher.is('_'))
+            .precomputed();
+
+    public JsonError
+    {
+        verify(MATCHER.matchesAllOf(code), "Error code must only contain uppercase letters and underscores: %s", code);
+        requireNonNull(code, "code is null");
+        requireNonNull(message, "message is null");
+    }
+
+    public static JsonCodec<JsonError> codec()
+    {
+        return jsonCodec(JsonError.class);
+    }
+}

--- a/jaxrs/src/main/java/io/airlift/jaxrs/JsonParsingExceptionMapper.java
+++ b/jaxrs/src/main/java/io/airlift/jaxrs/JsonParsingExceptionMapper.java
@@ -1,0 +1,25 @@
+package io.airlift.jaxrs;
+
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+
+import static com.google.common.base.Throwables.getRootCause;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
+import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
+
+@Provider
+public class JsonParsingExceptionMapper
+        implements ExceptionMapper<JsonParsingException>
+{
+    private static final String SERIALIZATION_ERROR_CODE = "JSON_PARSING_ERROR";
+
+    @Override
+    public Response toResponse(JsonParsingException e)
+    {
+        return Response.status(BAD_REQUEST)
+                .type(APPLICATION_JSON_TYPE)
+                .entity(new JsonError(SERIALIZATION_ERROR_CODE, getRootCause(e).getMessage()))
+                .build();
+    }
+}

--- a/jaxrs/src/main/java/io/airlift/jaxrs/JsonParsingFeature.java
+++ b/jaxrs/src/main/java/io/airlift/jaxrs/JsonParsingFeature.java
@@ -1,0 +1,35 @@
+package io.airlift.jaxrs;
+
+import com.google.inject.Inject;
+import jakarta.ws.rs.core.Feature;
+import jakarta.ws.rs.core.FeatureContext;
+
+import static io.airlift.jaxrs.JsonParsingFeature.MappingEnabled.DISABLED;
+import static java.util.Objects.requireNonNull;
+
+public record JsonParsingFeature(MappingEnabled enabled)
+        implements Feature
+{
+    public enum MappingEnabled
+    {
+        ENABLED,
+        DISABLED,
+    }
+
+    @Inject
+    public JsonParsingFeature
+    {
+        requireNonNull(enabled, "config is null");
+    }
+
+    @Override
+    public boolean configure(FeatureContext context)
+    {
+        if (enabled == DISABLED) {
+            return false;
+        }
+
+        context.register(new JsonParsingExceptionMapper());
+        return true;
+    }
+}

--- a/jaxrs/src/test/java/io/airlift/jaxrs/programmatic/ResourceWithBadJson.java
+++ b/jaxrs/src/test/java/io/airlift/jaxrs/programmatic/ResourceWithBadJson.java
@@ -1,0 +1,20 @@
+package io.airlift.jaxrs.programmatic;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@Path("/")
+public class ResourceWithBadJson
+{
+    public record DummyModel(String name) {}
+
+    @POST
+    @Consumes(APPLICATION_JSON)
+    public void takeBadJson(DummyModel ignore)
+    {
+        // do nothing
+    }
+}

--- a/jaxrs/src/test/java/io/airlift/jaxrs/programmatic/TestProgrammaticResource.java
+++ b/jaxrs/src/test/java/io/airlift/jaxrs/programmatic/TestProgrammaticResource.java
@@ -15,21 +15,41 @@
  */
 package io.airlift.jaxrs.programmatic;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.inject.Injector;
 import com.google.inject.Module;
 import io.airlift.bootstrap.Bootstrap;
+import io.airlift.bootstrap.LifeCycleManager;
+import io.airlift.http.client.HttpClientConfig;
+import io.airlift.http.client.Request;
+import io.airlift.http.client.StringResponseHandler.StringResponse;
+import io.airlift.http.client.jetty.JettyHttpClient;
+import io.airlift.http.server.testing.TestingHttpServer;
+import io.airlift.http.server.testing.TestingHttpServerModule;
+import io.airlift.jaxrs.JaxrsBinder;
 import io.airlift.jaxrs.JaxrsModule;
+import io.airlift.jaxrs.JsonError;
 import io.airlift.json.JsonModule;
+import io.airlift.node.testing.TestingNodeModule;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.server.model.Resource;
 import org.glassfish.jersey.server.model.ResourceMethod;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.lang.reflect.Method;
+import java.net.URI;
 import java.util.List;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.http.client.Request.Builder.preparePost;
+import static io.airlift.http.client.StaticBodyGenerator.createStaticBodyGenerator;
+import static io.airlift.http.client.StringResponseHandler.createStringResponseHandler;
 import static io.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
+import static jakarta.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestProgrammaticResource
@@ -61,5 +81,50 @@ public class TestProgrammaticResource
         ResourceMethod foundMethod = foundMethods.get(0);
         assertThat(foundMethod.getInvocable().getHandlingMethod()).isEqualTo(getResultMethod);
         assertThat(foundMethod.getInvocable().getHandler().getHandlerClass()).isEqualTo(getClass());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testJsonParsingExceptionMapper(boolean useMapper)
+            throws JsonProcessingException
+    {
+        Injector injector = new Bootstrap(
+                binder -> {
+                    JaxrsBinder jaxrsBinder = jaxrsBinder(binder);
+                    if (!useMapper) {
+                        jaxrsBinder.disableJsonExceptionMapper();
+                    }
+                    jaxrsBinder.bind(ResourceWithBadJson.class);
+                },
+                new TestingNodeModule(),
+                new JaxrsModule(),
+                new JsonModule(),
+                new TestingHttpServerModule())
+                .quiet()
+                .doNotInitializeLogging()
+                .initialize();
+
+        URI baseUri = injector.getInstance(TestingHttpServer.class).getBaseUrl();
+        try (JettyHttpClient client = new JettyHttpClient(new HttpClientConfig())) {
+            Request request = preparePost().setUri(baseUri)
+                    .setHeader("Content-Type", "application/json")
+                    .setBodyGenerator(createStaticBodyGenerator("this ain't json", UTF_8))
+                    .build();
+
+            StringResponse response = client.execute(request, createStringResponseHandler());
+
+            if (useMapper) {
+                assertThat(response.getStatusCode()).isEqualTo(400);
+                assertThat(response.getHeader(CONTENT_TYPE)).isEqualTo(APPLICATION_JSON_TYPE.toString());
+                JsonError error = JsonError.codec().fromJson(response.getBody());
+                assertThat(error.message()).startsWith("Unrecognized token 'this'");
+                assertThat(error.code()).isEqualTo("JSON_PARSING_ERROR");
+            }
+            else {
+                assertThat(response.getStatusCode()).isEqualTo(500);
+            }
+        }
+
+        injector.getInstance(LifeCycleManager.class).stop();
     }
 }


### PR DESCRIPTION
Add an optional Jackson exception mapper so that BadRequest (400) is returned instead of 500. This provides an optional standardized behavior for badly formatted JSON parsed on the server. Applications generally handle HTTP 4XX better than they handle 5XX.

# Airlift contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [x] All automated tests are passing.
 - [x] Pull request was categorized using one of the existing labels.
