### PR TITLE
[MCP] Resource templates imply resource capabilities on MCP initialize

### DIFF
--- a/mcp/src/main/java/io/airlift/mcp/internal/InternalMcpServer.java
+++ b/mcp/src/main/java/io/airlift/mcp/internal/InternalMcpServer.java
@@ -287,7 +287,7 @@ public class InternalMcpServer
                 completions.isEmpty() ? Optional.empty() : Optional.of(new CompletionCapabilities()),
                 sessionsEnabled ? Optional.of(new LoggingCapabilities()) : Optional.empty(),
                 prompts.isEmpty() ? Optional.empty() : Optional.of(new ListChanged(sessionsEnabled)),
-                resources.isEmpty() ? Optional.empty() : Optional.of(new SubscribeListChanged(sessionsEnabled, sessionsEnabled)),
+                resources.isEmpty() && resourceTemplates.isEmpty() ? Optional.empty() : Optional.of(new SubscribeListChanged(sessionsEnabled, sessionsEnabled)),
                 tools.isEmpty() ? Optional.empty() : Optional.of(new ListChanged(sessionsEnabled)),
                 Optional.empty());
 


### PR DESCRIPTION
If you expose a resource template but no resources, then initialize requests won't advertise the resources capability. Some clients fail from this.

# Airlift contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [x] All automated tests are passing.
 - [x] Pull request was categorized using one of the existing labels.
