### PR TITLE
Add MCP capability filtering

### DIFF
--- a/mcp/src/main/java/io/airlift/mcp/AllowAllCapabilityFilter.java
+++ b/mcp/src/main/java/io/airlift/mcp/AllowAllCapabilityFilter.java
@@ -1,0 +1,42 @@
+package io.airlift.mcp;
+
+import io.airlift.mcp.McpIdentity.Authenticated;
+import io.airlift.mcp.model.CompleteReference;
+import io.airlift.mcp.model.Prompt;
+import io.airlift.mcp.model.Resource;
+import io.airlift.mcp.model.ResourceTemplate;
+import io.airlift.mcp.model.Tool;
+
+class AllowAllCapabilityFilter
+        implements McpCapabilityFilter
+{
+    @Override
+    public boolean isAllowed(Authenticated<?> identity, Tool tool)
+    {
+        return true;
+    }
+
+    @Override
+    public boolean isAllowed(Authenticated<?> identity, Prompt prompt)
+    {
+        return true;
+    }
+
+    @Override
+    public boolean isAllowed(Authenticated<?> identity, Resource resource)
+    {
+        return true;
+    }
+
+    @Override
+    public boolean isAllowed(Authenticated<?> identity, ResourceTemplate resourceTemplate)
+    {
+        return true;
+    }
+
+    @Override
+    public boolean isAllowed(Authenticated<?> identity, CompleteReference reference)
+    {
+        return true;
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/McpCapabilityFilter.java
+++ b/mcp/src/main/java/io/airlift/mcp/McpCapabilityFilter.java
@@ -1,0 +1,56 @@
+package io.airlift.mcp;
+
+import io.airlift.mcp.McpIdentity.Authenticated;
+import io.airlift.mcp.model.CompleteReference;
+import io.airlift.mcp.model.Prompt;
+import io.airlift.mcp.model.Resource;
+import io.airlift.mcp.model.ResourceTemplate;
+import io.airlift.mcp.model.Tool;
+
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+/**
+ * Filter for controlling access to MCP capabilities based on authenticated identity.
+ */
+public interface McpCapabilityFilter
+{
+    boolean isAllowed(Authenticated<?> identity, Tool tool);
+
+    boolean isAllowed(Authenticated<?> identity, Prompt prompt);
+
+    boolean isAllowed(Authenticated<?> identity, Resource resource);
+
+    boolean isAllowed(Authenticated<?> identity, ResourceTemplate resourceTemplate);
+
+    boolean isAllowed(Authenticated<?> identity, CompleteReference reference);
+
+    default List<Tool> allowedTools(Authenticated<?> identity, List<Tool> tools)
+    {
+        return tools.stream()
+                .filter(tool -> isAllowed(identity, tool))
+                .collect(toImmutableList());
+    }
+
+    default List<Prompt> allowedPrompts(Authenticated<?> identity, List<Prompt> prompts)
+    {
+        return prompts.stream()
+                .filter(prompt -> isAllowed(identity, prompt))
+                .collect(toImmutableList());
+    }
+
+    default List<Resource> allowedResources(Authenticated<?> identity, List<Resource> resources)
+    {
+        return resources.stream()
+                .filter(resource -> isAllowed(identity, resource))
+                .collect(toImmutableList());
+    }
+
+    default List<ResourceTemplate> allowedResourceTemplates(Authenticated<?> identity, List<ResourceTemplate> resourceTemplates)
+    {
+        return resourceTemplates.stream()
+                .filter(resourceTemplate -> isAllowed(identity, resourceTemplate))
+                .collect(toImmutableList());
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/internal/InternalFilter.java
+++ b/mcp/src/main/java/io/airlift/mcp/internal/InternalFilter.java
@@ -382,15 +382,15 @@ public class InternalFilter
 
         Object result = switch (rpcMethod) {
             case METHOD_INITIALIZE -> mcpServer.initialize(request, response, authenticated, convertParams(rpcRequest, InitializeRequest.class));
-            case METHOD_TOOLS_LIST -> withManagement(request, requestId, messageWriter, () -> mcpServer.listTools(currentProtocol, convertParams(rpcRequest, ListRequest.class)));
-            case METHOD_TOOLS_CALL -> withManagement(request, requestId, messageWriter, () -> mcpServer.callTool(request, messageWriter, convertParams(rpcRequest, CallToolRequest.class)));
-            case METHOD_PROMPT_LIST -> withManagement(request, requestId, messageWriter, () -> mcpServer.listPrompts(currentProtocol, convertParams(rpcRequest, ListRequest.class)));
-            case METHOD_PROMPT_GET -> withManagement(request, requestId, messageWriter, () -> mcpServer.getPrompt(request, messageWriter, convertParams(rpcRequest, GetPromptRequest.class)));
-            case METHOD_RESOURCES_LIST -> withManagement(request, requestId, messageWriter, () -> mcpServer.listResources(currentProtocol, convertParams(rpcRequest, ListRequest.class)));
-            case METHOD_RESOURCES_TEMPLATES_LIST -> withManagement(request, requestId, messageWriter, () -> mcpServer.listResourceTemplates(currentProtocol, convertParams(rpcRequest, ListRequest.class)));
-            case METHOD_RESOURCES_READ -> withManagement(request, requestId, messageWriter, () -> mcpServer.readResources(request, messageWriter, convertParams(rpcRequest, ReadResourceRequest.class)));
+            case METHOD_TOOLS_LIST -> withManagement(request, requestId, messageWriter, () -> mcpServer.listTools(currentProtocol, authenticated, convertParams(rpcRequest, ListRequest.class)));
+            case METHOD_TOOLS_CALL -> withManagement(request, requestId, messageWriter, () -> mcpServer.callTool(request, authenticated, messageWriter, convertParams(rpcRequest, CallToolRequest.class)));
+            case METHOD_PROMPT_LIST -> withManagement(request, requestId, messageWriter, () -> mcpServer.listPrompts(currentProtocol, authenticated, convertParams(rpcRequest, ListRequest.class)));
+            case METHOD_PROMPT_GET -> withManagement(request, requestId, messageWriter, () -> mcpServer.getPrompt(request, authenticated, messageWriter, convertParams(rpcRequest, GetPromptRequest.class)));
+            case METHOD_RESOURCES_LIST -> withManagement(request, requestId, messageWriter, () -> mcpServer.listResources(currentProtocol, authenticated, convertParams(rpcRequest, ListRequest.class)));
+            case METHOD_RESOURCES_TEMPLATES_LIST -> withManagement(request, requestId, messageWriter, () -> mcpServer.listResourceTemplates(currentProtocol, authenticated, convertParams(rpcRequest, ListRequest.class)));
+            case METHOD_RESOURCES_READ -> withManagement(request, requestId, messageWriter, () -> mcpServer.readResources(request, authenticated, messageWriter, convertParams(rpcRequest, ReadResourceRequest.class)));
             case METHOD_PING -> ImmutableMap.of();
-            case METHOD_COMPLETION_COMPLETE -> mcpServer.completionComplete(request, messageWriter, convertParams(rpcRequest, CompleteRequest.class));
+            case METHOD_COMPLETION_COMPLETE -> mcpServer.completionComplete(request, authenticated, messageWriter, convertParams(rpcRequest, CompleteRequest.class));
             case METHOD_LOGGING_SET_LEVEL -> mcpServer.setLoggingLevel(request, convertParams(rpcRequest, SetLevelRequest.class));
             case METHOD_RESOURCES_SUBSCRIBE -> mcpServer.resourcesSubscribe(request, messageWriter, convertParams(rpcRequest, SubscribeRequest.class));
             case METHOD_RESOURCES_UNSUBSCRIBE -> mcpServer.resourcesUnsubscribe(request, convertParams(rpcRequest, SubscribeRequest.class));

--- a/mcp/src/test/java/io/airlift/mcp/TestMcp.java
+++ b/mcp/src/test/java/io/airlift/mcp/TestMcp.java
@@ -736,7 +736,7 @@ public abstract class TestMcp
         return assertThat(result);
     }
 
-    private void assertMcpError(Throwable throwable, int code, String message)
+    public static void assertMcpError(Throwable throwable, int code, String message)
     {
         assertThat(throwable)
                 .asInstanceOf(type(McpError.class))

--- a/mcp/src/test/java/io/airlift/mcp/TestMcpCapabilityFiltering.java
+++ b/mcp/src/test/java/io/airlift/mcp/TestMcpCapabilityFiltering.java
@@ -1,0 +1,465 @@
+package io.airlift.mcp;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Closer;
+import io.airlift.http.server.testing.TestingHttpServer;
+import io.airlift.mcp.McpIdentity.Authenticated;
+import io.airlift.mcp.model.CallToolResult;
+import io.airlift.mcp.model.CompleteReference;
+import io.airlift.mcp.model.CompleteRequest.CompleteArgument;
+import io.airlift.mcp.model.Content.TextContent;
+import io.airlift.mcp.model.GetPromptResult;
+import io.airlift.mcp.model.Prompt;
+import io.airlift.mcp.model.Resource;
+import io.airlift.mcp.model.ResourceContents;
+import io.airlift.mcp.model.ResourceTemplate;
+import io.airlift.mcp.model.ResourceTemplateValues;
+import io.airlift.mcp.model.Role;
+import io.airlift.mcp.model.Tool;
+import io.airlift.mcp.sessions.MemorySessionController;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CompleteRequest;
+import io.modelcontextprotocol.spec.McpSchema.CompleteResult;
+import io.modelcontextprotocol.spec.McpSchema.GetPromptRequest;
+import io.modelcontextprotocol.spec.McpSchema.ListPromptsResult;
+import io.modelcontextprotocol.spec.McpSchema.ListResourceTemplatesResult;
+import io.modelcontextprotocol.spec.McpSchema.ListResourcesResult;
+import io.modelcontextprotocol.spec.McpSchema.ListToolsResult;
+import io.modelcontextprotocol.spec.McpSchema.PromptReference;
+import io.modelcontextprotocol.spec.McpSchema.ReadResourceRequest;
+import io.modelcontextprotocol.spec.McpSchema.ReadResourceResult;
+import io.modelcontextprotocol.spec.McpSchema.ResourceReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.inject.Scopes.SINGLETON;
+import static io.airlift.mcp.TestMcp.assertMcpError;
+import static io.airlift.mcp.TestingIdentityMapper.ANOTHER_IDENTITY;
+import static io.airlift.mcp.TestingIdentityMapper.EXPECTED_IDENTITY;
+import static io.modelcontextprotocol.spec.McpSchema.ErrorCodes.INVALID_PARAMS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestMcpCapabilityFiltering
+{
+    private final Closer closer = Closer.create();
+
+    @AfterEach
+    public void teardown()
+            throws IOException
+    {
+        closer.close();
+    }
+
+    @Test
+    public void testNoFilterAllowsAll()
+    {
+        // Setup MCP server without filter to get the default 'allow all' filter
+        TestingServer testingServer = new TestingServer(
+                ImmutableMap.of(),
+                Optional.empty(),
+                builder -> builder
+                        .withIdentityMapper(TestingIdentity.class, binding -> binding.to(TestingIdentityMapper.class).in(SINGLETON))
+                        .withSessions(binding -> binding.to(MemorySessionController.class).in(SINGLETON))
+                        .withAllInClass(TestFilteringEnabledEndpoints.class)
+                        .build());
+        closer.register(testingServer);
+
+        String baseUri = testingServer.injector().getInstance(TestingHttpServer.class).getBaseUrl().toString();
+        TestingClient client = TestingClient.buildClient(closer, baseUri, "testUser");
+
+        // Verify all tools are visible
+        ListToolsResult tools = client.mcpClient().listTools();
+        assertThat(tools.tools().stream().map(McpSchema.Tool::name).collect(toImmutableList()))
+                .containsExactlyInAnyOrder("public-tool", "admin-tool");
+
+        // Verify all prompts are visible
+        ListPromptsResult prompts = client.mcpClient().listPrompts();
+        assertThat(prompts.prompts().stream().map(McpSchema.Prompt::name).collect(toImmutableList()))
+                .containsExactlyInAnyOrder("public-prompt", "admin-prompt");
+
+        // Verify all resources are visible
+        ListResourcesResult resources = client.mcpClient().listResources();
+        assertThat(resources.resources().stream().map(McpSchema.Resource::uri).collect(toImmutableList()))
+                .containsExactlyInAnyOrder("file://public-resource.txt", "file://admin-resource.txt");
+
+        // Verify all resource templates are visible
+        ListResourceTemplatesResult resourceTemplates = client.mcpClient().listResourceTemplates();
+        assertThat(resourceTemplates.resourceTemplates().stream().map(McpSchema.ResourceTemplate::uriTemplate).collect(toImmutableList()))
+                .containsExactlyInAnyOrder("file://public/{name}", "file://admin/{name}");
+
+        // Verify all tools can be invoked
+        McpSchema.CallToolResult publicToolResult = client.mcpClient().callTool(new CallToolRequest("public-tool", ImmutableMap.of()));
+        assertThat(publicToolResult.content()).hasSize(1);
+
+        McpSchema.CallToolResult adminToolResult = client.mcpClient().callTool(new CallToolRequest("admin-tool", ImmutableMap.of()));
+        assertThat(adminToolResult.content()).hasSize(1);
+    }
+
+    @Test
+    public void testFilteringTools()
+    {
+        // Setup MCP server with role-based filter
+        TestingServer testingServer = new TestingServer(
+                ImmutableMap.of(),
+                Optional.empty(),
+                builder -> builder
+                        .withIdentityMapper(TestingIdentity.class, binding -> binding.to(TestingIdentityMapper.class).in(SINGLETON))
+                        .withSessions(binding -> binding.to(MemorySessionController.class).in(SINGLETON))
+                        .withCapabilityFilter(binding -> binding.toInstance(new TestMcpCapabilityFilter()))
+                        .withAllInClass(TestFilteringEnabledEndpoints.class)
+                        .build());
+        closer.register(testingServer);
+
+        String baseUri = testingServer.injector().getInstance(TestingHttpServer.class).getBaseUrl().toString();
+        TestingClient client = TestingClient.buildClient(closer, baseUri, ANOTHER_IDENTITY, ANOTHER_IDENTITY);
+
+        // Verify only public tools are visible
+        ListToolsResult tools = client.mcpClient().listTools();
+        assertThat(tools.tools().stream().map(McpSchema.Tool::name).collect(toImmutableList()))
+                .containsOnly("public-tool");
+
+        // Verify public tool can be invoked, but admin cannot
+        McpSchema.CallToolResult publicToolResult = client.mcpClient().callTool(new CallToolRequest("public-tool", ImmutableMap.of()));
+        assertThat(publicToolResult.content()).hasSize(1);
+        McpSchema.CallToolResult adminToolResult = client.mcpClient().callTool(new CallToolRequest("admin-tool", ImmutableMap.of()));
+        assertThat(adminToolResult.content()).hasSize(1).containsOnly(new McpSchema.TextContent("Tool not allowed: admin-tool"));
+        assertThat(adminToolResult.isError()).isTrue();
+
+        // Verify all tools are visible to admin
+        TestingClient adminClient = TestingClient.buildClient(closer, baseUri, EXPECTED_IDENTITY, EXPECTED_IDENTITY);
+        tools = adminClient.mcpClient().listTools();
+        assertThat(tools.tools().stream().map(McpSchema.Tool::name).collect(toImmutableList()))
+                .containsExactlyInAnyOrder("public-tool", "admin-tool");
+
+        // Verify all tools can be invoked by admin
+        publicToolResult = adminClient.mcpClient().callTool(new CallToolRequest("public-tool", ImmutableMap.of()));
+        assertThat(publicToolResult.content()).hasSize(1);
+
+        adminToolResult = adminClient.mcpClient().callTool(new CallToolRequest("admin-tool", ImmutableMap.of()));
+        assertThat(adminToolResult.content()).hasSize(1);
+    }
+
+    @Test
+    public void testFilteringPrompts()
+    {
+        // Setup MCP server with role-based filter
+        TestingServer testingServer = new TestingServer(
+                ImmutableMap.of(),
+                Optional.empty(),
+                builder -> builder
+                        .withIdentityMapper(TestingIdentity.class, binding -> binding.to(TestingIdentityMapper.class).in(SINGLETON))
+                        .withSessions(binding -> binding.to(MemorySessionController.class).in(SINGLETON))
+                        .withCapabilityFilter(binding -> binding.toInstance(new TestMcpCapabilityFilter()))
+                        .withAllInClass(TestFilteringEnabledEndpoints.class)
+                        .build());
+        closer.register(testingServer);
+
+        String baseUri = testingServer.injector().getInstance(TestingHttpServer.class).getBaseUrl().toString();
+        TestingClient client = TestingClient.buildClient(closer, baseUri, ANOTHER_IDENTITY, ANOTHER_IDENTITY);
+
+        // Verify only public prompts are visible
+        ListPromptsResult prompts = client.mcpClient().listPrompts();
+        assertThat(prompts.prompts().stream().map(McpSchema.Prompt::name).collect(toImmutableList()))
+                .containsOnly("public-prompt");
+
+        // Verify public prompt can be retrieved, but admin can't
+        McpSchema.GetPromptResult publicPromptResult = client.mcpClient().getPrompt(new GetPromptRequest("public-prompt", ImmutableMap.of()));
+        assertThat(publicPromptResult.messages()).hasSize(1);
+        assertThatThrownBy(() -> client.mcpClient().getPrompt(new GetPromptRequest("admin-prompt", ImmutableMap.of())))
+                .satisfies(e -> assertMcpError(e, INVALID_PARAMS, "Prompt not allowed: admin-prompt"));
+
+        // Verify all tools are visible to admin
+        TestingClient adminClient = TestingClient.buildClient(closer, baseUri, EXPECTED_IDENTITY, EXPECTED_IDENTITY);
+        prompts = adminClient.mcpClient().listPrompts();
+        assertThat(prompts.prompts().stream().map(McpSchema.Prompt::name).collect(toImmutableList()))
+                .containsExactlyInAnyOrder("public-prompt", "admin-prompt");
+
+        // Verify all tools can be invoked by admin
+        publicPromptResult = adminClient.mcpClient().getPrompt(new GetPromptRequest("public-prompt", ImmutableMap.of()));
+        assertThat(publicPromptResult.messages()).hasSize(1);
+
+        McpSchema.GetPromptResult adminPromptResult = adminClient.mcpClient().getPrompt(new GetPromptRequest("admin-prompt", ImmutableMap.of()));
+        assertThat(adminPromptResult.messages()).hasSize(1);
+    }
+
+    @Test
+    public void testFilteringResources()
+    {
+        // Setup MCP server with role-based filter
+        TestingServer testingServer = new TestingServer(
+                ImmutableMap.of(),
+                Optional.empty(),
+                builder -> builder
+                        .withIdentityMapper(TestingIdentity.class, binding -> binding.to(TestingIdentityMapper.class).in(SINGLETON))
+                        .withSessions(binding -> binding.to(MemorySessionController.class).in(SINGLETON))
+                        .withCapabilityFilter(binding -> binding.toInstance(new TestMcpCapabilityFilter()))
+                        .withAllInClass(TestFilteringEnabledEndpoints.class)
+                        .build());
+        closer.register(testingServer);
+
+        String baseUri = testingServer.injector().getInstance(TestingHttpServer.class).getBaseUrl().toString();
+        TestingClient client = TestingClient.buildClient(closer, baseUri, ANOTHER_IDENTITY, ANOTHER_IDENTITY);
+
+        // Verify only public resources are visible
+        ListResourcesResult resources = client.mcpClient().listResources();
+        assertThat(resources.resources().stream().map(McpSchema.Resource::uri).collect(toImmutableList()))
+                .containsExactly("file://public-resource.txt");
+
+        // Verify public resource can be read, but admin can't
+        ReadResourceResult publicResourceResult = client.mcpClient().readResource(new ReadResourceRequest("file://public-resource.txt"));
+        assertThat(publicResourceResult.contents()).hasSize(1);
+        assertThatThrownBy(() -> client.mcpClient().readResource(new ReadResourceRequest("file://admin-resource.txt")))
+                .satisfies(e -> assertMcpError(e, INVALID_PARAMS, "Resource access not allowed: file://admin-resource.txt"));
+
+        // Verify all tools are visible to admin
+        TestingClient adminClient = TestingClient.buildClient(closer, baseUri, EXPECTED_IDENTITY, EXPECTED_IDENTITY);
+        resources = adminClient.mcpClient().listResources();
+        assertThat(resources.resources().stream().map(McpSchema.Resource::uri).collect(toImmutableList()))
+                .containsExactlyInAnyOrder("file://public-resource.txt", "file://admin-resource.txt");
+
+        publicResourceResult = adminClient.mcpClient().readResource(new ReadResourceRequest("file://public-resource.txt"));
+        assertThat(publicResourceResult.contents()).hasSize(1);
+
+        McpSchema.ReadResourceResult adminResourceResult = adminClient.mcpClient().readResource(new ReadResourceRequest("file://public-resource.txt"));
+        assertThat(adminResourceResult.contents()).hasSize(1);
+    }
+
+    @Test
+    public void testFilteringResourceTemplates()
+    {
+        // Setup MCP server with role-based filter
+        TestingServer testingServer = new TestingServer(
+                ImmutableMap.of(),
+                Optional.empty(),
+                builder -> builder
+                        .withIdentityMapper(TestingIdentity.class, binding -> binding.to(TestingIdentityMapper.class).in(SINGLETON))
+                        .withSessions(binding -> binding.to(MemorySessionController.class).in(SINGLETON))
+                        .withCapabilityFilter(binding -> binding.toInstance(new TestMcpCapabilityFilter()))
+                        .withAllInClass(TestFilteringEnabledEndpoints.class)
+                        .build());
+        closer.register(testingServer);
+
+        String baseUri = testingServer.injector().getInstance(TestingHttpServer.class).getBaseUrl().toString();
+        TestingClient client = TestingClient.buildClient(closer, baseUri, ANOTHER_IDENTITY, ANOTHER_IDENTITY);
+
+        // Verify only public resource templates are visible
+        ListResourceTemplatesResult resourceTemplates = client.mcpClient().listResourceTemplates();
+        assertThat(resourceTemplates.resourceTemplates().stream().map(McpSchema.ResourceTemplate::uriTemplate).collect(toImmutableList()))
+                .containsOnly("file://public/{name}");
+
+        // Verify public resource template can be read, but admin cannot
+        ReadResourceResult publicTemplateResult = client.mcpClient().readResource(new ReadResourceRequest("file://public/test.txt"));
+        assertThat(publicTemplateResult.contents()).hasSize(1);
+        assertThatThrownBy(() -> client.mcpClient().readResource(new ReadResourceRequest("file://admin/test.txt")))
+                .satisfies(e -> assertMcpError(e, INVALID_PARAMS, "Resource access not allowed: file://admin/test.txt"));
+
+        // Verify all tools are visible to admin
+        TestingClient adminClient = TestingClient.buildClient(closer, baseUri, EXPECTED_IDENTITY, EXPECTED_IDENTITY);
+        resourceTemplates = adminClient.mcpClient().listResourceTemplates();
+        assertThat(resourceTemplates.resourceTemplates().stream().map(McpSchema.ResourceTemplate::uriTemplate).collect(toImmutableList()))
+                .containsExactlyInAnyOrder("file://public/{name}", "file://admin/{name}");
+
+        // Verify all tools can be invoked by admin
+        publicTemplateResult = adminClient.mcpClient().readResource(new ReadResourceRequest("file://public/test.txt"));
+        assertThat(publicTemplateResult.contents()).hasSize(1);
+
+        ReadResourceResult adminResourceResult = adminClient.mcpClient().readResource(new ReadResourceRequest("file://admin/test.txt"));
+        assertThat(adminResourceResult.contents()).hasSize(1);
+    }
+
+    @Test
+    public void testFilteringPromptCompletions()
+    {
+        // Setup MCP server with role-based filter
+        TestingServer testingServer = new TestingServer(
+                ImmutableMap.of(),
+                Optional.empty(),
+                builder -> builder
+                        .withIdentityMapper(TestingIdentity.class, binding -> binding.to(TestingIdentityMapper.class).in(SINGLETON))
+                        .withSessions(binding -> binding.to(MemorySessionController.class).in(SINGLETON))
+                        .withCapabilityFilter(binding -> binding.toInstance(new TestMcpCapabilityFilter()))
+                        .withAllInClass(TestFilteringEnabledEndpoints.class)
+                        .build());
+        closer.register(testingServer);
+
+        String baseUri = testingServer.injector().getInstance(TestingHttpServer.class).getBaseUrl().toString();
+        TestingClient client = TestingClient.buildClient(closer, baseUri, ANOTHER_IDENTITY, ANOTHER_IDENTITY);
+
+        // Verify non-admin can get completions for public prompt
+        CompleteRequest publicPromptCompleteRequest = new CompleteRequest(
+                new PromptReference("public-prompt"),
+                new McpSchema.CompleteRequest.CompleteArgument("arg", ""));
+        CompleteResult publicPromptResult = client.mcpClient().completeCompletion(publicPromptCompleteRequest);
+        assertThat(publicPromptResult.completion().values()).hasSize(2);
+
+        // Verify non-admin gets empty completions for admin prompt (filtered out)
+        CompleteRequest adminPromptCompleteRequest = new CompleteRequest(
+                new PromptReference("admin-prompt"),
+                new McpSchema.CompleteRequest.CompleteArgument("arg", ""));
+        CompleteResult adminPromptResult = client.mcpClient().completeCompletion(adminPromptCompleteRequest);
+        assertThat(adminPromptResult.completion().values()).isEmpty();
+
+        // Verify non-admin can get completions for public resource template
+        CompleteRequest publicResourceCompleteRequest = new CompleteRequest(
+                new ResourceReference("file://public/{name}"),
+                new McpSchema.CompleteRequest.CompleteArgument("name", ""));
+        CompleteResult publicResourceResult = client.mcpClient().completeCompletion(publicResourceCompleteRequest);
+        assertThat(publicResourceResult.completion().values()).hasSize(2);
+
+        // Verify non-admin gets empty completions for admin resource template (filtered out)
+        CompleteRequest adminResourceCompleteRequest = new CompleteRequest(
+                new ResourceReference("file://admin/{name}"),
+                new McpSchema.CompleteRequest.CompleteArgument("name", ""));
+        CompleteResult adminResourceResult = client.mcpClient().completeCompletion(adminResourceCompleteRequest);
+        assertThat(adminResourceResult.completion().values()).isEmpty();
+
+        TestingClient adminClient = TestingClient.buildClient(closer, baseUri, EXPECTED_IDENTITY, EXPECTED_IDENTITY);
+
+        // Verify admin can get completions for admin prompt
+        adminPromptResult = adminClient.mcpClient().completeCompletion(adminPromptCompleteRequest);
+        assertThat(adminPromptResult.completion().values()).hasSize(2);
+
+        // Verify admin can get completions for admin resource template
+        adminResourceResult = adminClient.mcpClient().completeCompletion(adminResourceCompleteRequest);
+        assertThat(adminResourceResult.completion().values()).hasSize(2);
+    }
+
+    private static class TestMcpCapabilityFilter
+            implements McpCapabilityFilter
+    {
+        TestMcpCapabilityFilter() {}
+
+        @Override
+        public boolean isAllowed(Authenticated<?> identity, Tool tool)
+        {
+            TestingIdentity actualIdentity = (TestingIdentity) identity.identity();
+            return EXPECTED_IDENTITY.equals(actualIdentity.name()) || tool.name().equals("public-tool");
+        }
+
+        @Override
+        public boolean isAllowed(Authenticated<?> identity, Prompt prompt)
+        {
+            TestingIdentity actualIdentity = (TestingIdentity) identity.identity();
+            return EXPECTED_IDENTITY.equals(actualIdentity.name()) || prompt.name().equals("public-prompt");
+        }
+
+        @Override
+        public boolean isAllowed(Authenticated<?> identity, Resource resource)
+        {
+            TestingIdentity actualIdentity = (TestingIdentity) identity.identity();
+            return EXPECTED_IDENTITY.equals(actualIdentity.name()) || resource.uri().contains("public");
+        }
+
+        @Override
+        public boolean isAllowed(Authenticated<?> identity, ResourceTemplate resourceTemplate)
+        {
+            TestingIdentity actualIdentity = (TestingIdentity) identity.identity();
+            return EXPECTED_IDENTITY.equals(actualIdentity.name()) || resourceTemplate.uriTemplate().contains("public");
+        }
+
+        @Override
+        public boolean isAllowed(Authenticated<?> identity, CompleteReference reference)
+        {
+            TestingIdentity actualIdentity = (TestingIdentity) identity.identity();
+            return EXPECTED_IDENTITY.equals(actualIdentity.name()) || switch (reference) {
+                case CompleteReference.PromptReference promptReference -> promptReference.name().contains("public");
+                case CompleteReference.ResourceReference resourceReference -> resourceReference.uri().contains("public");
+            };
+        }
+    }
+
+    public static class TestFilteringEnabledEndpoints
+    {
+        @McpTool(name = "public-tool", description = "Available to all")
+        public CallToolResult publicTool()
+        {
+            return new CallToolResult(ImmutableList.of(new TextContent("public")), Optional.empty(), false);
+        }
+
+        @McpTool(name = "admin-tool", description = "Admin only")
+        public CallToolResult adminTool()
+        {
+            return new CallToolResult(ImmutableList.of(new TextContent("admin")), Optional.empty(), false);
+        }
+
+        @McpPrompt(name = "public-prompt", description = "Available to all")
+        public GetPromptResult publicPrompt()
+        {
+            return new GetPromptResult(
+                    Optional.of("Public prompt"),
+                    ImmutableList.of(new GetPromptResult.PromptMessage(Role.USER, new TextContent("Public prompt content"))));
+        }
+
+        @McpPrompt(name = "admin-prompt", description = "Admin only")
+        public GetPromptResult adminPrompt()
+        {
+            return new GetPromptResult(
+                    Optional.of("Admin prompt"),
+                    ImmutableList.of(new GetPromptResult.PromptMessage(Role.USER, new TextContent("Admin prompt content"))));
+        }
+
+        @McpResource(name = "public-resource", uri = "file://public-resource.txt", description = "Available to all", mimeType = "text/plain")
+        public ResourceContents publicResource()
+        {
+            return new ResourceContents("public-resource", "file://public-resource.txt", "text/plain", "Public resource content");
+        }
+
+        @McpResource(name = "admin-resource", uri = "file://admin-resource.txt", description = "Admin only", mimeType = "text/plain")
+        public ResourceContents adminResource()
+        {
+            return new ResourceContents("admin-resource", "file://admin-resource.txt", "text/plain", "Admin resource content");
+        }
+
+        @McpResourceTemplate(name = "public-template", uriTemplate = "file://public/{name}", description = "Available to all", mimeType = "text/plain")
+        public List<ResourceContents> publicResourceTemplate(io.airlift.mcp.model.ReadResourceRequest request, ResourceTemplateValues resourceTemplateValues)
+        {
+            String name = resourceTemplateValues.templateValues().getOrDefault("name", "unknown");
+            return ImmutableList.of(new ResourceContents("public-" + name, request.uri(), "text/plain", "Public template: " + name));
+        }
+
+        @McpResourceTemplate(name = "admin-template", uriTemplate = "file://admin/{name}", description = "Admin only", mimeType = "text/plain")
+        public List<ResourceContents> adminResourceTemplate(io.airlift.mcp.model.ReadResourceRequest request, ResourceTemplateValues resourceTemplateValues)
+        {
+            String name = resourceTemplateValues.templateValues().getOrDefault("name", "unknown");
+            return ImmutableList.of(new ResourceContents("admin-" + name, request.uri(), "text/plain", "Admin template: " + name));
+        }
+
+        @McpPromptCompletion(name = "public-prompt")
+        public List<String> publicPromptCompletions(CompleteArgument argument)
+        {
+            return ImmutableList.of("public-completion-1", "public-completion-2");
+        }
+
+        @McpPromptCompletion(name = "admin-prompt")
+        public List<String> adminPromptCompletions(CompleteArgument argument)
+        {
+            return ImmutableList.of("admin-completion-1", "admin-completion-2");
+        }
+
+        @McpResourceTemplateCompletion(uriTemplate = "file://public/{name}")
+        public List<String> publicResourceTemplateCompletions(CompleteArgument argument)
+        {
+            if (argument.name().equals("name")) {
+                return ImmutableList.of("public-file-1.txt", "public-file-2.txt");
+            }
+            return ImmutableList.of();
+        }
+
+        @McpResourceTemplateCompletion(uriTemplate = "file://admin/{name}")
+        public List<String> adminResourceTemplateCompletions(CompleteArgument argument)
+        {
+            if (argument.name().equals("name")) {
+                return ImmutableList.of("admin-file-1.txt", "admin-file-2.txt");
+            }
+            return ImmutableList.of();
+        }
+    }
+}

--- a/mcp/src/test/java/io/airlift/mcp/TestingIdentityMapper.java
+++ b/mcp/src/test/java/io/airlift/mcp/TestingIdentityMapper.java
@@ -15,6 +15,7 @@ public class TestingIdentityMapper
         implements McpIdentityMapper
 {
     public static final String EXPECTED_IDENTITY = "Mr. Tester";
+    public static final String ANOTHER_IDENTITY = "Mrs. Other Tester";
     public static final String ERRORED_IDENTITY = "Bad Actor";
     public static final String IDENTITY_HEADER = "X-Testing-Identity";
 
@@ -28,9 +29,9 @@ public class TestingIdentityMapper
         if (authHeader.equals(ERRORED_IDENTITY)) {
             return error(exception(INTERNAL_ERROR, "This identity cannot catch a break"));
         }
-        if (!authHeader.equals(EXPECTED_IDENTITY)) {
+        if (!authHeader.equals(EXPECTED_IDENTITY) && !authHeader.equals(ANOTHER_IDENTITY)) {
             return unauthorized("Identity %s is not authorized to access".formatted(authHeader));
         }
-        return authenticated(new TestingIdentity(EXPECTED_IDENTITY));
+        return authenticated(new TestingIdentity(authHeader));
     }
 }


### PR DESCRIPTION
This commit adds the ability to additionally filter MCP operations after authentication.

For example, in some environments, some users may not be able to use some tools that others may be able to, or server administrators want to slowly roll out tools to small beta groups of users.

<!-- Thank you for submitting pull request to Airlift -->

# Airlift contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [x] All automated tests are passing.
 - [x] Pull request was categorized using one of the existing labels.
