### PR TITLE
Add documentation comparing Airlift API Builder to JAX-RS + Swagger

### DIFF
--- a/api/docs/why.md
+++ b/api/docs/why.md
@@ -98,7 +98,7 @@ The same resource with Airlift API Builder:
 @ResourceSecurity(AUTHENTICATED_USER)
 public class RoleResource
 {
-    @List(description = "...")
+    @ApiList(description = "...")
     public List<Role> listAll(@Context UserInfo userInfo)
     {
         return roleApi.listAll(userInfo);


### PR DESCRIPTION
Explains benefits of migrating from traditional JAX-RS + Swagger approach to Airlift API Builder with concrete code examples:

- 60-75% reduction in annotation boilerplate per endpoint
- Automatic OpenAPI generation at /public/openapi/v1/json
- Framework-enforced HTTP status codes (201 for create, 204 for delete)
- Built-in pagination, filtering, and validation dry-run support
- Prevention of schema drift and undocumented endpoints
- Alignment with Google Cloud API Design Guide principles
