### PR TITLE
Deliver fully-received responses despite request-side failures

### DIFF
--- a/http-client/src/main/java/io/airlift/http/client/jetty/JettyResponseListener.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/JettyResponseListener.java
@@ -1,8 +1,11 @@
 package io.airlift.http.client.jetty;
 
+import io.airlift.log.Logger;
 import org.eclipse.jetty.client.AbstractResponseListener;
 import org.eclipse.jetty.client.Request;
+import org.eclipse.jetty.client.Response;
 import org.eclipse.jetty.client.Result;
+import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.io.RetainableByteBuffer;
 
@@ -15,6 +18,8 @@ import static java.util.Objects.requireNonNull;
 class JettyResponseListener<T, E extends Exception>
         extends AbstractResponseListener
 {
+    private static final Logger log = Logger.get(JettyResponseListener.class);
+
     private final Request request;
     private final JettyResponseFuture<T, E> future;
 
@@ -34,16 +39,73 @@ class JettyResponseListener<T, E extends Exception>
     @Override
     public void onComplete(Result result)
     {
-        if (result.isFailed()) {
-            future.failed(result.getFailure());
+        // Request-side-only failures surface differently on HTTP/1.1 vs stream-based protocols.
+        Response response = result.getResponse();
+        if (response != null && isStreamBased(response.getVersion())) {
+            completeStreamBased(result, response);
         }
         else {
-            try (InputStream stream = takeContentAsInputStream()) {
-                future.completed(result.getResponse(), stream);
+            completeHttp1(result, response);
+        }
+    }
+
+    private static boolean isStreamBased(HttpVersion version)
+    {
+        return switch (version) {
+            case null -> false;
+            case HTTP_2, HTTP_3 -> true;
+            case HTTP_0_9, HTTP_1_0, HTTP_1_1 -> false;
+        };
+    }
+
+    private void completeHttp1(Result result, Response response)
+    {
+        Throwable responseFailure = result.getResponseFailure();
+        if (responseFailure != null) {
+            future.failed(responseFailure);
+            return;
+        }
+        if (response == null) {
+            Throwable requestFailure = result.getRequestFailure();
+            if (requestFailure == null) {
+                // Settle the future so the caller is not left blocking on a violated invariant.
+                future.failed(new IllegalStateException("Result has neither response nor failure: " + result));
+                return;
             }
-            catch (IOException e) {
-                future.failed(new UncheckedIOException("Failed communicating with server: " + result.getRequest().getURI().toASCIIString(), e));
-            }
+            future.failed(requestFailure);
+            return;
+        }
+        Throwable requestFailure = result.getRequestFailure();
+        if (requestFailure != null) {
+            log.debug(requestFailure, "Suppressing request failure for fully-received response from %s", request.getURI());
+        }
+        deliver(response);
+    }
+
+    private void completeStreamBased(Result result, Response response)
+    {
+        Throwable responseFailure = result.getResponseFailure();
+        if (responseFailure == null) {
+            deliver(response);
+            return;
+        }
+        // Transport-layer failure after headers were committed (e.g. a server stream reset
+        // following an early response). Locally-initiated aborts propagate as RuntimeException.
+        if (response.getStatus() > 0 && responseFailure instanceof IOException) {
+            log.debug(responseFailure, "Suppressing transport failure after headers were received from %s", request.getURI());
+            deliver(response);
+            return;
+        }
+        future.failed(responseFailure);
+    }
+
+    private void deliver(Response response)
+    {
+        try (InputStream stream = takeContentAsInputStream()) {
+            future.completed(response, stream);
+        }
+        catch (IOException e) {
+            future.failed(new UncheckedIOException("Failed communicating with server: " + request.getURI().toASCIIString(), e));
         }
     }
 }

--- a/http-client/src/test/java/io/airlift/http/client/AbstractHttpClientTest.java
+++ b/http-client/src/test/java/io/airlift/http/client/AbstractHttpClientTest.java
@@ -17,6 +17,7 @@ import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.client.HttpResponseException;
+import org.eclipse.jetty.http.HttpHeaderValue;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -25,6 +26,7 @@ import org.junit.jupiter.api.parallel.Execution;
 import java.io.ByteArrayInputStream;
 import java.io.Closeable;
 import java.io.File;
+import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -51,6 +53,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -838,6 +841,104 @@ public abstract class AbstractHttpClientTest
     }
 
     @Test
+    @Timeout(30)
+    public void testEarlyServerResponseIsDelivered()
+            throws Exception
+    {
+        // The server commits a final response without reading the upload body and
+        // tears down the exchange. The already-received response must still reach
+        // the caller even though the upload could not finish.
+        try (CloseableTestHttpServer server = newServerWithServlet(new EarlyResponseServlet())) {
+            Request request = rejectingUploadRequest(server);
+            StatusResponse response = executeRequest(server, request, createStatusResponseHandler());
+            assertThat(response.getStatusCode()).isEqualTo(503);
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    public void testSharedConnectionStaysUsableAfterEarlyResponse()
+            throws Exception
+    {
+        // Pinning the pool to a single connection forces the second request to either
+        // reuse the same connection (HTTP/2 multiplexing) or use one freshly opened
+        // by the pool after the previous one was closed (HTTP/1.1 abort path).
+        HttpClientConfig config = createClientConfig().setMaxConnectionsPerServer(1);
+        try (CloseableTestHttpServer server = newServerWithServlet(new EarlyResponseServlet())) {
+            Request rejected = rejectingUploadRequest(server);
+            Request regular = prepareGet()
+                    .setUri(server.baseURI())
+                    .build();
+
+            assertThat(executeRequest(server, config, rejected, createStatusResponseHandler()).getStatusCode()).isEqualTo(503);
+            assertThat(executeRequest(server, config, regular, createStatusResponseHandler()).getStatusCode()).isEqualTo(200);
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    public void testEarlyServerResponseAbortsUploadEarly()
+            throws Exception
+    {
+        // The Expect header makes the client withhold the body until the server
+        // acknowledges it; on a non-acknowledging early response the body source
+        // must not be read at all, so the upload never goes on the wire.
+        AtomicLong bytesPulled = new AtomicLong();
+        InputStream source = new CountingInputStream(new ByteArrayInputStream(new byte[8 * 1024 * 1024]), bytesPulled);
+        try (CloseableTestHttpServer server = newServerWithServlet(new EarlyResponseServlet())) {
+            Request request = preparePost()
+                    .setUri(server.baseURI())
+                    .addHeader(HeaderNames.EXPECT, HttpHeaderValue.CONTINUE.asString())
+                    .setBodyGenerator(streamingBodyGenerator(source))
+                    .build();
+            StatusResponse response = executeRequest(server, request, createStatusResponseHandler());
+            assertThat(response.getStatusCode()).isEqualTo(503);
+        }
+        assertThat(bytesPulled.get()).isZero();
+    }
+
+    @Test
+    @Timeout(30)
+    public void testEarlyServerResponseLimitsUploadBuffering()
+            throws Exception
+    {
+        // Without Expect: 100-continue the client starts streaming the body
+        // immediately, so some bytes go on the wire before the server's early
+        // response can stop the upload. The amount must still be bounded by
+        // socket and protocol buffers — not the whole body. The exchange may
+        // succeed (503 delivered) or fail depending on how the underlying
+        // transport tears the connection down; that is not what this test asserts.
+        int bodySize = 32 * 1024 * 1024;
+        AtomicLong bytesPulled = new AtomicLong();
+        InputStream source = new CountingInputStream(new ByteArrayInputStream(new byte[bodySize]), bytesPulled);
+        try (CloseableTestHttpServer server = newServerWithServlet(new EarlyResponseServlet())) {
+            Request request = preparePost()
+                    .setUri(server.baseURI())
+                    .setBodyGenerator(streamingBodyGenerator(source))
+                    .build();
+            try {
+                executeRequest(server, request, createStatusResponseHandler());
+            }
+            catch (Exception ignored) {
+                // Some transports surface the early-response teardown as a request failure.
+            }
+        }
+        assertThat(bytesPulled.get()).isLessThan(bodySize);
+    }
+
+    protected static Request rejectingUploadRequest(CloseableTestHttpServer server)
+    {
+        // The Expect header makes the client withhold the body until the server
+        // acknowledges it, so a non-acknowledging early response deterministically
+        // exercises the post-headers request-side abort path on every transport.
+        return preparePost()
+                .setUri(server.baseURI())
+                .addHeader(HeaderNames.EXPECT, HttpHeaderValue.CONTINUE.asString())
+                .setBodyGenerator(streamingBodyGenerator(new ByteArrayInputStream(new byte[1024 * 1024])))
+                .build();
+    }
+
+    @Test
     public void testHttpProtocolUsed()
             throws Exception
     {
@@ -1501,6 +1602,70 @@ public abstract class AbstractHttpClientTest
         }
         catch (Exception e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    protected CloseableTestHttpServer newServerWithServlet(HttpServlet servlet)
+    {
+        try {
+            return new CloseableTestHttpServer(getScheme(), new TestingHttpServer(keystore, servlet), HashMultiset.create(), new EchoServlet());
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static final class CountingInputStream
+            extends FilterInputStream
+    {
+        private final AtomicLong bytesRead;
+
+        CountingInputStream(InputStream in, AtomicLong bytesRead)
+        {
+            super(in);
+            this.bytesRead = requireNonNull(bytesRead, "bytesRead is null");
+        }
+
+        @Override
+        public int read()
+                throws IOException
+        {
+            int b = super.read();
+            if (b >= 0) {
+                bytesRead.incrementAndGet();
+            }
+            return b;
+        }
+
+        @Override
+        public int read(byte[] buffer, int offset, int length)
+                throws IOException
+        {
+            int n = super.read(buffer, offset, length);
+            if (n > 0) {
+                bytesRead.addAndGet(n);
+            }
+            return n;
+        }
+    }
+
+    public static final class EarlyResponseServlet
+            extends HttpServlet
+    {
+        @Override
+        protected void service(HttpServletRequest request, HttpServletResponse response)
+                throws IOException
+        {
+            // Reject any upload without reading the body. The early non-acknowledging
+            // response aborts the in-flight request and lets the test inspect how
+            // much of the upload was actually streamed before the abort kicked in.
+            if ("POST".equals(request.getMethod())) {
+                response.setStatus(503);
+                response.getOutputStream().print("rejected");
+                return;
+            }
+            response.setStatus(200);
+            response.getOutputStream().print("ok");
         }
     }
 

--- a/http-client/src/test/java/io/airlift/http/client/jetty/TestAsyncJettyHttpClientHttp2.java
+++ b/http-client/src/test/java/io/airlift/http/client/jetty/TestAsyncJettyHttpClientHttp2.java
@@ -1,6 +1,15 @@
 package io.airlift.http.client.jetty;
 
+import io.airlift.http.client.HttpClient.HttpResponseFuture;
 import io.airlift.http.client.HttpClientConfig;
+import io.airlift.http.client.Request;
+import io.airlift.http.client.StatusResponseHandler.StatusResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import static io.airlift.http.client.Request.Builder.prepareGet;
+import static io.airlift.http.client.StatusResponseHandler.createStatusResponseHandler;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestAsyncJettyHttpClientHttp2
         extends TestAsyncJettyHttpClient
@@ -10,5 +19,30 @@ public class TestAsyncJettyHttpClientHttp2
     {
         return super.createClientConfig()
                 .setHttp2Enabled(true);
+    }
+
+    @Test
+    @Timeout(30)
+    public void testConcurrentHttp2StreamsUnaffectedByEarlyResponse()
+            throws Exception
+    {
+        // Pin the destination to a single shared HTTP/2 connection, then issue a
+        // regular request concurrently with one that the server rejects after an
+        // early response. The streams must complete independently: rejection
+        // delivers 503 while the regular request still gets 200.
+        HttpClientConfig config = createClientConfig().setMaxConnectionsPerServer(1);
+        try (CloseableTestHttpServer server = newServerWithServlet(new EarlyResponseServlet());
+                JettyHttpClient client = server.createClient(config)) {
+            Request rejected = rejectingUploadRequest(server);
+            Request regular = prepareGet()
+                    .setUri(server.baseURI())
+                    .build();
+
+            HttpResponseFuture<StatusResponse> rejectedFuture = client.executeAsync(rejected, createStatusResponseHandler());
+            HttpResponseFuture<StatusResponse> regularFuture = client.executeAsync(regular, createStatusResponseHandler());
+
+            assertThat(rejectedFuture.get().getStatusCode()).isEqualTo(503);
+            assertThat(regularFuture.get().getStatusCode()).isEqualTo(200);
+        }
     }
 }

--- a/http-client/src/test/java/io/airlift/http/client/jetty/TestJettyHttpClientResponseTruncation.java
+++ b/http-client/src/test/java/io/airlift/http/client/jetty/TestJettyHttpClientResponseTruncation.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.http.client.jetty;
+
+import io.airlift.http.client.HttpClientConfig;
+import io.airlift.http.client.Request;
+import io.airlift.http.client.Response;
+import io.airlift.http.client.ResponseHandler;
+import io.airlift.http.client.StatusResponseHandler.StatusResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.URI;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static io.airlift.http.client.Request.Builder.prepareGet;
+import static io.airlift.http.client.StatusResponseHandler.createStatusResponseHandler;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestJettyHttpClientResponseTruncation
+{
+    @Test
+    @Timeout(30)
+    public void testTruncatedResponseRoutedToHandleException()
+            throws Exception
+    {
+        AtomicBoolean handleExceptionCalled = new AtomicBoolean();
+        try (TruncatedResponseServer server = new TruncatedResponseServer();
+                JettyHttpClient client = new JettyHttpClient(new HttpClientConfig())) {
+            Request request = prepareGet()
+                    .setUri(server.uri())
+                    .build();
+            assertThatThrownBy(() -> client.executeAsync(request, trackingHandler(handleExceptionCalled)).get())
+                    .isInstanceOf(ExecutionException.class)
+                    .hasCauseInstanceOf(RuntimeException.class);
+        }
+        assertThat(handleExceptionCalled).isTrue();
+    }
+
+    private static ResponseHandler<StatusResponse, RuntimeException> trackingHandler(AtomicBoolean handleExceptionCalled)
+    {
+        ResponseHandler<StatusResponse, RuntimeException> delegate = createStatusResponseHandler();
+        return new ResponseHandler<>()
+        {
+            @Override
+            public StatusResponse handleException(Request request, Exception exception)
+            {
+                handleExceptionCalled.set(true);
+                throw new RuntimeException(exception);
+            }
+
+            @Override
+            public StatusResponse handle(Request request, Response response)
+            {
+                return delegate.handle(request, response);
+            }
+        };
+    }
+
+    @SuppressWarnings("SocketOpenedButNotSafelyClosed")
+    private static final class TruncatedResponseServer
+            implements AutoCloseable
+    {
+        private final ServerSocket serverSocket;
+
+        TruncatedResponseServer()
+                throws IOException
+        {
+            this.serverSocket = new ServerSocket(0, 50, InetAddress.getByName("localhost"));
+            Thread acceptor = new Thread(this::run, "TruncatedResponseServer");
+            acceptor.setDaemon(true);
+            acceptor.start();
+        }
+
+        private void run()
+        {
+            while (!serverSocket.isClosed()) {
+                try (Socket socket = serverSocket.accept();
+                        OutputStream out = socket.getOutputStream()) {
+                    // Promise 100 bytes, deliver 5, then close to truncate the response body.
+                    out.write("HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\nshort".getBytes(US_ASCII));
+                    out.flush();
+                }
+                catch (IOException ignored) {
+                    // close() causes accept() to throw; isClosed() then exits the loop.
+                }
+            }
+        }
+
+        URI uri()
+        {
+            return URI.create("http://localhost:" + serverSocket.getLocalPort() + "/");
+        }
+
+        @Override
+        public void close()
+                throws IOException
+        {
+            serverSocket.close();
+        }
+    }
+}


### PR DESCRIPTION
## Background

`JettyResponseListener#onComplete` used to fail the future whenever `Result#isFailed()` was true. In Jetty 12 that flag is also set when the response was received in full but the request side aborted afterwards, so the handler never saw the response.

The motivating case: a server commits an early final response and refuses to read the upload body. The client throws even though a complete response is sitting on the wire.

## HTTP/1.1

When the response is fully parsed and the upload is aborted afterwards, the `Result` has a parsed response and `responseFailure == null` while `requestFailure` is set. Deliver the response and log the suppressed request failure at DEBUG. Genuine truncation still sets `responseFailure` and continues to fail.

## HTTP/2 / HTTP/3

A server-initiated stream reset that follows a committed response surfaces here as an `IOException` after the status line was parsed. Deliver the response. Locally-initiated aborts (max-content-length violations, `HttpStatusListener` exceptions) propagate as `RuntimeException` and continue to fail.

Replace `checkState()` in `completeHttp1` with `future.failed()`; throwing `IllegalStateException` from Jetty's I/O thread left the future unsettled and the caller blocked until idle timeout.

## Tests

Two scenarios were added to `AbstractHttpClientTest` so they exercise every existing client configuration (sync vs async, HTTP/1.1 vs HTTP/2, plain vs TLS, direct vs proxy):

- `testEarlyServerResponseIsDelivered` verifies the early-response path.
- `testSharedConnectionStaysUsableAfterEarlyResponse` verifies that the connection pool recovers afterwards.

An HTTP/2-specific concurrent streams test lives in `TestAsyncJettyHttpClientHttp2`. A focused HTTP/1.1 truncation test (raw-socket server, doesn't fit the abstract pattern) lives in `TestJettyHttpClientResponseTruncation`.

# Airlift contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [x] All automated tests are passing.
 - [ ] Pull request was categorized using one of the existing labels.