### PR TITLE
[API] Fix recursion issue in ResourceSerializationValidator

### DIFF
--- a/api/src/test/java/io/airlift/api/validation/RecursiveResource.java
+++ b/api/src/test/java/io/airlift/api/validation/RecursiveResource.java
@@ -1,0 +1,9 @@
+package io.airlift.api.validation;
+
+import io.airlift.api.ApiDescription;
+import io.airlift.api.ApiResource;
+
+@ApiResource(name = "test", description = "foo")
+public record RecursiveResource(@ApiDescription("foo") RecursiveResourceBase base)
+{
+}

--- a/api/src/test/java/io/airlift/api/validation/RecursiveResourceBase.java
+++ b/api/src/test/java/io/airlift/api/validation/RecursiveResourceBase.java
@@ -1,0 +1,17 @@
+package io.airlift.api.validation;
+
+import io.airlift.api.ApiDescription;
+import io.airlift.api.ApiPolyResource;
+import io.airlift.api.ApiResource;
+
+import java.util.List;
+import java.util.Optional;
+
+@ApiPolyResource(key = "typeKey", name = "foo", description = "foo")
+public sealed interface RecursiveResourceBase
+{
+    @ApiResource(name = "actualResource", description = "foo")
+    record ActualResource(
+            @ApiDescription("foo") Optional<List<RecursiveResourceBase>> nested)
+            implements RecursiveResourceBase {}
+}


### PR DESCRIPTION
`ResourceSerializationValidator` was subject to a stack overflow if a resource had a List of a recursive resource. Additional calls to `validationContext.addValidatingResources()` were needed.

Additionally, fix a hole where the Optional default value generator was not checking for recursion.

# Airlift contribution check list

 - [X] Git commit messages follow https://cbea.ms/git-commit/.
 - [X] All automated tests are passing.
 - [x] Pull request was categorized using one of the existing labels.
