### PR TITLE
[MCP Server] Make MCP tests that use async Java SDK client more resilient

### DIFF
--- a/mcp/src/test/java/io/airlift/mcp/TestMcp.java
+++ b/mcp/src/test/java/io/airlift/mcp/TestMcp.java
@@ -235,19 +235,19 @@ public abstract class TestMcp
 
         client1.mcpClient().callTool(new CallToolRequest("log", ImmutableMap.of()));
         client2.mcpClient().callTool(new CallToolRequest("log", ImmutableMap.of()));
-        assertThat(client1.logs()).isEmpty();
-        assertThat(client2.logs()).isEmpty();
+        assertThat(takeNFromQueue(client1.logs(), 1)).isEmpty();
+        assertThat(takeNFromQueue(client2.logs(), 1)).isEmpty();
 
         client1.mcpClient().setLoggingLevel(ALERT);
         client2.mcpClient().setLoggingLevel(DEBUG);
 
         client1.mcpClient().callTool(new CallToolRequest("log", ImmutableMap.of()));
-        assertThat(client1.logs()).containsExactly("This is alert");
+        assertThat(takeNFromQueue(client1.logs(), 2)).containsExactly("This is alert");
         assertThat(client2.logs()).isEmpty();
 
         client2.mcpClient().callTool(new CallToolRequest("log", ImmutableMap.of()));
-        assertThat(client1.logs()).containsExactly("This is alert");
-        assertThat(client2.logs()).containsExactlyInAnyOrder("This is alert", "This is debug");
+        assertThat(takeNFromQueue(client1.logs(), 1)).isEmpty();
+        assertThat(takeNFromQueue(client2.logs(), 2)).containsExactlyInAnyOrder("This is alert", "This is debug");
     }
 
     @Test
@@ -258,12 +258,12 @@ public abstract class TestMcp
                 .collect(toImmutableList());
 
         client1.mcpClient().callTool(new CallToolRequest("progress", ImmutableMap.of()));
-        assertThat(client1.progress()).isEqualTo(expectedProgress);
-        assertThat(client2.progress()).isEmpty();
+        assertThat(takeNFromQueue(client1.progress(), 101)).isEqualTo(expectedProgress);
+        assertThat(takeNFromQueue(client2.progress(), 1)).isEmpty();
 
         client2.mcpClient().callTool(new CallToolRequest("progress", ImmutableMap.of()));
-        assertThat(client1.progress()).isEqualTo(expectedProgress);
-        assertThat(client2.progress()).isEqualTo(expectedProgress);
+        assertThat(takeNFromQueue(client1.progress(), 1)).isEmpty();
+        assertThat(takeNFromQueue(client2.progress(), 101)).isEqualTo(expectedProgress);
     }
 
     @Test
@@ -696,5 +696,24 @@ public abstract class TestMcp
                 .extracting(McpError::getJsonRpcError)
                 .extracting(JSONRPCError::code, JSONRPCError::message)
                 .contains(code, message);
+    }
+
+    private List<String> takeNFromQueue(BlockingQueue<String> queue, int qty)
+    {
+        ImmutableList.Builder<String> builder = ImmutableList.builder();
+        while (qty-- > 0) {
+            try {
+                String value = queue.poll(250, MILLISECONDS);
+                if (value == null) {
+                    break;
+                }
+                builder.add(value);
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+        }
+        return builder.build();
     }
 }

--- a/mcp/src/test/java/io/airlift/mcp/TestingClient.java
+++ b/mcp/src/test/java/io/airlift/mcp/TestingClient.java
@@ -10,9 +10,7 @@ import io.modelcontextprotocol.spec.McpSchema;
 
 import java.io.Closeable;
 import java.time.Duration;
-import java.util.List;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import static io.airlift.mcp.TestingIdentityMapper.EXPECTED_IDENTITY;
@@ -20,7 +18,7 @@ import static io.airlift.mcp.TestingIdentityMapper.IDENTITY_HEADER;
 import static io.modelcontextprotocol.spec.McpSchema.ElicitResult.Action.ACCEPT;
 import static java.util.Objects.requireNonNull;
 
-public record TestingClient(String name, McpSyncClient mcpClient, List<String> logs, List<String> progress, BlockingQueue<String> changes)
+public record TestingClient(String name, McpSyncClient mcpClient, BlockingQueue<String> logs, BlockingQueue<String> progress, BlockingQueue<String> changes)
         implements Closeable
 {
     public TestingClient
@@ -61,8 +59,8 @@ public record TestingClient(String name, McpSyncClient mcpClient, List<String> l
 
     public static TestingClient buildClient(Closer closer, String name, McpClientTransport clientTransport)
     {
-        List<String> logs = new CopyOnWriteArrayList<>();
-        List<String> progress = new CopyOnWriteArrayList<>();
+        BlockingQueue<String> logs = new LinkedBlockingQueue<>();
+        BlockingQueue<String> progress = new LinkedBlockingQueue<>();
         BlockingQueue<String> changes = new LinkedBlockingQueue<>();
 
         // can't record resource subscription changes until https://github.com/modelcontextprotocol/java-sdk/pull/735 is accepted/merged


### PR DESCRIPTION
The Java MCP SDK is inherently async. This is making some tests flakey as the client does not update lists synchronously. Change to using blocking queues so that they can be polled.

# Airlift contribution check list

 - [X] Git commit messages follow https://cbea.ms/git-commit/.
 - [X] All automated tests are passing.
 - [x] Pull request was categorized using one of the existing labels.
