### PR TITLE
Do not stop http server on shutdown

### DIFF
--- a/http-server/src/main/java/io/airlift/http/server/HttpServer.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServer.java
@@ -168,7 +168,9 @@ public class HttpServer
 
         server = new Server(threadPool, createScheduler(name + "-scheduler"), createByteBufferPool(maxBufferSize, config));
         server.setName(name);
-        server.setStopAtShutdown(true);
+        // stopAtShutdown registers a shutdown hook that stops the server, when JVM exits. It's not needed
+        // as the LifeCycleManager takes care of stopping the server at exit.
+        server.setStopAtShutdown(false);
         server.setStopTimeout(config.getStopTimeout().toMillis());
 
         this.monitoredQueuedThreadPoolMBean = new MonitoredQueuedThreadPoolMBean(threadPool);


### PR DESCRIPTION
This registers a shutdown hook thread that interferes with already registered shutdown hook thread managed by LifeCycle.

<!-- Thank you for submitting pull request to Airlift -->

# Airlift contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [x] All automated tests are passing.
 - [x] Pull request was categorized using one of the existing labels.
