### PR TITLE
Add option to preserve content decoder

### DIFF
--- a/http-client/src/main/java/io/airlift/http/client/HttpClientConfig.java
+++ b/http-client/src/main/java/io/airlift/http/client/HttpClientConfig.java
@@ -93,6 +93,7 @@ public class HttpClientConfig
     private Optional<Duration> tcpKeepAliveIdleTime = Optional.empty();
     private boolean strictEventOrdering;
     private boolean useVirtualThreads;
+    private boolean preserveContentDecoderFactories;
 
     /**
      * This property is initialized with Jetty's default excluded ciphers list.
@@ -774,6 +775,19 @@ public class HttpClientConfig
     public HttpClientConfig setUseVirtualThreads(boolean useVirtualThreads)
     {
         this.useVirtualThreads = useVirtualThreads;
+        return this;
+    }
+
+    public boolean isPreserveContentDecoderFactories()
+    {
+        return preserveContentDecoderFactories;
+    }
+
+    @ConfigHidden
+    @Config("http-client.preserve-content-decoder-factories")
+    public HttpClientConfig setPreserveContentDecoderFactories(boolean preserveContentDecoderFactories)
+    {
+        this.preserveContentDecoderFactories = preserveContentDecoderFactories;
         return this;
     }
 

--- a/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
@@ -359,7 +359,9 @@ public class JettyHttpClient
 
             // remove the GZIP encoding from the client
             // TODO: there should be a better way to to do this
-            httpClient.getContentDecoderFactories().clear();
+            if (!config.isPreserveContentDecoderFactories()) {
+                httpClient.getContentDecoderFactories().clear();
+            }
         }
         catch (Exception e) {
             if (e instanceof InterruptedException) {

--- a/http-client/src/test/java/io/airlift/http/client/AbstractHttpClientTest.java
+++ b/http-client/src/test/java/io/airlift/http/client/AbstractHttpClientTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.parallel.Execution;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
@@ -48,12 +49,14 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.zip.GZIPOutputStream;
 
 import static com.google.common.base.Throwables.getStackTraceAsString;
 import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.net.HttpHeaders.ACCEPT_ENCODING;
 import static com.google.common.net.HttpHeaders.AUTHORIZATION;
+import static com.google.common.net.HttpHeaders.CONTENT_ENCODING;
 import static com.google.common.net.HttpHeaders.CONTENT_LENGTH;
 import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
 import static com.google.common.net.HttpHeaders.LOCATION;
@@ -710,6 +713,39 @@ public abstract class AbstractHttpClientTest
             server.servlet().addResponseHeader(CONTENT_TYPE, "application/json");
 
             StringResponse response = executeRequest(server, request, createStringResponseHandler());
+            assertThat(response.getHeader(CONTENT_TYPE)).isEqualTo("application/json");
+            assertThat(response.getBody()).isEqualTo(json);
+        }
+    }
+
+    @Test
+    public void testCompressionIsEnabled()
+            throws Exception
+    {
+        HttpClientConfig clientConfig = createClientConfig().setPreserveContentDecoderFactories(true);
+        try (CloseableTestHttpServer server = newServer(); JettyHttpClient client = server.createClient(clientConfig)) {
+            Request request = prepareGet()
+                    .setUri(server.baseURI())
+                    .setHeader(ACCEPT_ENCODING, "gzip")
+                    .build();
+
+            StringResponse response = client.execute(request, createStringResponseHandler());
+            Thread.sleep(1000);
+
+            String body = response.getBody();
+            assertThat(body).isEqualTo("");
+            assertThat(server.servlet().getRequestHeaders().containsKey(HeaderName.of(ACCEPT_ENCODING))).isTrue();
+
+            String json = "{\"fuite\":\"apple\",\"hello\":\"world\"}";
+            ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
+            try (GZIPOutputStream gzip = new GZIPOutputStream(byteStream)) {
+                gzip.write(json.getBytes(UTF_8));
+            }
+            server.servlet().setResponseByte(byteStream.toByteArray());
+            server.servlet().addResponseHeader(CONTENT_TYPE, "application/json");
+            server.servlet().addResponseHeader(CONTENT_ENCODING, "gzip");
+
+            response = client.execute(request, createStringResponseHandler());
             assertThat(response.getHeader(CONTENT_TYPE)).isEqualTo("application/json");
             assertThat(response.getBody()).isEqualTo(json);
         }

--- a/http-client/src/test/java/io/airlift/http/client/EchoServlet.java
+++ b/http-client/src/test/java/io/airlift/http/client/EchoServlet.java
@@ -42,7 +42,7 @@ public final class EchoServlet
 
     private int responseStatusCode = 200;
     private final ListMultimap<String, String> responseHeaders = ArrayListMultimap.create();
-    private String responseBody;
+    private byte[] responseByte;
 
     @Override
     protected void service(HttpServletRequest request, HttpServletResponse response)
@@ -87,8 +87,8 @@ public final class EchoServlet
             response.sendRedirect(request.getParameter("redirect"));
         }
 
-        if (responseBody != null) {
-            response.getOutputStream().write(responseBody.getBytes(UTF_8));
+        if (responseByte != null) {
+            response.getOutputStream().write(responseByte);
         }
     }
 
@@ -129,6 +129,11 @@ public final class EchoServlet
 
     public void setResponseBody(String responseBody)
     {
-        this.responseBody = responseBody;
+        responseByte = responseBody.getBytes(UTF_8);
+    }
+
+    public void setResponseByte(byte[] responseByte)
+    {
+        this.responseByte = responseByte;
     }
 }

--- a/http-client/src/test/java/io/airlift/http/client/TestHttpClientConfig.java
+++ b/http-client/src/test/java/io/airlift/http/client/TestHttpClientConfig.java
@@ -95,7 +95,8 @@ public class TestHttpClientConfig
                 .setLogCompressionEnabled(true)
                 .setTcpKeepAliveIdleTime(null)
                 .setStrictEventOrdering(false)
-                .setUseVirtualThreads(false));
+                .setUseVirtualThreads(false)
+                .setPreserveContentDecoderFactories(false));
     }
 
     @Test
@@ -151,6 +152,7 @@ public class TestHttpClientConfig
                 .put("http-client.tcp-keep-alive-idle-time", "1m")
                 .put("http-client.strict-event-ordering", "true")
                 .put("http-client.use-virtual-threads", "true")
+                .put("http-client.preserve-content-decoder-factories", "true")
                 .build();
 
         HttpClientConfig expected = new HttpClientConfig()
@@ -202,7 +204,8 @@ public class TestHttpClientConfig
                 .setLogCompressionEnabled(false)
                 .setTcpKeepAliveIdleTime(new Duration(1, MINUTES))
                 .setStrictEventOrdering(true)
-                .setUseVirtualThreads(true);
+                .setUseVirtualThreads(true)
+                .setPreserveContentDecoderFactories(true);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
<!-- Thank you for submitting pull request to Airlift -->
Add option to preserve content decoder.

Airlift Http Client by default disable compression by removing content decoder factories.
In Trino Gateway, we are forwarding request from client to Trino using Airlift Http Client.
We would like to preserve the encoding and allow the communication between Client, Gateway and Trino to use compression.

Relates to: https://github.com/trinodb/trino-gateway/pull/765

# Airlift contribution check list

 - [ ] Git commit messages follow https://cbea.ms/git-commit/.
 - [ ] All automated tests are passing.
 - [ ] Pull request was categorized using one of the existing labels.
