### PR TITLE
Reduce data copying in HTTP async JSON requests

### DIFF
--- a/http-client/src/main/java/io/airlift/http/client/FullJsonResponseHandler.java
+++ b/http-client/src/main/java/io/airlift/http/client/FullJsonResponseHandler.java
@@ -27,8 +27,8 @@ import java.util.List;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
+import static io.airlift.http.client.ResponseHandlerUtils.getResponseBytes;
 import static io.airlift.http.client.ResponseHandlerUtils.propagate;
-import static io.airlift.http.client.ResponseHandlerUtils.readResponseBytes;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
@@ -59,7 +59,7 @@ public class FullJsonResponseHandler<T>
     @Override
     public JsonResponse<T> handle(Request request, Response response)
     {
-        byte[] bytes = readResponseBytes(request, response);
+        byte[] bytes = getResponseBytes(request, response);
         String contentType = response.getHeader(CONTENT_TYPE);
         if ((contentType == null) || !MediaType.parse(contentType).is(MEDIA_TYPE_JSON)) {
             return new JsonResponse<>(response.getStatusCode(), response.getHeaders(), bytes);

--- a/http-client/src/main/java/io/airlift/http/client/Response.java
+++ b/http-client/src/main/java/io/airlift/http/client/Response.java
@@ -15,12 +15,15 @@
  */
 package io.airlift.http.client;
 
+import com.google.common.annotations.Beta;
 import com.google.common.collect.ListMultimap;
 import jakarta.annotation.Nullable;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
+
+import static java.util.Objects.requireNonNull;
 
 public interface Response
 {
@@ -42,8 +45,39 @@ public interface Response
 
     ListMultimap<HeaderName, String> getHeaders();
 
-    long getBytesRead();
+    @Beta
+    Content getContent();
 
+    // TODO eventually deprecate in favor of getContent()
     InputStream getInputStream()
             throws IOException;
+
+    /**
+     * Returns number of bytes read via {@link #getContent()} or {@link #getInputStream()}.
+     */
+    long getBytesRead();
+
+    @Beta
+    sealed interface Content
+            permits BytesContent, InputStreamContent {}
+
+    @Beta
+    record BytesContent(byte[] bytes)
+            implements Content
+    {
+        public BytesContent
+        {
+            requireNonNull(bytes, "bytes is null");
+        }
+    }
+
+    @Beta
+    record InputStreamContent(InputStream inputStream)
+            implements Content
+    {
+        public InputStreamContent
+        {
+            requireNonNull(inputStream, "inputStream is null");
+        }
+    }
 }

--- a/http-client/src/main/java/io/airlift/http/client/ResponseHandlerUtils.java
+++ b/http-client/src/main/java/io/airlift/http/client/ResponseHandlerUtils.java
@@ -1,6 +1,7 @@
 package io.airlift.http.client;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.net.ConnectException;
 
@@ -24,10 +25,13 @@ public final class ResponseHandlerUtils
         throw new RuntimeException(exception);
     }
 
-    public static byte[] readResponseBytes(Request request, Response response)
+    public static byte[] getResponseBytes(Request request, Response response)
     {
         try {
-            return response.getInputStream().readAllBytes();
+            return switch (response.getContent()) {
+                case Response.BytesContent(byte[] bytes) -> bytes;
+                case Response.InputStreamContent(InputStream inputStream) -> inputStream.readAllBytes();
+            };
         }
         catch (IOException e) {
             throw new UncheckedIOException("Failed reading response from server: " + urlFor(request), e);

--- a/http-client/src/main/java/io/airlift/http/client/StringResponseHandler.java
+++ b/http-client/src/main/java/io/airlift/http/client/StringResponseHandler.java
@@ -26,8 +26,8 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
+import static io.airlift.http.client.ResponseHandlerUtils.getResponseBytes;
 import static io.airlift.http.client.ResponseHandlerUtils.propagate;
-import static io.airlift.http.client.ResponseHandlerUtils.readResponseBytes;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class StringResponseHandler
@@ -53,7 +53,7 @@ public class StringResponseHandler
     @Override
     public StringResponse handle(Request request, Response response)
     {
-        byte[] bytes = readResponseBytes(request, response);
+        byte[] bytes = getResponseBytes(request, response);
 
         Charset charset = Optional.ofNullable(response.getHeader(CONTENT_TYPE))
                 .map(MediaType::parse)

--- a/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
@@ -731,15 +731,21 @@ public class JettyHttpClient
                 }
 
                 @Override
-                public long getBytesRead()
+                public Content getContent()
                 {
-                    return response.jettyResponse.getBytesRead();
+                    return response.jettyResponse.getContent();
                 }
 
                 @Override
                 public InputStream getInputStream()
                 {
                     return response.jettyResponse.getInputStream();
+                }
+
+                @Override
+                public long getBytesRead()
+                {
+                    return response.jettyResponse.getBytesRead();
                 }
 
                 @Override

--- a/http-client/src/main/java/io/airlift/http/client/jetty/JettyResponseFuture.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/JettyResponseFuture.java
@@ -13,7 +13,6 @@ import io.opentelemetry.semconv.NetworkAttributes;
 import io.opentelemetry.semconv.incubating.HttpIncubatingAttributes;
 import org.eclipse.jetty.client.Response;
 
-import java.io.InputStream;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.LongSupplier;
@@ -89,7 +88,7 @@ class JettyResponseFuture<T, E extends Exception>
         }
     }
 
-    void completed(Response response, InputStream content)
+    void completed(Response response, byte[] content)
     {
         if (state.get() == JettyAsyncHttpState.CANCELED) {
             return;
@@ -120,7 +119,7 @@ class JettyResponseFuture<T, E extends Exception>
         span.end();
     }
 
-    private T processResponse(Response response, InputStream content)
+    private T processResponse(Response response, byte[] content)
             throws E
     {
         // this time will not include the data fetching portion of the response,

--- a/http-client/src/main/java/io/airlift/http/client/jetty/JettyResponseListener.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/JettyResponseListener.java
@@ -7,6 +7,7 @@ import org.eclipse.jetty.client.Result;
 import static java.util.Objects.requireNonNull;
 
 class JettyResponseListener<T, E extends Exception>
+        // TODO use RetainingResponseListener to reduce data copying?
         extends BufferingResponseListener
 {
     private final Request request;
@@ -32,7 +33,11 @@ class JettyResponseListener<T, E extends Exception>
             future.failed(result.getFailure());
         }
         else {
-            future.completed(result.getResponse(), getContentAsInputStream());
+            // TODO it would be better to return response data as InputStream based on Jetty chunks, without any data copying
+            // There is no such builtin Jetty response listener to use, see https://github.com/jetty/jetty.project/issues/14373.
+            // Doing so would also require removal of data buffering in e.g. `JsonResponseHandler` which is used for error reporting.
+            // Perhaps buffering for errors could be done only on retries?
+            future.completed(result.getResponse(), getContent());
         }
     }
 }

--- a/http-client/src/test/java/io/airlift/http/client/jetty/TestingStreamingResponse.java
+++ b/http-client/src/test/java/io/airlift/http/client/jetty/TestingStreamingResponse.java
@@ -87,9 +87,9 @@ public class TestingStreamingResponse
     }
 
     @Override
-    public long getBytesRead()
+    public Content getContent()
     {
-        return delegate.getBytesRead();
+        return delegate.getContent();
     }
 
     @Override
@@ -97,6 +97,12 @@ public class TestingStreamingResponse
             throws IOException
     {
         return delegate.getInputStream();
+    }
+
+    @Override
+    public long getBytesRead()
+    {
+        return delegate.getBytesRead();
     }
 
     @Override


### PR DESCRIPTION
When performing async HTTP requests (`JettyHttpClient.executeAsync`) to get JSON data (using `JsonResponseHandler`), the response data gets copied a few times along the way.

Before the changes the flow is:

0. Jetty receives data from socket and has it in chunks
1. `JettyResponseListener` extends `BufferingResponseListener`, so it supposedly copies incoming chunks into internal buffer(s).
2. `JettyResponseListener.onComplete` asks for an `InputStream`. It gets `ByteArrayInputStream` over a fresh `byte[]` buffer.
3. `JsonResponseHandler` calls `InputStream.readAllBytes()`, which is another data copy.

This commit combines points (2) and (3) together. The `InputStream.readAllBytes()` is skipped, because `JettyResponseListener` operates directly on content bytes and exposes them to response handler.

Potential follow-ups

- Switching from `BufferingResponseListener` to `RetainingResponseListener` to avoid data copy in (1). This change needs to make sure we don't run out of Jetty buffers or anything like that.

- Switch `JsonResponseHandler` to operate directly on `InputStream`. It uses `byte[]` for error reporting though.
