### PR TITLE
Introduce ApiParsedResponse to aid in getting response errors

### DIFF
--- a/api/src/main/java/io/airlift/api/responses/ApiParsedResponse.java
+++ b/api/src/main/java/io/airlift/api/responses/ApiParsedResponse.java
@@ -1,0 +1,63 @@
+package io.airlift.api.responses;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import io.airlift.json.JsonCodec;
+import io.airlift.json.ObjectMapperProvider;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.airlift.json.JsonCodec.mapJsonCodec;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+
+public record ApiParsedResponse(String message, Optional<String> description, List<String> fields)
+{
+    private static final JsonCodec<Map<String, Object>> CODEC = mapJsonCodec(String.class, Object.class);
+    private static final ObjectMapper MAPPER = new ObjectMapperProvider().get();
+    private static final TypeReference<List<String>> LIST_TYPE = new TypeReference<>() {};
+
+    public ApiParsedResponse
+    {
+        requireNonNull(message, "message is null");
+        requireNonNull(description, "description is null");
+        fields = ImmutableList.copyOf(fields);
+    }
+
+    public static Optional<ApiParsedResponse> parse(byte[] responseBytes)
+    {
+        try {
+            Map<String, Object> values = CODEC.fromJson(responseBytes);
+            if (values.containsKey("message")) {
+                String message = String.valueOf(values.get("message"));
+                Optional<String> description = values.containsKey("description") ? Optional.of(String.valueOf(values.get("description"))) : Optional.empty();
+                List<String> fields;
+                if (values.containsKey("fields")) {
+                    try {
+                        fields = MAPPER.convertValue(values.get("fields"), LIST_TYPE);
+                    }
+                    catch (IllegalArgumentException _) {
+                        // ignore it
+                        fields = ImmutableList.of();
+                    }
+                }
+                else {
+                    fields = ImmutableList.of();
+                }
+                return Optional.of(new ApiParsedResponse(message, description, fields));
+            }
+        }
+        catch (IllegalArgumentException _) {
+            // ignore
+        }
+        return Optional.empty();
+    }
+
+    public static Optional<ApiParsedResponse> parse(String response)
+    {
+        return parse(response.getBytes(UTF_8));
+    }
+}

--- a/api/src/test/java/io/airlift/api/servertests/exceptions/ExceptionApi.java
+++ b/api/src/test/java/io/airlift/api/servertests/exceptions/ExceptionApi.java
@@ -1,0 +1,28 @@
+package io.airlift.api.servertests.exceptions;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.api.ApiCreate;
+import io.airlift.api.ApiService;
+import io.airlift.api.ApiUpdate;
+import io.airlift.api.ServiceType;
+import jakarta.ws.rs.WebApplicationException;
+
+import static io.airlift.api.responses.ApiException.badRequest;
+import static jakarta.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static jakarta.ws.rs.core.Response.status;
+
+@ApiService(type = ServiceType.class, name = "exception", description = "Throws exceptions")
+public class ExceptionApi
+{
+    @ApiUpdate(description = "Throws a known exception")
+    public void throwsKnownException()
+    {
+        throw badRequest("This is the message", ImmutableList.of("field1", "field2"));
+    }
+
+    @ApiCreate(description = "Throws an unknown exception", quotas = "dummy")
+    public void throwsUnknownException()
+    {
+        throw new WebApplicationException(status(INTERNAL_SERVER_ERROR).build());
+    }
+}

--- a/api/src/test/java/io/airlift/api/servertests/exceptions/ExceptionTest.java
+++ b/api/src/test/java/io/airlift/api/servertests/exceptions/ExceptionTest.java
@@ -1,0 +1,57 @@
+package io.airlift.api.servertests.exceptions;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.api.responses.ApiParsedResponse;
+import io.airlift.api.servertests.ServerTestBase;
+import io.airlift.http.client.FullJsonResponseHandler.JsonResponse;
+import io.airlift.http.client.Request;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.UriBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.Optional;
+
+import static io.airlift.http.client.FullJsonResponseHandler.createFullJsonResponseHandler;
+import static io.airlift.http.client.Request.Builder.preparePost;
+import static io.airlift.http.client.Request.Builder.preparePut;
+import static io.airlift.json.JsonCodec.jsonCodec;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ExceptionTest
+        extends ServerTestBase
+{
+    public ExceptionTest()
+    {
+        super(ExceptionApi.class);
+    }
+
+    @Test
+    public void testKnownException()
+    {
+        UriBuilder uriBuilder = UriBuilder.fromUri(baseUri).path("public/api/v1");
+        URI uri = uriBuilder.build();
+        Request request = preparePut()
+                .setUri(uri)
+                .setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .build();
+        JsonResponse<Void> response = httpClient.execute(request, createFullJsonResponseHandler(jsonCodec(Void.class)));
+        Optional<ApiParsedResponse> parsed = ApiParsedResponse.parse(response.getResponseBytes());
+        assertThat(parsed).contains(new ApiParsedResponse("This is the message", Optional.empty(), ImmutableList.of("field1", "field2")));
+    }
+
+    @Test
+    public void testUnknownException()
+    {
+        UriBuilder uriBuilder = UriBuilder.fromUri(baseUri).path("public/api/v1");
+        URI uri = uriBuilder.build();
+        Request request = preparePost()
+                .setUri(uri)
+                .setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .build();
+        JsonResponse<Void> response = httpClient.execute(request, createFullJsonResponseHandler(jsonCodec(Void.class)));
+        Optional<ApiParsedResponse> parsed = ApiParsedResponse.parse(response.getResponseBytes());
+        assertThat(parsed).isEmpty();
+    }
+}


### PR DESCRIPTION
`ApiParsedResponse` can be used by clients to get detailed response messages from APIs that follow the `ApiException` naming conventions and add a JSON payload to responses. `ApiException` methods work as expected and are the preferred response mechanism.

@wendigo what do you think of this approach?

Closes #1681

# Airlift contribution check list

 - [X] Git commit messages follow https://cbea.ms/git-commit/.
 - [X] All automated tests are passing.
 - [ ] Pull request was categorized using one of the existing labels.
