### PR TITLE
Service all HTTP methods for MCP

### DIFF
--- a/mcp/src/main/java/io/airlift/mcp/reference/ReferenceFilter.java
+++ b/mcp/src/main/java/io/airlift/mcp/reference/ReferenceFilter.java
@@ -1,5 +1,6 @@
 package io.airlift.mcp.reference;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import io.airlift.log.Logger;
 import io.airlift.mcp.McpException;
@@ -23,6 +24,7 @@ import jakarta.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
 import java.util.Optional;
+import java.util.Set;
 
 import static com.google.common.net.HttpHeaders.WWW_AUTHENTICATE;
 import static io.modelcontextprotocol.server.transport.HttpServletStatelessServerTransport.APPLICATION_JSON;
@@ -34,6 +36,7 @@ public class ReferenceFilter
         extends HttpFilter
 {
     private static final String MCP_IDENTITY_ATTRIBUTE = "airlift.mcp.identity";
+    private static final Set<String> ALLOWED_HTTP_METHODS = ImmutableSet.of("GET", "POST");
     private static final Logger log = Logger.get(ReferenceFilter.class);
 
     private final HttpServletStatelessServerTransport transport;
@@ -95,7 +98,7 @@ public class ReferenceFilter
 
     private boolean isMcpRequest(HttpServletRequest request)
     {
-        if (request.getMethod().equalsIgnoreCase("POST")) {
+        if (ALLOWED_HTTP_METHODS.contains(request.getMethod())) {
             return metadata.uriPath().equals(request.getRequestURI());
         }
         return false;


### PR DESCRIPTION
Some MCP clients will submit a request to `GET /mcp` initially, to open up a potential SSE stream for events. This results in a 404 for our code since only POSTs were accepted. Standard says we should throw a 405 instead: https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#listening-for-messages-from-the-server

<!-- Thank you for submitting pull request to Airlift -->

# Airlift contribution check list

 - [ ] Git commit messages follow https://cbea.ms/git-commit/.
 - [ ] All automated tests are passing.
 - [ ] Pull request was categorized using one of the existing labels.
