### PR TITLE
Restore log level guards around expensive calls

### DIFF
--- a/log/src/main/java/io/airlift/log/Logger.java
+++ b/log/src/main/java/io/airlift/log/Logger.java
@@ -236,7 +236,7 @@ public class Logger
      */
     public void error(String message)
     {
-        logger.severe(message);
+        logger.log(SEVERE, message);
     }
 
     /**


### PR DESCRIPTION
This avoid formatting if the log level is not enabled.
Restore log levels accidentally removed in https://github.com/airlift/airlift/pull/1782.

<!-- Thank you for submitting pull request to Airlift -->

# Airlift contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [x] All automated tests are passing.
 - [x] Pull request was categorized using one of the existing labels.
