### PR TITLE
Make configuration quiet with system property

### DIFF
--- a/bootstrap/src/main/java/io/airlift/bootstrap/Bootstrap.java
+++ b/bootstrap/src/main/java/io/airlift/bootstrap/Bootstrap.java
@@ -56,6 +56,7 @@ import static io.airlift.bootstrap.FuzzyMatcher.findSimilar;
 import static io.airlift.configuration.ConfigurationLoader.getSystemProperties;
 import static io.airlift.configuration.ConfigurationLoader.loadPropertiesFrom;
 import static io.airlift.configuration.TomlConfiguration.createTomlConfiguration;
+import static java.lang.Boolean.parseBoolean;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -84,7 +85,7 @@ public class Bootstrap
     private boolean initializeLogging = true;
     private boolean envInterpolation = true;
     private boolean useSystemProperties = true;
-    private boolean quiet;
+    private boolean quiet = parseBoolean(System.getProperty("airlift.quiet"));
     private boolean loadSecretsPlugins;
     private boolean skipErrorReporting;
 


### PR DESCRIPTION
Introduce a system property for controlling default value of `Bootstrap.quiet`. This can be useful in situations where multiple components using Airlift are loaded in short succession, and logging all configuration properties is too verbose. For example, in tests, or when components are loaded dynamically and ad-hoc. This is a system property, so that a system using Airlift can log its initial configuration and then toggle the system property value.
