### PR TITLE
Add support for tracing request headers in HttpServerConfig

### DIFF
--- a/http-server/src/main/java/io/airlift/http/server/HttpServerConfig.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServerConfig.java
@@ -96,7 +96,6 @@ public class HttpServerConfig
     private DataSize http2InitialStreamReceiveWindowSize = DataSize.of(16, MEGABYTE);
     private DataSize http2InputBufferSize = DataSize.of(8, KILOBYTE);
     private Duration http2StreamIdleTimeout = new Duration(15, SECONDS);
-
     private boolean showStackTrace = true;
 
     private boolean compressionEnabled = true;

--- a/http-server/src/main/java/io/airlift/http/server/HttpServerModule.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServerModule.java
@@ -21,7 +21,6 @@ import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.airlift.discovery.client.AnnouncementHttpServerInfo;
 import io.airlift.http.server.HttpServer.ClientCertificate;
 import io.airlift.http.server.HttpServerBinder.HttpResourceBinding;
-import io.airlift.http.server.tracing.TracingServletFilter;
 import jakarta.annotation.Nullable;
 import jakarta.servlet.Filter;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
@@ -98,8 +97,9 @@ public class HttpServerModule
         newExporter(binder).export(qualifiedKey(HttpServer.class)).withGeneratedName();
         newSetBinder(binder, qualifiedKey(ServerFeature.class));
         newSetBinder(binder, qualifiedKey(Filter.class)).addBinding()
-                .to(TracingServletFilter.class)
+                .toProvider(new TracingServletFilterProvider(qualifier))
                 .in(SINGLETON);
+        configBinder(binder).bindConfig(qualifiedKey(HttpTracingConfig.class), HttpTracingConfig.class, configPrefix);
         newSetBinder(binder, qualifiedKey(HttpResourceBinding.class));
         newOptionalBinder(binder, qualifiedKey(SslContextFactory.Server.class));
         configBinder(binder).bindConfig(qualifiedKey(HttpServerConfig.class), HttpServerConfig.class, configPrefix);

--- a/http-server/src/main/java/io/airlift/http/server/HttpTracingConfig.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpTracingConfig.java
@@ -1,0 +1,39 @@
+package io.airlift.http.server;
+
+import com.google.common.collect.ImmutableSet;
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+
+import java.util.Set;
+
+public class HttpTracingConfig
+{
+    private Set<String> tracingRequestHeaders = ImmutableSet.of();
+    private Set<String> tracingResponseHeaders = ImmutableSet.of();
+
+    public Set<String> getTracingRequestHeaders()
+    {
+        return tracingRequestHeaders;
+    }
+
+    @Config("http-server.tracing.request-headers")
+    @ConfigDescription("Comma separated list of request header names to include as span attributes (e.g., cf-ray, x-request-id)")
+    public HttpTracingConfig setTracingRequestHeaders(Set<String> tracingRequestHeaders)
+    {
+        this.tracingRequestHeaders = ImmutableSet.copyOf(tracingRequestHeaders);
+        return this;
+    }
+
+    public Set<String> getTracingResponseHeaders()
+    {
+        return tracingResponseHeaders;
+    }
+
+    @Config("http-server.tracing.response-headers")
+    @ConfigDescription("Comma separated list of response header names to include as span attributes (e.g., cf-ray, x-request-id)")
+    public HttpTracingConfig setTracingResponseHeaders(Set<String> tracingResponseHeaders)
+    {
+        this.tracingResponseHeaders = ImmutableSet.copyOf(tracingResponseHeaders);
+        return this;
+    }
+}

--- a/http-server/src/main/java/io/airlift/http/server/TracingServletFilterProvider.java
+++ b/http-server/src/main/java/io/airlift/http/server/TracingServletFilterProvider.java
@@ -1,0 +1,52 @@
+package io.airlift.http.server;
+
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import io.airlift.http.server.tracing.TracingServletFilter;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Tracer;
+import jakarta.servlet.Filter;
+
+import java.lang.annotation.Annotation;
+import java.util.Optional;
+
+import static io.airlift.http.server.BinderUtils.qualifiedKey;
+import static java.util.Objects.requireNonNull;
+
+public class TracingServletFilterProvider
+        implements com.google.inject.Provider<Filter>
+{
+    private final Optional<Class<? extends Annotation>> qualifier;
+    private Injector injector;
+    private OpenTelemetry telemetry;
+    private Tracer tracer;
+
+    public TracingServletFilterProvider(Optional<Class<? extends Annotation>> qualifier)
+    {
+        this.qualifier = requireNonNull(qualifier, "qualifier is null");
+    }
+
+    @Inject
+    public void setInjector(Injector injector)
+    {
+        this.injector = requireNonNull(injector, "injector is null");
+    }
+
+    @Inject
+    public void setOpenTelemetry(OpenTelemetry openTelemetry)
+    {
+        this.telemetry = requireNonNull(openTelemetry, "openTelemetry is null");
+    }
+
+    @Inject
+    public void setTracer(Tracer tracer)
+    {
+        this.tracer = requireNonNull(tracer, "tracer is null");
+    }
+
+    @Override
+    public Filter get()
+    {
+        return new TracingServletFilter(telemetry, tracer, injector.getInstance(qualifiedKey(qualifier, HttpTracingConfig.class)));
+    }
+}

--- a/http-server/src/main/java/io/airlift/http/server/tracing/TracingServletFilter.java
+++ b/http-server/src/main/java/io/airlift/http/server/tracing/TracingServletFilter.java
@@ -1,6 +1,8 @@
 package io.airlift.http.server.tracing;
 
+import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
+import io.airlift.http.server.HttpTracingConfig;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
@@ -29,14 +31,21 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpServletResponseWrapper;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.base.Strings.nullToEmpty;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.net.HttpHeaders.CONTENT_LENGTH;
 import static com.google.common.net.HttpHeaders.USER_AGENT;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_REQUEST_HEADER;
+import static io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_HEADER;
+import static java.util.Collections.list;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
+import static java.util.function.Function.identity;
 import static org.eclipse.jetty.ee11.servlet.ServletContextRequest.SSL_CIPHER_SUITE;
 import static org.eclipse.jetty.ee11.servlet.ServletContextRequest.SSL_SESSION_ID;
 
@@ -49,12 +58,22 @@ public final class TracingServletFilter
 
     private final TextMapPropagator propagator;
     private final Tracer tracer;
+    private final Map<String, AttributeKey<List<String>>> tracingRequestHeaderKeys;
+    private final Map<String, AttributeKey<List<String>>> tracingResponseHeaderKeys;
 
     @Inject
-    public TracingServletFilter(OpenTelemetry openTelemetry, Tracer tracer)
+    public TracingServletFilter(OpenTelemetry openTelemetry, Tracer tracer, HttpTracingConfig config)
     {
         this.propagator = openTelemetry.getPropagators().getTextMapPropagator();
         this.tracer = requireNonNull(tracer, "tracer is null");
+        this.tracingRequestHeaderKeys = config.getTracingRequestHeaders().stream()
+                .map(TracingServletFilter::normalizeHeaderName)
+                .distinct()
+                .collect(toImmutableMap(identity(), name -> HTTP_REQUEST_HEADER.getAttributeKey(normalizeHeaderName(name))));
+        this.tracingResponseHeaderKeys = config.getTracingResponseHeaders().stream()
+                .map(TracingServletFilter::normalizeHeaderName)
+                .distinct()
+                .collect(toImmutableMap(identity(), name -> HTTP_RESPONSE_HEADER.getAttributeKey(normalizeHeaderName(name))));
     }
 
     public static void updateRequestSpan(HttpServletRequest request, Consumer<Span> spanConsumer)
@@ -108,12 +127,19 @@ public final class TracingServletFilter
             spanBuilder.setAttribute(UserAgentAttributes.USER_AGENT_ORIGINAL, userAgent);
         }
 
+        for (Map.Entry<String, AttributeKey<List<String>>> entry : tracingRequestHeaderKeys.entrySet()) {
+            List<String> values = list(request.getHeaders(entry.getKey()));
+            if (!values.isEmpty()) {
+                spanBuilder.setAttribute(entry.getValue(), values);
+            }
+        }
+
         Span span = spanBuilder.startSpan();
         // Add to request attributes for TracingFilter to be able to update Span attributes
         request.setAttribute(REQUEST_SPAN, span);
 
         try (Scope ignored = span.makeCurrent()) {
-            chain.doFilter(request, new TracingHttpServletResponse(response, span));
+            chain.doFilter(request, new TracingHttpServletResponse(response, tracingResponseHeaderKeys, span));
         }
         catch (Throwable t) {
             span.setStatus(StatusCode.ERROR, t.getMessage());
@@ -169,10 +195,12 @@ public final class TracingServletFilter
             extends HttpServletResponseWrapper
     {
         private final Span span;
+        private final Map<String, AttributeKey<List<String>>> responseHeaders;
 
-        public TracingHttpServletResponse(HttpServletResponse delegate, Span span)
+        public TracingHttpServletResponse(HttpServletResponse delegate, Map<String, AttributeKey<List<String>>> responseHeaders, Span span)
         {
             super(delegate);
+            this.responseHeaders = requireNonNull(responseHeaders, "responseHeaders is null");
             this.span = requireNonNull(span, "span is null");
         }
 
@@ -204,37 +232,69 @@ public final class TracingServletFilter
         @Override
         public void setHeader(String name, String value)
         {
+            super.setHeader(name, value);
+
             if (name.equalsIgnoreCase(CONTENT_LENGTH)) {
                 span.setAttribute(HttpIncubatingAttributes.HTTP_RESPONSE_BODY_SIZE, Long.parseLong(value));
             }
-            super.setHeader(name, value);
+
+            updateResponseHeaderAttributes(name);
         }
 
         @Override
         public void addHeader(String name, String value)
         {
+            super.addHeader(name, value);
+
             if (name.equalsIgnoreCase(CONTENT_LENGTH)) {
                 span.setAttribute(HttpIncubatingAttributes.HTTP_RESPONSE_BODY_SIZE, Long.parseLong(value));
             }
-            super.addHeader(name, value);
+
+            updateResponseHeaderAttributes(name);
         }
 
         @Override
         public void setIntHeader(String name, int value)
         {
+            super.setIntHeader(name, value);
+
             if (name.equalsIgnoreCase(CONTENT_LENGTH)) {
                 span.setAttribute(HttpIncubatingAttributes.HTTP_RESPONSE_BODY_SIZE, value);
             }
-            super.setIntHeader(name, value);
+
+            updateResponseHeaderAttributes(name);
         }
 
         @Override
         public void addIntHeader(String name, int value)
         {
+            super.addIntHeader(name, value);
+
             if (name.equalsIgnoreCase(CONTENT_LENGTH)) {
                 span.setAttribute(HttpIncubatingAttributes.HTTP_RESPONSE_BODY_SIZE, value);
             }
-            super.addIntHeader(name, value);
+
+            updateResponseHeaderAttributes(name);
+        }
+
+        private void updateResponseHeaderAttributes(String headerName)
+        {
+            String normalizedHeaderName = normalizeHeaderName(headerName);
+
+            if (headerName.equalsIgnoreCase(CONTENT_LENGTH)) {
+                return;
+            }
+
+            AttributeKey<List<String>> responseAttribute = responseHeaders.get(normalizedHeaderName);
+            if (responseAttribute == null) {
+                return;
+            }
+
+            List<String> values = ImmutableList.copyOf(super.getHeaders(normalizedHeaderName));
+            if (values.isEmpty()) {
+                return;
+            }
+            span.setAttribute(responseAttribute, values);
         }
 
         @Override
@@ -250,5 +310,10 @@ public final class TracingServletFilter
             span.setAttribute(HttpIncubatingAttributes.HTTP_RESPONSE_BODY_SIZE, length);
             super.setContentLengthLong(length);
         }
+    }
+
+    private static String normalizeHeaderName(String headerName)
+    {
+        return headerName.toLowerCase(ENGLISH);
     }
 }

--- a/http-server/src/test/java/io/airlift/http/server/TestHttpTracingConfig.java
+++ b/http-server/src/test/java/io/airlift/http/server/TestHttpTracingConfig.java
@@ -1,0 +1,37 @@
+package io.airlift.http.server;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Set;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+class TestHttpTracingConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(HttpTracingConfig.class)
+                .setTracingRequestHeaders(Set.of())
+                .setTracingResponseHeaders(Set.of()));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("http-server.tracing.request-headers", "cf-ray,x-request-id")
+                .put("http-server.tracing.response-headers", "x-session-id")
+                .build();
+
+        HttpTracingConfig expected = new HttpTracingConfig()
+                .setTracingRequestHeaders(Set.of("cf-ray", "x-request-id"))
+                .setTracingResponseHeaders(Set.of("x-session-id"));
+
+        assertFullMapping(properties, expected);
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting pull request to Airlift -->

Exposes a config property to capture HTTP request headers as server span attributes 

https://opentelemetry.io/docs/specs/semconv/registry/attributes/http/#http-request-header
https://opentelemetry.io/docs/specs/semconv/registry/attributes/http/#http-response-header

# Airlift contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [x] All automated tests are passing.
 - [x] Pull request was categorized using one of the existing labels.
