### PR TITLE
Deprecate ConditionalModule and SwitchModule

### DIFF
--- a/bootstrap/src/test/java/io/airlift/bootstrap/TestBootstrap.java
+++ b/bootstrap/src/test/java/io/airlift/bootstrap/TestBootstrap.java
@@ -33,7 +33,6 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
-import static io.airlift.configuration.ConditionalModule.conditionalModule;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -164,10 +163,9 @@ public class TestBootstrap
             @Override
             protected void setup(Binder binder)
             {
-                install(conditionalModule(
-                        FooConfig.class,
-                        FooConfig::isFoo,
-                        innerBinder -> configBinder(innerBinder).bindConfig(BarConfig.class)));
+                if (buildConfigObject(FooConfig.class).isFoo()) {
+                    configBinder(binder).bindConfig(BarConfig.class);
+                }
             }
         };
         Bootstrap bootstrap = new Bootstrap(module);

--- a/configuration/src/main/java/io/airlift/configuration/ConditionalModule.java
+++ b/configuration/src/main/java/io/airlift/configuration/ConditionalModule.java
@@ -23,9 +23,28 @@ import java.util.function.Predicate;
 import static io.airlift.configuration.ConfigurationAwareModule.combine;
 import static java.util.Objects.requireNonNull;
 
+/**
+ * ConditionalModule is not preferable to using buildConfigObject directly.
+ * For example,
+ * <pre>
+ * install(conditionalModule(
+ *         SomeConfig.class,
+ *         config -> config.getSomeOption().equals("x"),
+ *         binder -> binder.bind(String.class).toInstance("X")));
+ * </pre>
+ *
+ * can be replaced with:
+ * <pre>
+ * SomeConfig testConfig = buildConfigObject(SomeConfig.class);
+ * if (testConfig.getSomeOption().equals("x")) {
+ *         binder.bind(String.class).toInstance("X");
+ * }
+ * </pre>
+ */
 public class ConditionalModule<T>
         extends AbstractConfigurationAwareModule
 {
+    @Deprecated
     public static <T> Module conditionalModule(Class<T> config, Predicate<T> predicate, Module module, Module otherwise)
     {
         return combine(
@@ -33,6 +52,7 @@ public class ConditionalModule<T>
                 conditionalModule(config, predicate.negate(), otherwise));
     }
 
+    @Deprecated
     public static <T> Module conditionalModule(Class<T> config, String prefix, Predicate<T> predicate, Module module, Module otherwise)
     {
         return combine(
@@ -40,16 +60,19 @@ public class ConditionalModule<T>
                 conditionalModule(config, prefix, predicate.negate(), otherwise));
     }
 
+    @Deprecated
     public static <T> Module conditionalModule(Class<T> config, Predicate<T> predicate, Module module)
     {
         return conditionalModule(config, null, predicate, module);
     }
 
+    @Deprecated
     public static <T> Module conditionalModule(Class<T> config, String prefix, Predicate<T> predicate, Module module)
     {
         return new ConditionalModule<>(Key.get(config), config, prefix, predicate, module);
     }
 
+    @Deprecated
     public static <T> Module conditionalModule(Key<T> key, Class<T> config, String prefix, Predicate<T> predicate, Module module)
     {
         return new ConditionalModule<>(key, config, prefix, predicate, module);

--- a/configuration/src/main/java/io/airlift/configuration/SwitchModule.java
+++ b/configuration/src/main/java/io/airlift/configuration/SwitchModule.java
@@ -20,9 +20,32 @@ import java.util.function.Function;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * SwitchModule is not preferable to using buildConfigObject directly.
+ * For example,
+ * <pre>
+ * install(switchModule(
+ *     SomeConfig.class,
+ *     SomeConfig::getSomeOption,
+ *     value -> switch (value) {
+ *         case "x" -> binder -> binder.bind(String.class).toInstance("X");
+ *         default -> throw new IllegalArgumentException("Unsupported value: " + value);
+ * }));
+ * </pre>
+ *
+ * can be replaced with:
+ * <pre>
+ * SomeConfig someConfig = buildConfigObject(SomeConfig.class);
+ * switch (someConfig.getSomeOption()) {
+ *     case "x" -> binder.bind(String.class).toInstance("X");
+ *     default -> throw new IllegalArgumentException("Unsupported value: " + someConfig.getSomeOption());
+ * }
+ * </pre>
+ */
 public class SwitchModule<T>
         extends AbstractConfigurationAwareModule
 {
+    @Deprecated
     public static <C, V> Module switchModule(
             Class<C> config,
             Function<C, V> valueProvider,

--- a/configuration/src/test/java/io/airlift/configuration/TestConditionalModule.java
+++ b/configuration/src/test/java/io/airlift/configuration/TestConditionalModule.java
@@ -13,17 +13,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
-import static io.airlift.configuration.ConditionalModule.conditionalModule;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@SuppressWarnings("deprecation")
 public class TestConditionalModule
 {
     @Test
     public void testConditionalModule()
     {
         Supplier<AbstractConfigurationAwareModule> moduleXY = () -> {
-            Module moduleX = conditionalModule(SomeConfig.class, config -> config.getSomeOption().equals("x"), binder -> binder.bind(String.class).toInstance("X"));
-            Module moduleY = conditionalModule(SomeConfig.class, config -> config.getSomeOption().equals("y"), binder -> binder.bind(String.class).toInstance("Y"));
+            Module moduleX = ConditionalModule.conditionalModule(SomeConfig.class, config -> config.getSomeOption().equals("x"), binder -> binder.bind(String.class).toInstance("X"));
+            Module moduleY = ConditionalModule.conditionalModule(SomeConfig.class, config -> config.getSomeOption().equals("y"), binder -> binder.bind(String.class).toInstance("Y"));
             return new AbstractConfigurationAwareModule()
             {
                 @Override
@@ -35,7 +35,7 @@ public class TestConditionalModule
             };
         };
 
-        Supplier<Module> moduleXElseZ = () -> conditionalModule(SomeConfig.class,
+        Supplier<Module> moduleXElseZ = () -> ConditionalModule.conditionalModule(SomeConfig.class,
                 config -> config.getSomeOption().equals("x"),
                 binder -> binder.bind(String.class).toInstance("X"),
                 binder -> binder.bind(String.class).toInstance("Z"));
@@ -58,8 +58,8 @@ public class TestConditionalModule
     public void testConditionalModuleWithPrefix()
     {
         Supplier<AbstractConfigurationAwareModule> moduleXY = () -> {
-            Module moduleX = conditionalModule(SomeConfig.class, "prefix", config -> config.getSomeOption().equals("x"), binder -> binder.bind(String.class).toInstance("X"));
-            Module moduleY = conditionalModule(SomeConfig.class, "prefix", config -> config.getSomeOption().equals("y"), binder -> binder.bind(String.class).toInstance("Y"));
+            Module moduleX = ConditionalModule.conditionalModule(SomeConfig.class, "prefix", config -> config.getSomeOption().equals("x"), binder -> binder.bind(String.class).toInstance("X"));
+            Module moduleY = ConditionalModule.conditionalModule(SomeConfig.class, "prefix", config -> config.getSomeOption().equals("y"), binder -> binder.bind(String.class).toInstance("Y"));
             return new AbstractConfigurationAwareModule()
             {
                 @Override
@@ -70,7 +70,7 @@ public class TestConditionalModule
                 }
             };
         };
-        Supplier<Module> moduleXElseZ = () -> conditionalModule(SomeConfig.class,
+        Supplier<Module> moduleXElseZ = () -> ConditionalModule.conditionalModule(SomeConfig.class,
                 "prefix",
                 config -> config.getSomeOption().equals("x"),
                 binder -> binder.bind(String.class).toInstance("X"),

--- a/configuration/src/test/java/io/airlift/configuration/TestConfig.java
+++ b/configuration/src/test/java/io/airlift/configuration/TestConfig.java
@@ -44,7 +44,6 @@ import static com.google.inject.name.Names.named;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.configuration.MyEnum.BAR;
 import static io.airlift.configuration.MyEnum.FOO;
-import static io.airlift.configuration.SwitchModule.switchModule;
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.PARAMETER;
@@ -281,6 +280,7 @@ public class TestConfig
                 new ConfigurationBinding<>(Key.get(AnotherConfig.class), AnotherConfig.class, Optional.empty())));
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testSwitchModule()
     {
@@ -295,7 +295,7 @@ public class TestConfig
                 ConfigBinder configBinder = configBinder(binder);
                 configBinder.bindConfig(SwitchConfig.class);
 
-                install(switchModule(
+                install(SwitchModule.switchModule(
                         SwitchConfig.class,
                         SwitchConfig::getValue,
                         value -> {

--- a/http-server/src/main/java/io/airlift/http/server/HttpServerModule.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServerModule.java
@@ -33,7 +33,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.inject.Scopes.SINGLETON;
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
-import static io.airlift.configuration.ConditionalModule.conditionalModule;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static java.util.Objects.requireNonNull;
 import static org.weakref.jmx.guice.ExportBinder.newExporter;
@@ -114,8 +113,9 @@ public class HttpServerModule
                     .toProvider(new HttpServerInfoProvider(qualifier))
                     .in(SINGLETON);
 
-        install(conditionalModule(qualifiedKey(HttpServerConfig.class), HttpServerConfig.class, configPrefix, HttpServerConfig::isHttpsEnabled, moduleBinder ->
-                configBinder(moduleBinder).bindConfig(qualifiedKey(HttpsConfig.class), HttpsConfig.class, configPrefix)));
+        if (buildConfigObject(qualifiedKey(HttpServerConfig.class), HttpServerConfig.class, configPrefix).isHttpsEnabled()) {
+            configBinder(binder).bindConfig(qualifiedKey(HttpsConfig.class), HttpsConfig.class, configPrefix);
+        }
 
         configBinder(binder).bindConfig(qualifiedKey(HttpServerConfig.class), HttpServerConfig.class, configPrefix);
     }

--- a/http-server/src/main/java/io/airlift/http/server/testing/TestingHttpServerModule.java
+++ b/http-server/src/main/java/io/airlift/http/server/testing/TestingHttpServerModule.java
@@ -29,7 +29,6 @@ import jakarta.servlet.Filter;
 
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
-import static io.airlift.configuration.ConditionalModule.conditionalModule;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.http.server.HttpServerBinder.HttpResourceBinding;
 
@@ -79,13 +78,13 @@ public class TestingHttpServerModule
         binder.bind(AnnouncementHttpServerInfo.class).to(LocalAnnouncementHttpServerInfo.class);
 
         newOptionalBinder(binder, HttpsConfig.class);
-        install(conditionalModule(HttpServerConfig.class, HttpServerConfig::isHttpsEnabled, moduleBinder -> {
-            configBinder(moduleBinder).bindConfig(HttpsConfig.class);
-            configBinder(moduleBinder).bindConfigDefaults(HttpsConfig.class, config -> {
+        if (buildConfigObject(HttpServerConfig.class).isHttpsEnabled()) {
+            configBinder(binder).bindConfig(HttpsConfig.class);
+            configBinder(binder).bindConfigDefaults(HttpsConfig.class, config -> {
                 if (httpPort == 0) {
                     config.setHttpsPort(0);
                 }
             });
-        }));
+        }
     }
 }


### PR DESCRIPTION
ConditionalModule and SwitchModule provides little value and they make
code unnecessarily complex.

Instead of using opaque abstraction, they can be replaced with regular java control syntax.

Consider ConditionalModule:

    install(conditionalModule(
            SomeConfig.class,
            config -> config.getSomeOption().equals("x"),
            binder -> binder.bind(String.class).toInstance("X")));

can be replaced with:

    SomeConfig testConfig = buildConfigObject(SomeConfig.class);
    if (testConfig.getSomeOption().equals("x")) {
	    binder.bind(String.class).toInstance("X");
    }

Consider SwitchModule:

    install(switchModule(
	    SomeConfig.class,
	    SomeConfig::getSomeOption,
	    value -> switch (value) {
		  case "x" -> binder -> binder.bind(String.class).toInstance("X");
		  default -> throw new IllegalArgumentException("Unsupported value: " + value);
	    }));

can be replaced with:

    SomeConfig someConfig = buildConfigObject(SomeConfig.class);
    switch (someConfig.getSomeOption()) {
	  case "x" -> binder.bind(String.class).toInstance("X");
	  default -> throw new IllegalArgumentException("Unsupported value: " + someConfig.getSomeOption());
    }

<!-- Thank you for submitting pull request to Airlift -->

# Airlift contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [x] All automated tests are passing.
 - [x] Pull request was categorized using one of the existing labels.
