### PR TITLE
Bump io.modelcontextprotocol.sdk from 0.12.1 to 0.13.0

### DIFF
--- a/mcp/pom.xml
+++ b/mcp/pom.xml
@@ -35,11 +35,6 @@
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
 
@@ -56,7 +51,26 @@
 
         <dependency>
             <groupId>io.modelcontextprotocol.sdk</groupId>
-            <artifactId>mcp</artifactId>
+            <artifactId>mcp-core</artifactId>
+            <!-- mcp-core and mcp-json-jackson2 depend on mcp-json, but mcp-core shades it -->
+            <exclusions>
+                <exclusion>
+                    <groupId>io.modelcontextprotocol.sdk</groupId>
+                    <artifactId>mcp-json</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>io.modelcontextprotocol.sdk</groupId>
+            <artifactId>mcp-json-jackson2</artifactId>
+            <!-- mcp-core and mcp-json-jackson2 depend on mcp-json, but mcp-core shades it -->
+            <exclusions>
+                <exclusion>
+                    <groupId>io.modelcontextprotocol.sdk</groupId>
+                    <artifactId>mcp-json</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -73,6 +87,12 @@
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/mcp/src/main/java/io/airlift/mcp/reference/ReferenceServer.java
+++ b/mcp/src/main/java/io/airlift/mcp/reference/ReferenceServer.java
@@ -1,6 +1,5 @@
 package io.airlift.mcp.reference;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
 import io.airlift.log.Logger;
 import io.airlift.mcp.McpServer;
@@ -13,6 +12,7 @@ import io.airlift.mcp.handler.ToolHandler;
 import io.airlift.mcp.model.Prompt;
 import io.airlift.mcp.model.Resource;
 import io.airlift.mcp.model.Tool;
+import io.modelcontextprotocol.json.McpJsonMapper;
 import io.modelcontextprotocol.server.McpStatelessSyncServer;
 import jakarta.annotation.PreDestroy;
 
@@ -27,10 +27,10 @@ public class ReferenceServer
     private static final Logger log = Logger.get(ReferenceServer.class);
 
     private final McpStatelessSyncServer server;
-    private final ObjectMapper objectMapper;
+    private final McpJsonMapper objectMapper;
 
     @Inject
-    public ReferenceServer(McpStatelessSyncServer server, ObjectMapper objectMapper, Set<ToolEntry> tools, Set<PromptEntry> prompts, Set<ResourceEntry> resources)
+    public ReferenceServer(McpStatelessSyncServer server, McpJsonMapper objectMapper, Set<ToolEntry> tools, Set<PromptEntry> prompts, Set<ResourceEntry> resources)
     {
         this.server = requireNonNull(server, "server is null");
         this.objectMapper = requireNonNull(objectMapper, "objectMapper is null");

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
 
         <dep.airlift.version>360-SNAPSHOT</dep.airlift.version>
         <dep.bouncycastle.version>1.82</dep.bouncycastle.version>
-        <dep.mcp.sdk.version>0.12.1</dep.mcp.sdk.version>
+        <dep.mcp.sdk.version>0.13.0</dep.mcp.sdk.version>
         <dep.jersey.version>3.1.11</dep.jersey.version>
         <dep.jjwt.version>0.13.0</dep.jjwt.version>
     </properties>
@@ -300,7 +300,13 @@
 
             <dependency>
                 <groupId>io.modelcontextprotocol.sdk</groupId>
-                <artifactId>mcp</artifactId>
+                <artifactId>mcp-core</artifactId>
+                <version>${dep.mcp.sdk.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.modelcontextprotocol.sdk</groupId>
+                <artifactId>mcp-json-jackson2</artifactId>
                 <version>${dep.mcp.sdk.version}</version>
             </dependency>
 


### PR DESCRIPTION
<!-- Thank you for submitting pull request to Airlift -->

0.13.0 introduced some breaking changes, specifically around decoupling jackson from json parsing.

Stems from https://github.com/airlift/airlift/pull/1560

# Airlift contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [x] All automated tests are passing.
 - [x] Pull request was categorized using one of the existing labels.
