### PR TITLE
Fix TimeDistribution partial handling

### DIFF
--- a/stats/src/main/java/io/airlift/stats/ExponentialDecay.java
+++ b/stats/src/main/java/io/airlift/stats/ExponentialDecay.java
@@ -10,6 +10,11 @@ public final class ExponentialDecay
     {
     }
 
+    public static double all()
+    {
+        return 0;
+    }
+
     public static double oneMinute()
     {
         // alpha for a target weight of 1/E at 1 minute

--- a/stats/src/main/java/io/airlift/stats/TimeDistribution.java
+++ b/stats/src/main/java/io/airlift/stats/TimeDistribution.java
@@ -1,5 +1,7 @@
 package io.airlift.stats;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Ticker;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import org.weakref.jmx.Managed;
 
@@ -7,6 +9,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import static com.google.common.base.Ticker.systemTicker;
 import static com.google.common.base.Verify.verify;
 import static java.lang.Math.floorMod;
 import static java.util.Objects.requireNonNull;
@@ -15,7 +18,8 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class TimeDistribution
 {
-    private static final long MERGE_THRESHOLD_NANOS = MILLISECONDS.toNanos(100);
+    @VisibleForTesting
+    static final long MERGE_THRESHOLD_NANOS = MILLISECONDS.toNanos(100);
     private static final double[] SNAPSHOT_QUANTILES = new double[] {0.5, 0.75, 0.9, 0.95, 0.99};
     private static final double[] PERCENTILES;
     private static final int STRIPES = 16;
@@ -27,6 +31,7 @@ public class TimeDistribution
         }
     }
 
+    private final Ticker ticker;
     private final double alpha;
     private final Object[] locks = new Object[STRIPES];
     @GuardedBy("locks")
@@ -36,6 +41,7 @@ public class TimeDistribution
     @GuardedBy("this")
     private long lastMerge;
     private final DecayCounter total;
+    private final DecayCounter partialTotal;
     private final TimeUnit unit;
 
     public TimeDistribution()
@@ -45,16 +51,22 @@ public class TimeDistribution
 
     public TimeDistribution(TimeUnit unit)
     {
-        this(0, unit);
+        this(systemTicker(), 0, unit);
+    }
+
+    public TimeDistribution(Ticker ticker)
+    {
+        this(ticker, 0, SECONDS);
     }
 
     public TimeDistribution(double alpha)
     {
-        this(alpha, SECONDS);
+        this(systemTicker(), alpha, SECONDS);
     }
 
-    public TimeDistribution(double alpha, TimeUnit unit)
+    public TimeDistribution(Ticker ticker, double alpha, TimeUnit unit)
     {
+        requireNonNull(ticker, "ticker is null");
         requireNonNull(unit, "unit is null");
         this.alpha = alpha;
         merged = new DecayTDigest(TDigest.DEFAULT_COMPRESSION, alpha);
@@ -63,7 +75,10 @@ public class TimeDistribution
             partials[i] = new DecayTDigest(TDigest.DEFAULT_COMPRESSION, alpha);
         }
         total = new DecayCounter(alpha);
+        partialTotal = new DecayCounter(alpha);
+        this.ticker = ticker;
         this.unit = unit;
+        this.lastMerge = ticker.read(); // do not merge immediately
     }
 
     public void add(long value)
@@ -72,7 +87,7 @@ public class TimeDistribution
         synchronized (locks[segment]) {
             partials[segment].add(value);
         }
-        total.add(value);
+        partialTotal.add(value); // Fine outside of lock as DecayCounter is thread safe
     }
 
     @Managed
@@ -126,7 +141,8 @@ public class TimeDistribution
     @Managed
     public synchronized double getAvg()
     {
-        return convertToUnit(total.getCount()) / getCount();
+        double digestCount = mergeAndGetIfNeeded().getCount();
+        return convertToUnit(total.getCount()) / digestCount;
     }
 
     @Managed
@@ -159,8 +175,7 @@ public class TimeDistribution
     private DecayTDigest mergeAndGetIfNeeded(boolean forceMerge)
     {
         synchronized (this) {
-            if (forceMerge || System.nanoTime() - lastMerge > MERGE_THRESHOLD_NANOS) {
-                merged = new DecayTDigest(TDigest.DEFAULT_COMPRESSION, alpha);
+            if (forceMerge || ticker.read() - lastMerge >= MERGE_THRESHOLD_NANOS) {
                 for (int i = 0; i < STRIPES; i++) {
                     synchronized (locks[i]) {
                         merged.merge(partials[i]);
@@ -168,7 +183,9 @@ public class TimeDistribution
                         partials[i] = new DecayTDigest(TDigest.DEFAULT_COMPRESSION, alpha);
                     }
                 }
-                lastMerge = System.nanoTime();
+                total.merge(partialTotal);
+                partialTotal.reset();
+                lastMerge = ticker.read();
             }
         }
 
@@ -219,6 +236,7 @@ public class TimeDistribution
     public synchronized void reset()
     {
         total.reset();
+        partialTotal.reset();
         merged = new DecayTDigest(TDigest.DEFAULT_COMPRESSION, alpha);
         // Reset all partial digests (stripes) to avoid stale data
         for (int i = 0; i < partials.length; i++) {

--- a/stats/src/main/java/io/airlift/stats/TimeStat.java
+++ b/stats/src/main/java/io/airlift/stats/TimeStat.java
@@ -52,10 +52,10 @@ public class TimeStat
     public TimeStat(Ticker ticker, TimeUnit unit)
     {
         this.ticker = ticker;
-        oneMinute = new TimeDistribution(ExponentialDecay.oneMinute(), unit);
-        fiveMinutes = new TimeDistribution(ExponentialDecay.fiveMinutes(), unit);
-        fifteenMinutes = new TimeDistribution(ExponentialDecay.fifteenMinutes(), unit);
-        allTime = new TimeDistribution(unit);
+        oneMinute = new TimeDistribution(ticker, ExponentialDecay.oneMinute(), unit);
+        fiveMinutes = new TimeDistribution(ticker, ExponentialDecay.fiveMinutes(), unit);
+        fifteenMinutes = new TimeDistribution(ticker, ExponentialDecay.fifteenMinutes(), unit);
+        allTime = new TimeDistribution(ticker, ExponentialDecay.all(), unit);
     }
 
     public void add(double value, TimeUnit timeUnit)

--- a/stats/src/test/java/io/airlift/stats/TestTimeDistribution.java
+++ b/stats/src/test/java/io/airlift/stats/TestTimeDistribution.java
@@ -1,0 +1,43 @@
+package io.airlift.stats;
+
+import io.airlift.testing.TestingTicker;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static io.airlift.stats.TimeDistribution.MERGE_THRESHOLD_NANOS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestTimeDistribution
+{
+    @Test
+    public void testPartialMerging()
+    {
+        TestingTicker ticker = new TestingTicker();
+        TimeDistribution distribution = new TimeDistribution(ticker);
+        distribution.add(SECONDS.toNanos(1));
+        distribution.add(SECONDS.toNanos(3));
+
+        assertThat(distribution.getCount()).isEqualTo(0);
+        assertThat(distribution.getAvg()).isNaN();
+
+        // This will merge on next get or snapshot
+        ticker.increment(MERGE_THRESHOLD_NANOS, TimeUnit.NANOSECONDS); // force a merge
+
+        assertThat(distribution.getCount()).isEqualTo(2);
+        assertThat(distribution.getAvg()).isEqualTo(2);
+
+        distribution.add(SECONDS.toNanos(5));
+        ticker.increment(MERGE_THRESHOLD_NANOS / 2, TimeUnit.NANOSECONDS); // time not lapsed enough to merge
+
+        assertThat(distribution.getCount()).isEqualTo(2);
+        ticker.increment(MERGE_THRESHOLD_NANOS / 2, TimeUnit.NANOSECONDS); // time lapsed enough to merge
+
+        // This will merge partials again
+        assertThat(distribution.snapshot().avg()).isEqualTo(3);
+
+        assertThat(distribution.getCount()).isEqualTo(3);
+        assertThat(distribution.getAvg()).isEqualTo(3);
+    }
+}


### PR DESCRIPTION
1) Do not reset merged state unless explicit reset() is called 2) Merge while getting avg
3) Delay merging until initial delay is passed
4) Add test

<!-- Thank you for submitting pull request to Airlift -->

# Airlift contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [x] All automated tests are passing.
 - [x] Pull request was categorized using one of the existing labels.
