### PR TITLE
Always use named test http servers

### DIFF
--- a/api/src/test/java/io/airlift/api/servertests/ServerTestBase.java
+++ b/api/src/test/java/io/airlift/api/servertests/ServerTestBase.java
@@ -64,7 +64,7 @@ public class ServerTestBase
     {
         ImmutableList.Builder<Module> modules = ImmutableList.<Module>builder()
                 .add(new NodeModule())
-                .add(new TestingHttpServerModule())
+                .add(new TestingHttpServerModule(getClass().getName()))
                 .add(binder -> binder.bind(new TypeLiteral<Map<String, AtomicInteger>>() {}).toInstance(counters))
                 .add(new JsonModule())
                 .add(new JaxrsModule());

--- a/api/src/test/java/io/airlift/api/servertests/integration/testingserver/TestingServer.java
+++ b/api/src/test/java/io/airlift/api/servertests/integration/testingserver/TestingServer.java
@@ -31,7 +31,7 @@ public class TestingServer
         ImmutableList.Builder<Module> modules = ImmutableList.<Module>builder()
                 .add(new TestingServerModule())
                 .add(new NodeModule())
-                .add(new TestingHttpServerModule(port))
+                .add(new TestingHttpServerModule(getClass().getName(), port))
                 .add(new JsonModule())
                 .add(new JaxrsModule());
 

--- a/http-server/src/main/java/io/airlift/http/server/testing/ForTestingServer.java
+++ b/http-server/src/main/java/io/airlift/http/server/testing/ForTestingServer.java
@@ -1,0 +1,13 @@
+package io.airlift.http.server.testing;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@BindingAnnotation
+public @interface ForTestingServer
+{
+}

--- a/http-server/src/main/java/io/airlift/http/server/testing/TestingHttpServer.java
+++ b/http-server/src/main/java/io/airlift/http/server/testing/TestingHttpServer.java
@@ -38,16 +38,18 @@ public class TestingHttpServer
     private final HttpServerInfo httpServerInfo;
 
     public TestingHttpServer(
+            String name,
             HttpServerInfo httpServerInfo,
             NodeInfo nodeInfo,
             HttpServerConfig config,
             Servlet servlet)
             throws IOException
     {
-        this(httpServerInfo, nodeInfo, config, servlet, ServerFeature.builder().build());
+        this(name, httpServerInfo, nodeInfo, config, servlet, ServerFeature.builder().build());
     }
 
     public TestingHttpServer(
+            String name,
             HttpServerInfo httpServerInfo,
             NodeInfo nodeInfo,
             HttpServerConfig config,
@@ -55,7 +57,9 @@ public class TestingHttpServer
             Set<ServerFeature> serverFeatures)
             throws IOException
     {
-        this(httpServerInfo,
+        this(
+                name,
+                httpServerInfo,
                 nodeInfo,
                 config,
                 Optional.empty(),
@@ -68,6 +72,7 @@ public class TestingHttpServer
 
     @Inject
     public TestingHttpServer(
+            @ForTestingServer String name,
             HttpServerInfo httpServerInfo,
             NodeInfo nodeInfo,
             HttpServerConfig config,
@@ -79,7 +84,7 @@ public class TestingHttpServer
             ClientCertificate clientCertificate)
             throws IOException
     {
-        super("testing",
+        super(name,
                 httpServerInfo,
                 nodeInfo,
                 config.setLogEnabled(false),

--- a/http-server/src/main/java/io/airlift/http/server/testing/TestingHttpServerModule.java
+++ b/http-server/src/main/java/io/airlift/http/server/testing/TestingHttpServerModule.java
@@ -36,15 +36,17 @@ import static io.airlift.http.server.HttpServerBinder.HttpResourceBinding;
 public class TestingHttpServerModule
         extends AbstractConfigurationAwareModule
 {
+    private final String name;
     private final int httpPort;
 
-    public TestingHttpServerModule()
+    public TestingHttpServerModule(String name)
     {
-        this(0);
+        this(name, 0);
     }
 
-    public TestingHttpServerModule(int httpPort)
+    public TestingHttpServerModule(String name, int httpPort)
     {
+        this.name = name;
         this.httpPort = httpPort;
     }
 
@@ -54,8 +56,10 @@ public class TestingHttpServerModule
         binder.disableCircularProxies();
 
         configBinder(binder).bindConfig(HttpServerConfig.class);
-        configBinder(binder).bindConfigDefaults(HttpServerConfig.class, config -> config.setHttpPort(httpPort));
+        configBinder(binder).bindConfigDefaults(HttpServerConfig.class, config -> config
+                .setHttpPort(httpPort));
 
+        binder.bind(String.class).annotatedWith(ForTestingServer.class).toInstance(name);
         binder.bind(HttpServerInfo.class).in(Scopes.SINGLETON);
         binder.bind(TestingHttpServer.class).in(Scopes.SINGLETON);
         newOptionalBinder(binder, ClientCertificate.class).setDefault().toInstance(ClientCertificate.NONE);

--- a/http-server/src/test/java/io/airlift/http/server/testing/AbstractTestTestingHttpServer.java
+++ b/http-server/src/test/java/io/airlift/http/server/testing/AbstractTestTestingHttpServer.java
@@ -165,7 +165,7 @@ public abstract class AbstractTestTestingHttpServer
 
         Bootstrap app = new Bootstrap(
                 new TestingNodeModule(),
-                new TestingHttpServerModule(),
+                new TestingHttpServerModule(getClass().getName()),
                 binder -> {
                     binder.bind(Servlet.class).toInstance(servlet);
                 });
@@ -197,7 +197,7 @@ public abstract class AbstractTestTestingHttpServer
 
         Bootstrap app = new Bootstrap(
                 new TestingNodeModule(),
-                new TestingHttpServerModule(),
+                new TestingHttpServerModule(getClass().getName()),
                 binder -> {
                     binder.bind(Servlet.class).toInstance(servlet);
                     newSetBinder(binder, Filter.class).addBinding().toInstance(filter);
@@ -231,7 +231,7 @@ public abstract class AbstractTestTestingHttpServer
 
         Bootstrap app = new Bootstrap(
                 new TestingNodeModule(),
-                new TestingHttpServerModule(0),
+                new TestingHttpServerModule(getClass().getName()),
                 binder -> {
                     binder.bind(Servlet.class).toInstance(servlet);
                     httpServerBinder(binder).bindResource("/", "webapp/user").withWelcomeFile("user-welcome.txt");
@@ -354,7 +354,7 @@ public abstract class AbstractTestTestingHttpServer
         NodeInfo nodeInfo = new NodeInfo("test");
         HttpServerConfig config = new HttpServerConfig().setHttpPort(0);
         HttpServerInfo httpServerInfo = new HttpServerInfo(config, nodeInfo);
-        return new TestingHttpServer(httpServerInfo, nodeInfo, config, servlet, serverFeatures);
+        return new TestingHttpServer("testing", httpServerInfo, nodeInfo, config, servlet, serverFeatures);
     }
 
     private static TestingHttpServer createTestingHttpServerWithFilter(Set<ServerFeature> serverFeatures, DummyServlet servlet, DummyFilter filter)
@@ -363,7 +363,7 @@ public abstract class AbstractTestTestingHttpServer
         NodeInfo nodeInfo = new NodeInfo("test");
         HttpServerConfig config = new HttpServerConfig().setHttpPort(0);
         HttpServerInfo httpServerInfo = new HttpServerInfo(config, nodeInfo);
-        return new TestingHttpServer(httpServerInfo, nodeInfo, config, Optional.empty(), servlet, ImmutableSet.of(filter), ImmutableSet.of(), serverFeatures, ClientCertificate.NONE);
+        return new TestingHttpServer("testing", httpServerInfo, nodeInfo, config, Optional.empty(), servlet, ImmutableSet.of(filter), ImmutableSet.of(), serverFeatures, ClientCertificate.NONE);
     }
 
     static class DummyServlet

--- a/jaxrs/src/test/java/io/airlift/jaxrs/TestLegacyUriMode.java
+++ b/jaxrs/src/test/java/io/airlift/jaxrs/TestLegacyUriMode.java
@@ -107,7 +107,7 @@ public class TestLegacyUriMode
                     }
                 },
                 new TestingNodeModule(),
-                new TestingHttpServerModule(),
+                new TestingHttpServerModule(getClass().getName()),
                 new JaxrsModule(),
                 new JsonModule())
                 .quiet()

--- a/jaxrs/src/test/java/io/airlift/jaxrs/programmatic/TestProgrammaticResource.java
+++ b/jaxrs/src/test/java/io/airlift/jaxrs/programmatic/TestProgrammaticResource.java
@@ -112,7 +112,7 @@ public class TestProgrammaticResource
                 new TestingNodeModule(),
                 new JaxrsModule(),
                 new JsonModule(),
-                new TestingHttpServerModule())
+                new TestingHttpServerModule(getClass().getName()))
                 .quiet()
                 .doNotInitializeLogging()
                 .initialize();

--- a/jmx-http/src/test/java/io/airlift/jmx/TestMBeanResource.java
+++ b/jmx-http/src/test/java/io/airlift/jmx/TestMBeanResource.java
@@ -54,7 +54,7 @@ public class TestMBeanResource
     {
         Bootstrap app = new Bootstrap(
                 new TestingNodeModule(),
-                new TestingHttpServerModule(),
+                new TestingHttpServerModule(getClass().getName()),
                 new JsonModule(),
                 new JaxrsModule(),
                 new JmxHttpModule(),

--- a/mcp/src/test/java/io/airlift/mcp/LocalServer.java
+++ b/mcp/src/test/java/io/airlift/mcp/LocalServer.java
@@ -43,7 +43,7 @@ public class LocalServer
                 .add(mcpModule)
                 .add(binder -> binder.bind(TestingEndpoints.class).in(SINGLETON))
                 .add(new NodeModule())
-                .add(new TestingHttpServerModule(port.orElse(0)))
+                .add(new TestingHttpServerModule(LocalServer.class.getName(), port.orElse(0)))
                 .add(new JaxrsModule())
                 .add(new JsonModule());
 

--- a/mcp/src/test/java/io/airlift/mcp/TestMcp.java
+++ b/mcp/src/test/java/io/airlift/mcp/TestMcp.java
@@ -95,7 +95,7 @@ public class TestMcp
                 .add(mcpModule)
                 .add(binder -> httpClientBinder(binder).bindHttpClient("test", ForTest.class))
                 .add(new NodeModule())
-                .add(new TestingHttpServerModule())
+                .add(new TestingHttpServerModule(getClass().getName()))
                 .add(new JaxrsModule())
                 .add(new JsonModule());
 

--- a/sample-server/src/test/java/io/airlift/sample/TestServer.java
+++ b/sample-server/src/test/java/io/airlift/sample/TestServer.java
@@ -82,7 +82,7 @@ public class TestServer
     {
         Bootstrap app = new Bootstrap(
                 new TestingNodeModule(),
-                new TestingHttpServerModule(),
+                new TestingHttpServerModule(getClass().getName()),
                 new JsonModule(),
                 new JaxrsModule(),
                 new MainModule());

--- a/skeleton-server/src/test/java/io/airlift/skeleton/TestServer.java
+++ b/skeleton-server/src/test/java/io/airlift/skeleton/TestServer.java
@@ -41,7 +41,7 @@ public class TestServer
     {
         Bootstrap app = new Bootstrap(
                 new TestingNodeModule(),
-                new TestingHttpServerModule(),
+                new TestingHttpServerModule(getClass().getName()),
                 new JsonModule(),
                 new JaxrsModule(),
                 new JmxHttpModule(),


### PR DESCRIPTION
This makes it easier to diagnose resource usage when testing http server instances are named.

This is backward incompatible for purpose to enforce migration.

<!-- Thank you for submitting pull request to Airlift -->

# Airlift contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [x] All automated tests are passing.
 - [x] Pull request was categorized using one of the existing labels.
