### PR TITLE
Disable outbound buffering

### DIFF
--- a/jaxrs/src/main/java/io/airlift/jaxrs/JaxrsResourceConfigProvider.java
+++ b/jaxrs/src/main/java/io/airlift/jaxrs/JaxrsResourceConfigProvider.java
@@ -13,6 +13,7 @@ import java.util.Set;
 
 import static io.airlift.jaxrs.BinderUtils.qualifiedKey;
 import static java.util.Objects.requireNonNull;
+import static org.glassfish.jersey.CommonProperties.OUTBOUND_CONTENT_LENGTH_BUFFER;
 import static org.glassfish.jersey.server.ServerProperties.RESPONSE_SET_STATUS_OVER_SEND_ERROR;
 
 public class JaxrsResourceConfigProvider
@@ -37,6 +38,12 @@ public class JaxrsResourceConfigProvider
     {
         Set<Object> singletons = injector.getInstance(qualifiedKey(qualifier, new TypeLiteral<>() {}));
         return new JaxrsResourceConfig(singletons)
-                .setProperties(ImmutableMap.of(RESPONSE_SET_STATUS_OVER_SEND_ERROR, "true"));
+                .setProperties(ImmutableMap.of(
+                        RESPONSE_SET_STATUS_OVER_SEND_ERROR, "true",
+                        // Jetty http server buffers output when writing which makes Jersey server-side buffering redundant.
+                        // For small responses, allocating 8KB buffer is wasteful. For large responses, Jetty will buffer
+                        // as needed. Having Content-Length for small responses is not critical as in the HTTP/2
+                        // Content-Length can be inferred from DATA frame length.
+                        OUTBOUND_CONTENT_LENGTH_BUFFER, "0"));
     }
 }


### PR DESCRIPTION
Jetty buffers output when writing so Jersey buffering is redundant as it will be handled by http server.

<!-- Thank you for submitting pull request to Airlift -->

# Airlift contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [x] All automated tests are passing.
 - [x] Pull request was categorized using one of the existing labels.
