### PR TITLE
[MCP Server] Support server-to-client notifications during a request

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -16,13 +16,12 @@ variations of MCP servers defined by the standard. This module supports:
 - Tools [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/server/tools)
 - Ping [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/basic/utilities/ping)
 - Structured content [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content)
+- Progress notifications [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/basic/utilities/progress)
 
 It uses the [MCP reference Java SDK](https://github.com/modelcontextprotocol/java-sdk) as its internal implementation.
 This implementation is very limited at does not support:
 
 - Completions [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/server/utilities/completion)
-- Progress notifications [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/basic/utilities/progress)
-- Limited server-sent notifications during processing (e.g. for progress: [see spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/utilities/progress))
 - `_meta` field [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/basic#meta)
 - `context` field [(see spec)](https://modelcontextprotocol.io/specification/2025-06-18/changelog) in `CompletionRequest`
 - Sessions [(see spec)](https://modelcontextprotocol.io/docs/concepts/transports#session-management)
@@ -88,7 +87,7 @@ Example of creating a tool programmatically:
 - Register the tool with the [McpServer](src/main/java/io/airlift/mcp/McpServer.java) (which can be `@Inject`ed):
 
 ```java
-mcpServer.addTool(tool, (httpRequest, callToolRequest) -> {
+mcpServer.addTool(tool, (requestContext, callToolRequest) -> {
     // ... etc ...
     return new CallToolResult(...);
 });
@@ -120,6 +119,7 @@ A browser should open with the MCP Inspector tool. Set the "Transport Type" to
 
 - Parameters can be:
     - `HttpServletRequest`
+    - `McpRequestContext`
     - An Identity instance (via [McpIdentityMapper](src/main/java/io/airlift/mcp/McpIdentityMapper.java))
     - [CallToolRequest](src/main/java/io/airlift/mcp/model/CallToolRequest.java)
     - supported Java types
@@ -156,6 +156,7 @@ A browser should open with the MCP Inspector tool. Set the "Transport Type" to
 
 - Parameters can be:
     - `HttpServletRequest`
+    - `McpRequestContext`
     - An Identity instance (via [McpIdentityMapper](src/main/java/io/airlift/mcp/McpIdentityMapper.java))
     - [Resource](src/main/java/io/airlift/mcp/model/Resource.java) - the source resource being read
     - [ReadResourceRequest](src/main/java/io/airlift/mcp/model/ReadResourceRequest.java)
@@ -167,6 +168,7 @@ A browser should open with the MCP Inspector tool. Set the "Transport Type" to
 
 - Parameters can be:
     - `HttpServletRequest`
+    - `McpRequestContext`
     - An Identity instance (via [McpIdentityMapper](src/main/java/io/airlift/mcp/McpIdentityMapper.java))
     - [ResourceTemplate](src/main/java/io/airlift/mcp/model/ResourceTemplate.java) - the source resource template being read
     - [ReadResourceRequest](src/main/java/io/airlift/mcp/model/ReadResourceRequest.java)

--- a/mcp/src/main/java/io/airlift/mcp/McpException.java
+++ b/mcp/src/main/java/io/airlift/mcp/McpException.java
@@ -18,6 +18,13 @@ public class McpException
         this.errorDetail = requireNonNull(errorDetail, "errorDetail is null");
     }
 
+    public McpException(Throwable cause, JsonRpcErrorDetail errorDetail)
+    {
+        super(cause);
+
+        this.errorDetail = requireNonNull(errorDetail, "errorDetail is null");
+    }
+
     public JsonRpcErrorDetail errorDetail()
     {
         return errorDetail;
@@ -51,5 +58,11 @@ public class McpException
     {
         JsonRpcErrorDetail detail = new JsonRpcErrorDetail(code, message, data);
         return new McpException(detail);
+    }
+
+    public static McpException exception(Throwable cause)
+    {
+        JsonRpcErrorDetail detail = new JsonRpcErrorDetail(INVALID_REQUEST, Optional.ofNullable(cause.getMessage()).orElse("Internal error"), Optional.empty());
+        return new McpException(cause, detail);
     }
 }

--- a/mcp/src/main/java/io/airlift/mcp/McpMetadata.java
+++ b/mcp/src/main/java/io/airlift/mcp/McpMetadata.java
@@ -8,7 +8,7 @@ import static java.util.Objects.requireNonNull;
 
 public record McpMetadata(String uriPath, Implementation implementation, Optional<String> instructions, boolean tools, boolean prompts, boolean resources)
 {
-    public static final String CONTEXT_REQUEST_KEY = McpMetadata.class.getName();
+    public static final String CONTEXT_REQUEST_KEY = McpMetadata.class.getName() + ".request";
 
     public McpMetadata
     {

--- a/mcp/src/main/java/io/airlift/mcp/McpRequestContext.java
+++ b/mcp/src/main/java/io/airlift/mcp/McpRequestContext.java
@@ -1,0 +1,10 @@
+package io.airlift.mcp;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public interface McpRequestContext
+{
+    HttpServletRequest request();
+
+    void sendProgress(double progress, double total, String message);
+}

--- a/mcp/src/main/java/io/airlift/mcp/handler/PromptHandler.java
+++ b/mcp/src/main/java/io/airlift/mcp/handler/PromptHandler.java
@@ -1,10 +1,10 @@
 package io.airlift.mcp.handler;
 
+import io.airlift.mcp.McpRequestContext;
 import io.airlift.mcp.model.GetPromptRequest;
 import io.airlift.mcp.model.GetPromptResult;
-import jakarta.servlet.http.HttpServletRequest;
 
 public interface PromptHandler
 {
-    GetPromptResult getPrompt(HttpServletRequest request, GetPromptRequest getPromptRequest);
+    GetPromptResult getPrompt(McpRequestContext requestContext, GetPromptRequest getPromptRequest);
 }

--- a/mcp/src/main/java/io/airlift/mcp/handler/RequestContextProvider.java
+++ b/mcp/src/main/java/io/airlift/mcp/handler/RequestContextProvider.java
@@ -1,0 +1,12 @@
+package io.airlift.mcp.handler;
+
+import io.airlift.mcp.McpRequestContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.util.Optional;
+
+public interface RequestContextProvider
+{
+    McpRequestContext get(HttpServletRequest request, HttpServletResponse response, Optional<Object> progressToken);
+}

--- a/mcp/src/main/java/io/airlift/mcp/handler/ResourceHandler.java
+++ b/mcp/src/main/java/io/airlift/mcp/handler/ResourceHandler.java
@@ -1,13 +1,13 @@
 package io.airlift.mcp.handler;
 
+import io.airlift.mcp.McpRequestContext;
 import io.airlift.mcp.model.ReadResourceRequest;
 import io.airlift.mcp.model.Resource;
 import io.airlift.mcp.model.ResourceContents;
-import jakarta.servlet.http.HttpServletRequest;
 
 import java.util.List;
 
 public interface ResourceHandler
 {
-    List<ResourceContents> readResource(HttpServletRequest request, Resource sourceResource, ReadResourceRequest readResourceRequest);
+    List<ResourceContents> readResource(McpRequestContext requestContext, Resource sourceResource, ReadResourceRequest readResourceRequest);
 }

--- a/mcp/src/main/java/io/airlift/mcp/handler/ResourceTemplateHandler.java
+++ b/mcp/src/main/java/io/airlift/mcp/handler/ResourceTemplateHandler.java
@@ -1,14 +1,14 @@
 package io.airlift.mcp.handler;
 
+import io.airlift.mcp.McpRequestContext;
 import io.airlift.mcp.model.ReadResourceRequest;
 import io.airlift.mcp.model.ResourceContents;
 import io.airlift.mcp.model.ResourceTemplate;
 import io.airlift.mcp.model.ResourceTemplateValues;
-import jakarta.servlet.http.HttpServletRequest;
 
 import java.util.List;
 
 public interface ResourceTemplateHandler
 {
-    List<ResourceContents> readResourceTemplate(HttpServletRequest request, ResourceTemplate sourceResourceTemplate, ReadResourceRequest readResourceRequest, ResourceTemplateValues resourceTemplateValues);
+    List<ResourceContents> readResourceTemplate(McpRequestContext requestContext, ResourceTemplate sourceResourceTemplate, ReadResourceRequest readResourceRequest, ResourceTemplateValues resourceTemplateValues);
 }

--- a/mcp/src/main/java/io/airlift/mcp/handler/ToolHandler.java
+++ b/mcp/src/main/java/io/airlift/mcp/handler/ToolHandler.java
@@ -1,10 +1,10 @@
 package io.airlift.mcp.handler;
 
+import io.airlift.mcp.McpRequestContext;
 import io.airlift.mcp.model.CallToolRequest;
 import io.airlift.mcp.model.CallToolResult;
-import jakarta.servlet.http.HttpServletRequest;
 
 public interface ToolHandler
 {
-    CallToolResult callTool(HttpServletRequest request, CallToolRequest toolRequest);
+    CallToolResult callTool(McpRequestContext requestContext, CallToolRequest toolRequest);
 }

--- a/mcp/src/main/java/io/airlift/mcp/model/ProgressNotification.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ProgressNotification.java
@@ -1,10 +1,11 @@
 package io.airlift.mcp.model;
 
+import java.util.Optional;
 import java.util.OptionalDouble;
 
 import static java.util.Objects.requireNonNull;
 
-public record ProgressNotification(String progressToken, String message, OptionalDouble progress, OptionalDouble total)
+public record ProgressNotification(Optional<Object> progressToken, String message, OptionalDouble progress, OptionalDouble total)
 {
     public ProgressNotification
     {

--- a/mcp/src/main/java/io/airlift/mcp/reference/Mapper.java
+++ b/mcp/src/main/java/io/airlift/mcp/reference/Mapper.java
@@ -2,8 +2,9 @@ package io.airlift.mcp.reference;
 
 import com.google.common.collect.ImmutableMap;
 import io.airlift.mcp.McpException;
-import io.airlift.mcp.McpMetadata;
+import io.airlift.mcp.McpRequestContext;
 import io.airlift.mcp.handler.PromptHandler;
+import io.airlift.mcp.handler.RequestContextProvider;
 import io.airlift.mcp.handler.ResourceHandler;
 import io.airlift.mcp.handler.ResourceTemplateHandler;
 import io.airlift.mcp.handler.ToolHandler;
@@ -30,6 +31,7 @@ import io.modelcontextprotocol.server.McpStatelessServerFeatures;
 import io.modelcontextprotocol.spec.McpError;
 import io.modelcontextprotocol.spec.McpSchema;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -40,6 +42,8 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.mcp.McpMetadata.CONTEXT_REQUEST_KEY;
+import static io.airlift.mcp.reference.ReferenceFilter.CONTEXT_RESPONSE_KEY;
 
 interface Mapper
 {
@@ -85,7 +89,24 @@ interface Mapper
         return McpSchema.Role.valueOf(ourRole.name().toUpperCase());
     }
 
-    static McpStatelessServerFeatures.SyncResourceSpecification mapResource(Resource ourResource, ResourceHandler ourHandler)
+    static McpRequestContext buildMcpRequestContext(McpTransportContext mcpTransportContext, Optional<Map<String, Object>> meta, RequestContextProvider requestContextProvider)
+    {
+        Optional<Object> progressToken = meta.flatMap(values -> {
+            Object value = values.get("progressToken");
+            if (value instanceof Number number) {
+                return Optional.of(number.longValue());
+            }
+            if (value != null) {
+                return Optional.of(String.valueOf(value));
+            }
+            return Optional.empty();
+        });
+        HttpServletRequest request = (HttpServletRequest) mcpTransportContext.get(CONTEXT_REQUEST_KEY);
+        HttpServletResponse response = (HttpServletResponse) request.getAttribute(CONTEXT_RESPONSE_KEY);
+        return requestContextProvider.get(request, response, progressToken);
+    }
+
+    static McpStatelessServerFeatures.SyncResourceSpecification mapResource(RequestContextProvider requestContextProvider, Resource ourResource, ResourceHandler ourHandler)
     {
         McpSchema.Resource.Builder theirResourceBuilder = McpSchema.Resource.builder()
                 .name(ourResource.name())
@@ -103,10 +124,9 @@ interface Mapper
         ourResource.size().ifPresent(theirResourceBuilder::size);
 
         BiFunction<McpTransportContext, McpSchema.ReadResourceRequest, McpSchema.ReadResourceResult> handler = ((context, theirReadResourceRequest) -> {
-            HttpServletRequest request = (HttpServletRequest) context.get(McpMetadata.CONTEXT_REQUEST_KEY);
             ReadResourceRequest readResourceRequest = new ReadResourceRequest(theirReadResourceRequest.uri(), Optional.ofNullable(theirReadResourceRequest.meta()));
-
-            List<ResourceContents> ourResourceContents = ourHandler.readResource(request, ourResource, readResourceRequest);
+            McpRequestContext mcpRequestContext = buildMcpRequestContext(context, Optional.ofNullable(theirReadResourceRequest.meta()), requestContextProvider);
+            List<ResourceContents> ourResourceContents = ourHandler.readResource(mcpRequestContext, ourResource, readResourceRequest);
 
             List<McpSchema.ResourceContents> theirResourceContents = ourResourceContents.stream()
                     .map(Mapper::mapResourceContents)
@@ -118,7 +138,7 @@ interface Mapper
         return new McpStatelessServerFeatures.SyncResourceSpecification(theirResourceBuilder.build(), exceptionSafeHandler(handler));
     }
 
-    static McpStatelessServerFeatures.SyncResourceTemplateSpecification mapResourceTemplate(ResourceTemplate ourResourceTemplate, ResourceTemplateHandler ourHandler, Function<String, Map<String, String>> templateValuesMapper)
+    static McpStatelessServerFeatures.SyncResourceTemplateSpecification mapResourceTemplate(RequestContextProvider requestContextProvider, ResourceTemplate ourResourceTemplate, ResourceTemplateHandler ourHandler, Function<String, Map<String, String>> templateValuesMapper)
     {
         McpSchema.ResourceTemplate.Builder theirResourceTemplateBuilder = McpSchema.ResourceTemplate.builder()
                 .name(ourResourceTemplate.name())
@@ -134,11 +154,11 @@ interface Mapper
         theirResourceTemplateBuilder.mimeType(ourResourceTemplate.mimeType());
 
         BiFunction<McpTransportContext, McpSchema.ReadResourceRequest, McpSchema.ReadResourceResult> handler = ((context, theirReadResourceRequest) -> {
-            HttpServletRequest request = (HttpServletRequest) context.get(McpMetadata.CONTEXT_REQUEST_KEY);
             ReadResourceRequest readResourceRequest = new ReadResourceRequest(theirReadResourceRequest.uri(), Optional.ofNullable(theirReadResourceRequest.meta()));
+            McpRequestContext requestContext = buildMcpRequestContext(context, Optional.ofNullable(theirReadResourceRequest.meta()), requestContextProvider);
 
             Map<String, String> templateValues = templateValuesMapper.apply(readResourceRequest.uri());
-            List<ResourceContents> ourResourceContents = ourHandler.readResourceTemplate(request, ourResourceTemplate, readResourceRequest, new ResourceTemplateValues(templateValues));
+            List<ResourceContents> ourResourceContents = ourHandler.readResourceTemplate(requestContext, ourResourceTemplate, readResourceRequest, new ResourceTemplateValues(templateValues));
 
             List<McpSchema.ResourceContents> theirResourceContents = ourResourceContents.stream()
                     .map(Mapper::mapResourceContents)
@@ -167,7 +187,7 @@ interface Mapper
         };
     }
 
-    static McpStatelessServerFeatures.SyncPromptSpecification mapPrompt(Prompt ourPrompt, PromptHandler ourHandler)
+    static McpStatelessServerFeatures.SyncPromptSpecification mapPrompt(RequestContextProvider requestContextProvider, Prompt ourPrompt, PromptHandler ourHandler)
     {
         List<McpSchema.PromptArgument> ourArguments = ourPrompt
                 .arguments()
@@ -181,10 +201,10 @@ interface Mapper
                 ourArguments);
 
         BiFunction<McpTransportContext, McpSchema.GetPromptRequest, McpSchema.GetPromptResult> handler = (context, theirGetPromptRequest) -> {
-            HttpServletRequest request = (HttpServletRequest) context.get(McpMetadata.CONTEXT_REQUEST_KEY);
             GetPromptRequest getPromptRequest = new GetPromptRequest(theirGetPromptRequest.name(), theirGetPromptRequest.arguments(), Optional.ofNullable(theirGetPromptRequest.meta()));
+            McpRequestContext requestContext = buildMcpRequestContext(context, Optional.ofNullable(theirGetPromptRequest.meta()), requestContextProvider);
 
-            GetPromptResult promptResult = ourHandler.getPrompt(request, getPromptRequest);
+            GetPromptResult promptResult = ourHandler.getPrompt(requestContext, getPromptRequest);
 
             List<McpSchema.PromptMessage> promptMessages = promptResult.messages()
                     .stream()
@@ -207,7 +227,7 @@ interface Mapper
         return new McpSchema.PromptArgument(ourArgument.name(), ourArgument.description().orElse(null), ourArgument.required());
     }
 
-    static McpStatelessServerFeatures.SyncToolSpecification mapTool(McpJsonMapper objectMapper, Tool ourTool, ToolHandler ourHandler)
+    static McpStatelessServerFeatures.SyncToolSpecification mapTool(RequestContextProvider requestContextProvider, McpJsonMapper objectMapper, Tool ourTool, ToolHandler ourHandler)
     {
         try {
             McpSchema.Tool.Builder theirToolBuilder = McpSchema.Tool.builder()
@@ -229,10 +249,10 @@ interface Mapper
             theirToolBuilder.annotations(theirToolAnnotations);
 
             BiFunction<McpTransportContext, McpSchema.CallToolRequest, McpSchema.CallToolResult> callHandler = ((context, theirCallToolRequest) -> {
-                HttpServletRequest request = (HttpServletRequest) context.get(McpMetadata.CONTEXT_REQUEST_KEY);
                 CallToolRequest callToolRequest = new CallToolRequest(theirCallToolRequest.name(), theirCallToolRequest.arguments(), Optional.ofNullable(theirCallToolRequest.meta()));
+                McpRequestContext requestContext = buildMcpRequestContext(context, Optional.ofNullable(theirCallToolRequest.meta()), requestContextProvider);
 
-                CallToolResult callToolResult = ourHandler.callTool(request, callToolRequest);
+                CallToolResult callToolResult = ourHandler.callTool(requestContext, callToolRequest);
 
                 List<McpSchema.Content> theirContent = callToolResult.content()
                         .stream()

--- a/mcp/src/main/java/io/airlift/mcp/reference/ReferenceModule.java
+++ b/mcp/src/main/java/io/airlift/mcp/reference/ReferenceModule.java
@@ -7,6 +7,7 @@ import com.google.inject.Module;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import io.airlift.mcp.McpMetadata;
+import io.airlift.mcp.handler.RequestContextProvider;
 import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.json.McpJsonMapper;
 import io.modelcontextprotocol.json.jackson.JacksonMcpJsonMapper;
@@ -35,6 +36,7 @@ public class ReferenceModule
         binder.bind(io.airlift.mcp.McpServer.class).to(ReferenceServer.class).in(SINGLETON);
         newSetBinder(binder, Filter.class).addBinding().to(ReferenceFilter.class).in(SINGLETON);
         binder.bind(McpUriTemplateManagerFactory.class).to(DefaultMcpUriTemplateManagerFactory.class).in(SINGLETON);
+        binder.bind(RequestContextProvider.class).to(ReferenceRequestContextProvider.class).in(SINGLETON);
     }
 
     @Singleton

--- a/mcp/src/main/java/io/airlift/mcp/reference/ReferenceRequestContextProvider.java
+++ b/mcp/src/main/java/io/airlift/mcp/reference/ReferenceRequestContextProvider.java
@@ -1,0 +1,75 @@
+package io.airlift.mcp.reference;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Inject;
+import io.airlift.mcp.McpRequestContext;
+import io.airlift.mcp.handler.RequestContextProvider;
+import io.airlift.mcp.model.JsonRpcRequest;
+import io.airlift.mcp.model.ProgressNotification;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Optional;
+import java.util.OptionalDouble;
+
+import static io.airlift.mcp.McpException.exception;
+import static java.util.Objects.requireNonNull;
+
+public class ReferenceRequestContextProvider
+        implements RequestContextProvider
+{
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public ReferenceRequestContextProvider(ObjectMapper objectMapper)
+    {
+        this.objectMapper = requireNonNull(objectMapper, "objectMapper is null");
+    }
+
+    @Override
+    public McpRequestContext get(HttpServletRequest request, HttpServletResponse response, Optional<Object> progressToken)
+    {
+        return new McpRequestContext()
+        {
+            @Override
+            public HttpServletRequest request()
+            {
+                return request;
+            }
+
+            @SuppressWarnings("SwitchStatementWithTooFewBranches")
+            @Override
+            public void sendProgress(double progress, double total, String message)
+            {
+                Optional<Object> appliedProgressToken = progressToken.map(token -> switch (token) {
+                    case Number value -> Optional.of(value.longValue());
+                    default -> progressToken;
+                });
+
+                ProgressNotification notification = new ProgressNotification(appliedProgressToken, message, OptionalDouble.of(progress), OptionalDouble.of(total));
+                sendNotification("notifications/progress", Optional.of(notification));
+            }
+
+            private void sendNotification(String method, Optional<Object> params)
+            {
+                try {
+                    PrintWriter writer = response.getWriter();
+                    if (!(writer instanceof SsePrintWriter ssePrintWriter)) {
+                        throw exception("Expected writer to be an instance of SsePrintWriter but got %s".formatted(writer.getClass().getName()));
+                    }
+                    JsonRpcRequest<?> notification = params
+                            .map(values -> JsonRpcRequest.buildNotification(method, values))
+                            .orElseGet(() -> JsonRpcRequest.buildNotification(method));
+                    String json = objectMapper.writeValueAsString(notification);
+                    ssePrintWriter.writeMessage(json);
+                    ssePrintWriter.flush();
+                }
+                catch (IOException e) {
+                    throw exception(e);
+                }
+            }
+        };
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/reference/ReferenceServer.java
+++ b/mcp/src/main/java/io/airlift/mcp/reference/ReferenceServer.java
@@ -5,6 +5,7 @@ import io.airlift.log.Logger;
 import io.airlift.mcp.McpServer;
 import io.airlift.mcp.handler.PromptEntry;
 import io.airlift.mcp.handler.PromptHandler;
+import io.airlift.mcp.handler.RequestContextProvider;
 import io.airlift.mcp.handler.ResourceEntry;
 import io.airlift.mcp.handler.ResourceHandler;
 import io.airlift.mcp.handler.ResourceTemplateEntry;
@@ -34,13 +35,23 @@ public class ReferenceServer
     private final McpStatelessSyncServer server;
     private final McpJsonMapper objectMapper;
     private final McpUriTemplateManagerFactory uriTemplateManagerFactory;
+    private final RequestContextProvider requestContextProvider;
 
     @Inject
-    public ReferenceServer(McpStatelessSyncServer server, McpJsonMapper objectMapper, McpUriTemplateManagerFactory uriTemplateManagerFactory, Set<ToolEntry> tools, Set<PromptEntry> prompts, Set<ResourceEntry> resources, Set<ResourceTemplateEntry> resourceTemplates)
+    public ReferenceServer(
+            McpStatelessSyncServer server,
+            McpJsonMapper objectMapper,
+            McpUriTemplateManagerFactory uriTemplateManagerFactory,
+            Set<ToolEntry> tools,
+            Set<PromptEntry> prompts,
+            Set<ResourceEntry> resources,
+            Set<ResourceTemplateEntry> resourceTemplates,
+            RequestContextProvider requestContextProvider)
     {
         this.server = requireNonNull(server, "server is null");
         this.objectMapper = requireNonNull(objectMapper, "objectMapper is null");
         this.uriTemplateManagerFactory = requireNonNull(uriTemplateManagerFactory, "uriTemplateManagerFactory is null");
+        this.requestContextProvider = requireNonNull(requestContextProvider, "requestContextProvider is null");
 
         tools.forEach(tool -> addTool(tool.tool(), tool.toolHandler()));
         prompts.forEach(prompt -> addPrompt(prompt.prompt(), prompt.promptHandler()));
@@ -64,7 +75,7 @@ public class ReferenceServer
     @Override
     public void addTool(Tool tool, ToolHandler toolHandler)
     {
-        server.addTool(Mapper.mapTool(objectMapper, tool, toolHandler));
+        server.addTool(Mapper.mapTool(requestContextProvider, objectMapper, tool, toolHandler));
     }
 
     @Override
@@ -76,7 +87,7 @@ public class ReferenceServer
     @Override
     public void addPrompt(Prompt prompt, PromptHandler promptHandler)
     {
-        server.addPrompt(Mapper.mapPrompt(prompt, promptHandler));
+        server.addPrompt(Mapper.mapPrompt(requestContextProvider, prompt, promptHandler));
     }
 
     @Override
@@ -88,7 +99,7 @@ public class ReferenceServer
     @Override
     public void addResource(Resource resource, ResourceHandler handler)
     {
-        server.addResource(Mapper.mapResource(resource, handler));
+        server.addResource(Mapper.mapResource(requestContextProvider, resource, handler));
     }
 
     @Override
@@ -101,7 +112,7 @@ public class ReferenceServer
     public void addResourceTemplate(ResourceTemplate resourceTemplate, ResourceTemplateHandler handler)
     {
         McpUriTemplateManager manager = uriTemplateManagerFactory.create(resourceTemplate.uriTemplate());
-        server.addResourceTemplate(Mapper.mapResourceTemplate(resourceTemplate, handler, manager::extractVariableValues));
+        server.addResourceTemplate(Mapper.mapResourceTemplate(requestContextProvider, resourceTemplate, handler, manager::extractVariableValues));
     }
 
     @Override

--- a/mcp/src/main/java/io/airlift/mcp/reference/SsePrintWriter.java
+++ b/mcp/src/main/java/io/airlift/mcp/reference/SsePrintWriter.java
@@ -1,0 +1,62 @@
+package io.airlift.mcp.reference;
+
+import java.io.PrintWriter;
+import java.io.Writer;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static io.airlift.mcp.McpException.exception;
+import static java.util.Objects.requireNonNull;
+
+class SsePrintWriter
+        extends PrintWriter
+{
+    private final AtomicLong nextId = new AtomicLong();
+    private final Runnable upgradeHandler;
+    private boolean hasBeenUpgraded;
+
+    SsePrintWriter(Writer out, Runnable upgradeHandler)
+    {
+        super(out, false);
+        this.upgradeHandler = requireNonNull(upgradeHandler, "upgradeHandler is null");
+    }
+
+    @Override
+    public void write(String data)
+    {
+        if (hasBeenUpgraded) {
+            writeMessage(data);
+        }
+        else {
+            // no messages were sent, keep it as a standard JSON response
+            super.write(data);
+        }
+    }
+
+    public void writeMessage(String data)
+    {
+        writeMessage(data, Optional.of(Long.toString(nextId.getAndIncrement())));
+    }
+
+    public void writeMessage(String data, Optional<String> messageId)
+    {
+        if (!hasBeenUpgraded) {
+            hasBeenUpgraded = true;
+            // this will change response to an SSE response
+            upgradeHandler.run();
+        }
+
+        messageId.ifPresent(id -> super.write("id: " + encode(id) + "\n"));
+
+        super.write("data: " + encode(data) + "\n\n");
+        if (checkError()) {
+            throw exception("Error writing SSE message");
+        }
+    }
+
+    private String encode(String str)
+    {
+        // Escape newlines and carriage returns for SSE compliance
+        return str.replace("\n", "\\n").replace("\r", "\\r");
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/reference/SseResponseWrapper.java
+++ b/mcp/src/main/java/io/airlift/mcp/reference/SseResponseWrapper.java
@@ -1,0 +1,51 @@
+package io.airlift.mcp.reference;
+
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponseWrapper;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+/**
+ * <p>
+ *     Intercept output from {@link io.modelcontextprotocol.server.transport.HttpServletStatelessServerTransport}. This class
+ *     has deep internal knowledge of how {@link io.modelcontextprotocol.server.transport.HttpServletStatelessServerTransport} works.
+ *     {@link io.modelcontextprotocol.server.transport.HttpServletStatelessServerTransport} will think it's outputting a single
+ *     JSON RPC response but this class, via {@link SsePrintWriter}, will convert that output into an SSE stream which allows
+ *     us to support server-to-client notifications during request processing. NOTE: if {@link io.modelcontextprotocol.server.transport.HttpServletStatelessServerTransport}
+ *     should change, then this class and {@link SsePrintWriter} will need to change.
+ * </p>
+ *
+ * <p>
+ *     Note: I've been trying to get traction in the MCP project for native support with this PR and others.
+ *     <a href="https://github.com/modelcontextprotocol/java-sdk/pull/472">pull/472</a>. Additionally, I've started this discussion:
+ *     <a href="https://github.com/modelcontextprotocol/java-sdk/discussions/665">discussions/665</a>
+ * </p>
+ */
+class SseResponseWrapper
+        extends HttpServletResponseWrapper
+{
+    private SsePrintWriter ssePrintWriter;
+
+    SseResponseWrapper(HttpServletResponse response)
+    {
+        super(response);
+    }
+
+    @Override
+    public PrintWriter getWriter()
+            throws IOException
+    {
+        int status = getStatus();
+        boolean useSse = (status >= SC_OK) && (status < SC_MULTIPLE_CHOICES);
+        if (useSse) {
+            if (ssePrintWriter == null) {
+                ssePrintWriter = new SsePrintWriter(super.getWriter(), () -> super.setContentType("text/event-stream"));
+            }
+
+            return ssePrintWriter;
+        }
+
+        return super.getWriter();
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/reflection/MethodParameter.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/MethodParameter.java
@@ -13,6 +13,12 @@ public sealed interface MethodParameter
         public static final HttpRequestParameter INSTANCE = new HttpRequestParameter();
     }
 
+    record McpRequestContextParameter()
+            implements MethodParameter
+    {
+        public static final McpRequestContextParameter INSTANCE = new McpRequestContextParameter();
+    }
+
     record GetPromptRequestParameter()
             implements MethodParameter
     {

--- a/mcp/src/main/java/io/airlift/mcp/reflection/Predicates.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/Predicates.java
@@ -6,6 +6,7 @@ import io.airlift.mcp.reflection.MethodParameter.CallToolRequestParameter;
 import io.airlift.mcp.reflection.MethodParameter.GetPromptRequestParameter;
 import io.airlift.mcp.reflection.MethodParameter.HttpRequestParameter;
 import io.airlift.mcp.reflection.MethodParameter.IdentityParameter;
+import io.airlift.mcp.reflection.MethodParameter.McpRequestContextParameter;
 import io.airlift.mcp.reflection.MethodParameter.ObjectParameter;
 import io.airlift.mcp.reflection.MethodParameter.ReadResourceRequestParameter;
 import io.airlift.mcp.reflection.MethodParameter.ResourceTemplateValuesParameter;
@@ -21,7 +22,7 @@ import static io.airlift.mcp.reflection.ReflectionHelper.listArgument;
 
 public interface Predicates
 {
-    Predicate<MethodParameter> isHttpRequest = methodParameter -> methodParameter instanceof HttpRequestParameter;
+    Predicate<MethodParameter> isHttpRequestOrContext = methodParameter -> methodParameter instanceof HttpRequestParameter || methodParameter instanceof McpRequestContextParameter;
     Predicate<MethodParameter> isIdentity = methodParameter -> methodParameter instanceof IdentityParameter;
     Predicate<MethodParameter> isGetPromptRequest = methodParameter -> methodParameter instanceof GetPromptRequestParameter;
     Predicate<MethodParameter> isCallToolRequest = methodParameter -> methodParameter instanceof CallToolRequestParameter;

--- a/mcp/src/main/java/io/airlift/mcp/reflection/ReflectionHelper.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/ReflectionHelper.java
@@ -1,6 +1,7 @@
 package io.airlift.mcp.reflection;
 
 import io.airlift.mcp.McpDescription;
+import io.airlift.mcp.McpRequestContext;
 import io.airlift.mcp.model.CallToolRequest;
 import io.airlift.mcp.model.Content;
 import io.airlift.mcp.model.Content.TextContent;
@@ -13,6 +14,7 @@ import io.airlift.mcp.reflection.MethodParameter.CallToolRequestParameter;
 import io.airlift.mcp.reflection.MethodParameter.GetPromptRequestParameter;
 import io.airlift.mcp.reflection.MethodParameter.HttpRequestParameter;
 import io.airlift.mcp.reflection.MethodParameter.IdentityParameter;
+import io.airlift.mcp.reflection.MethodParameter.McpRequestContextParameter;
 import io.airlift.mcp.reflection.MethodParameter.ObjectParameter;
 import io.airlift.mcp.reflection.MethodParameter.ReadResourceRequestParameter;
 import io.airlift.mcp.reflection.MethodParameter.ResourceTemplateValuesParameter;
@@ -65,6 +67,10 @@ public interface ReflectionHelper
 
                     if (parameter.getType().equals(HttpServletRequest.class)) {
                         return HttpRequestParameter.INSTANCE;
+                    }
+
+                    if (parameter.getType().equals(McpRequestContext.class)) {
+                        return McpRequestContextParameter.INSTANCE;
                     }
 
                     if (GetPromptRequest.class.isAssignableFrom(parameter.getType())) {

--- a/mcp/src/main/java/io/airlift/mcp/reflection/ResourceHandlerProvider.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/ResourceHandlerProvider.java
@@ -21,7 +21,7 @@ import java.util.OptionalDouble;
 import java.util.OptionalLong;
 
 import static io.airlift.mcp.McpException.exception;
-import static io.airlift.mcp.reflection.Predicates.isHttpRequest;
+import static io.airlift.mcp.reflection.Predicates.isHttpRequestOrContext;
 import static io.airlift.mcp.reflection.Predicates.isIdentity;
 import static io.airlift.mcp.reflection.Predicates.isReadResourceRequest;
 import static io.airlift.mcp.reflection.Predicates.isSourceResource;
@@ -48,7 +48,7 @@ public class ResourceHandlerProvider
         this.method = requireNonNull(method, "method is null");
         this.parameters = ImmutableList.copyOf(parameters);
 
-        validate(method, parameters, isHttpRequest.or(isIdentity).or(isReadResourceRequest).or(isSourceResource), returnsResourceContents.or(returnsResourceContentsList));
+        validate(method, parameters, isHttpRequestOrContext.or(isIdentity).or(isReadResourceRequest).or(isSourceResource), returnsResourceContents.or(returnsResourceContentsList));
         resultIsSingleContent = returnsResourceContents.test(method);
 
         resource = buildResource(
@@ -79,8 +79,8 @@ public class ResourceHandlerProvider
         Provider<?> instance = injector.getProvider(clazz);
         MethodInvoker methodInvoker = new MethodInvoker(instance, method, parameters, objectMapper);
 
-        ResourceHandler resourceHandler = (request, sourceResource, readResourceRequest) -> {
-            Object result = methodInvoker.builder(request)
+        ResourceHandler resourceHandler = (requestContext, sourceResource, readResourceRequest) -> {
+            Object result = methodInvoker.builder(requestContext)
                     .withReadResourceRequest(sourceResource, readResourceRequest)
                     .invoke();
             return mapResult(method, result, resultIsSingleContent);

--- a/mcp/src/main/java/io/airlift/mcp/reflection/ResourceTemplateHandlerProvider.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/ResourceTemplateHandlerProvider.java
@@ -17,7 +17,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.OptionalDouble;
 
-import static io.airlift.mcp.reflection.Predicates.isHttpRequest;
+import static io.airlift.mcp.reflection.Predicates.isHttpRequestOrContext;
 import static io.airlift.mcp.reflection.Predicates.isIdentity;
 import static io.airlift.mcp.reflection.Predicates.isReadResourceRequest;
 import static io.airlift.mcp.reflection.Predicates.isResourceTemplateValues;
@@ -46,7 +46,7 @@ public class ResourceTemplateHandlerProvider
         this.method = requireNonNull(method, "method is null");
         this.parameters = ImmutableList.copyOf(parameters);
 
-        validate(method, parameters, isHttpRequest.or(isIdentity).or(isReadResourceRequest).or(isSourceResourceTemplate).or(isResourceTemplateValues), returnsResourceContents.or(returnsResourceContentsList));
+        validate(method, parameters, isHttpRequestOrContext.or(isIdentity).or(isReadResourceRequest).or(isSourceResourceTemplate).or(isResourceTemplateValues), returnsResourceContents.or(returnsResourceContentsList));
         this.resultIsSingleContent = returnsResourceContents.test(method);
 
         this.resourceTemplate = buildResourceTemplate(
@@ -76,8 +76,8 @@ public class ResourceTemplateHandlerProvider
         Provider<?> instance = injector.getProvider(clazz);
         MethodInvoker methodInvoker = new MethodInvoker(instance, method, parameters, objectMapper);
 
-        ResourceTemplateHandler resourceTemplateHandler = (request, sourceResourceTemplate, readResourceRequest, resourceTemplateValues) -> {
-            Object result = methodInvoker.builder(request)
+        ResourceTemplateHandler resourceTemplateHandler = (requestContext, sourceResourceTemplate, readResourceRequest, resourceTemplateValues) -> {
+            Object result = methodInvoker.builder(requestContext)
                     .withReadResourceTemplateRequest(sourceResourceTemplate, readResourceRequest)
                     .withResourceTemplateValues(resourceTemplateValues)
                     .invoke();

--- a/mcp/src/main/java/io/airlift/mcp/reflection/ToolHandlerProvider.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/ToolHandlerProvider.java
@@ -25,7 +25,7 @@ import static io.airlift.mcp.McpException.exception;
 import static io.airlift.mcp.model.JsonSchemaBuilder.isPrimitiveType;
 import static io.airlift.mcp.model.JsonSchemaBuilder.isSupportedType;
 import static io.airlift.mcp.reflection.Predicates.isCallToolRequest;
-import static io.airlift.mcp.reflection.Predicates.isHttpRequest;
+import static io.airlift.mcp.reflection.Predicates.isHttpRequestOrContext;
 import static io.airlift.mcp.reflection.Predicates.isIdentity;
 import static io.airlift.mcp.reflection.Predicates.isObject;
 import static io.airlift.mcp.reflection.Predicates.returnsAnything;
@@ -51,7 +51,7 @@ public class ToolHandlerProvider
         this.method = requireNonNull(method, "method is null");
         this.parameters = ImmutableList.copyOf(parameters);
 
-        validate(method, parameters, isHttpRequest.or(isIdentity).or(isObject).or(isCallToolRequest), returnsAnything);
+        validate(method, parameters, isHttpRequestOrContext.or(isIdentity).or(isObject).or(isCallToolRequest), returnsAnything);
 
         tool = buildTool(mcpTool, method, parameters);
 
@@ -101,8 +101,8 @@ public class ToolHandlerProvider
         Provider<?> instance = injector.getProvider(clazz);
         MethodInvoker methodInvoker = new MethodInvoker(instance, method, parameters, objectMapper);
 
-        ToolHandler toolHandler = (request, toolRequest) -> {
-            Object result = methodInvoker.builder(request)
+        ToolHandler toolHandler = (requestContext, toolRequest) -> {
+            Object result = methodInvoker.builder(requestContext)
                     .withArguments(toolRequest.arguments())
                     .withCallToolRequest(toolRequest)
                     .invoke();

--- a/mcp/src/test/java/io/airlift/mcp/TestMcp.java
+++ b/mcp/src/test/java/io/airlift/mcp/TestMcp.java
@@ -9,6 +9,7 @@
  */
 package io.airlift.mcp;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -25,9 +26,11 @@ import io.airlift.http.client.FullJsonResponseHandler.JsonResponse;
 import io.airlift.http.client.HttpClient;
 import io.airlift.http.client.JsonBodyGenerator;
 import io.airlift.http.client.Request;
+import io.airlift.http.client.StreamingResponse;
 import io.airlift.http.server.HttpServerInfo;
 import io.airlift.http.server.testing.TestingHttpServerModule;
 import io.airlift.jaxrs.JaxrsModule;
+import io.airlift.json.JsonCodec;
 import io.airlift.json.JsonModule;
 import io.airlift.mcp.model.CallToolRequest;
 import io.airlift.mcp.model.CallToolResult;
@@ -41,6 +44,7 @@ import io.airlift.mcp.model.JsonRpcResponse;
 import io.airlift.mcp.model.ListPromptsResult;
 import io.airlift.mcp.model.ListResourcesResult;
 import io.airlift.mcp.model.ListToolsResult;
+import io.airlift.mcp.model.ProgressNotification;
 import io.airlift.mcp.model.Prompt;
 import io.airlift.mcp.model.ReadResourceRequest;
 import io.airlift.mcp.model.ReadResourceResult;
@@ -50,13 +54,21 @@ import io.airlift.mcp.model.StructuredContent;
 import io.airlift.mcp.model.Tool;
 import io.airlift.node.NodeModule;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
+import java.util.OptionalDouble;
 import java.util.stream.Stream;
 
 import static com.google.inject.Scopes.SINGLETON;
@@ -70,6 +82,7 @@ import static io.airlift.mcp.TestingIdentityMapper.EXPECTED_IDENTITY;
 import static io.airlift.mcp.model.JsonRpcErrorCode.INVALID_REQUEST;
 import static jakarta.servlet.http.HttpServletResponse.SC_METHOD_NOT_ALLOWED;
 import static jakarta.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.type;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
@@ -83,6 +96,7 @@ public class TestMcp
     private final Injector injector;
     private final URI baseUri;
     private final ObjectMapper objectMapper;
+    private final List<String> lastRequestEvents = new ArrayList<>();
 
     public TestMcp()
     {
@@ -108,6 +122,12 @@ public class TestMcp
         httpClient = injector.getInstance(Key.get(HttpClient.class, ForTest.class));
         baseUri = injector.getInstance(HttpServerInfo.class).getHttpUri().resolve("/mcp");
         objectMapper = injector.getInstance(ObjectMapper.class);
+    }
+
+    @BeforeAll
+    public void setup()
+    {
+        lastRequestEvents.clear();
     }
 
     @AfterAll
@@ -157,13 +177,13 @@ public class TestMcp
     public void testInvalidRpcRequests()
     {
         CallToolRequest callToolRequest = new CallToolRequest("add", ImmutableMap.of("a", 1, "b", 2));
-        JsonRpcRequest<?> jsonrpcRequest = JsonRpcRequest.buildRequest(1, "tools/call", callToolRequest);
+        JsonRpcRequest<?> rpcRequest = JsonRpcRequest.buildRequest(1, "tools/call", callToolRequest);
 
         // missing proper Accept header
         Request request = preparePost().setUri(baseUri)
                 .addHeader("Content-Type", "application/json")
                 .addHeader(IDENTITY_HEADER, "Mr. Tester")
-                .setBodyGenerator(JsonBodyGenerator.jsonBodyGenerator(jsonCodec(new TypeToken<JsonRpcRequest<?>>() {}), jsonrpcRequest))
+                .setBodyGenerator(JsonBodyGenerator.jsonBodyGenerator(jsonCodec(new TypeToken<JsonRpcRequest<?>>() {}), rpcRequest))
                 .build();
 
         FullJsonResponseHandler.JsonResponse<Object> response = httpClient.execute(request, createFullJsonResponseHandler(jsonCodec(new TypeToken<>() {})));
@@ -199,8 +219,8 @@ public class TestMcp
                 .satisfies(node -> assertThat(node.isEmpty()));
 
         CallToolRequest callToolRequest = new CallToolRequest("addThree", ImmutableMap.of("a", 1, "b", 2, "c", 3));
-        JsonRpcRequest<?> jsonrpcRequest = JsonRpcRequest.buildRequest(1, "tools/call", callToolRequest);
-        JsonRpcResponse<?> response = rpcCall(jsonrpcRequest);
+        JsonRpcRequest<?> rpcRequest = JsonRpcRequest.buildRequest(1, "tools/call", callToolRequest);
+        JsonRpcResponse<?> response = rpcCall(rpcRequest);
         CallToolResult callToolResult = objectMapper.convertValue(response.result().orElseThrow(), new TypeReference<>() {});
         assertThat(callToolResult.structuredContent())
                 .isEmpty();
@@ -242,8 +262,8 @@ public class TestMcp
                 });
 
         CallToolRequest callToolRequest = new CallToolRequest("addFirstTwoAndAllThree", ImmutableMap.of("a", 1, "b", 2, "c", 3));
-        JsonRpcRequest<?> jsonrpcRequest = JsonRpcRequest.buildRequest(1, "tools/call", callToolRequest);
-        JsonRpcResponse<?> response = rpcCall(jsonrpcRequest);
+        JsonRpcRequest<?> rpcRequest = JsonRpcRequest.buildRequest(1, "tools/call", callToolRequest);
+        JsonRpcResponse<?> response = rpcCall(rpcRequest);
         CallToolResult twoAndThreeCallToolResult = objectMapper.convertValue(response.result().orElseThrow(), new TypeReference<>() {});
         assertThat(twoAndThreeCallToolResult.isError()).isFalse();
         assertThat(twoAndThreeCallToolResult.structuredContent())
@@ -254,7 +274,7 @@ public class TestMcp
 
         // Test not sending an optional parameter
         callToolRequest = new CallToolRequest("addFirstTwoAndAllThree", ImmutableMap.of("a", 1, "b", 2));
-        jsonrpcRequest = JsonRpcRequest.buildRequest(1, "tools/call", callToolRequest);
+        JsonRpcRequest<?> jsonrpcRequest = JsonRpcRequest.buildRequest(1, "tools/call", callToolRequest);
         response = rpcCall(jsonrpcRequest);
         twoAndThreeCallToolResult = objectMapper.convertValue(response.result().orElseThrow(), new TypeReference<>() {});
         assertThat(twoAndThreeCallToolResult.isError()).isFalse();
@@ -266,8 +286,8 @@ public class TestMcp
 
         // Test the "error" path
         callToolRequest = new CallToolRequest("addFirstTwoAndAllThree", ImmutableMap.of("a", -1, "b", -2, "c", -3));
-        jsonrpcRequest = JsonRpcRequest.buildRequest(1, "tools/call", callToolRequest);
-        response = rpcCall(jsonrpcRequest);
+        rpcRequest = JsonRpcRequest.buildRequest(1, "tools/call", callToolRequest);
+        response = rpcCall(rpcRequest);
         twoAndThreeCallToolResult = objectMapper.convertValue(response.result().orElseThrow(), new TypeReference<>() {});
         assertThat(twoAndThreeCallToolResult.isError()).isTrue();
         assertThat(twoAndThreeCallToolResult.structuredContent()).isEmpty();
@@ -282,17 +302,17 @@ public class TestMcp
     @Test
     public void testTools()
     {
-        JsonRpcRequest<?> jsonrpcRequest = JsonRpcRequest.buildRequest(1, "tools/list");
+        JsonRpcRequest<?> rpcRequest = JsonRpcRequest.buildRequest(1, "tools/list");
 
-        JsonRpcResponse<?> response = rpcCall(jsonrpcRequest);
+        JsonRpcResponse<?> response = rpcCall(rpcRequest);
         ListToolsResult listToolsResult = objectMapper.convertValue(response.result().orElseThrow(), ListToolsResult.class);
         assertThat(listToolsResult.tools())
                 .extracting(Tool::name)
-                .containsExactlyInAnyOrder("add", "throws", "addThree", "addFirstTwoAndAllThree");
+                .containsExactlyInAnyOrder("add", "throws", "addThree", "addFirstTwoAndAllThree", "progress");
 
         CallToolRequest callToolRequest = new CallToolRequest("add", ImmutableMap.of("a", 1, "b", 2));
-        jsonrpcRequest = JsonRpcRequest.buildRequest(1, "tools/call", callToolRequest);
-        response = rpcCall(jsonrpcRequest);
+        rpcRequest = JsonRpcRequest.buildRequest(1, "tools/call", callToolRequest);
+        response = rpcCall(rpcRequest);
         CallToolResult callToolResult = objectMapper.convertValue(response.result().orElseThrow(), CallToolResult.class);
         assertThat(callToolResult.content())
                 .hasSize(1)
@@ -306,8 +326,8 @@ public class TestMcp
     public void testExceptionWrapping()
     {
         CallToolRequest callToolRequest = new CallToolRequest("throws", ImmutableMap.of());
-        JsonRpcRequest<?> jsonrpcRequest = JsonRpcRequest.buildRequest(1, "tools/call", callToolRequest);
-        JsonRpcResponse<?> response = rpcCall(jsonrpcRequest);
+        JsonRpcRequest<?> rpcRequest = JsonRpcRequest.buildRequest(1, "tools/call", callToolRequest);
+        JsonRpcResponse<?> response = rpcCall(rpcRequest);
 
         assertThat(response.error())
                 .contains(new JsonRpcErrorDetail(INVALID_REQUEST, "this ain't good"));
@@ -316,17 +336,17 @@ public class TestMcp
     @Test
     public void testPrompts()
     {
-        JsonRpcRequest<?> jsonrpcRequest = JsonRpcRequest.buildRequest(1, "prompts/list", 1);
+        JsonRpcRequest<?> rpcRequest = JsonRpcRequest.buildRequest(1, "prompts/list", 1);
 
-        JsonRpcResponse<?> response = rpcCall(jsonrpcRequest);
+        JsonRpcResponse<?> response = rpcCall(rpcRequest);
         ListPromptsResult listPromptsResult = objectMapper.convertValue(response.result().orElseThrow(), ListPromptsResult.class);
         assertThat(listPromptsResult.prompts())
                 .extracting(Prompt::name)
                 .containsExactlyInAnyOrder("greeting");
 
         GetPromptRequest getPromptRequest = new GetPromptRequest("greeting", ImmutableMap.of("name", "Galt"));
-        jsonrpcRequest = JsonRpcRequest.buildRequest(1, "prompts/get", getPromptRequest);
-        response = rpcCall(jsonrpcRequest);
+        rpcRequest = JsonRpcRequest.buildRequest(1, "prompts/get", getPromptRequest);
+        response = rpcCall(rpcRequest);
         GetPromptResult getPromptResult = objectMapper.convertValue(response.result().orElseThrow(), GetPromptResult.class);
         assertThat(getPromptResult.messages())
                 .hasSize(1)
@@ -340,17 +360,17 @@ public class TestMcp
     @Test
     public void testResources()
     {
-        JsonRpcRequest<?> jsonrpcRequest = JsonRpcRequest.buildRequest(1, "resources/list");
+        JsonRpcRequest<?> rpcRequest = JsonRpcRequest.buildRequest(1, "resources/list");
 
-        JsonRpcResponse<?> response = rpcCall(jsonrpcRequest);
+        JsonRpcResponse<?> response = rpcCall(rpcRequest);
         ListResourcesResult listResourcesResult = objectMapper.convertValue(response.result().orElseThrow(), ListResourcesResult.class);
         assertThat(listResourcesResult.resources())
                 .extracting(Resource::name)
                 .containsExactlyInAnyOrder("example1", "example2");
 
         ReadResourceRequest readResourceRequest = new ReadResourceRequest("file://example2.txt");
-        jsonrpcRequest = JsonRpcRequest.buildRequest(1, "resources/read", readResourceRequest);
-        response = rpcCall(jsonrpcRequest);
+        rpcRequest = JsonRpcRequest.buildRequest(1, "resources/read", readResourceRequest);
+        response = rpcCall(rpcRequest);
         ReadResourceResult readResourceResult = objectMapper.convertValue(response.result().orElseThrow(), ReadResourceResult.class);
         assertThat(readResourceResult.contents())
                 .hasSize(1)
@@ -359,8 +379,8 @@ public class TestMcp
                 .isEqualTo(Optional.of("This is the content of file://example2.txt"));
 
         readResourceRequest = new ReadResourceRequest("file://test.template");
-        jsonrpcRequest = JsonRpcRequest.buildRequest(1, "resources/read", readResourceRequest);
-        response = rpcCall(jsonrpcRequest);
+        rpcRequest = JsonRpcRequest.buildRequest(1, "resources/read", readResourceRequest);
+        response = rpcCall(rpcRequest);
         readResourceResult = objectMapper.convertValue(response.result().orElseThrow(), ReadResourceResult.class);
         assertThat(readResourceResult.contents())
                 .hasSize(1)
@@ -369,8 +389,8 @@ public class TestMcp
                 .isEqualTo(Optional.of("ID is: test"));
 
         readResourceRequest = new ReadResourceRequest("file://not-a-template");
-        jsonrpcRequest = JsonRpcRequest.buildRequest(1, "resources/read", readResourceRequest);
-        response = rpcCall(jsonrpcRequest);
+        rpcRequest = JsonRpcRequest.buildRequest(1, "resources/read", readResourceRequest);
+        response = rpcCall(rpcRequest);
         assertThat(response.error()).map(JsonRpcErrorDetail::code).contains(-32002);
     }
 
@@ -395,20 +415,87 @@ public class TestMcp
         assertThat(response.getStatusCode()).isEqualTo(SC_METHOD_NOT_ALLOWED);
     }
 
-    private JsonRpcResponse<?> rpcCall(JsonRpcRequest<?> jsonrpcRequest)
+    @Test
+    public void testProgress()
+            throws JsonProcessingException
     {
-        return rpcCall("Mr. Tester", jsonrpcRequest).getValue();
+        CallToolRequest callToolRequest = new CallToolRequest("progress", ImmutableMap.of());
+        JsonRpcRequest<?> rpcRequest = JsonRpcRequest.buildRequest(1, "tools/call", callToolRequest);
+        JsonRpcResponse<?> response = rpcCallSse("Mr. Tester", rpcRequest).getValue();
+
+        for (int i = 0; i <= 100; ++i) {
+            ProgressNotification progressNotification = new ProgressNotification(Optional.empty(), "Progress " + i + "%", OptionalDouble.of(i), OptionalDouble.of(100));
+            String expectedProgressEvent = objectMapper.writeValueAsString(JsonRpcRequest.buildNotification("notifications/progress", progressNotification));
+            assertThat(lastRequestEvents).hasSizeGreaterThanOrEqualTo(i);
+            String event = lastRequestEvents.get(i);
+            assertThat(event).isEqualTo(expectedProgressEvent);
+        }
+
+        CallToolResult callToolResult = objectMapper.convertValue(response.result().orElseThrow(), new TypeReference<>() {});
+        assertThat(callToolResult.content())
+                .hasSize(1)
+                .first()
+                .asInstanceOf(type(TextContent.class))
+                .extracting(TextContent::text)
+                .isEqualTo("true");
     }
 
-    private JsonResponse<JsonRpcResponse<?>> rpcCall(String identityHeader, JsonRpcRequest<?> jsonrpcRequest)
+    private JsonRpcResponse<?> rpcCall(JsonRpcRequest<?> rpcRequest)
+    {
+        return rpcCall("Mr. Tester", rpcRequest).getValue();
+    }
+
+    private JsonResponse<JsonRpcResponse<?>> rpcCall(String identityHeader, JsonRpcRequest<?> rpcRequest)
     {
         Request request = preparePost().setUri(baseUri)
                 .addHeader("Content-Type", "application/json")
                 .addHeader("Accept", "application/json,text/event-stream")
                 .addHeader(IDENTITY_HEADER, identityHeader)
-                .setBodyGenerator(JsonBodyGenerator.jsonBodyGenerator(jsonCodec(new TypeToken<JsonRpcRequest<?>>() {}), jsonrpcRequest))
+                .setBodyGenerator(JsonBodyGenerator.jsonBodyGenerator(jsonCodec(new TypeToken<JsonRpcRequest<?>>() {}), rpcRequest))
                 .build();
 
         return httpClient.execute(request, createFullJsonResponseHandler(jsonCodec(new TypeToken<>() {})));
+    }
+
+    private JsonResponse<JsonRpcResponse<?>> rpcCallSse(String identityHeader, JsonRpcRequest<?> rpcRequest)
+    {
+        JsonCodec<JsonRpcResponse<?>> responseCodec = jsonCodec(new TypeToken<>() {});
+
+        Request request = preparePost().setUri(baseUri)
+                .addHeader("Content-Type", "application/json")
+                .addHeader("Accept", "application/json,text/event-stream")
+                .addHeader(IDENTITY_HEADER, identityHeader)
+                .setBodyGenerator(JsonBodyGenerator.jsonBodyGenerator(jsonCodec(new TypeToken<JsonRpcRequest<?>>() {}), rpcRequest))
+                .build();
+
+        lastRequestEvents.clear();
+
+        try (StreamingResponse response = httpClient.executeStreaming(request)) {
+            if (response.getStatusCode() > 299) {
+                return new JsonResponse<>(response.getStatusCode(), response.getHeaders(), responseCodec, response.getInputStream().readAllBytes());
+            }
+
+            BufferedReader reader = new BufferedReader(new InputStreamReader(response.getInputStream()));
+
+            while (true) {
+                String line = reader.readLine();
+                if (line == null) {
+                    break;
+                }
+
+                if (line.startsWith("data: ")) {
+                    lastRequestEvents.add(line.substring("data: ".length()));
+                }
+            }
+
+            if (lastRequestEvents.isEmpty()) {
+                throw new UncheckedIOException(new IOException("No events received from MCP server"));
+            }
+
+            return new JsonResponse<>(response.getStatusCode(), response.getHeaders(), responseCodec, lastRequestEvents.getLast().getBytes(UTF_8));
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 }

--- a/mcp/src/test/java/io/airlift/mcp/TestingEndpoints.java
+++ b/mcp/src/test/java/io/airlift/mcp/TestingEndpoints.java
@@ -11,6 +11,7 @@ import io.airlift.mcp.model.StructuredContentResult;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 import static io.airlift.mcp.McpException.exception;
 import static java.util.Objects.requireNonNull;
@@ -33,6 +34,22 @@ public class TestingEndpoints
         assertThat(testingIdentity.name()).isEqualTo("Mr. Tester");
 
         return a + b;
+    }
+
+    @McpTool(name = "progress", description = "Test progress notifications")
+    public boolean toolWithNotifications(McpRequestContext requestContext)
+    {
+        for (int i = 0; i <= 100; ++i) {
+            requestContext.sendProgress(i, 100, "Progress " + i + "%");
+            try {
+                TimeUnit.MILLISECONDS.sleep(10);
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+        }
+        return true;
     }
 
     @McpTool(name = "throws", description = "Throws an exception for testing purposes")


### PR DESCRIPTION
The reference MCP server does not support server-to-client messages. This change wraps the servlet objects sent to the reference implementation's Servlet so that we can change the response to an SSE response for the purpose of supporting server-to-client messages. The response is changed only if a message is actually sent.

Added tests for this.

Note: this takes advantage of inner knowledge of how `HttpServletStatelessServerTransport` works. Hopefully the MCP team will add native support for this in the future. We've opened PRs with possible implementations and have started GitHub discussions about future features.

# Airlift contribution check list

 - [X] Git commit messages follow https://cbea.ms/git-commit/.
 - [X] All automated tests are passing.
 - [ ] Pull request was categorized using one of the existing labels.
