### PR TITLE
Make MCP structured content optional

### DIFF
--- a/mcp/src/main/java/io/airlift/mcp/model/StructuredContentResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/StructuredContentResult.java
@@ -3,14 +3,20 @@ package io.airlift.mcp.model;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
+import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
-public record StructuredContentResult<T>(List<Content> content, T structuredContent, boolean isError)
+public record StructuredContentResult<T>(List<Content> content, Optional<T> structuredContent, boolean isError)
 {
     public StructuredContentResult
     {
         content = ImmutableList.copyOf(content);
         requireNonNull(structuredContent, "structuredContent is null");
+    }
+
+    public StructuredContentResult(List<Content> content, T structuredContent, boolean isError)
+    {
+        this(content, Optional.ofNullable(structuredContent), isError);
     }
 }

--- a/mcp/src/main/java/io/airlift/mcp/reflection/ToolHandlerProvider.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/ToolHandlerProvider.java
@@ -132,7 +132,7 @@ public class ToolHandlerProvider
 
     private CallToolResult mapStructuredContentResult(StructuredContentResult<?> result)
     {
-        return new CallToolResult(result.content(), Optional.of(new StructuredContent<>(result.structuredContent())), result.isError());
+        return new CallToolResult(result.content(), result.structuredContent().map(StructuredContent::new), result.isError());
     }
 
     private static Tool buildTool(McpTool tool, Method method, List<MethodParameter> parameters)

--- a/mcp/src/test/java/io/airlift/mcp/TestingEndpoints.java
+++ b/mcp/src/test/java/io/airlift/mcp/TestingEndpoints.java
@@ -57,10 +57,17 @@ public class TestingEndpoints
 
     public record TwoAndThree(int firstTwo, int allThree) {}
 
-    @McpTool(name = "addFirstTwoAndAllThree", description = "Add the first two numbers together, and add all three numbers together")
+    @McpTool(name = "addFirstTwoAndAllThree", description = "Add the first two numbers together, and add all three numbers together. Numbers must be >= 0")
     public StructuredContentResult<TwoAndThree> addTwoAndThree(TestingIdentity testingIdentity, int a, int b, int c)
     {
         assertThat(testingIdentity.name()).isEqualTo("Mr. Tester");
+
+        if (a < 0 || b < 0 || c < 0) {
+            return new StructuredContentResult<>(
+                    ImmutableList.of(new Content.TextContent("Negative numbers are not allowed")),
+                    Optional.empty(),
+                    true);
+        }
 
         return new StructuredContentResult<>(
                 ImmutableList.of(new Content.TextContent(String.valueOf(a + b + c))),


### PR DESCRIPTION
There may be cases in errors during tool execution where the structured output may not make sense, e.g. parameter validation. This commit makes structured output optional, as most clients would ignore it any way in favor of the `content` when `isError` = true

<!-- Thank you for submitting pull request to Airlift -->

# Airlift contribution check list

 - [ ] Git commit messages follow https://cbea.ms/git-commit/.
 - [ ] All automated tests are passing.
 - [ ] Pull request was categorized using one of the existing labels.
