### PR TITLE
Add supported platforms for native brotli dependency

### DIFF
--- a/http-server/pom.xml
+++ b/http-server/pom.xml
@@ -174,6 +174,34 @@
         </dependency>
 
         <dependency>
+            <groupId>com.aayushatharva.brotli4j</groupId>
+            <artifactId>native-linux-aarch64</artifactId>
+            <version>${dep.brotli4j.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.aayushatharva.brotli4j</groupId>
+            <artifactId>native-linux-x86_64</artifactId>
+            <version>${dep.brotli4j.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.aayushatharva.brotli4j</groupId>
+            <artifactId>native-osx-aarch64</artifactId>
+            <version>${dep.brotli4j.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.aayushatharva.brotli4j</groupId>
+            <artifactId>native-osx-x86_64</artifactId>
+            <version>${dep.brotli4j.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-alpn-java-server</artifactId>
             <scope>runtime</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@
         <air.modernizer.java-version>8</air.modernizer.java-version>
 
         <dep.airlift.version>364-SNAPSHOT</dep.airlift.version>
+        <dep.brotli4j.version>1.20.0</dep.brotli4j.version>
         <dep.bouncycastle.version>1.82</dep.bouncycastle.version>
         <dep.mcp.sdk.version>0.13.1</dep.mcp.sdk.version>
         <dep.jersey.version>3.1.11</dep.jersey.version>


### PR DESCRIPTION
brotli4j transitive dependency has profile activations that detect current os/arch combination and pulls the native dependency. If you then run this on a different os/arch combination, native libraries will be missing.

<!-- Thank you for submitting pull request to Airlift -->

# Airlift contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [x] All automated tests are passing.
 - [x] Pull request was categorized using one of the existing labels.
