### PR TITLE
Support CallToolResult as MCP tool return type

### DIFF
--- a/mcp/src/main/java/io/airlift/mcp/McpServer.java
+++ b/mcp/src/main/java/io/airlift/mcp/McpServer.java
@@ -11,7 +11,7 @@ public interface McpServer
 {
     void stop();
 
-    void addTool(Tool tool, ToolHandler toolHandler);
+    void addTool(Tool tool, ToolHandler<?> toolHandler);
 
     void removeTool(String toolName);
 

--- a/mcp/src/main/java/io/airlift/mcp/handler/ToolEntry.java
+++ b/mcp/src/main/java/io/airlift/mcp/handler/ToolEntry.java
@@ -4,7 +4,7 @@ import io.airlift.mcp.model.Tool;
 
 import static java.util.Objects.requireNonNull;
 
-public record ToolEntry(Tool tool, ToolHandler toolHandler)
+public record ToolEntry(Tool tool, ToolHandler<?> toolHandler)
 {
     public ToolEntry
     {

--- a/mcp/src/main/java/io/airlift/mcp/handler/ToolHandler.java
+++ b/mcp/src/main/java/io/airlift/mcp/handler/ToolHandler.java
@@ -4,7 +4,7 @@ import io.airlift.mcp.model.CallToolRequest;
 import io.airlift.mcp.model.CallToolResult;
 import jakarta.servlet.http.HttpServletRequest;
 
-public interface ToolHandler
+public interface ToolHandler<T>
 {
-    CallToolResult callTool(HttpServletRequest request, CallToolRequest toolRequest);
+    CallToolResult<T> callTool(HttpServletRequest request, CallToolRequest toolRequest);
 }

--- a/mcp/src/main/java/io/airlift/mcp/model/CallToolResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/CallToolResult.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
-public record CallToolResult(List<Content> content, Optional<StructuredContent<?>> structuredContent, boolean isError)
+public record CallToolResult<T>(List<Content> content, Optional<StructuredContent<T>> structuredContent, boolean isError)
 {
     public CallToolResult
     {

--- a/mcp/src/main/java/io/airlift/mcp/reference/Mapper.java
+++ b/mcp/src/main/java/io/airlift/mcp/reference/Mapper.java
@@ -171,7 +171,7 @@ interface Mapper
         return new McpSchema.PromptArgument(ourArgument.name(), ourArgument.description().orElse(null), ourArgument.required());
     }
 
-    static McpStatelessServerFeatures.SyncToolSpecification mapTool(ObjectMapper objectMapper, Tool ourTool, ToolHandler ourHandler)
+    static McpStatelessServerFeatures.SyncToolSpecification mapTool(ObjectMapper objectMapper, Tool ourTool, ToolHandler<?> ourHandler)
     {
         try {
             McpSchema.Tool.Builder theirToolBuilder = McpSchema.Tool.builder()
@@ -196,7 +196,7 @@ interface Mapper
                 HttpServletRequest request = (HttpServletRequest) context.get(McpMetadata.CONTEXT_REQUEST_KEY);
                 CallToolRequest callToolRequest = new CallToolRequest(theirCallToolRequest.name(), theirCallToolRequest.arguments(), Optional.ofNullable(theirCallToolRequest.meta()));
 
-                CallToolResult callToolResult = ourHandler.callTool(request, callToolRequest);
+                CallToolResult<?> callToolResult = ourHandler.callTool(request, callToolRequest);
 
                 List<McpSchema.Content> theirContent = callToolResult.content()
                         .stream()

--- a/mcp/src/main/java/io/airlift/mcp/reference/ReferenceServer.java
+++ b/mcp/src/main/java/io/airlift/mcp/reference/ReferenceServer.java
@@ -54,7 +54,7 @@ public class ReferenceServer
     }
 
     @Override
-    public void addTool(Tool tool, ToolHandler toolHandler)
+    public void addTool(Tool tool, ToolHandler<?> toolHandler)
     {
         server.addTool(Mapper.mapTool(objectMapper, tool, toolHandler));
     }

--- a/mcp/src/test/java/io/airlift/mcp/TestingEndpoints.java
+++ b/mcp/src/test/java/io/airlift/mcp/TestingEndpoints.java
@@ -1,6 +1,12 @@
 package io.airlift.mcp;
 
+import com.google.common.collect.ImmutableList;
+import io.airlift.mcp.model.CallToolResult;
+import io.airlift.mcp.model.Content;
 import io.airlift.mcp.model.ResourceContents;
+import io.airlift.mcp.model.StructuredContent;
+
+import java.util.Optional;
 
 import static io.airlift.mcp.McpException.exception;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -13,6 +19,28 @@ public class TestingEndpoints
         assertThat(testingIdentity.name()).isEqualTo("Mr. Tester");
 
         return a + b;
+    }
+
+    @McpTool(name = "addThree", description = "Add three numbers")
+    public CallToolResult<String> addThree(TestingIdentity testingIdentity, int a, int b, int c)
+    {
+        assertThat(testingIdentity.name()).isEqualTo("Mr. Tester");
+
+        return new CallToolResult<>(ImmutableList.of(new Content.TextContent(String.valueOf(a + b + c))),
+                Optional.empty(),
+                false);
+    }
+
+    public record TwoAndThree(int firstTwo, int allThree) {}
+
+    @McpTool(name = "addFirstTwoAndAllThree", description = "Add the first two numbers together, and add all three numbers together")
+    public CallToolResult<TwoAndThree> addTwoAndThree(TestingIdentity testingIdentity, int a, int b, int c)
+    {
+        assertThat(testingIdentity.name()).isEqualTo("Mr. Tester");
+
+        return new CallToolResult<>(ImmutableList.of(new Content.TextContent(String.valueOf(a + b + c))),
+                Optional.of(new StructuredContent<>(new TwoAndThree(a + b, a + b + c))),
+                false);
     }
 
     @McpTool(name = "throws", description = "Throws an exception for testing purposes")


### PR DESCRIPTION
Previous to this commit, `CallToolResult` was unsupported as a return type due to the `ToolHandlerProvider` being unable to handle the nested sealed interface types of the `CallToolResult.Content`. This commit both supports that as a return type, and attempts to use a type parameter to determine the structured content of the tool if the type parameter is a record.

<!-- Thank you for submitting pull request to Airlift -->

# Airlift contribution check list

 - [ ] Git commit messages follow https://cbea.ms/git-commit/.
 - [ ] All automated tests are passing.
 - [ ] Pull request was categorized using one of the existing labels.
