### PR TITLE
[MCP] WIP - support the mutli-roundtrip requests proposal

### DIFF
--- a/mcp/src/main/java/io/airlift/mcp/McpEntities.java
+++ b/mcp/src/main/java/io/airlift/mcp/McpEntities.java
@@ -46,7 +46,7 @@ public interface McpEntities
 
     Optional<CompletionEntry> completionEntry(McpRequestContext requestContext, CompleteReference ref);
 
-    Optional<ReadResourceResult> readResourceContents(McpRequestContext requestContext, ReadResourceRequest readResourceRequest);
+    Optional<ReadResourceResult> readResourceContents(McpRequestContext requestContext, ReadResourceRequest readResourceRequest, boolean allowIncompleteResult);
 
     void addTool(Tool tool, ToolHandler toolHandler);
 

--- a/mcp/src/main/java/io/airlift/mcp/McpEntities.java
+++ b/mcp/src/main/java/io/airlift/mcp/McpEntities.java
@@ -12,8 +12,8 @@ import io.airlift.mcp.handler.ToolHandler;
 import io.airlift.mcp.model.CompleteReference;
 import io.airlift.mcp.model.Prompt;
 import io.airlift.mcp.model.ReadResourceRequest;
+import io.airlift.mcp.model.ReadResourceResult;
 import io.airlift.mcp.model.Resource;
-import io.airlift.mcp.model.ResourceContents;
 import io.airlift.mcp.model.ResourceTemplate;
 import io.airlift.mcp.model.Tool;
 
@@ -46,7 +46,7 @@ public interface McpEntities
 
     Optional<CompletionEntry> completionEntry(McpRequestContext requestContext, CompleteReference ref);
 
-    Optional<List<ResourceContents>> readResourceContents(McpRequestContext requestContext, ReadResourceRequest readResourceRequest);
+    Optional<ReadResourceResult> readResourceContents(McpRequestContext requestContext, ReadResourceRequest readResourceRequest);
 
     void addTool(Tool tool, ToolHandler toolHandler);
 

--- a/mcp/src/main/java/io/airlift/mcp/McpEntities.java
+++ b/mcp/src/main/java/io/airlift/mcp/McpEntities.java
@@ -12,7 +12,7 @@ import io.airlift.mcp.handler.ToolHandler;
 import io.airlift.mcp.model.CompleteReference;
 import io.airlift.mcp.model.Prompt;
 import io.airlift.mcp.model.ReadResourceRequest;
-import io.airlift.mcp.model.ReadResourceResult;
+import io.airlift.mcp.model.ReadResourceResponse;
 import io.airlift.mcp.model.Resource;
 import io.airlift.mcp.model.ResourceTemplate;
 import io.airlift.mcp.model.Tool;
@@ -46,7 +46,7 @@ public interface McpEntities
 
     Optional<CompletionEntry> completionEntry(McpRequestContext requestContext, CompleteReference ref);
 
-    Optional<ReadResourceResult> readResourceContents(McpRequestContext requestContext, ReadResourceRequest readResourceRequest, boolean allowIncompleteResult);
+    Optional<ReadResourceResponse> readResourceContents(McpRequestContext requestContext, ReadResourceRequest readResourceRequest, boolean allowIncompleteResult);
 
     void addTool(Tool tool, ToolHandler toolHandler);
 

--- a/mcp/src/main/java/io/airlift/mcp/McpRequestContext.java
+++ b/mcp/src/main/java/io/airlift/mcp/McpRequestContext.java
@@ -2,15 +2,10 @@ package io.airlift.mcp;
 
 import io.airlift.mcp.McpIdentity.Authenticated;
 import io.airlift.mcp.model.InitializeRequest.ClientCapabilities;
-import io.airlift.mcp.model.JsonRpcResponse;
 import io.airlift.mcp.model.LoggingLevel;
-import io.airlift.mcp.model.Root;
 import jakarta.servlet.http.HttpServletRequest;
 
-import java.time.Duration;
-import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.TimeoutException;
 
 public interface McpRequestContext
 {
@@ -34,14 +29,4 @@ public interface McpRequestContext
 
     // NOTE - may not be supported depending on how you've configured MCP - see the README regarding Sessions and Storage
     void sendLog(LoggingLevel level, Optional<String> logger, Optional<Object> data);
-
-    /**
-     * Sends a server-to-client request and waits for the response until given timeout. NOTE - may not be supported depending on how you've configured MCP - see the README regarding Sessions and Storage
-     */
-    <R> JsonRpcResponse<R> serverToClientRequest(String method, Object params, Class<R> responseType, Duration timeout, Duration pollInterval)
-            throws InterruptedException, TimeoutException;
-
-    // NOTE - may not be supported depending on how you've configured MCP - see the README regarding Sessions and Storage
-    List<Root> requestRoots(Duration timeout, Duration pollInterval)
-            throws InterruptedException, TimeoutException;
 }

--- a/mcp/src/main/java/io/airlift/mcp/handler/PromptHandler.java
+++ b/mcp/src/main/java/io/airlift/mcp/handler/PromptHandler.java
@@ -2,9 +2,9 @@ package io.airlift.mcp.handler;
 
 import io.airlift.mcp.McpRequestContext;
 import io.airlift.mcp.model.GetPromptRequest;
-import io.airlift.mcp.model.GetPromptResult;
+import io.airlift.mcp.model.GetPromptResponse;
 
 public interface PromptHandler
 {
-    GetPromptResult getPrompt(McpRequestContext requestContext, GetPromptRequest getPromptRequest);
+    GetPromptResponse getPrompt(McpRequestContext requestContext, GetPromptRequest getPromptRequest);
 }

--- a/mcp/src/main/java/io/airlift/mcp/handler/ResourceHandler.java
+++ b/mcp/src/main/java/io/airlift/mcp/handler/ResourceHandler.java
@@ -7,5 +7,5 @@ import io.airlift.mcp.model.Resource;
 
 public interface ResourceHandler
 {
-    ReadResourceResult readResource(McpRequestContext requestContext, Resource sourceResource, ReadResourceRequest readResourceRequest);
+    ReadResourceResult readResource(McpRequestContext requestContext, Resource sourceResource, ReadResourceRequest readResourceRequest, boolean allowIncompleteResult);
 }

--- a/mcp/src/main/java/io/airlift/mcp/handler/ResourceHandler.java
+++ b/mcp/src/main/java/io/airlift/mcp/handler/ResourceHandler.java
@@ -2,12 +2,10 @@ package io.airlift.mcp.handler;
 
 import io.airlift.mcp.McpRequestContext;
 import io.airlift.mcp.model.ReadResourceRequest;
+import io.airlift.mcp.model.ReadResourceResult;
 import io.airlift.mcp.model.Resource;
-import io.airlift.mcp.model.ResourceContents;
-
-import java.util.List;
 
 public interface ResourceHandler
 {
-    List<ResourceContents> readResource(McpRequestContext requestContext, Resource sourceResource, ReadResourceRequest readResourceRequest);
+    ReadResourceResult readResource(McpRequestContext requestContext, Resource sourceResource, ReadResourceRequest readResourceRequest);
 }

--- a/mcp/src/main/java/io/airlift/mcp/handler/ResourceHandler.java
+++ b/mcp/src/main/java/io/airlift/mcp/handler/ResourceHandler.java
@@ -2,10 +2,10 @@ package io.airlift.mcp.handler;
 
 import io.airlift.mcp.McpRequestContext;
 import io.airlift.mcp.model.ReadResourceRequest;
-import io.airlift.mcp.model.ReadResourceResult;
+import io.airlift.mcp.model.ReadResourceResponse;
 import io.airlift.mcp.model.Resource;
 
 public interface ResourceHandler
 {
-    ReadResourceResult readResource(McpRequestContext requestContext, Resource sourceResource, ReadResourceRequest readResourceRequest, boolean allowIncompleteResult);
+    ReadResourceResponse readResource(McpRequestContext requestContext, Resource sourceResource, ReadResourceRequest readResourceRequest, boolean allowIncompleteResult);
 }

--- a/mcp/src/main/java/io/airlift/mcp/handler/ResourceTemplateHandler.java
+++ b/mcp/src/main/java/io/airlift/mcp/handler/ResourceTemplateHandler.java
@@ -2,11 +2,11 @@ package io.airlift.mcp.handler;
 
 import io.airlift.mcp.McpRequestContext;
 import io.airlift.mcp.model.ReadResourceRequest;
-import io.airlift.mcp.model.ReadResourceResult;
+import io.airlift.mcp.model.ReadResourceResponse;
 import io.airlift.mcp.model.ResourceTemplate;
 import io.airlift.mcp.model.ResourceTemplateValues;
 
 public interface ResourceTemplateHandler
 {
-    ReadResourceResult readResourceTemplate(McpRequestContext requestContext, ResourceTemplate sourceResourceTemplate, ReadResourceRequest readResourceRequest, ResourceTemplateValues resourceTemplateValues, boolean allowIncompleteResult);
+    ReadResourceResponse readResourceTemplate(McpRequestContext requestContext, ResourceTemplate sourceResourceTemplate, ReadResourceRequest readResourceRequest, ResourceTemplateValues resourceTemplateValues, boolean allowIncompleteResult);
 }

--- a/mcp/src/main/java/io/airlift/mcp/handler/ResourceTemplateHandler.java
+++ b/mcp/src/main/java/io/airlift/mcp/handler/ResourceTemplateHandler.java
@@ -8,5 +8,5 @@ import io.airlift.mcp.model.ResourceTemplateValues;
 
 public interface ResourceTemplateHandler
 {
-    ReadResourceResult readResourceTemplate(McpRequestContext requestContext, ResourceTemplate sourceResourceTemplate, ReadResourceRequest readResourceRequest, ResourceTemplateValues resourceTemplateValues);
+    ReadResourceResult readResourceTemplate(McpRequestContext requestContext, ResourceTemplate sourceResourceTemplate, ReadResourceRequest readResourceRequest, ResourceTemplateValues resourceTemplateValues, boolean allowIncompleteResult);
 }

--- a/mcp/src/main/java/io/airlift/mcp/handler/ResourceTemplateHandler.java
+++ b/mcp/src/main/java/io/airlift/mcp/handler/ResourceTemplateHandler.java
@@ -2,13 +2,11 @@ package io.airlift.mcp.handler;
 
 import io.airlift.mcp.McpRequestContext;
 import io.airlift.mcp.model.ReadResourceRequest;
-import io.airlift.mcp.model.ResourceContents;
+import io.airlift.mcp.model.ReadResourceResult;
 import io.airlift.mcp.model.ResourceTemplate;
 import io.airlift.mcp.model.ResourceTemplateValues;
 
-import java.util.List;
-
 public interface ResourceTemplateHandler
 {
-    List<ResourceContents> readResourceTemplate(McpRequestContext requestContext, ResourceTemplate sourceResourceTemplate, ReadResourceRequest readResourceRequest, ResourceTemplateValues resourceTemplateValues);
+    ReadResourceResult readResourceTemplate(McpRequestContext requestContext, ResourceTemplate sourceResourceTemplate, ReadResourceRequest readResourceRequest, ResourceTemplateValues resourceTemplateValues);
 }

--- a/mcp/src/main/java/io/airlift/mcp/handler/ToolHandler.java
+++ b/mcp/src/main/java/io/airlift/mcp/handler/ToolHandler.java
@@ -2,9 +2,9 @@ package io.airlift.mcp.handler;
 
 import io.airlift.mcp.McpRequestContext;
 import io.airlift.mcp.model.CallToolRequest;
-import io.airlift.mcp.model.CallToolResult;
+import io.airlift.mcp.model.CallToolResponse;
 
 public interface ToolHandler
 {
-    CallToolResult callTool(McpRequestContext requestContext, CallToolRequest toolRequest);
+    CallToolResponse callTool(McpRequestContext requestContext, CallToolRequest toolRequest);
 }

--- a/mcp/src/main/java/io/airlift/mcp/internal/InternalEntities.java
+++ b/mcp/src/main/java/io/airlift/mcp/internal/InternalEntities.java
@@ -239,7 +239,7 @@ public class InternalEntities
     }
 
     @Override
-    public Optional<ReadResourceResult> readResourceContents(McpRequestContext requestContext, ReadResourceRequest readResourceRequest)
+    public Optional<ReadResourceResult> readResourceContents(McpRequestContext requestContext, ReadResourceRequest readResourceRequest, boolean allowIncompleteResult)
     {
         if (!capabilityFilter.isAllowed(requestContext.identity(), readResourceRequest.uri())) {
             throw new McpClientException(exception(INVALID_PARAMS, "Resource access not allowed: " + readResourceRequest.uri()));
@@ -263,8 +263,8 @@ public class InternalEntities
         }
 
         return findResource(readResourceRequest.uri())
-                .map(readResourceEntry -> readResourceEntry.handler().readResource(requestContext, readResourceEntry.resource(), readResourceRequest))
-                .or(() -> findResourceTemplate(readResourceRequest.uri()).map(match -> match.entry.handler().readResourceTemplate(requestContext, match.entry.resourceTemplate(), readResourceRequest, match.values)));
+                .map(readResourceEntry -> readResourceEntry.handler().readResource(requestContext, readResourceEntry.resource(), readResourceRequest, allowIncompleteResult))
+                .or(() -> findResourceTemplate(readResourceRequest.uri()).map(match -> match.entry.handler().readResourceTemplate(requestContext, match.entry.resourceTemplate(), readResourceRequest, match.values, allowIncompleteResult)));
     }
 
     private Optional<ResourceEntry> findResource(String uriString)

--- a/mcp/src/main/java/io/airlift/mcp/internal/InternalEntities.java
+++ b/mcp/src/main/java/io/airlift/mcp/internal/InternalEntities.java
@@ -20,8 +20,8 @@ import io.airlift.mcp.model.CompleteReference.PromptReference;
 import io.airlift.mcp.model.CompleteReference.ResourceReference;
 import io.airlift.mcp.model.Prompt;
 import io.airlift.mcp.model.ReadResourceRequest;
+import io.airlift.mcp.model.ReadResourceResult;
 import io.airlift.mcp.model.Resource;
-import io.airlift.mcp.model.ResourceContents;
 import io.airlift.mcp.model.ResourceTemplate;
 import io.airlift.mcp.model.ResourceTemplateValues;
 import io.airlift.mcp.model.Tool;
@@ -239,7 +239,7 @@ public class InternalEntities
     }
 
     @Override
-    public Optional<List<ResourceContents>> readResourceContents(McpRequestContext requestContext, ReadResourceRequest readResourceRequest)
+    public Optional<ReadResourceResult> readResourceContents(McpRequestContext requestContext, ReadResourceRequest readResourceRequest)
     {
         if (!capabilityFilter.isAllowed(requestContext.identity(), readResourceRequest.uri())) {
             throw new McpClientException(exception(INVALID_PARAMS, "Resource access not allowed: " + readResourceRequest.uri()));

--- a/mcp/src/main/java/io/airlift/mcp/internal/InternalEntities.java
+++ b/mcp/src/main/java/io/airlift/mcp/internal/InternalEntities.java
@@ -18,9 +18,10 @@ import io.airlift.mcp.handler.ToolHandler;
 import io.airlift.mcp.model.CompleteReference;
 import io.airlift.mcp.model.CompleteReference.PromptReference;
 import io.airlift.mcp.model.CompleteReference.ResourceReference;
+import io.airlift.mcp.model.InputRequests;
 import io.airlift.mcp.model.Prompt;
 import io.airlift.mcp.model.ReadResourceRequest;
-import io.airlift.mcp.model.ReadResourceResult;
+import io.airlift.mcp.model.ReadResourceResponse;
 import io.airlift.mcp.model.Resource;
 import io.airlift.mcp.model.ResourceTemplate;
 import io.airlift.mcp.model.ResourceTemplateValues;
@@ -239,7 +240,7 @@ public class InternalEntities
     }
 
     @Override
-    public Optional<ReadResourceResult> readResourceContents(McpRequestContext requestContext, ReadResourceRequest readResourceRequest, boolean allowIncompleteResult)
+    public Optional<ReadResourceResponse> readResourceContents(McpRequestContext requestContext, ReadResourceRequest readResourceRequest, boolean allowIncompleteResult)
     {
         if (!capabilityFilter.isAllowed(requestContext.identity(), readResourceRequest.uri())) {
             throw new McpClientException(exception(INVALID_PARAMS, "Resource access not allowed: " + readResourceRequest.uri()));
@@ -264,7 +265,13 @@ public class InternalEntities
 
         return findResource(readResourceRequest.uri())
                 .map(readResourceEntry -> readResourceEntry.handler().readResource(requestContext, readResourceEntry.resource(), readResourceRequest, allowIncompleteResult))
-                .or(() -> findResourceTemplate(readResourceRequest.uri()).map(match -> match.entry.handler().readResourceTemplate(requestContext, match.entry.resourceTemplate(), readResourceRequest, match.values, allowIncompleteResult)));
+                .or(() -> findResourceTemplate(readResourceRequest.uri()).map(match -> match.entry.handler().readResourceTemplate(requestContext, match.entry.resourceTemplate(), readResourceRequest, match.values, allowIncompleteResult)))
+                .filter(response -> {
+                    if (!allowIncompleteResult && (response instanceof InputRequests)) {
+                        throw new McpClientException(exception(INVALID_PARAMS, "Incomplete resource result not allowed: " + readResourceRequest.uri()));
+                    }
+                    return true;
+                });
     }
 
     private Optional<ResourceEntry> findResource(String uriString)

--- a/mcp/src/main/java/io/airlift/mcp/model/AllowIncompleteResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/AllowIncompleteResult.java
@@ -1,0 +1,5 @@
+package io.airlift.mcp.model;
+
+public record AllowIncompleteResult(boolean allow)
+{
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/CallToolRequest.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/CallToolRequest.java
@@ -8,29 +8,37 @@ import java.util.Optional;
 import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
 
-public record CallToolRequest(String name, Map<String, Object> arguments, Optional<Map<String, Object>> meta)
-        implements Meta
+public record CallToolRequest(String name, Map<String, Object> arguments, Optional<Map<String, InputResponse>> inputResponses, Optional<String> requestState, Optional<Map<String, Object>> meta)
+        implements Meta, InputResponsable<CallToolRequest>
 {
     public CallToolRequest
     {
         requireNonNull(name, "name is null");
         arguments = requireNonNullElse(arguments, ImmutableMap.of());
+        inputResponses = requireNonNullElse(inputResponses, Optional.empty());
+        requestState = requireNonNullElse(requestState, Optional.empty());
         meta = requireNonNullElse(meta, Optional.empty());
     }
 
     public CallToolRequest(String name, Map<String, Object> arguments)
     {
-        this(name, arguments, Optional.empty());
+        this(name, arguments, Optional.empty(), Optional.empty(), Optional.empty());
     }
 
     public CallToolRequest(String name)
     {
-        this(name, ImmutableMap.of(), Optional.empty());
+        this(name, ImmutableMap.of(), Optional.empty(), Optional.empty(), Optional.empty());
+    }
+
+    @Override
+    public CallToolRequest withInputResponses(InputResponses inputResponses)
+    {
+        return new CallToolRequest(name, arguments, Optional.of(inputResponses.inputResponses()), inputResponses.requestState(), meta);
     }
 
     @Override
     public CallToolRequest withMeta(Map<String, Object> meta)
     {
-        return new CallToolRequest(name, arguments, Optional.of(meta));
+        return new CallToolRequest(name, arguments, inputResponses, requestState, Optional.of(meta));
     }
 }

--- a/mcp/src/main/java/io/airlift/mcp/model/CallToolResponse.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/CallToolResponse.java
@@ -1,0 +1,7 @@
+package io.airlift.mcp.model;
+
+public sealed interface CallToolResponse
+        extends Result
+        permits CallToolResult, InputRequests
+{
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/CallToolResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/CallToolResult.java
@@ -1,16 +1,18 @@
 package io.airlift.mcp.model;
 
 import com.google.common.collect.ImmutableList;
+import io.airlift.mcp.model.Content.TextContent;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static io.airlift.mcp.model.ResultType.COMPLETE;
 import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
 
 public record CallToolResult(List<Content> content, Optional<StructuredContent<?>> structuredContent, boolean isError, Optional<Map<String, Object>> meta)
-        implements Meta
+        implements CallToolResponse
 {
     public CallToolResult
     {
@@ -32,6 +34,17 @@ public record CallToolResult(List<Content> content, Optional<StructuredContent<?
     public CallToolResult(List<Content> content)
     {
         this(content, Optional.empty(), false, Optional.empty());
+    }
+
+    public CallToolResult(String texContent)
+    {
+        this(ImmutableList.of(new TextContent(texContent)), Optional.empty(), false, Optional.empty());
+    }
+
+    @Override
+    public Optional<ResultType> resultType()
+    {
+        return Optional.of(COMPLETE);
     }
 
     @Override

--- a/mcp/src/main/java/io/airlift/mcp/model/CreateMessageRequest.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/CreateMessageRequest.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalDouble;
 
+import static io.airlift.mcp.model.Constants.METHOD_SAMPLING_CREATE_MESSAGE;
 import static java.util.Locale.ROOT;
 import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
@@ -22,7 +23,7 @@ public record CreateMessageRequest(
         Optional<List<String>> stopSequences,
         Optional<Map<String, Object>> metadata,
         Optional<Map<String, Object>> meta)
-        implements Meta
+        implements Meta, InputRequest
 {
     public CreateMessageRequest
     {
@@ -49,6 +50,18 @@ public record CreateMessageRequest(
     public CreateMessageRequest(Role role, Content content, int maxTokens)
     {
         this(ImmutableList.of(new SamplingMessage(role, content)), Optional.empty(), Optional.empty(), Optional.empty(), OptionalDouble.empty(), maxTokens, Optional.empty(), Optional.empty(), Optional.empty());
+    }
+
+    @Override
+    public String methodName()
+    {
+        return METHOD_SAMPLING_CREATE_MESSAGE;
+    }
+
+    @Override
+    public Class<? extends InputResponse> responseType()
+    {
+        return CreateMessageResult.class;
     }
 
     @Override

--- a/mcp/src/main/java/io/airlift/mcp/model/CreateMessageResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/CreateMessageResult.java
@@ -9,6 +9,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
 
 public record CreateMessageResult(Role role, Content content, String model, Optional<StopReason> stopReason)
+        implements InputResponse
 {
     public CreateMessageResult
     {

--- a/mcp/src/main/java/io/airlift/mcp/model/ElicitRequestForm.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ElicitRequestForm.java
@@ -5,11 +5,12 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.Map;
 import java.util.Optional;
 
+import static io.airlift.mcp.model.Constants.METHOD_ELICITATION_CREATE;
 import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
 
 public record ElicitRequestForm(Optional<String> mode, String message, ObjectNode requestedSchema, Optional<Map<String, Object>> meta)
-        implements Meta
+        implements Meta, InputRequest
 {
     public ElicitRequestForm
     {
@@ -22,6 +23,18 @@ public record ElicitRequestForm(Optional<String> mode, String message, ObjectNod
     public ElicitRequestForm(String message, ObjectNode requestedSchema)
     {
         this(Optional.of("form"), message, requestedSchema, Optional.empty());
+    }
+
+    @Override
+    public String methodName()
+    {
+        return METHOD_ELICITATION_CREATE;
+    }
+
+    @Override
+    public Class<? extends InputResponse> responseType()
+    {
+        return ElicitResult.class;
     }
 
     @Override

--- a/mcp/src/main/java/io/airlift/mcp/model/ElicitRequestUrl.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ElicitRequestUrl.java
@@ -3,11 +3,12 @@ package io.airlift.mcp.model;
 import java.util.Map;
 import java.util.Optional;
 
+import static io.airlift.mcp.model.Constants.METHOD_ELICITATION_CREATE;
 import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
 
 public record ElicitRequestUrl(Optional<String> mode, String elicitationId, String message, String url, Optional<Map<String, Object>> meta)
-        implements Meta
+        implements Meta, InputRequest
 {
     public ElicitRequestUrl
     {
@@ -21,6 +22,18 @@ public record ElicitRequestUrl(Optional<String> mode, String elicitationId, Stri
     public ElicitRequestUrl(String elicitationId, String message, String url)
     {
         this(Optional.of("url"), elicitationId, message, url, Optional.empty());
+    }
+
+    @Override
+    public String methodName()
+    {
+        return METHOD_ELICITATION_CREATE;
+    }
+
+    @Override
+    public Class<? extends InputResponse> responseType()
+    {
+        return ElicitResult.class;
     }
 
     @Override

--- a/mcp/src/main/java/io/airlift/mcp/model/ElicitResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ElicitResult.java
@@ -10,7 +10,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
 
 public record ElicitResult(Action action, Optional<Map<String, Object>> content, Optional<Map<String, Object>> meta)
-        implements Meta
+        implements Meta, InputResponse
 {
     public ElicitResult
     {

--- a/mcp/src/main/java/io/airlift/mcp/model/GetPromptRequest.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/GetPromptRequest.java
@@ -8,24 +8,32 @@ import java.util.Optional;
 import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
 
-public record GetPromptRequest(String name, Map<String, Object> arguments, Optional<Map<String, Object>> meta)
-        implements Meta
+public record GetPromptRequest(String name, Map<String, Object> arguments, Optional<Map<String, InputResponse>> inputResponses, Optional<String> requestState, Optional<Map<String, Object>> meta)
+        implements Meta, InputResponsable<GetPromptRequest>
 {
     public GetPromptRequest
     {
         requireNonNull(name, "name is null");
         arguments = requireNonNullElse(arguments, ImmutableMap.of());
+        inputResponses = requireNonNullElse(inputResponses, Optional.empty());
+        requestState = requireNonNullElse(requestState, Optional.empty());
         meta = requireNonNullElse(meta, Optional.empty());
     }
 
     public GetPromptRequest(String name, Map<String, Object> arguments)
     {
-        this(name, arguments, Optional.empty());
+        this(name, arguments, Optional.empty(), Optional.empty(), Optional.empty());
+    }
+
+    @Override
+    public GetPromptRequest withInputResponses(InputResponses inputResponses)
+    {
+        return new GetPromptRequest(name, arguments, Optional.of(inputResponses.inputResponses()), inputResponses.requestState(), meta);
     }
 
     @Override
     public GetPromptRequest withMeta(Map<String, Object> meta)
     {
-        return new GetPromptRequest(name, arguments, Optional.of(meta));
+        return new GetPromptRequest(name, arguments, inputResponses, requestState, Optional.of(meta));
     }
 }

--- a/mcp/src/main/java/io/airlift/mcp/model/GetPromptResponse.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/GetPromptResponse.java
@@ -1,0 +1,7 @@
+package io.airlift.mcp.model;
+
+public sealed interface GetPromptResponse
+        extends Result
+        permits GetPromptResult, InputRequests
+{
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/GetPromptResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/GetPromptResult.java
@@ -3,12 +3,15 @@ package io.airlift.mcp.model;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
+import static io.airlift.mcp.model.ResultType.COMPLETE;
 import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
 
-public record GetPromptResult(Optional<String> description, List<PromptMessage> messages)
+public record GetPromptResult(Optional<String> description, List<PromptMessage> messages, Optional<Map<String, Object>> meta)
+        implements GetPromptResponse
 {
     public record PromptMessage(Role role, Content content)
     {
@@ -23,5 +26,23 @@ public record GetPromptResult(Optional<String> description, List<PromptMessage> 
     {
         description = requireNonNullElse(description, Optional.empty());
         messages = ImmutableList.copyOf(messages);
+        meta = requireNonNullElse(meta, Optional.empty());
+    }
+
+    public GetPromptResult(Optional<String> description, List<PromptMessage> messages)
+    {
+        this(description, messages, Optional.empty());
+    }
+
+    @Override
+    public Optional<ResultType> resultType()
+    {
+        return Optional.of(COMPLETE);
+    }
+
+    @Override
+    public GetPromptResult withMeta(Map<String, Object> meta)
+    {
+        return new GetPromptResult(description, messages, Optional.of(meta));
     }
 }

--- a/mcp/src/main/java/io/airlift/mcp/model/InputRequest.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/InputRequest.java
@@ -1,0 +1,13 @@
+package io.airlift.mcp.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+public sealed interface InputRequest
+        permits CreateMessageRequest, ElicitRequestForm, ElicitRequestUrl, ListRootsRequest
+{
+    @JsonIgnore
+    String methodName();
+
+    @JsonIgnore
+    Class<? extends InputResponse> responseType();
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/InputRequests.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/InputRequests.java
@@ -1,0 +1,42 @@
+package io.airlift.mcp.model;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static io.airlift.mcp.model.ResultType.INCOMPLETE;
+import static java.util.Objects.requireNonNullElse;
+
+public record InputRequests(Map<String, InputRequest> inputRequests, Optional<String> requestState, Optional<Map<String, Object>> meta)
+        implements CallToolResponse, ReadResourceResponse, GetPromptResponse
+{
+    public InputRequests
+    {
+        inputRequests = ImmutableMap.copyOf(inputRequests);
+        requestState = requireNonNullElse(requestState, Optional.empty());
+        meta = requireNonNullElse(meta, Optional.empty());
+    }
+
+    public InputRequests(String key, InputRequest request)
+    {
+        this(ImmutableMap.of(key, request), Optional.empty(), Optional.empty());
+    }
+
+    @Override
+    public Optional<ResultType> resultType()
+    {
+        return Optional.of(INCOMPLETE);
+    }
+
+    public InputRequests withRequestState(String requestState)
+    {
+        return new InputRequests(inputRequests, Optional.of(requestState), meta);
+    }
+
+    @Override
+    public InputRequests withMeta(Map<String, Object> meta)
+    {
+        return new InputRequests(inputRequests, requestState, Optional.of(meta));
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/InputResponsable.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/InputResponsable.java
@@ -1,0 +1,23 @@
+package io.airlift.mcp.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+import java.util.Optional;
+
+public interface InputResponsable<T extends InputResponsable<T>>
+{
+    @JsonProperty
+    Optional<Map<String, InputResponse>> inputResponses();
+
+    @JsonProperty
+    Optional<String> requestState();
+
+    default Optional<InputResponses> toInputResponses()
+    {
+        return inputResponses()
+                .map(responses -> new InputResponses(responses, requestState()));
+    }
+
+    T withInputResponses(InputResponses inputResponses);
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/InputResponse.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/InputResponse.java
@@ -1,0 +1,6 @@
+package io.airlift.mcp.model;
+
+public sealed interface InputResponse
+        permits CreateMessageResult, ElicitResult, ListRootsResult
+{
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/InputResponses.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/InputResponses.java
@@ -1,0 +1,25 @@
+package io.airlift.mcp.model;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNullElse;
+
+public record InputResponses(Map<String, InputResponse> inputResponses, Optional<String> requestState)
+{
+    public static final InputResponses EMPTY = new InputResponses(Map.of(), Optional.empty());
+
+    public InputResponses
+    {
+        inputResponses = ImmutableMap.copyOf(inputResponses);
+        requestState = requireNonNullElse(requestState, Optional.empty());
+    }
+
+    public <R extends InputResponse> Optional<R> response(String key, Class<R> type)
+    {
+        return Optional.ofNullable(inputResponses.get(key))
+                .map(type::cast);
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/JsonRpcErrorDetail.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/JsonRpcErrorDetail.java
@@ -22,4 +22,9 @@ public record JsonRpcErrorDetail(int code, String message, Optional<Object> data
     {
         this(errorCode.code(), message, Optional.of(data));
     }
+
+    public String toMessage()
+    {
+        return "Error " + code + ": " + message + (data.map(o -> " - " + o).orElse(""));
+    }
 }

--- a/mcp/src/main/java/io/airlift/mcp/model/ListRootsRequest.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ListRootsRequest.java
@@ -1,0 +1,19 @@
+package io.airlift.mcp.model;
+
+import static io.airlift.mcp.model.Constants.METHOD_ROOTS_LIST;
+
+public record ListRootsRequest()
+        implements InputRequest
+{
+    @Override
+    public String methodName()
+    {
+        return METHOD_ROOTS_LIST;
+    }
+
+    @Override
+    public Class<? extends InputResponse> responseType()
+    {
+        return ListRootsResult.class;
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/ListRootsResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ListRootsResult.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 import static java.util.Objects.requireNonNullElse;
 
 public record ListRootsResult(List<Root> roots, Optional<Map<String, Object>> meta)
-        implements Meta
+        implements Meta, InputResponse
 {
     public ListRootsResult
     {

--- a/mcp/src/main/java/io/airlift/mcp/model/ReadResourceRequest.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ReadResourceRequest.java
@@ -6,23 +6,31 @@ import java.util.Optional;
 import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
 
-public record ReadResourceRequest(String uri, Optional<Map<String, Object>> meta)
-        implements Meta
+public record ReadResourceRequest(String uri, Optional<Map<String, InputResponse>> inputResponses, Optional<String> requestState, Optional<Map<String, Object>> meta)
+        implements Meta, InputResponsable<ReadResourceRequest>
 {
     public ReadResourceRequest
     {
         requireNonNull(uri, "uri is null");
+        inputResponses = requireNonNullElse(inputResponses, Optional.empty());
+        requestState = requireNonNullElse(requestState, Optional.empty());
         meta = requireNonNullElse(meta, Optional.empty());
     }
 
     public ReadResourceRequest(String uri)
     {
-        this(uri, Optional.empty());
+        this(uri, Optional.empty(), Optional.empty(), Optional.empty());
+    }
+
+    @Override
+    public ReadResourceRequest withInputResponses(InputResponses inputResponses)
+    {
+        return new ReadResourceRequest(uri, Optional.of(inputResponses.inputResponses()), inputResponses.requestState(), meta);
     }
 
     @Override
     public ReadResourceRequest withMeta(Map<String, Object> meta)
     {
-        return new ReadResourceRequest(uri, Optional.of(meta));
+        return new ReadResourceRequest(uri, inputResponses, requestState, Optional.of(meta));
     }
 }

--- a/mcp/src/main/java/io/airlift/mcp/model/ReadResourceResponse.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ReadResourceResponse.java
@@ -1,0 +1,7 @@
+package io.airlift.mcp.model;
+
+public sealed interface ReadResourceResponse
+        extends Result
+        permits ReadResourceResult, InputRequests
+{
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/ReadResourceResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ReadResourceResult.java
@@ -3,11 +3,35 @@ package io.airlift.mcp.model;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
-public record ReadResourceResult(List<ResourceContents> contents)
+import static io.airlift.mcp.model.ResultType.COMPLETE;
+import static java.util.Objects.requireNonNullElse;
+
+public record ReadResourceResult(List<ResourceContents> contents, Optional<Map<String, Object>> meta)
+        implements ReadResourceResponse
 {
     public ReadResourceResult
     {
         contents = ImmutableList.copyOf(contents);
+        meta = requireNonNullElse(meta, Optional.empty());
+    }
+
+    public ReadResourceResult(List<ResourceContents> contents)
+    {
+        this(contents, Optional.empty());
+    }
+
+    @Override
+    public Optional<ResultType> resultType()
+    {
+        return Optional.of(COMPLETE);
+    }
+
+    @Override
+    public ReadResourceResult withMeta(Map<String, Object> meta)
+    {
+        return new ReadResourceResult(contents, Optional.of(meta));
     }
 }

--- a/mcp/src/main/java/io/airlift/mcp/model/Result.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/Result.java
@@ -1,0 +1,13 @@
+package io.airlift.mcp.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Optional;
+
+public sealed interface Result
+        extends Meta
+        permits CallToolResponse, GetPromptResponse, ReadResourceResponse
+{
+    @JsonProperty
+    Optional<ResultType> resultType();
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/ResultType.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ResultType.java
@@ -1,0 +1,17 @@
+package io.airlift.mcp.model;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import static java.util.Locale.ROOT;
+
+public enum ResultType
+{
+    COMPLETE,
+    INCOMPLETE;
+
+    @JsonValue
+    public String toJsonValue()
+    {
+        return name().toLowerCase(ROOT);
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/operations/LegacyOperations.java
+++ b/mcp/src/main/java/io/airlift/mcp/operations/LegacyOperations.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.google.common.base.Stopwatch;
 import com.google.common.base.Supplier;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
@@ -15,10 +16,14 @@ import io.airlift.mcp.McpIdentity;
 import io.airlift.mcp.McpMetadata;
 import io.airlift.mcp.SentMessages;
 import io.airlift.mcp.model.CallToolRequest;
+import io.airlift.mcp.model.CallToolResponse;
+import io.airlift.mcp.model.CallToolResult;
 import io.airlift.mcp.model.CancelledNotification;
 import io.airlift.mcp.model.CompleteReference;
 import io.airlift.mcp.model.CompleteRequest;
+import io.airlift.mcp.model.Content.TextContent;
 import io.airlift.mcp.model.GetPromptRequest;
+import io.airlift.mcp.model.GetPromptResponse;
 import io.airlift.mcp.model.Implementation;
 import io.airlift.mcp.model.InitializeRequest;
 import io.airlift.mcp.model.InitializeResult;
@@ -32,6 +37,7 @@ import io.airlift.mcp.model.Meta;
 import io.airlift.mcp.model.Prompt;
 import io.airlift.mcp.model.Protocol;
 import io.airlift.mcp.model.ReadResourceRequest;
+import io.airlift.mcp.model.ReadResourceResponse;
 import io.airlift.mcp.model.Resource;
 import io.airlift.mcp.model.ResourceTemplate;
 import io.airlift.mcp.model.SetLevelRequest;
@@ -110,12 +116,13 @@ public class LegacyOperations
     private final int maxResumableMessages;
     private final LegacyVersionsController versionsController;
     private final Duration sessionTimeout;
+    private final MrtrEmulator mrtrEmulator;
     private final OperationsCommon operationsCommon;
     private final McpEntities entities;
     private final Implementation serverImplementation;
 
     @Inject
-    public LegacyOperations(
+    LegacyOperations(
             McpMetadata metadata,
             JsonMapper jsonMapper,
             Optional<SessionController> sessionController,
@@ -125,7 +132,8 @@ public class LegacyOperations
             IconHelper iconHelper,
             @Named(MCP_SERVER_ICONS) Set<String> serverIcons,
             McpEntities entities,
-            OperationsCommon operationsCommon)
+            OperationsCommon operationsCommon,
+            MrtrEmulator mrtrEmulator)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.jsonMapper = requireNonNull(jsonMapper, "jsonMapper is null");
@@ -134,6 +142,7 @@ public class LegacyOperations
         this.versionsController = requireNonNull(versionsController, "versionsController is null");
         this.entities = requireNonNull(entities, "entities is null");
         this.operationsCommon = requireNonNull(operationsCommon, "operationsCommon is null");
+        this.mrtrEmulator = requireNonNull(mrtrEmulator, "mrtrEmulator is null");
 
         httpGetEventsEnabled = mcpConfig.isHttpGetEventsEnabled();
         streamingPingThreshold = mcpConfig.getEventStreamingPingThreshold().toJavaTime();
@@ -166,12 +175,12 @@ public class LegacyOperations
         Object result = switch (method) {
             case METHOD_INITIALIZE -> handleInitialize(requestContext, operationsCommon.convertParams(rpcRequest, InitializeRequest.class));
             case METHOD_TOOLS_LIST -> withManagement(requestContext, requestId, () -> operationsCommon.listTools(requestContext, operationsCommon.convertParams(rpcRequest, ListRequest.class)));
-            case METHOD_TOOLS_CALL -> withManagement(requestContext, requestId, () -> operationsCommon.callTool(requestContext, operationsCommon.convertParams(rpcRequest, CallToolRequest.class)));
+            case METHOD_TOOLS_CALL -> withManagement(requestContext, requestId, () -> internalCallTool(requestContext, operationsCommon.convertParams(rpcRequest, CallToolRequest.class)));
             case METHOD_PROMPT_LIST -> withManagement(requestContext, requestId, () -> operationsCommon.listPrompts(requestContext, operationsCommon.convertParams(rpcRequest, ListRequest.class)));
-            case METHOD_PROMPT_GET -> withManagement(requestContext, requestId, () -> operationsCommon.getPrompt(requestContext, operationsCommon.convertParams(rpcRequest, GetPromptRequest.class)));
+            case METHOD_PROMPT_GET -> withManagement(requestContext, requestId, () -> internalGetPrompt(requestContext, operationsCommon.convertParams(rpcRequest, GetPromptRequest.class)));
             case METHOD_RESOURCES_LIST -> withManagement(requestContext, requestId, () -> operationsCommon.listResources(requestContext, operationsCommon.convertParams(rpcRequest, ListRequest.class)));
             case METHOD_RESOURCES_TEMPLATES_LIST -> withManagement(requestContext, requestId, () -> operationsCommon.listResourceTemplates(requestContext, operationsCommon.convertParams(rpcRequest, ListRequest.class)));
-            case METHOD_RESOURCES_READ -> withManagement(requestContext, requestId, () -> operationsCommon.readResources(requestContext, operationsCommon.convertParams(rpcRequest, ReadResourceRequest.class)));
+            case METHOD_RESOURCES_READ -> withManagement(requestContext, requestId, () -> internalReadResources(requestContext, operationsCommon.convertParams(rpcRequest, ReadResourceRequest.class)));
             case METHOD_COMPLETION_COMPLETE -> operationsCommon.completionComplete(requestContext, operationsCommon.convertParams(rpcRequest, CompleteRequest.class));
             case METHOD_LOGGING_SET_LEVEL -> handleSetLoggingLevel(requestContext, operationsCommon.convertParams(rpcRequest, SetLevelRequest.class));
             case METHOD_RESOURCES_SUBSCRIBE -> handleResourcesSubscribe(requestContext, operationsCommon.convertParams(rpcRequest, SubscribeRequest.class));
@@ -468,5 +477,28 @@ public class LegacyOperations
         optionalSessionId(request)
                 .ifPresent(sessionId ->
                         updateRequestSpan(request, span -> span.setAttribute(MCP_SESSION_ID, sessionId.id())));
+    }
+
+    private CallToolResponse internalCallTool(RequestContextImpl requestContext, CallToolRequest callToolRequest)
+    {
+        MrtrEmulator.ErrorFactory<CallToolRequest, CallToolResponse> errorFactory = (_, errorDetail, _) ->
+                new CallToolResult(ImmutableList.of(new TextContent(errorDetail.toMessage())), Optional.empty(), true);
+        return mrtrEmulator.emulateMrtr(requestContext, callToolRequest, errorFactory, operationsCommon::callTool);
+    }
+
+    private GetPromptResponse internalGetPrompt(RequestContextImpl requestContext, GetPromptRequest getPromptRequest)
+    {
+        MrtrEmulator.ErrorFactory<GetPromptRequest, GetPromptResponse> errorFactory = (_, errorDetail, _) -> {
+            throw exception(errorDetail.code(), errorDetail.message(), errorDetail.data());
+        };
+        return mrtrEmulator.emulateMrtr(requestContext, getPromptRequest, errorFactory, operationsCommon::getPrompt);
+    }
+
+    private ReadResourceResponse internalReadResources(RequestContextImpl requestContext, ReadResourceRequest readResourceRequest)
+    {
+        MrtrEmulator.ErrorFactory<ReadResourceRequest, ReadResourceResponse> errorFactory = (_, errorDetail, _) -> {
+            throw exception(errorDetail.code(), errorDetail.message(), errorDetail.data());
+        };
+        return mrtrEmulator.emulateMrtr(requestContext, readResourceRequest, errorFactory, operationsCommon::readResources);
     }
 }

--- a/mcp/src/main/java/io/airlift/mcp/operations/LegacyVersionsController.java
+++ b/mcp/src/main/java/io/airlift/mcp/operations/LegacyVersionsController.java
@@ -188,7 +188,7 @@ class LegacyVersionsController
     {
         try {
             return resourceVersionsCache.get(uri, () -> {
-                Optional<ReadResourceResult> maybeResourceContents = entities.readResourceContents(requestContext, new ReadResourceRequest(uri, Optional.empty()), false)
+                Optional<ReadResourceResult> maybeResourceContents = entities.readResourceContents(requestContext, new ReadResourceRequest(uri), false)
                         .map(ReadResourceResult.class::cast);   // cast must succeed due to passing false for allowIncompleteResult
                 if (required && maybeResourceContents.isEmpty()) {
                     throw exception(RESOURCE_NOT_FOUND, "Resource not found: " + uri);

--- a/mcp/src/main/java/io/airlift/mcp/operations/LegacyVersionsController.java
+++ b/mcp/src/main/java/io/airlift/mcp/operations/LegacyVersionsController.java
@@ -188,7 +188,7 @@ class LegacyVersionsController
     {
         try {
             return resourceVersionsCache.get(uri, () -> {
-                Optional<ReadResourceResult> maybeResourceContents = entities.readResourceContents(requestContext, new ReadResourceRequest(uri, Optional.empty()));
+                Optional<ReadResourceResult> maybeResourceContents = entities.readResourceContents(requestContext, new ReadResourceRequest(uri, Optional.empty()), false);
                 if (required && maybeResourceContents.isEmpty()) {
                     throw exception(RESOURCE_NOT_FOUND, "Resource not found: " + uri);
                 }

--- a/mcp/src/main/java/io/airlift/mcp/operations/LegacyVersionsController.java
+++ b/mcp/src/main/java/io/airlift/mcp/operations/LegacyVersionsController.java
@@ -188,7 +188,8 @@ class LegacyVersionsController
     {
         try {
             return resourceVersionsCache.get(uri, () -> {
-                Optional<ReadResourceResult> maybeResourceContents = entities.readResourceContents(requestContext, new ReadResourceRequest(uri, Optional.empty()), false);
+                Optional<ReadResourceResult> maybeResourceContents = entities.readResourceContents(requestContext, new ReadResourceRequest(uri, Optional.empty()), false)
+                        .map(ReadResourceResult.class::cast);   // cast must succeed due to passing false for allowIncompleteResult
                 if (required && maybeResourceContents.isEmpty()) {
                     throw exception(RESOURCE_NOT_FOUND, "Resource not found: " + uri);
                 }

--- a/mcp/src/main/java/io/airlift/mcp/operations/LegacyVersionsController.java
+++ b/mcp/src/main/java/io/airlift/mcp/operations/LegacyVersionsController.java
@@ -15,7 +15,7 @@ import io.airlift.mcp.McpEntities;
 import io.airlift.mcp.McpException;
 import io.airlift.mcp.McpRequestContext;
 import io.airlift.mcp.model.ReadResourceRequest;
-import io.airlift.mcp.model.ResourceContents;
+import io.airlift.mcp.model.ReadResourceResult;
 import io.airlift.mcp.model.ResourcesUpdatedNotification;
 import io.airlift.mcp.model.SubscribeRequest;
 
@@ -188,12 +188,12 @@ class LegacyVersionsController
     {
         try {
             return resourceVersionsCache.get(uri, () -> {
-                Optional<List<ResourceContents>> resourceContents = entities.readResourceContents(requestContext, new ReadResourceRequest(uri, Optional.empty()));
-                if (required && resourceContents.isEmpty()) {
+                Optional<ReadResourceResult> maybeResourceContents = entities.readResourceContents(requestContext, new ReadResourceRequest(uri, Optional.empty()));
+                if (required && maybeResourceContents.isEmpty()) {
                     throw exception(RESOURCE_NOT_FOUND, "Resource not found: " + uri);
                 }
-                return resourceContents
-                        .map(contents -> listHash(contents.stream()))
+                return maybeResourceContents
+                        .map(resourceContents -> listHash(resourceContents.contents().stream()))
                         .orElse("");
             });
         }

--- a/mcp/src/main/java/io/airlift/mcp/operations/MrtrEmulator.java
+++ b/mcp/src/main/java/io/airlift/mcp/operations/MrtrEmulator.java
@@ -1,0 +1,113 @@
+package io.airlift.mcp.operations;
+
+import com.google.common.base.Stopwatch;
+import com.google.inject.Inject;
+import io.airlift.log.Logger;
+import io.airlift.mcp.McpConfig;
+import io.airlift.mcp.model.InputRequest;
+import io.airlift.mcp.model.InputRequests;
+import io.airlift.mcp.model.InputResponsable;
+import io.airlift.mcp.model.InputResponse;
+import io.airlift.mcp.model.InputResponses;
+import io.airlift.mcp.model.JsonRpcErrorDetail;
+import io.airlift.mcp.model.JsonRpcResponse;
+import io.airlift.mcp.model.ListRootsRequest;
+import io.airlift.mcp.model.ListRootsResult;
+import io.airlift.mcp.model.Result;
+import io.airlift.mcp.model.Root;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeoutException;
+import java.util.function.BiFunction;
+
+import static io.airlift.mcp.model.JsonRpcErrorCode.INTERNAL_ERROR;
+import static io.airlift.mcp.model.JsonRpcErrorCode.REQUEST_TIMEOUT;
+
+class MrtrEmulator
+{
+    private static final Logger log = Logger.get(MrtrEmulator.class);
+
+    private final Duration streamingTimeout;
+    private final Duration streamingPingThreshold;
+
+    @Inject
+    MrtrEmulator(McpConfig mcpConfig)
+    {
+        streamingTimeout = mcpConfig.getEventStreamingTimeout().toJavaTime();
+        streamingPingThreshold = mcpConfig.getEventStreamingPingThreshold().toJavaTime();
+    }
+
+    interface ErrorFactory<T extends InputResponsable<T>, R extends Result>
+    {
+        R createErrorResponse(RequestContextImpl requestContext, JsonRpcErrorDetail errorDetail, T request);
+    }
+
+    <T extends InputResponsable<T>, R extends Result> R emulateMrtr(RequestContextImpl requestContext, T request, ErrorFactory<T, R> errorFactory, BiFunction<RequestContextImpl, T, R> operation)
+    {
+        R operationResponse;
+
+        Stopwatch stopwatch = Stopwatch.createStarted();
+
+        while (true) {
+            operationResponse = operation.apply(requestContext, request);
+            if (!(operationResponse instanceof InputRequests(var inputRequests, var requestState, _))) {
+                break;
+            }
+
+            Map<String, InputResponse> inputResponses = new HashMap<>();
+            for (Map.Entry<String, InputRequest> entry : inputRequests.entrySet()) {
+                String key = entry.getKey();
+                InputRequest inputRequest = entry.getValue();
+
+                try {
+                    Duration elapsed = stopwatch.elapsed();
+                    Duration thisTimeout = streamingTimeout.minus(elapsed);
+                    if (thisTimeout.isNegative()) {
+                        return timeout(requestContext, request, errorFactory, key);
+                    }
+
+                    JsonRpcResponse<?> response;
+                    if (inputRequest instanceof ListRootsRequest) {
+                        List<Root> roots = requestContext.requestRoots(thisTimeout, streamingPingThreshold);
+                        response = new JsonRpcResponse<>("", Optional.empty(), Optional.of(new ListRootsResult(roots, Optional.empty())));
+                    }
+                    else {
+                        response = requestContext.serverToClientRequest(inputRequest.methodName(), inputRequest, inputRequest.responseType(), thisTimeout, streamingPingThreshold);
+                    }
+
+                    if (response.error().isPresent()) {
+                        JsonRpcErrorDetail errorDetail = response.error().orElseThrow();
+                        return errorFactory.createErrorResponse(requestContext, errorDetail, request);
+                    }
+                    else {
+                        Object result = response.result().orElseThrow(() -> new IllegalStateException("Missing result in response for input request: " + key));
+                        inputResponses.put(key, inputRequest.responseType().cast(result));
+                    }
+                }
+                catch (InterruptedException _) {
+                    Thread.currentThread().interrupt();
+
+                    log.warn("Interrupted while waiting for input request: %s", key);
+                    return errorFactory.createErrorResponse(requestContext, new JsonRpcErrorDetail(INTERNAL_ERROR, "Interrupted while waiting for input request: " + key), request);
+                }
+                catch (TimeoutException _) {
+                    log.warn("Timeout while waiting for input request: %s", key);
+                    return timeout(requestContext, request, errorFactory, key);
+                }
+            }
+
+            request = request.withInputResponses(new InputResponses(inputResponses, requestState));
+        }
+
+        return operationResponse;
+    }
+
+    private static <T extends InputResponsable<T>, R extends Result> R timeout(RequestContextImpl requestContext, T request, ErrorFactory<T, R> errorFactory, String key)
+    {
+        return errorFactory.createErrorResponse(requestContext, new JsonRpcErrorDetail(REQUEST_TIMEOUT, "Timeout waiting for input request: " + key), request);
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/operations/OperationsCommon.java
+++ b/mcp/src/main/java/io/airlift/mcp/operations/OperationsCommon.java
@@ -128,7 +128,7 @@ public class OperationsCommon
     {
         updateRequestSpan(requestContext.request(), span -> span.setAttribute(MCP_RESOURCE_URI, readResourceRequest.uri()));
 
-        return entities.readResourceContents(requestContext.withProgressToken(progressToken(readResourceRequest)), readResourceRequest)
+        return entities.readResourceContents(requestContext.withProgressToken(progressToken(readResourceRequest)), readResourceRequest, true)
                 .orElseThrow(() -> exception(RESOURCE_NOT_FOUND, "Resource not found: " + readResourceRequest.uri()));
     }
 

--- a/mcp/src/main/java/io/airlift/mcp/operations/OperationsCommon.java
+++ b/mcp/src/main/java/io/airlift/mcp/operations/OperationsCommon.java
@@ -27,6 +27,7 @@ import io.airlift.mcp.model.Meta;
 import io.airlift.mcp.model.OptionalBoolean;
 import io.airlift.mcp.model.Prompt;
 import io.airlift.mcp.model.ReadResourceRequest;
+import io.airlift.mcp.model.ReadResourceResponse;
 import io.airlift.mcp.model.Resource;
 import io.airlift.mcp.model.ResourceTemplate;
 import io.airlift.mcp.model.Tool;
@@ -125,7 +126,7 @@ public class OperationsCommon
         return paginationUtil.paginate(listRequest, localResourceTemplates, ResourceTemplate::name, ListResourceTemplatesResult::new);
     }
 
-    Object readResources(RequestContextImpl requestContext, ReadResourceRequest readResourceRequest)
+    ReadResourceResponse readResources(RequestContextImpl requestContext, ReadResourceRequest readResourceRequest)
     {
         updateRequestSpan(requestContext.request(), span -> span.setAttribute(MCP_RESOURCE_URI, readResourceRequest.uri()));
 

--- a/mcp/src/main/java/io/airlift/mcp/operations/OperationsCommon.java
+++ b/mcp/src/main/java/io/airlift/mcp/operations/OperationsCommon.java
@@ -10,12 +10,13 @@ import io.airlift.mcp.McpEntities;
 import io.airlift.mcp.handler.PromptEntry;
 import io.airlift.mcp.handler.ToolEntry;
 import io.airlift.mcp.model.CallToolRequest;
+import io.airlift.mcp.model.CallToolResponse;
 import io.airlift.mcp.model.CallToolResult;
 import io.airlift.mcp.model.CompleteRequest;
 import io.airlift.mcp.model.CompleteResult;
 import io.airlift.mcp.model.Content.TextContent;
 import io.airlift.mcp.model.GetPromptRequest;
-import io.airlift.mcp.model.GetPromptResult;
+import io.airlift.mcp.model.GetPromptResponse;
 import io.airlift.mcp.model.JsonRpcRequest;
 import io.airlift.mcp.model.ListPromptsResult;
 import io.airlift.mcp.model.ListRequest;
@@ -72,7 +73,7 @@ public class OperationsCommon
         return paginationUtil.paginate(listRequest, localTools, Tool::name, ListToolsResult::new);
     }
 
-    CallToolResult callTool(RequestContextImpl requestContext, CallToolRequest callToolRequest)
+    CallToolResponse callTool(RequestContextImpl requestContext, CallToolRequest callToolRequest)
     {
         entities.validateToolAllowed(requestContext, callToolRequest.name());
 
@@ -96,7 +97,7 @@ public class OperationsCommon
         return paginationUtil.paginate(listRequest, localPrompts, Prompt::name, ListPromptsResult::new);
     }
 
-    GetPromptResult getPrompt(RequestContextImpl requestContext, GetPromptRequest getPromptRequest)
+    GetPromptResponse getPrompt(RequestContextImpl requestContext, GetPromptRequest getPromptRequest)
     {
         entities.validatePromptAllowed(requestContext, getPromptRequest.name());
 

--- a/mcp/src/main/java/io/airlift/mcp/operations/OperationsCommon.java
+++ b/mcp/src/main/java/io/airlift/mcp/operations/OperationsCommon.java
@@ -26,9 +26,7 @@ import io.airlift.mcp.model.Meta;
 import io.airlift.mcp.model.OptionalBoolean;
 import io.airlift.mcp.model.Prompt;
 import io.airlift.mcp.model.ReadResourceRequest;
-import io.airlift.mcp.model.ReadResourceResult;
 import io.airlift.mcp.model.Resource;
-import io.airlift.mcp.model.ResourceContents;
 import io.airlift.mcp.model.ResourceTemplate;
 import io.airlift.mcp.model.Tool;
 
@@ -130,10 +128,8 @@ public class OperationsCommon
     {
         updateRequestSpan(requestContext.request(), span -> span.setAttribute(MCP_RESOURCE_URI, readResourceRequest.uri()));
 
-        List<ResourceContents> resourceContents = entities.readResourceContents(requestContext.withProgressToken(progressToken(readResourceRequest)), readResourceRequest)
+        return entities.readResourceContents(requestContext.withProgressToken(progressToken(readResourceRequest)), readResourceRequest)
                 .orElseThrow(() -> exception(RESOURCE_NOT_FOUND, "Resource not found: " + readResourceRequest.uri()));
-
-        return new ReadResourceResult(resourceContents);
     }
 
     CompleteResult completionComplete(RequestContextImpl requestContext, CompleteRequest completeRequest)

--- a/mcp/src/main/java/io/airlift/mcp/operations/OperationsModule.java
+++ b/mcp/src/main/java/io/airlift/mcp/operations/OperationsModule.java
@@ -18,5 +18,6 @@ public class OperationsModule
         newOptionalBinder(binder, ErrorHandler.class).setDefault().to(ErrorHandlerImpl.class);
 
         binder.bind(LegacyCancellationController.class).in(SINGLETON);
+        binder.bind(MrtrEmulator.class).in(SINGLETON);
     }
 }

--- a/mcp/src/main/java/io/airlift/mcp/operations/RequestContextImpl.java
+++ b/mcp/src/main/java/io/airlift/mcp/operations/RequestContextImpl.java
@@ -207,8 +207,7 @@ class RequestContextImpl
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})
-    @Override
-    public <R> JsonRpcResponse<R> serverToClientRequest(String method, Object params, Class<R> responseType, Duration timeout, Duration pollInterval)
+    <R> JsonRpcResponse<R> serverToClientRequest(String method, Object params, Class<R> responseType, Duration timeout, Duration pollInterval)
             throws InterruptedException, TimeoutException
     {
         SessionController localSessionController = sessionController.orElseThrow(() -> new IllegalStateException("Sessions are not enabled"));
@@ -249,8 +248,7 @@ class RequestContextImpl
     }
 
     @SuppressWarnings("ThrowableNotThrown")
-    @Override
-    public List<Root> requestRoots(Duration timeout, Duration pollInterval)
+    List<Root> requestRoots(Duration timeout, Duration pollInterval)
             throws InterruptedException, TimeoutException
     {
         SessionController localSessionController = sessionController.orElseThrow(() -> new IllegalStateException("Sessions not enabled"));

--- a/mcp/src/main/java/io/airlift/mcp/reflection/AppResourceHandlerProvider.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/AppResourceHandlerProvider.java
@@ -96,7 +96,7 @@ public class AppResourceHandlerProvider
     }
 
     @Override
-    public ReadResourceResult readResource(McpRequestContext requestContext, Resource sourceResource, ReadResourceRequest readResourceRequest)
+    public ReadResourceResult readResource(McpRequestContext requestContext, Resource sourceResource, ReadResourceRequest readResourceRequest, boolean allowIncompleteResult)
     {
         return requireNonNull(resourceContentsSupplier, "resourceContents is null").get();
     }

--- a/mcp/src/main/java/io/airlift/mcp/reflection/AppResourceHandlerProvider.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/AppResourceHandlerProvider.java
@@ -11,6 +11,7 @@ import io.airlift.mcp.handler.ResourceEntry;
 import io.airlift.mcp.handler.ResourceHandler;
 import io.airlift.mcp.model.OptionalBoolean;
 import io.airlift.mcp.model.ReadResourceRequest;
+import io.airlift.mcp.model.ReadResourceResponse;
 import io.airlift.mcp.model.ReadResourceResult;
 import io.airlift.mcp.model.Resource;
 import io.airlift.mcp.model.ResourceContents;
@@ -96,7 +97,7 @@ public class AppResourceHandlerProvider
     }
 
     @Override
-    public ReadResourceResult readResource(McpRequestContext requestContext, Resource sourceResource, ReadResourceRequest readResourceRequest, boolean allowIncompleteResult)
+    public ReadResourceResponse readResource(McpRequestContext requestContext, Resource sourceResource, ReadResourceRequest readResourceRequest, boolean allowIncompleteResult)
     {
         return requireNonNull(resourceContentsSupplier, "resourceContents is null").get();
     }

--- a/mcp/src/main/java/io/airlift/mcp/reflection/AppResourceHandlerProvider.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/AppResourceHandlerProvider.java
@@ -11,11 +11,11 @@ import io.airlift.mcp.handler.ResourceEntry;
 import io.airlift.mcp.handler.ResourceHandler;
 import io.airlift.mcp.model.OptionalBoolean;
 import io.airlift.mcp.model.ReadResourceRequest;
+import io.airlift.mcp.model.ReadResourceResult;
 import io.airlift.mcp.model.Resource;
 import io.airlift.mcp.model.ResourceContents;
 
 import java.net.URI;
-import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
@@ -37,7 +37,7 @@ public class AppResourceHandlerProvider
     private final Supplier<String> contentSupplier;
     private final int contentLength;
     private volatile String host;
-    private volatile Supplier<List<ResourceContents>> resourceContentsSupplier;
+    private volatile Supplier<ReadResourceResult> resourceContentsSupplier;
 
     public AppResourceHandlerProvider(McpApp app, String name, Optional<String> description, Supplier<String> contentSupplier, int contentLength)
     {
@@ -90,13 +90,13 @@ public class AppResourceHandlerProvider
         ImmutableMap.Builder<String, Object> meta = ImmutableMap.builder();
         meta.put("ui", uiMeta.build());
 
-        this.resourceContentsSupplier = () -> ImmutableList.of(new ResourceContents(resource.uri(), resource.uri(), resource.mimeType(), contentSupplier.get()).withMeta(meta.build()));
+        this.resourceContentsSupplier = () -> new ReadResourceResult(ImmutableList.of(new ResourceContents(resource.uri(), resource.uri(), resource.mimeType(), contentSupplier.get()).withMeta(meta.build())));
 
         return new ResourceEntry(resource, this);
     }
 
     @Override
-    public List<ResourceContents> readResource(McpRequestContext requestContext, Resource sourceResource, ReadResourceRequest readResourceRequest)
+    public ReadResourceResult readResource(McpRequestContext requestContext, Resource sourceResource, ReadResourceRequest readResourceRequest)
     {
         return requireNonNull(resourceContentsSupplier, "resourceContents is null").get();
     }

--- a/mcp/src/main/java/io/airlift/mcp/reflection/MethodInvoker.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/MethodInvoker.java
@@ -15,6 +15,8 @@ import io.airlift.mcp.model.CallToolRequest;
 import io.airlift.mcp.model.CompleteRequest.CompleteArgument;
 import io.airlift.mcp.model.CompleteRequest.CompleteContext;
 import io.airlift.mcp.model.GetPromptRequest;
+import io.airlift.mcp.model.InputResponsable;
+import io.airlift.mcp.model.InputResponses;
 import io.airlift.mcp.model.JsonRpcErrorDetail;
 import io.airlift.mcp.model.ReadResourceRequest;
 import io.airlift.mcp.model.Resource;
@@ -27,6 +29,7 @@ import io.airlift.mcp.reflection.MethodParameter.CompleteContextParameter;
 import io.airlift.mcp.reflection.MethodParameter.GetPromptRequestParameter;
 import io.airlift.mcp.reflection.MethodParameter.HttpRequestParameter;
 import io.airlift.mcp.reflection.MethodParameter.IdentityParameter;
+import io.airlift.mcp.reflection.MethodParameter.InputResponsesParameter;
 import io.airlift.mcp.reflection.MethodParameter.McpRequestContextParameter;
 import io.airlift.mcp.reflection.MethodParameter.ObjectParameter;
 import io.airlift.mcp.reflection.MethodParameter.ReadResourceRequestParameter;
@@ -196,6 +199,7 @@ public class MethodInvoker
                                 case CompleteArgumentParameter _ -> completeArgument.orElseThrow(() -> new IllegalStateException("CompleteArgument is required"));
                                 case CompleteContextParameter _ -> completeContext.orElseThrow(() -> new IllegalStateException("CompleteContext is required"));
                                 case AllowIncompleteResultParameter _ -> new AllowIncompleteResult(allowIncompleteResult);
+                                case InputResponsesParameter _ -> inputResponses();
                                 case ObjectParameter objectParameter -> valueForObjectParameter(arguments, objectParameter);
                             })
                             .toArray();
@@ -217,6 +221,14 @@ public class MethodInvoker
                         default -> new McpException(rootCause, new JsonRpcErrorDetail(INTERNAL_ERROR, "Failed to invoke method: " + methodName));
                     };
                 }
+            }
+
+            private InputResponses inputResponses()
+            {
+                return callToolRequest.flatMap(InputResponsable::toInputResponses)
+                        .or(() -> getPromptRequest.flatMap(InputResponsable::toInputResponses))
+                        .or(() -> readResourceRequest.flatMap(InputResponsable::toInputResponses))
+                        .orElse(InputResponses.EMPTY);
             }
         };
     }

--- a/mcp/src/main/java/io/airlift/mcp/reflection/MethodInvoker.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/MethodInvoker.java
@@ -10,6 +10,7 @@ import com.google.inject.Provider;
 import io.airlift.mcp.McpClientException;
 import io.airlift.mcp.McpException;
 import io.airlift.mcp.McpRequestContext;
+import io.airlift.mcp.model.AllowIncompleteResult;
 import io.airlift.mcp.model.CallToolRequest;
 import io.airlift.mcp.model.CompleteRequest.CompleteArgument;
 import io.airlift.mcp.model.CompleteRequest.CompleteContext;
@@ -19,6 +20,7 @@ import io.airlift.mcp.model.ReadResourceRequest;
 import io.airlift.mcp.model.Resource;
 import io.airlift.mcp.model.ResourceTemplate;
 import io.airlift.mcp.model.ResourceTemplateValues;
+import io.airlift.mcp.reflection.MethodParameter.AllowIncompleteResultParameter;
 import io.airlift.mcp.reflection.MethodParameter.CallToolRequestParameter;
 import io.airlift.mcp.reflection.MethodParameter.CompleteArgumentParameter;
 import io.airlift.mcp.reflection.MethodParameter.CompleteContextParameter;
@@ -91,6 +93,8 @@ public class MethodInvoker
 
         Builder withCompleteContext(CompleteContext completeContext);
 
+        Builder withAllowIncompleteResult(boolean allowIncompleteResult);
+
         Object invoke();
     }
 
@@ -107,6 +111,7 @@ public class MethodInvoker
             private Optional<ResourceTemplateValues> resourceTemplateValues = Optional.empty();
             private Optional<CompleteArgument> completeArgument = Optional.empty();
             private Optional<CompleteContext> completeContext = Optional.empty();
+            private boolean allowIncompleteResult = true;
 
             @Override
             public Builder withArguments(Map<String, Object> arguments)
@@ -167,6 +172,13 @@ public class MethodInvoker
             }
 
             @Override
+            public Builder withAllowIncompleteResult(boolean allowIncompleteResult)
+            {
+                this.allowIncompleteResult = allowIncompleteResult;
+                return this;
+            }
+
+            @Override
             public Object invoke()
             {
                 try {
@@ -183,6 +195,7 @@ public class MethodInvoker
                                 case IdentityParameter _ -> retrieveIdentityValue(requestContext.request());
                                 case CompleteArgumentParameter _ -> completeArgument.orElseThrow(() -> new IllegalStateException("CompleteArgument is required"));
                                 case CompleteContextParameter _ -> completeContext.orElseThrow(() -> new IllegalStateException("CompleteContext is required"));
+                                case AllowIncompleteResultParameter _ -> new AllowIncompleteResult(allowIncompleteResult);
                                 case ObjectParameter objectParameter -> valueForObjectParameter(arguments, objectParameter);
                             })
                             .toArray();

--- a/mcp/src/main/java/io/airlift/mcp/reflection/MethodParameter.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/MethodParameter.java
@@ -73,6 +73,12 @@ public sealed interface MethodParameter
         public static final CompleteContextParameter INSTANCE = new CompleteContextParameter();
     }
 
+    record AllowIncompleteResultParameter()
+            implements MethodParameter
+    {
+        public static final AllowIncompleteResultParameter INSTANCE = new AllowIncompleteResultParameter();
+    }
+
     record ObjectParameter(
             String name,
             Class<?> rawType,

--- a/mcp/src/main/java/io/airlift/mcp/reflection/MethodParameter.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/MethodParameter.java
@@ -79,6 +79,12 @@ public sealed interface MethodParameter
         public static final AllowIncompleteResultParameter INSTANCE = new AllowIncompleteResultParameter();
     }
 
+    record InputResponsesParameter()
+            implements MethodParameter
+    {
+        public static final InputResponsesParameter INSTANCE = new InputResponsesParameter();
+    }
+
     record ObjectParameter(
             String name,
             Class<?> rawType,

--- a/mcp/src/main/java/io/airlift/mcp/reflection/Predicates.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/Predicates.java
@@ -1,7 +1,9 @@
 package io.airlift.mcp.reflection;
 
 import io.airlift.mcp.model.CompleteResult.CompleteCompletion;
+import io.airlift.mcp.model.GetPromptResponse;
 import io.airlift.mcp.model.GetPromptResult;
+import io.airlift.mcp.model.ReadResourceResponse;
 import io.airlift.mcp.model.ReadResourceResult;
 import io.airlift.mcp.model.ResourceContents;
 import io.airlift.mcp.reflection.MethodParameter.CallToolRequestParameter;
@@ -41,6 +43,7 @@ public interface Predicates
     Predicate<Method> returnsAnything = _ -> true;
     Predicate<Method> returnsResourceContents = method -> method.getReturnType().equals(ResourceContents.class);
     Predicate<Method> returnsReadResourceResult = method -> method.getReturnType().equals(ReadResourceResult.class);
+    Predicate<Method> returnsReadResourceResponse = method -> method.getReturnType().equals(ReadResourceResponse.class);
     Predicate<Method> returnsCompleteCompletion = method -> method.getReturnType().equals(CompleteCompletion.class);
     Predicate<Method> returnsResourceContentsList = method -> listArgument(method.getGenericReturnType())
             .map(t -> t.equals(ResourceContents.class))
@@ -50,4 +53,5 @@ public interface Predicates
             .orElse(false);
     Predicate<Method> returnsString = method -> method.getReturnType().equals(String.class);
     Predicate<Method> returnsGetPromptResult = method -> method.getReturnType().equals(GetPromptResult.class);
+    Predicate<Method> returnsGetPromptResponse = method -> method.getReturnType().equals(GetPromptResponse.class);
 }

--- a/mcp/src/main/java/io/airlift/mcp/reflection/Predicates.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/Predicates.java
@@ -2,6 +2,7 @@ package io.airlift.mcp.reflection;
 
 import io.airlift.mcp.model.CompleteResult.CompleteCompletion;
 import io.airlift.mcp.model.GetPromptResult;
+import io.airlift.mcp.model.ReadResourceResult;
 import io.airlift.mcp.model.ResourceContents;
 import io.airlift.mcp.reflection.MethodParameter.CallToolRequestParameter;
 import io.airlift.mcp.reflection.MethodParameter.CompleteArgumentParameter;
@@ -39,6 +40,7 @@ public interface Predicates
 
     Predicate<Method> returnsAnything = _ -> true;
     Predicate<Method> returnsResourceContents = method -> method.getReturnType().equals(ResourceContents.class);
+    Predicate<Method> returnsReadResourceResult = method -> method.getReturnType().equals(ReadResourceResult.class);
     Predicate<Method> returnsCompleteCompletion = method -> method.getReturnType().equals(CompleteCompletion.class);
     Predicate<Method> returnsResourceContentsList = method -> listArgument(method.getGenericReturnType())
             .map(t -> t.equals(ResourceContents.class))

--- a/mcp/src/main/java/io/airlift/mcp/reflection/Predicates.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/Predicates.java
@@ -12,6 +12,7 @@ import io.airlift.mcp.reflection.MethodParameter.CompleteContextParameter;
 import io.airlift.mcp.reflection.MethodParameter.GetPromptRequestParameter;
 import io.airlift.mcp.reflection.MethodParameter.HttpRequestParameter;
 import io.airlift.mcp.reflection.MethodParameter.IdentityParameter;
+import io.airlift.mcp.reflection.MethodParameter.InputResponsesParameter;
 import io.airlift.mcp.reflection.MethodParameter.McpRequestContextParameter;
 import io.airlift.mcp.reflection.MethodParameter.ObjectParameter;
 import io.airlift.mcp.reflection.MethodParameter.ReadResourceRequestParameter;
@@ -36,6 +37,7 @@ public interface Predicates
     Predicate<MethodParameter> isSourceResource = methodParameter -> methodParameter instanceof SourceResourceParameter;
     Predicate<MethodParameter> isSourceResourceTemplate = methodParameter -> methodParameter instanceof SourceResourceTemplateParameter;
     Predicate<MethodParameter> isResourceTemplateValues = methodParameter -> methodParameter instanceof ResourceTemplateValuesParameter;
+    Predicate<MethodParameter> isInputResponses = methodParameter -> methodParameter instanceof InputResponsesParameter;
     Predicate<MethodParameter> isObject = methodParameter -> (methodParameter instanceof ObjectParameter);
     Predicate<MethodParameter> isString = methodParameter -> (methodParameter instanceof ObjectParameter objectParameter)
             && objectParameter.rawType().equals(String.class);

--- a/mcp/src/main/java/io/airlift/mcp/reflection/PromptHandlerProvider.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/PromptHandlerProvider.java
@@ -27,6 +27,7 @@ import static io.airlift.mcp.McpException.exception;
 import static io.airlift.mcp.reflection.Predicates.isGetPromptRequest;
 import static io.airlift.mcp.reflection.Predicates.isHttpRequestOrContext;
 import static io.airlift.mcp.reflection.Predicates.isIdentity;
+import static io.airlift.mcp.reflection.Predicates.isInputResponses;
 import static io.airlift.mcp.reflection.Predicates.isString;
 import static io.airlift.mcp.reflection.Predicates.returnsGetPromptResponse;
 import static io.airlift.mcp.reflection.Predicates.returnsGetPromptResult;
@@ -63,7 +64,10 @@ public class PromptHandlerProvider
         this.role = mcpPrompt.role();
         icons = ImmutableList.copyOf(mcpPrompt.icons());
 
-        validate(method, parameters, isHttpRequestOrContext.or(isIdentity).or(isString).or(isGetPromptRequest), returnsString.or(returnsGetPromptResult).or(returnsGetPromptResponse));
+        validate(method,
+                parameters,
+                isHttpRequestOrContext.or(isIdentity).or(isString).or(isGetPromptRequest).or(isInputResponses),
+                returnsString.or(returnsGetPromptResult).or(returnsGetPromptResponse));
 
         prompt = buildPrompt(mcpPrompt, parameters);
         if (returnsGetPromptResult.test(method)) {

--- a/mcp/src/main/java/io/airlift/mcp/reflection/PromptHandlerProvider.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/PromptHandlerProvider.java
@@ -9,6 +9,7 @@ import io.airlift.mcp.McpPrompt;
 import io.airlift.mcp.handler.PromptEntry;
 import io.airlift.mcp.handler.PromptHandler;
 import io.airlift.mcp.model.Content;
+import io.airlift.mcp.model.GetPromptResponse;
 import io.airlift.mcp.model.GetPromptResult;
 import io.airlift.mcp.model.GetPromptResult.PromptMessage;
 import io.airlift.mcp.model.JsonRpcErrorCode;
@@ -27,6 +28,7 @@ import static io.airlift.mcp.reflection.Predicates.isGetPromptRequest;
 import static io.airlift.mcp.reflection.Predicates.isHttpRequestOrContext;
 import static io.airlift.mcp.reflection.Predicates.isIdentity;
 import static io.airlift.mcp.reflection.Predicates.isString;
+import static io.airlift.mcp.reflection.Predicates.returnsGetPromptResponse;
 import static io.airlift.mcp.reflection.Predicates.returnsGetPromptResult;
 import static io.airlift.mcp.reflection.Predicates.returnsString;
 import static io.airlift.mcp.reflection.ReflectionHelper.mapToContent;
@@ -41,10 +43,17 @@ public class PromptHandlerProvider
     private final Method method;
     private final List<MethodParameter> parameters;
     private final Role role;
-    private final boolean isGetPromptResult;
+    private final ResultType resultType;
     private final List<String> icons;
     private Injector injector;
     private JsonMapper jsonMapper;
+
+    private enum ResultType
+    {
+        STRING,
+        GET_PROMPT_RESULT,
+        GET_PROMPT_RESPONSE
+    }
 
     public PromptHandlerProvider(McpPrompt mcpPrompt, Class<?> clazz, Method method, List<MethodParameter> parameters)
     {
@@ -54,10 +63,18 @@ public class PromptHandlerProvider
         this.role = mcpPrompt.role();
         icons = ImmutableList.copyOf(mcpPrompt.icons());
 
-        validate(method, parameters, isHttpRequestOrContext.or(isIdentity).or(isString).or(isGetPromptRequest), returnsString.or(returnsGetPromptResult));
+        validate(method, parameters, isHttpRequestOrContext.or(isIdentity).or(isString).or(isGetPromptRequest), returnsString.or(returnsGetPromptResult).or(returnsGetPromptResponse));
 
         prompt = buildPrompt(mcpPrompt, parameters);
-        isGetPromptResult = GetPromptResult.class.isAssignableFrom(method.getReturnType());
+        if (returnsGetPromptResult.test(method)) {
+            resultType = ResultType.GET_PROMPT_RESULT;
+        }
+        else if (returnsGetPromptResponse.test(method)) {
+            resultType = ResultType.GET_PROMPT_RESPONSE;
+        }
+        else {
+            resultType = ResultType.STRING;
+        }
     }
 
     @Inject
@@ -88,12 +105,16 @@ public class PromptHandlerProvider
                 throw exception(JsonRpcErrorCode.INTERNAL_ERROR, "Prompt %s returned null".formatted(method.getName()));
             }
 
-            if (isGetPromptResult) {
-                return (GetPromptResult) result;
-            }
+            return switch (resultType) {
+                case STRING -> {
+                    Content content = mapToContent(result);
+                    yield new GetPromptResult(prompt.description(), ImmutableList.of(new PromptMessage(role, content)));
+                }
 
-            Content content = mapToContent(result);
-            return new GetPromptResult(prompt.description(), ImmutableList.of(new PromptMessage(role, content)));
+                case GET_PROMPT_RESULT -> (GetPromptResult) result;
+
+                case GET_PROMPT_RESPONSE -> (GetPromptResponse) result;
+            };
         };
 
         return new PromptEntry(prompt.withIcons(iconHelper.mapIcons(icons)), promptHandler);

--- a/mcp/src/main/java/io/airlift/mcp/reflection/ReflectionHelper.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/ReflectionHelper.java
@@ -3,6 +3,7 @@ package io.airlift.mcp.reflection;
 import io.airlift.mcp.McpDefaultValue;
 import io.airlift.mcp.McpDescription;
 import io.airlift.mcp.McpRequestContext;
+import io.airlift.mcp.model.AllowIncompleteResult;
 import io.airlift.mcp.model.CallToolRequest;
 import io.airlift.mcp.model.CompleteRequest.CompleteArgument;
 import io.airlift.mcp.model.CompleteRequest.CompleteContext;
@@ -13,6 +14,7 @@ import io.airlift.mcp.model.ReadResourceRequest;
 import io.airlift.mcp.model.Resource;
 import io.airlift.mcp.model.ResourceTemplate;
 import io.airlift.mcp.model.ResourceTemplateValues;
+import io.airlift.mcp.reflection.MethodParameter.AllowIncompleteResultParameter;
 import io.airlift.mcp.reflection.MethodParameter.CallToolRequestParameter;
 import io.airlift.mcp.reflection.MethodParameter.CompleteArgumentParameter;
 import io.airlift.mcp.reflection.MethodParameter.CompleteContextParameter;
@@ -114,6 +116,10 @@ public interface ReflectionHelper
 
                     if (CompleteContext.class.isAssignableFrom(parameter.getType())) {
                         return CompleteContextParameter.INSTANCE;
+                    }
+
+                    if (AllowIncompleteResult.class.isAssignableFrom(parameter.getType())) {
+                        return AllowIncompleteResultParameter.INSTANCE;
                     }
 
                     Optional<String> description = Optional.ofNullable(parameter.getAnnotation(McpDescription.class)).map(McpDescription::value);

--- a/mcp/src/main/java/io/airlift/mcp/reflection/ReflectionHelper.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/ReflectionHelper.java
@@ -10,6 +10,7 @@ import io.airlift.mcp.model.CompleteRequest.CompleteContext;
 import io.airlift.mcp.model.Content;
 import io.airlift.mcp.model.Content.TextContent;
 import io.airlift.mcp.model.GetPromptRequest;
+import io.airlift.mcp.model.InputResponses;
 import io.airlift.mcp.model.ReadResourceRequest;
 import io.airlift.mcp.model.Resource;
 import io.airlift.mcp.model.ResourceTemplate;
@@ -21,6 +22,7 @@ import io.airlift.mcp.reflection.MethodParameter.CompleteContextParameter;
 import io.airlift.mcp.reflection.MethodParameter.GetPromptRequestParameter;
 import io.airlift.mcp.reflection.MethodParameter.HttpRequestParameter;
 import io.airlift.mcp.reflection.MethodParameter.IdentityParameter;
+import io.airlift.mcp.reflection.MethodParameter.InputResponsesParameter;
 import io.airlift.mcp.reflection.MethodParameter.McpRequestContextParameter;
 import io.airlift.mcp.reflection.MethodParameter.ObjectParameter;
 import io.airlift.mcp.reflection.MethodParameter.ReadResourceRequestParameter;
@@ -120,6 +122,10 @@ public interface ReflectionHelper
 
                     if (AllowIncompleteResult.class.isAssignableFrom(parameter.getType())) {
                         return AllowIncompleteResultParameter.INSTANCE;
+                    }
+
+                    if (InputResponses.class.isAssignableFrom(parameter.getType())) {
+                        return InputResponsesParameter.INSTANCE;
                     }
 
                     Optional<String> description = Optional.ofNullable(parameter.getAnnotation(McpDescription.class)).map(McpDescription::value);

--- a/mcp/src/main/java/io/airlift/mcp/reflection/ResourceHandlerProvider.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/ResourceHandlerProvider.java
@@ -9,6 +9,7 @@ import io.airlift.mcp.McpResource;
 import io.airlift.mcp.handler.ResourceEntry;
 import io.airlift.mcp.handler.ResourceHandler;
 import io.airlift.mcp.model.Annotations;
+import io.airlift.mcp.model.ReadResourceResponse;
 import io.airlift.mcp.model.ReadResourceResult;
 import io.airlift.mcp.model.Resource;
 import io.airlift.mcp.model.ResourceContents;
@@ -26,11 +27,13 @@ import static io.airlift.mcp.reflection.Predicates.isHttpRequestOrContext;
 import static io.airlift.mcp.reflection.Predicates.isIdentity;
 import static io.airlift.mcp.reflection.Predicates.isReadResourceRequest;
 import static io.airlift.mcp.reflection.Predicates.isSourceResource;
+import static io.airlift.mcp.reflection.Predicates.returnsReadResourceResponse;
 import static io.airlift.mcp.reflection.Predicates.returnsReadResourceResult;
 import static io.airlift.mcp.reflection.Predicates.returnsResourceContents;
 import static io.airlift.mcp.reflection.Predicates.returnsResourceContentsList;
 import static io.airlift.mcp.reflection.ReflectionHelper.validate;
 import static io.airlift.mcp.reflection.ResourceHandlerProvider.ResultType.CONTENT_LIST;
+import static io.airlift.mcp.reflection.ResourceHandlerProvider.ResultType.READ_RESOURCE_RESPONSE;
 import static io.airlift.mcp.reflection.ResourceHandlerProvider.ResultType.READ_RESOURCE_RESULT;
 import static io.airlift.mcp.reflection.ResourceHandlerProvider.ResultType.SINGLE_CONTENT;
 import static java.lang.Double.isNaN;
@@ -55,7 +58,7 @@ public class ResourceHandlerProvider
         this.parameters = ImmutableList.copyOf(parameters);
         icons = ImmutableList.copyOf(mcpResource.icons());
 
-        validate(method, parameters, isHttpRequestOrContext.or(isIdentity).or(isReadResourceRequest).or(isSourceResource), returnsResourceContents.or(returnsResourceContentsList).or(returnsReadResourceResult));
+        validate(method, parameters, isHttpRequestOrContext.or(isIdentity).or(isReadResourceRequest).or(isSourceResource), returnsResourceContents.or(returnsResourceContentsList).or(returnsReadResourceResult).or(returnsReadResourceResponse));
         resultType = determineResultType(method);
 
         resource = buildResource(
@@ -103,6 +106,7 @@ public class ResourceHandlerProvider
         SINGLE_CONTENT,
         CONTENT_LIST,
         READ_RESOURCE_RESULT,
+        READ_RESOURCE_RESPONSE,
     }
 
     static ResultType determineResultType(Method method)
@@ -116,11 +120,14 @@ public class ResourceHandlerProvider
         if (returnsReadResourceResult.test(method)) {
             return READ_RESOURCE_RESULT;
         }
+        if (returnsReadResourceResponse.test(method)) {
+            return READ_RESOURCE_RESPONSE;
+        }
         throw new IllegalArgumentException("Method %s does not have a valid return type".formatted(method.getName()));
     }
 
     @SuppressWarnings("unchecked")
-    static ReadResourceResult mapResult(Method method, Object result, ResultType resultType)
+    static ReadResourceResponse mapResult(Method method, Object result, ResultType resultType)
     {
         if (result == null) {
             throw exception(INTERNAL_ERROR, "ResourceHandler %s returned null".formatted(method.getName()));
@@ -129,6 +136,7 @@ public class ResourceHandlerProvider
         return switch (resultType) {
             case CONTENT_LIST -> new ReadResourceResult((List<ResourceContents>) result);
             case READ_RESOURCE_RESULT -> (ReadResourceResult) result;
+            case READ_RESOURCE_RESPONSE -> (ReadResourceResponse) result;
             case SINGLE_CONTENT -> new ReadResourceResult(ImmutableList.of((ResourceContents) result));
         };
     }

--- a/mcp/src/main/java/io/airlift/mcp/reflection/ResourceHandlerProvider.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/ResourceHandlerProvider.java
@@ -87,9 +87,10 @@ public class ResourceHandlerProvider
         MethodInvoker methodInvoker = new MethodInvoker(instance, method, parameters, jsonMapper);
         IconHelper iconHelper = injector.getInstance(IconHelper.class);
 
-        ResourceHandler resourceHandler = (requestContext, sourceResource, readResourceRequest) -> {
+        ResourceHandler resourceHandler = (requestContext, sourceResource, readResourceRequest, allowIncompleteResult) -> {
             Object result = methodInvoker.builder(requestContext)
                     .withReadResourceRequest(sourceResource, readResourceRequest)
+                    .withAllowIncompleteResult(allowIncompleteResult)
                     .invoke();
             return mapResult(method, result, resultType);
         };

--- a/mcp/src/main/java/io/airlift/mcp/reflection/ResourceHandlerProvider.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/ResourceHandlerProvider.java
@@ -25,6 +25,7 @@ import static io.airlift.mcp.McpException.exception;
 import static io.airlift.mcp.model.JsonRpcErrorCode.INTERNAL_ERROR;
 import static io.airlift.mcp.reflection.Predicates.isHttpRequestOrContext;
 import static io.airlift.mcp.reflection.Predicates.isIdentity;
+import static io.airlift.mcp.reflection.Predicates.isInputResponses;
 import static io.airlift.mcp.reflection.Predicates.isReadResourceRequest;
 import static io.airlift.mcp.reflection.Predicates.isSourceResource;
 import static io.airlift.mcp.reflection.Predicates.returnsReadResourceResponse;
@@ -58,7 +59,10 @@ public class ResourceHandlerProvider
         this.parameters = ImmutableList.copyOf(parameters);
         icons = ImmutableList.copyOf(mcpResource.icons());
 
-        validate(method, parameters, isHttpRequestOrContext.or(isIdentity).or(isReadResourceRequest).or(isSourceResource), returnsResourceContents.or(returnsResourceContentsList).or(returnsReadResourceResult).or(returnsReadResourceResponse));
+        validate(method,
+                parameters,
+                isHttpRequestOrContext.or(isIdentity).or(isReadResourceRequest).or(isSourceResource).or(isInputResponses),
+                returnsResourceContents.or(returnsResourceContentsList).or(returnsReadResourceResult).or(returnsReadResourceResponse));
         resultType = determineResultType(method);
 
         resource = buildResource(

--- a/mcp/src/main/java/io/airlift/mcp/reflection/ResourceHandlerProvider.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/ResourceHandlerProvider.java
@@ -9,6 +9,7 @@ import io.airlift.mcp.McpResource;
 import io.airlift.mcp.handler.ResourceEntry;
 import io.airlift.mcp.handler.ResourceHandler;
 import io.airlift.mcp.model.Annotations;
+import io.airlift.mcp.model.ReadResourceResult;
 import io.airlift.mcp.model.Resource;
 import io.airlift.mcp.model.ResourceContents;
 import io.airlift.mcp.model.Role;
@@ -25,9 +26,13 @@ import static io.airlift.mcp.reflection.Predicates.isHttpRequestOrContext;
 import static io.airlift.mcp.reflection.Predicates.isIdentity;
 import static io.airlift.mcp.reflection.Predicates.isReadResourceRequest;
 import static io.airlift.mcp.reflection.Predicates.isSourceResource;
+import static io.airlift.mcp.reflection.Predicates.returnsReadResourceResult;
 import static io.airlift.mcp.reflection.Predicates.returnsResourceContents;
 import static io.airlift.mcp.reflection.Predicates.returnsResourceContentsList;
 import static io.airlift.mcp.reflection.ReflectionHelper.validate;
+import static io.airlift.mcp.reflection.ResourceHandlerProvider.ResultType.CONTENT_LIST;
+import static io.airlift.mcp.reflection.ResourceHandlerProvider.ResultType.READ_RESOURCE_RESULT;
+import static io.airlift.mcp.reflection.ResourceHandlerProvider.ResultType.SINGLE_CONTENT;
 import static java.lang.Double.isNaN;
 import static java.util.Objects.requireNonNull;
 
@@ -38,8 +43,8 @@ public class ResourceHandlerProvider
     private final Class<?> clazz;
     private final Method method;
     private final List<MethodParameter> parameters;
-    private final boolean resultIsSingleContent;
     private final List<String> icons;
+    private final ResultType resultType;
     private Injector injector;
     private JsonMapper jsonMapper;
 
@@ -50,8 +55,8 @@ public class ResourceHandlerProvider
         this.parameters = ImmutableList.copyOf(parameters);
         icons = ImmutableList.copyOf(mcpResource.icons());
 
-        validate(method, parameters, isHttpRequestOrContext.or(isIdentity).or(isReadResourceRequest).or(isSourceResource), returnsResourceContents.or(returnsResourceContentsList));
-        resultIsSingleContent = returnsResourceContents.test(method);
+        validate(method, parameters, isHttpRequestOrContext.or(isIdentity).or(isReadResourceRequest).or(isSourceResource), returnsResourceContents.or(returnsResourceContentsList).or(returnsReadResourceResult));
+        resultType = determineResultType(method);
 
         resource = buildResource(
                 mcpResource.name(),
@@ -86,24 +91,45 @@ public class ResourceHandlerProvider
             Object result = methodInvoker.builder(requestContext)
                     .withReadResourceRequest(sourceResource, readResourceRequest)
                     .invoke();
-            return mapResult(method, result, resultIsSingleContent);
+            return mapResult(method, result, resultType);
         };
 
         return new ResourceEntry(resource.withIcons(iconHelper.mapIcons(icons)), resourceHandler);
     }
 
+    enum ResultType
+    {
+        SINGLE_CONTENT,
+        CONTENT_LIST,
+        READ_RESOURCE_RESULT,
+    }
+
+    static ResultType determineResultType(Method method)
+    {
+        if (returnsResourceContents.test(method)) {
+            return SINGLE_CONTENT;
+        }
+        if (returnsResourceContentsList.test(method)) {
+            return CONTENT_LIST;
+        }
+        if (returnsReadResourceResult.test(method)) {
+            return READ_RESOURCE_RESULT;
+        }
+        throw new IllegalArgumentException("Method %s does not have a valid return type".formatted(method.getName()));
+    }
+
     @SuppressWarnings("unchecked")
-    static List<ResourceContents> mapResult(Method method, Object result, boolean resultIsSingleContent)
+    static ReadResourceResult mapResult(Method method, Object result, ResultType resultType)
     {
         if (result == null) {
             throw exception(INTERNAL_ERROR, "ResourceHandler %s returned null".formatted(method.getName()));
         }
 
-        if (resultIsSingleContent) {
-            return ImmutableList.of((ResourceContents) result);
-        }
-
-        return (List<ResourceContents>) result;
+        return switch (resultType) {
+            case CONTENT_LIST -> new ReadResourceResult((List<ResourceContents>) result);
+            case READ_RESOURCE_RESULT -> (ReadResourceResult) result;
+            case SINGLE_CONTENT -> new ReadResourceResult(ImmutableList.of((ResourceContents) result));
+        };
     }
 
     private static Resource buildResource(String name, String uri, String mimeType, String descriptionOrEmpty, long size, Role[] audience, double priority)

--- a/mcp/src/main/java/io/airlift/mcp/reflection/ResourceTemplateHandlerProvider.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/ResourceTemplateHandlerProvider.java
@@ -23,6 +23,7 @@ import static io.airlift.mcp.reflection.Predicates.isIdentity;
 import static io.airlift.mcp.reflection.Predicates.isReadResourceRequest;
 import static io.airlift.mcp.reflection.Predicates.isResourceTemplateValues;
 import static io.airlift.mcp.reflection.Predicates.isSourceResourceTemplate;
+import static io.airlift.mcp.reflection.Predicates.returnsReadResourceResponse;
 import static io.airlift.mcp.reflection.Predicates.returnsReadResourceResult;
 import static io.airlift.mcp.reflection.Predicates.returnsResourceContents;
 import static io.airlift.mcp.reflection.Predicates.returnsResourceContentsList;
@@ -51,7 +52,7 @@ public class ResourceTemplateHandlerProvider
         this.parameters = ImmutableList.copyOf(parameters);
         icons = ImmutableList.copyOf(mcpResourceTemplate.icons());
 
-        validate(method, parameters, isHttpRequestOrContext.or(isIdentity).or(isReadResourceRequest).or(isSourceResourceTemplate).or(isResourceTemplateValues), returnsResourceContents.or(returnsResourceContentsList).or(returnsReadResourceResult));
+        validate(method, parameters, isHttpRequestOrContext.or(isIdentity).or(isReadResourceRequest).or(isSourceResourceTemplate).or(isResourceTemplateValues), returnsResourceContents.or(returnsResourceContentsList).or(returnsReadResourceResult).or(returnsReadResourceResponse));
         resultType = determineResultType(method);
 
         this.resourceTemplate = buildResourceTemplate(

--- a/mcp/src/main/java/io/airlift/mcp/reflection/ResourceTemplateHandlerProvider.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/ResourceTemplateHandlerProvider.java
@@ -82,10 +82,11 @@ public class ResourceTemplateHandlerProvider
         IconHelper iconHelper = injector.getInstance(IconHelper.class);
         MethodInvoker methodInvoker = new MethodInvoker(instance, method, parameters, jsonMapper);
 
-        ResourceTemplateHandler resourceTemplateHandler = (requestContext, sourceResourceTemplate, readResourceRequest, resourceTemplateValues) -> {
+        ResourceTemplateHandler resourceTemplateHandler = (requestContext, sourceResourceTemplate, readResourceRequest, resourceTemplateValues, allowIncompleteResult) -> {
             Object result = methodInvoker.builder(requestContext)
                     .withReadResourceTemplateRequest(sourceResourceTemplate, readResourceRequest)
                     .withResourceTemplateValues(resourceTemplateValues)
+                    .withAllowIncompleteResult(allowIncompleteResult)
                     .invoke();
             return mapResult(method, result, resultType);
         };

--- a/mcp/src/main/java/io/airlift/mcp/reflection/ResourceTemplateHandlerProvider.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/ResourceTemplateHandlerProvider.java
@@ -11,6 +11,7 @@ import io.airlift.mcp.handler.ResourceTemplateHandler;
 import io.airlift.mcp.model.Annotations;
 import io.airlift.mcp.model.ResourceTemplate;
 import io.airlift.mcp.model.Role;
+import io.airlift.mcp.reflection.ResourceHandlerProvider.ResultType;
 
 import java.lang.reflect.Method;
 import java.util.List;
@@ -22,9 +23,11 @@ import static io.airlift.mcp.reflection.Predicates.isIdentity;
 import static io.airlift.mcp.reflection.Predicates.isReadResourceRequest;
 import static io.airlift.mcp.reflection.Predicates.isResourceTemplateValues;
 import static io.airlift.mcp.reflection.Predicates.isSourceResourceTemplate;
+import static io.airlift.mcp.reflection.Predicates.returnsReadResourceResult;
 import static io.airlift.mcp.reflection.Predicates.returnsResourceContents;
 import static io.airlift.mcp.reflection.Predicates.returnsResourceContentsList;
 import static io.airlift.mcp.reflection.ReflectionHelper.validate;
+import static io.airlift.mcp.reflection.ResourceHandlerProvider.determineResultType;
 import static io.airlift.mcp.reflection.ResourceHandlerProvider.mapResult;
 import static java.lang.Double.isNaN;
 import static java.util.Objects.requireNonNull;
@@ -36,8 +39,8 @@ public class ResourceTemplateHandlerProvider
     private final Class<?> clazz;
     private final Method method;
     private final List<MethodParameter> parameters;
-    private final boolean resultIsSingleContent;
     private final List<String> icons;
+    private final ResultType resultType;
     private Injector injector;
     private JsonMapper jsonMapper;
 
@@ -48,8 +51,8 @@ public class ResourceTemplateHandlerProvider
         this.parameters = ImmutableList.copyOf(parameters);
         icons = ImmutableList.copyOf(mcpResourceTemplate.icons());
 
-        validate(method, parameters, isHttpRequestOrContext.or(isIdentity).or(isReadResourceRequest).or(isSourceResourceTemplate).or(isResourceTemplateValues), returnsResourceContents.or(returnsResourceContentsList));
-        this.resultIsSingleContent = returnsResourceContents.test(method);
+        validate(method, parameters, isHttpRequestOrContext.or(isIdentity).or(isReadResourceRequest).or(isSourceResourceTemplate).or(isResourceTemplateValues), returnsResourceContents.or(returnsResourceContentsList).or(returnsReadResourceResult));
+        resultType = determineResultType(method);
 
         this.resourceTemplate = buildResourceTemplate(
                 mcpResourceTemplate.name(),
@@ -84,7 +87,7 @@ public class ResourceTemplateHandlerProvider
                     .withReadResourceTemplateRequest(sourceResourceTemplate, readResourceRequest)
                     .withResourceTemplateValues(resourceTemplateValues)
                     .invoke();
-            return mapResult(method, result, resultIsSingleContent);
+            return mapResult(method, result, resultType);
         };
 
         return new ResourceTemplateEntry(resourceTemplate.withIcons(iconHelper.mapIcons(icons)), resourceTemplateHandler);

--- a/mcp/src/main/java/io/airlift/mcp/reflection/ResourceTemplateHandlerProvider.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/ResourceTemplateHandlerProvider.java
@@ -20,6 +20,7 @@ import java.util.OptionalDouble;
 
 import static io.airlift.mcp.reflection.Predicates.isHttpRequestOrContext;
 import static io.airlift.mcp.reflection.Predicates.isIdentity;
+import static io.airlift.mcp.reflection.Predicates.isInputResponses;
 import static io.airlift.mcp.reflection.Predicates.isReadResourceRequest;
 import static io.airlift.mcp.reflection.Predicates.isResourceTemplateValues;
 import static io.airlift.mcp.reflection.Predicates.isSourceResourceTemplate;
@@ -52,7 +53,10 @@ public class ResourceTemplateHandlerProvider
         this.parameters = ImmutableList.copyOf(parameters);
         icons = ImmutableList.copyOf(mcpResourceTemplate.icons());
 
-        validate(method, parameters, isHttpRequestOrContext.or(isIdentity).or(isReadResourceRequest).or(isSourceResourceTemplate).or(isResourceTemplateValues), returnsResourceContents.or(returnsResourceContentsList).or(returnsReadResourceResult).or(returnsReadResourceResponse));
+        validate(method,
+                parameters,
+                isHttpRequestOrContext.or(isIdentity).or(isReadResourceRequest).or(isSourceResourceTemplate).or(isResourceTemplateValues).or(isInputResponses),
+                returnsResourceContents.or(returnsResourceContentsList).or(returnsReadResourceResult).or(returnsReadResourceResponse));
         resultType = determineResultType(method);
 
         this.resourceTemplate = buildResourceTemplate(

--- a/mcp/src/main/java/io/airlift/mcp/reflection/ToolHandlerProvider.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/ToolHandlerProvider.java
@@ -14,6 +14,7 @@ import io.airlift.mcp.McpTool;
 import io.airlift.mcp.handler.ResourceEntry;
 import io.airlift.mcp.handler.ToolEntry;
 import io.airlift.mcp.handler.ToolHandler;
+import io.airlift.mcp.model.CallToolResponse;
 import io.airlift.mcp.model.CallToolResult;
 import io.airlift.mcp.model.Content;
 import io.airlift.mcp.model.JsonSchemaBuilder;
@@ -77,6 +78,9 @@ public class ToolHandlerProvider
         if (void.class.equals(method.getReturnType())) {
             returnType = ReturnType.VOID;
         }
+        else if (CallToolResponse.class.isAssignableFrom(method.getReturnType())) {
+            returnType = ReturnType.CALL_TOOL_RESPONSE;
+        }
         else if (CallToolResult.class.isAssignableFrom(method.getReturnType())) {
             returnType = ReturnType.CALL_TOOL_RESULT;
         }
@@ -113,6 +117,7 @@ public class ToolHandlerProvider
         CONTENT,
         STRUCTURED,
         STRUCTURED_RESULT,
+        CALL_TOOL_RESPONSE,
     }
 
     @Override
@@ -136,6 +141,7 @@ public class ToolHandlerProvider
                 case CONTENT -> new CallToolResult(mapToContent(result));
                 case STRUCTURED -> new CallToolResult(ImmutableList.of(mapToContent(result)), Optional.of(new StructuredContent<>(result)), false, Optional.empty());
                 case CALL_TOOL_RESULT -> (CallToolResult) result;
+                case CALL_TOOL_RESPONSE -> (CallToolResponse) result;
                 case STRUCTURED_RESULT -> mapStructuredContentResult((StructuredContentResult<?>) result);
             };
         };

--- a/mcp/src/main/java/io/airlift/mcp/reflection/ToolHandlerProvider.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/ToolHandlerProvider.java
@@ -40,6 +40,7 @@ import static io.airlift.mcp.model.JsonSchemaBuilder.isSupportedType;
 import static io.airlift.mcp.reflection.Predicates.isCallToolRequest;
 import static io.airlift.mcp.reflection.Predicates.isHttpRequestOrContext;
 import static io.airlift.mcp.reflection.Predicates.isIdentity;
+import static io.airlift.mcp.reflection.Predicates.isInputResponses;
 import static io.airlift.mcp.reflection.Predicates.isObject;
 import static io.airlift.mcp.reflection.Predicates.returnsAnything;
 import static io.airlift.mcp.reflection.ReflectionHelper.mapToContent;
@@ -71,7 +72,7 @@ public class ToolHandlerProvider
         icons = ImmutableList.copyOf(mcpTool.icons());
         this.resourceHandlerConsumer = requireNonNull(resourceHandlerConsumer, "resourceHandlerConsumer is null");
 
-        validate(method, parameters, isHttpRequestOrContext.or(isIdentity).or(isObject).or(isCallToolRequest), returnsAnything);
+        validate(method, parameters, isHttpRequestOrContext.or(isIdentity).or(isObject).or(isCallToolRequest).or(isInputResponses), returnsAnything);
 
         tool = buildTool(mcpTool, method, parameters);
 

--- a/mcp/src/test/java/io/airlift/mcp/ConformanceEndpoints.java
+++ b/mcp/src/test/java/io/airlift/mcp/ConformanceEndpoints.java
@@ -7,6 +7,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import io.airlift.mcp.model.CallToolRequest;
+import io.airlift.mcp.model.CallToolResponse;
 import io.airlift.mcp.model.CallToolResult;
 import io.airlift.mcp.model.CompleteResult.CompleteCompletion;
 import io.airlift.mcp.model.Content;
@@ -20,7 +21,8 @@ import io.airlift.mcp.model.ElicitRequestForm;
 import io.airlift.mcp.model.ElicitResult;
 import io.airlift.mcp.model.GetPromptResult;
 import io.airlift.mcp.model.GetPromptResult.PromptMessage;
-import io.airlift.mcp.model.JsonRpcResponse;
+import io.airlift.mcp.model.InputRequests;
+import io.airlift.mcp.model.InputResponses;
 import io.airlift.mcp.model.JsonSchemaBuilder;
 import io.airlift.mcp.model.OptionalBoolean;
 import io.airlift.mcp.model.ReadResourceRequest;
@@ -28,16 +30,12 @@ import io.airlift.mcp.model.ResourceContents;
 import io.airlift.mcp.model.ResourceTemplateValues;
 import io.airlift.mcp.model.Role;
 
-import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
-import java.util.concurrent.TimeoutException;
 
 import static io.airlift.mcp.McpException.exception;
-import static io.airlift.mcp.model.Constants.METHOD_ELICITATION_CREATE;
-import static io.airlift.mcp.model.Constants.METHOD_SAMPLING_CREATE_MESSAGE;
 import static io.airlift.mcp.model.LoggingLevel.INFO;
 import static java.util.Objects.requireNonNull;
 
@@ -118,26 +116,30 @@ public class ConformanceEndpoints
     }
 
     @McpTool(name = "test_sampling", description = "Tests server-initiated sampling (LLM completion request)")
-    public String testSampling(McpRequestContext requestContext, @McpDescription("The prompt to send to the LLM") String prompt)
-            throws InterruptedException, TimeoutException
+    public CallToolResponse testSampling(@McpDescription("The prompt to send to the LLM") String prompt, InputResponses inputResponses)
     {
-        CreateMessageRequest createMessageRequest = new CreateMessageRequest(Role.USER, new TextContent(prompt), 100);
-        JsonRpcResponse<CreateMessageResult> response = requestContext.serverToClientRequest(METHOD_SAMPLING_CREATE_MESSAGE, createMessageRequest, CreateMessageResult.class, Duration.ofMinutes(1), Duration.ofSeconds(1));
-        String responseText = response.result().map(messageResult -> (messageResult.content() instanceof TextContent textContent) ? textContent.text() : "No response").orElse("No response");
-        return "LLM response: " + responseText;
+        return inputResponses.response("sampling", CreateMessageResult.class)
+                .map(messageResult -> {
+                    String responseText = (messageResult.content() instanceof TextContent textContent) ? textContent.text() : "No response";
+                    return (CallToolResponse) new CallToolResult("LLM response: " + responseText);
+                })
+                .orElseGet(() -> {
+                    CreateMessageRequest createMessageRequest = new CreateMessageRequest(Role.USER, new TextContent(prompt), 100);
+                    return new InputRequests("sampling", createMessageRequest);
+                });
     }
 
     public record TestElicitation(String response) {}
 
     @McpTool(name = "test_elicitation", description = "Tests server-initiated elicitation (user input request)")
-    public String testElicitation(McpRequestContext requestContext, @McpDescription("The message to show the user") String message)
-            throws InterruptedException, TimeoutException
+    public CallToolResponse testElicitation(@McpDescription("The message to show the user") String message, InputResponses inputResponses)
     {
-        ObjectNode schema = new JsonSchemaBuilder("testElicitation").build(Optional.of("User's response"), TestElicitation.class);
-        ElicitRequestForm elicitRequestForm = new ElicitRequestForm(message, schema);
-        JsonRpcResponse<ElicitResult> response = requestContext.serverToClientRequest(METHOD_ELICITATION_CREATE, elicitRequestForm, ElicitResult.class, Duration.ofMinutes(5), Duration.ofSeconds(1));
-        return response.result().map(result -> "User response: action=%s, content=%s".formatted(result.action(), mapToJson(result.content())))
-                .orElse("No response");
+        return inputResponses.response("elicitation", ElicitResult.class)
+                .map(result -> (CallToolResponse) new CallToolResult("User response: action=%s, content=%s".formatted(result.action(), mapToJson(result.content()))))
+                .orElseGet(() -> {
+                    ObjectNode schema = new JsonSchemaBuilder("testElicitation").build(Optional.of("User's response"), TestElicitation.class);
+                    return new InputRequests("elicitation", new ElicitRequestForm(message, schema));
+                });
     }
 
     private String mapToJson(Optional<Map<String, Object>> map)

--- a/mcp/src/test/java/io/airlift/mcp/TestingEndpoints.java
+++ b/mcp/src/test/java/io/airlift/mcp/TestingEndpoints.java
@@ -8,17 +8,20 @@ import com.google.inject.Inject;
 import io.airlift.mcp.handler.PromptEntry;
 import io.airlift.mcp.handler.ResourceEntry;
 import io.airlift.mcp.handler.ToolEntry;
+import io.airlift.mcp.model.CallToolResponse;
 import io.airlift.mcp.model.CallToolResult;
 import io.airlift.mcp.model.CompleteRequest.CompleteArgument;
 import io.airlift.mcp.model.CompleteRequest.CompleteContext;
-import io.airlift.mcp.model.Constants;
 import io.airlift.mcp.model.Content.TextContent;
 import io.airlift.mcp.model.CreateMessageRequest;
 import io.airlift.mcp.model.CreateMessageResult;
 import io.airlift.mcp.model.ElicitRequestForm;
 import io.airlift.mcp.model.ElicitResult;
-import io.airlift.mcp.model.JsonRpcResponse;
+import io.airlift.mcp.model.InputRequests;
+import io.airlift.mcp.model.InputResponses;
 import io.airlift.mcp.model.JsonSchemaBuilder;
+import io.airlift.mcp.model.ListRootsRequest;
+import io.airlift.mcp.model.ListRootsResult;
 import io.airlift.mcp.model.LoggingLevel;
 import io.airlift.mcp.model.Prompt;
 import io.airlift.mcp.model.ReadResourceRequest;
@@ -30,13 +33,11 @@ import io.airlift.mcp.model.Root;
 import io.airlift.mcp.model.StructuredContentResult;
 import io.airlift.mcp.model.Tool;
 
-import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.mcp.McpException.exception;
@@ -298,73 +299,56 @@ public class TestingEndpoints
     public record Person(String firstName, String lastName) {}
 
     @McpTool(name = "elicitation", description = "Test elicitation")
-    public String elicitation(McpRequestContext requestContext)
+    public CallToolResponse elicitation(McpRequestContext requestContext, InputResponses inputResponses)
     {
         if (requestContext.clientCapabilities().elicitation().isEmpty()) {
             throw new RuntimeException("Client does not support elicitation");
         }
 
-        ObjectNode elicitation = new JsonSchemaBuilder("elicitation").build(Optional.empty(), Person.class);
-        ElicitRequestForm elicitRequest = new ElicitRequestForm("Who are you?", elicitation);
-        JsonRpcResponse<ElicitResult> response;
-        try {
-            response = requestContext.serverToClientRequest(Constants.METHOD_ELICITATION_CREATE, elicitRequest, ElicitResult.class, Duration.ofMinutes(5), Duration.ofSeconds(30));
-        }
-        catch (InterruptedException | TimeoutException e) {
-            throw new RuntimeException(e);
-        }
-        ElicitResult elicitResult = response.result().orElseThrow();
-        if (elicitResult.action() != ACCEPT) {
-            return elicitResult.action().toJsonValue();
-        }
-        return elicitResult.content()
-                .map(contentMap -> "Hello, " + contentMap.get("firstName") + " " + contentMap.get("lastName") + "!")
-                .orElse("No content");
+        return inputResponses.response("elicitation", ElicitResult.class)
+                .map(elicitResult -> {
+                    if (elicitResult.action() != ACCEPT) {
+                        return new CallToolResult(elicitResult.action().toJsonValue());
+                    }
+                    return (CallToolResponse) new CallToolResult(elicitResult.content()
+                            .map(contentMap -> "Hello, " + contentMap.get("firstName") + " " + contentMap.get("lastName") + "!")
+                            .orElse("No content"));
+                })
+                .orElseGet(() -> {
+                    ObjectNode elicitation = new JsonSchemaBuilder("elicitation").build(Optional.empty(), Person.class);
+                    return new InputRequests("elicitation", new ElicitRequestForm("Who are you?", elicitation));
+                });
     }
 
     @McpTool(name = "sampling", description = "Test sampling")
-    public String sampling(McpRequestContext requestContext)
+    public CallToolResponse sampling(McpRequestContext requestContext, InputResponses inputResponses)
     {
         if (requestContext.clientCapabilities().sampling().isEmpty()) {
             throw new RuntimeException("Client does not support sampling");
         }
 
-        CreateMessageRequest createMessageRequest = new CreateMessageRequest(Role.USER, new TextContent("Are you sure?"), 100);
-        JsonRpcResponse<CreateMessageResult> response;
-        try {
-            response = requestContext.serverToClientRequest(Constants.METHOD_SAMPLING_CREATE_MESSAGE, createMessageRequest, CreateMessageResult.class, Duration.ofMinutes(5), Duration.ofSeconds(1));
-        }
-        catch (InterruptedException | TimeoutException e) {
-            throw new RuntimeException(e);
-        }
+        return inputResponses.response("sampling", CreateMessageResult.class)
+                .map(createMessageResult -> {
+                    if (createMessageResult.stopReason().isPresent()) {
+                        return new CallToolResult("Stopped: " + createMessageResult.stopReason().orElseThrow().toJsonValue());
+                    }
 
-        if (response.error().isPresent()) {
-            return response.error().orElseThrow().message();
-        }
+                    if (createMessageResult.content() instanceof TextContent(var text, _)) {
+                        return new CallToolResult("Response: " + text);
+                    }
 
-        CreateMessageResult createMessageResult = response.result().orElseThrow();
-        if (createMessageResult.stopReason().isPresent()) {
-            return "Stopped: " + createMessageResult.stopReason().orElseThrow().toJsonValue();
-        }
-
-        if (createMessageResult.content() instanceof TextContent(var text, _)) {
-            return "Response: " + text;
-        }
-
-        return "Response: unknown";
+                    return (CallToolResponse) new CallToolResult("Response: unknown");
+                })
+                .orElseGet(() -> new InputRequests("sampling", new CreateMessageRequest(Role.USER, new TextContent("Are you sure?"), 100)));
     }
 
     @McpTool(name = "roots", description = "List roots")
-    public String listRoots(McpRequestContext requestContext)
+    public CallToolResponse listRoots(McpRequestContext requestContext, InputResponses inputResponses)
     {
-        try {
-            return requestContext.requestRoots(Duration.ofMinutes(1), Duration.ofSeconds(30))
-                    .stream()
-                    .map(Root::uri)
-                    .collect(joining(", "));
-        }
-        catch (InterruptedException | TimeoutException e) {
-            throw new RuntimeException(e);
-        }
+        return inputResponses.response("roots", ListRootsResult.class)
+                .map(result -> (CallToolResponse) new CallToolResult(result.roots().stream()
+                        .map(Root::uri)
+                        .collect(joining(", "))))
+                .orElseGet(() -> new InputRequests("roots", new ListRootsRequest()));
     }
 }


### PR DESCRIPTION
### Remove server-to-client features in favor of MRTR

Standardize on the upcoming MRTR spec changes (preliminary). For
clients that use an older protocol, emulate MRTR.

### Models, etc. to support MRTR

Based on the preliminary spec. Likely to change in the future.

### Make CallToolResult a sealed interface

- In upcoming protocols, tool calls return a union model of many different types
- Make CallToolResult a sealed interface so that it can model any needed type
- Rename old model for `CallToolResult` to `ToolContent`

----

Part of https://github.com/airlift/airlift/issues/1858

# Airlift contribution check list

 - [X] Git commit messages follow https://cbea.ms/git-commit/.
 - [X] All automated tests are passing.
 - [X] Pull request was categorized using one of the existing labels.
