### PR TITLE
Support async cancellations during HTTP sync execution

### DIFF
--- a/http-client/src/main/java/io/airlift/http/client/HttpClient.java
+++ b/http-client/src/main/java/io/airlift/http/client/HttpClient.java
@@ -22,7 +22,13 @@ import java.io.Closeable;
 public interface HttpClient
         extends Closeable
 {
-    <T, E extends Exception> T execute(Request request, ResponseHandler<T, E> responseHandler)
+    default <T, E extends Exception> T execute(Request request, ResponseHandler<T, E> responseHandler)
+            throws E
+    {
+        return execute(request, RequestLifecycleHandler.create(), responseHandler);
+    }
+
+    <T, E extends Exception> T execute(Request request, RequestLifecycleHandler lifecycleHandler, ResponseHandler<T, E> responseHandler)
             throws E;
 
     <T, E extends Exception> HttpResponseFuture<T> executeAsync(Request request, ResponseHandler<T, E> responseHandler);

--- a/http-client/src/main/java/io/airlift/http/client/RequestLifecycleHandler.java
+++ b/http-client/src/main/java/io/airlift/http/client/RequestLifecycleHandler.java
@@ -1,0 +1,41 @@
+package io.airlift.http.client;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+
+import static java.util.Objects.requireNonNull;
+
+public final class RequestLifecycleHandler
+{
+    public static RequestLifecycleHandler create()
+    {
+        return new RequestLifecycleHandler();
+    }
+
+    private SettableFuture<?> cancelled;
+
+    private RequestLifecycleHandler()
+    {
+        this.cancelled = SettableFuture.create();
+    }
+
+    public void cancel()
+    {
+        requireNonNull(cancelled, "handler is destroyed").set(null);
+    }
+
+    public void destroy()
+    {
+        // Prevent reuse of the lifecycle handler. Allowing reuse would require resetting listeners on the cancelled future,
+        // or otherwise we would get a memory leak.
+        cancelled = null;
+    }
+
+    /**
+     * Returns the cancellation future. Typically used by the HTTP client implementation.
+     */
+    public ListenableFuture<?> cancelled()
+    {
+        return requireNonNull(cancelled, "handler is destroyed");
+    }
+}

--- a/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
@@ -13,6 +13,7 @@ import io.airlift.http.client.HttpClientConfig;
 import io.airlift.http.client.HttpRequestFilter;
 import io.airlift.http.client.HttpStatusListener;
 import io.airlift.http.client.Request;
+import io.airlift.http.client.RequestLifecycleHandler;
 import io.airlift.http.client.RequestStats;
 import io.airlift.http.client.ResponseHandler;
 import io.airlift.http.client.StaticBodyGenerator;
@@ -117,6 +118,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.net.InetAddresses.isInetAddress;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.http.client.ResponseHandlerUtils.propagate;
 import static io.airlift.node.AddressToHostname.tryDecodeHostnameToAddress;
 import static io.airlift.security.mtls.AutomaticMtls.addClientTrust;
@@ -656,7 +658,7 @@ public class JettyHttpClient
     }
 
     @Override
-    public <T, E extends Exception> T execute(Request request, ResponseHandler<T, E> responseHandler)
+    public <T, E extends Exception> T execute(Request request, RequestLifecycleHandler lifecycleHandler, ResponseHandler<T, E> responseHandler)
             throws E
     {
         request = applyRequestFilters(request);
@@ -665,7 +667,12 @@ public class JettyHttpClient
         request = injectTracing(request, span);
 
         try {
-            InternalResponse<T> internalResponse = internalExecute(request, OptionalLong.of(getMaxResponseContentLength(request).toBytes()), responseHandler::handleException, span);
+            InternalResponse<T> internalResponse = internalExecute(
+                    request,
+                    lifecycleHandler,
+                    OptionalLong.of(getMaxResponseContentLength(request).toBytes()),
+                    responseHandler::handleException,
+                    span);
             return switch (internalResponse) {
                 case InternalExceptionResponse<T> response -> response.exceptionResponse;
                 case InternalStandardResponse<T> response -> {
@@ -685,6 +692,7 @@ public class JettyHttpClient
         }
         finally {
             span.end();
+            lifecycleHandler.destroy();
         }
     }
 
@@ -708,7 +716,8 @@ public class JettyHttpClient
             }
         };
 
-        return switch (internalExecute(request, OptionalLong.empty(), exceptionHandler, span)) {
+        InternalResponse<StreamingResponse> internalResponse = internalExecute(request, RequestLifecycleHandler.create(), OptionalLong.empty(), exceptionHandler, span);
+        return switch (internalResponse) {
             case InternalExceptionResponse<StreamingResponse> response -> response.exceptionResponse;
             case InternalStandardResponse<StreamingResponse> response -> new StreamingResponse()
             {
@@ -785,7 +794,12 @@ public class JettyHttpClient
         }
     }
 
-    private <T, E extends Exception> InternalResponse<T> internalExecute(Request request, OptionalLong maxResponseContentLength, ExceptionHandler<T, E> exceptionHandler, Span span)
+    private <T, E extends Exception> InternalResponse<T> internalExecute(
+            Request request,
+            RequestLifecycleHandler lifecycleHandler,
+            OptionalLong maxResponseContentLength,
+            ExceptionHandler<T, E> exceptionHandler,
+            Span span)
             throws E
     {
         long requestStart = System.nanoTime();
@@ -796,6 +810,7 @@ public class JettyHttpClient
         InputStreamResponseListener listener = new InputStreamResponseListener();
         // fire the request
         context.request().send(listener);
+        lifecycleHandler.cancelled().addListener(() -> context.request().abort(RequestCancelledException.INSTANCE), directExecutor());
 
         // wait for response to begin
         Response response;

--- a/http-client/src/main/java/io/airlift/http/client/testing/TestingHttpClient.java
+++ b/http-client/src/main/java/io/airlift/http/client/testing/TestingHttpClient.java
@@ -5,6 +5,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import io.airlift.http.client.HttpClient;
 import io.airlift.http.client.Request;
+import io.airlift.http.client.RequestLifecycleHandler;
 import io.airlift.http.client.RequestStats;
 import io.airlift.http.client.Response;
 import io.airlift.http.client.ResponseHandler;
@@ -55,10 +56,11 @@ public class TestingHttpClient
     }
 
     @Override
-    public <T, E extends Exception> T execute(Request request, ResponseHandler<T, E> responseHandler)
+    public <T, E extends Exception> T execute(Request request, RequestLifecycleHandler lifecycleHandler, ResponseHandler<T, E> responseHandler)
             throws E
     {
         requireNonNull(request, "request is null");
+        requireNonNull(lifecycleHandler, "lifecycleHandler is null");
         requireNonNull(responseHandler, "responseHandler is null");
         checkState(!closed.get(), "client is closed");
         return execute(request, responseHandler, new AtomicReference<>("SENDING_REQUEST"));


### PR DESCRIPTION
Provide a way to asynchronously cancel HTTP requests executing using
synchronous `HttpClient.execute` API.

This is similar to cancellation available in `executeAsync`. The
synchronous API has the advantage of not buffering the response data
before invoking the request handler.


