### PR TITLE
Run tests on JDK 24, 25 and 26-ea

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
         java-version:
           - 24
           - 25
+          - 26-ea
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,8 @@ jobs:
       fail-fast: false
       matrix:
         java-version:
-          - 23
           - 24
-          - 25-ea
+          - 25
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4


### PR DESCRIPTION
We don't need 23 and 25 was just fully released

<!-- Thank you for submitting pull request to Airlift -->

# Airlift contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [x] All automated tests are passing.
 - [x] Pull request was categorized using one of the existing labels.
