### PR TITLE
Remove `useSystemProperties` from ConfigurationLoader

### DIFF
--- a/configuration/src/main/java/io/airlift/configuration/ConfigurationLoader.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConfigurationLoader.java
@@ -32,14 +32,7 @@ public final class ConfigurationLoader
 {
     private ConfigurationLoader() {}
 
-    @Deprecated
     public static Map<String, String> loadProperties()
-            throws IOException
-    {
-        return loadProperties(true);
-    }
-
-    public static Map<String, String> loadProperties(boolean useSystemProperties)
             throws IOException
     {
         Map<String, String> result = new TreeMap<>();
@@ -48,9 +41,7 @@ public final class ConfigurationLoader
             result.putAll(loadPropertiesFrom(configFile));
         }
 
-        if (useSystemProperties) {
-            result.putAll(getSystemProperties());
-        }
+        result.putAll(getSystemProperties());
 
         return ImmutableSortedMap.copyOf(result);
     }

--- a/configuration/src/test/java/io/airlift/configuration/TestConfigurationLoader.java
+++ b/configuration/src/test/java/io/airlift/configuration/TestConfigurationLoader.java
@@ -59,7 +59,7 @@ public class TestConfigurationLoader
     {
         System.setProperty("test", "foo");
 
-        Map<String, String> properties = loadProperties(true);
+        Map<String, String> properties = loadProperties();
 
         assertThat(properties.get("test")).isEqualTo("foo");
 
@@ -73,25 +73,12 @@ public class TestConfigurationLoader
         File file = createConfigFile(out -> out.print("test: foo"));
         System.setProperty("config", file.getAbsolutePath());
 
-        Map<String, String> properties = loadProperties(true);
+        Map<String, String> properties = loadProperties();
 
         assertThat(properties.get("test")).isEqualTo("foo");
         assertThat(properties.get("config")).isEqualTo(file.getAbsolutePath());
 
         System.clearProperty("config");
-    }
-
-    @Test
-    public void testLoadsFromFileWithoutSystemProperties()
-            throws IOException
-    {
-        System.setProperty("test", "foo");
-
-        Map<String, String> properties = loadProperties(false);
-
-        assertThat(properties.get("test")).isNull();
-
-        System.clearProperty("test");
     }
 
     @Test
@@ -105,7 +92,7 @@ public class TestConfigurationLoader
         System.setProperty("config", file.getAbsolutePath());
         System.setProperty("trim-whitespace-key2", " \t key2-value \t ");
 
-        Map<String, String> properties = loadProperties(true);
+        Map<String, String> properties = loadProperties();
 
         // config files are often human-managed and we need to be permissive, stripping trailing whitespace if any
         assertThat(properties.get("trim-whitespace-key1")).isEqualTo("key1-value");
@@ -128,7 +115,7 @@ public class TestConfigurationLoader
         System.setProperty("config", file.getAbsolutePath());
         System.setProperty("key1", "overridden");
 
-        Map<String, String> properties = loadProperties(true);
+        Map<String, String> properties = loadProperties();
 
         assertThat(properties.get("config")).isEqualTo(file.getAbsolutePath());
         assertThat(properties.get("key1")).isEqualTo("overridden");


### PR DESCRIPTION
The `ConfigurationLoader.loadProperties` loads values from system properties and is useless otherwise. If the caller is not interested in system properties, they should rather avoid calling that method.

The current implementation is not consequential. When `! useSystemProperties`, it still consults `config` system property, but no others. This commit addresses that by restoring previous behavior.
