### PR TITLE
Make injecting `McpServer` more straightforward

### DIFF
--- a/mcp/src/main/java/io/airlift/mcp/reflection/PromptHandlerProvider.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/PromptHandlerProvider.java
@@ -73,7 +73,7 @@ public class PromptHandlerProvider
     @Override
     public PromptEntry get()
     {
-        Object instance = injector.getInstance(clazz);
+        Provider<?> instance = injector.getProvider(clazz);
         MethodInvoker methodInvoker = new MethodInvoker(instance, method, parameters, objectMapper);
 
         PromptHandler promptHandler = (request, promptRequest) -> {

--- a/mcp/src/main/java/io/airlift/mcp/reflection/ResourceHandlerProvider.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/ResourceHandlerProvider.java
@@ -76,7 +76,7 @@ public class ResourceHandlerProvider
     @Override
     public ResourceEntry get()
     {
-        Object instance = injector.getInstance(clazz);
+        Provider<?> instance = injector.getProvider(clazz);
         MethodInvoker methodInvoker = new MethodInvoker(instance, method, parameters, objectMapper);
 
         ResourceHandler resourceHandler = (request, sourceResource, readResourceRequest) -> {

--- a/mcp/src/main/java/io/airlift/mcp/reflection/ResourceTemplateHandlerProvider.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/ResourceTemplateHandlerProvider.java
@@ -73,8 +73,7 @@ public class ResourceTemplateHandlerProvider
     @Override
     public ResourceTemplateEntry get()
     {
-        Object instance = injector.getInstance(clazz);
-
+        Provider<?> instance = injector.getProvider(clazz);
         MethodInvoker methodInvoker = new MethodInvoker(instance, method, parameters, objectMapper);
 
         ResourceTemplateHandler resourceTemplateHandler = (request, sourceResourceTemplate, readResourceRequest, resourceTemplateValues) -> {

--- a/mcp/src/main/java/io/airlift/mcp/reflection/ToolHandlerProvider.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/ToolHandlerProvider.java
@@ -98,7 +98,7 @@ public class ToolHandlerProvider
     @Override
     public ToolEntry get()
     {
-        Object instance = injector.getInstance(clazz);
+        Provider<?> instance = injector.getProvider(clazz);
         MethodInvoker methodInvoker = new MethodInvoker(instance, method, parameters, objectMapper);
 
         ToolHandler toolHandler = (request, toolRequest) -> {

--- a/mcp/src/test/java/io/airlift/mcp/TestingEndpoints.java
+++ b/mcp/src/test/java/io/airlift/mcp/TestingEndpoints.java
@@ -1,6 +1,7 @@
 package io.airlift.mcp;
 
 import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
 import io.airlift.mcp.model.CallToolResult;
 import io.airlift.mcp.model.Content;
 import io.airlift.mcp.model.ReadResourceRequest;
@@ -12,10 +13,20 @@ import java.util.List;
 import java.util.Optional;
 
 import static io.airlift.mcp.McpException.exception;
+import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@SuppressWarnings({"unused", "FieldCanBeLocal"})
 public class TestingEndpoints
 {
+    private final McpServer mcpServer;
+
+    @Inject
+    public TestingEndpoints(McpServer mcpServer)
+    {
+        this.mcpServer = requireNonNull(mcpServer, "mcpServer is null");
+    }
+
     @McpTool(name = "add", description = "Add two numbers")
     public int add(TestingIdentity testingIdentity, int a, int b)
     {


### PR DESCRIPTION
There are some circular Guice dependencies with `MethodInvoker` and the reference McpServer. Due to this, it was required that `McpServer` be injected as a Guice `Provider`. This PR improves this by having `MethodInvoker` use `Provider` internally so that the provided tools/prompts/resources/etc. don't cause this circular dependency issue. Also, added a ctor with a `McpServer` as a parameter to `TestingEndpoints` to prove that this works.

# Airlift contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [x] All automated tests are passing.
 - [x] Pull request was categorized using one of the existing labels.
