### PR TITLE
[MCP Server] Update to MCP SDK 0.17.2

### DIFF
--- a/mcp/src/test/java/io/airlift/mcp/TestingClient.java
+++ b/mcp/src/test/java/io/airlift/mcp/TestingClient.java
@@ -63,8 +63,6 @@ public record TestingClient(String name, McpSyncClient mcpClient, BlockingQueue<
         BlockingQueue<String> progress = new LinkedBlockingQueue<>();
         BlockingQueue<String> changes = new LinkedBlockingQueue<>();
 
-        // can't record resource subscription changes until https://github.com/modelcontextprotocol/java-sdk/pull/735 is accepted/merged
-
         McpSyncClient client = McpClient.sync(clientTransport)
                 .requestTimeout(Duration.ofMinutes(1))
                 .capabilities(McpSchema.ClientCapabilities.builder().roots(true).sampling().elicitation().build())
@@ -74,6 +72,7 @@ public record TestingClient(String name, McpSyncClient mcpClient, BlockingQueue<
                 .toolsChangeConsumer(_ -> changes.add("tools"))
                 .promptsChangeConsumer(_ -> changes.add("prompts"))
                 .resourcesChangeConsumer(resources -> resources.forEach(resource -> changes.add(resource.uri())))
+                .resourcesUpdateConsumer(resources -> resources.forEach(resource -> changes.add(resource.uri())))
                 .build();
         client.initialize();
 

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <dep.airlift.version>395-SNAPSHOT</dep.airlift.version>
         <dep.brotli4j.version>1.20.0</dep.brotli4j.version>
         <dep.bouncycastle.version>1.83</dep.bouncycastle.version>
-        <dep.mcp.sdk.version>0.17.1</dep.mcp.sdk.version>
+        <dep.mcp.sdk.version>0.17.2</dep.mcp.sdk.version>
         <dep.jersey.version>4.0.0</dep.jersey.version>
         <dep.jjwt.version>0.13.0</dep.jjwt.version>
     </properties>


### PR DESCRIPTION
This allows us to test for resource subscriptions now that my PR has been merged: https://github.com/modelcontextprotocol/java-sdk/pull/735

# Airlift contribution check list

 - [X] Git commit messages follow https://cbea.ms/git-commit/.
 - [X] All automated tests are passing.
 - [x] Pull request was categorized using one of the existing labels.
