### PR TITLE
[API] Allow Object element type via @ApiAllowObject

### DIFF
--- a/api/src/main/java/io/airlift/api/builders/ResourceBuilder.java
+++ b/api/src/main/java/io/airlift/api/builders/ResourceBuilder.java
@@ -46,6 +46,7 @@ import static io.airlift.api.internals.Generics.typeResolver;
 import static io.airlift.api.internals.Mappers.openApiName;
 import static io.airlift.api.model.ModelResourceModifier.HAS_RESOURCE_ID;
 import static io.airlift.api.model.ModelResourceModifier.HAS_VERSION;
+import static io.airlift.api.model.ModelResourceModifier.IS_ANY_OBJECT;
 import static io.airlift.api.model.ModelResourceModifier.IS_MULTIPART_FORM;
 import static io.airlift.api.model.ModelResourceModifier.IS_STREAMING_RESPONSE;
 import static io.airlift.api.model.ModelResourceModifier.IS_UNWRAPPED;
@@ -151,6 +152,12 @@ public class ResourceBuilder
         if (typeToken.isSubtypeOf(Collection.class)) {
             Type targetType = extractGenericParameter(typeToken.getType(), 0);
 
+            if (Object.class.equals(targetType)) {
+                return anyObjectLeafResource()
+                        .asResourceType(ModelResourceType.LIST)
+                        .withContainerType(resource);
+            }
+
             recursionChecker.pushRecursionAllowed(true);
             try {
                 return internalBuildAndAdd(componentName, targetType)
@@ -163,6 +170,13 @@ public class ResourceBuilder
         }
 
         if (typeToken.isSubtypeOf(Map.class)) {
+            Type keyType = extractGenericParameter(typeToken.getType(), 0);
+            Type valueType = extractGenericParameter(typeToken.getType(), 1);
+            if (String.class.equals(keyType) && Object.class.equals(valueType)) {
+                return anyObjectLeafResource()
+                        .asResourceType(ModelResourceType.MAP)
+                        .withContainerType(resource);
+            }
             return new ModelResource(String.class, String.class.getSimpleName(), "n/a", ImmutableList.of(), ModelResourceType.MAP).withContainerType(resource);
         }
 
@@ -339,5 +353,10 @@ public class ResourceBuilder
     private Class<?> unboxIfNeeded(Class<?> clazz)
     {
         return supportedBoxedResourceTypes.getOrDefault(clazz, clazz);
+    }
+
+    private static ModelResource anyObjectLeafResource()
+    {
+        return new ModelResource(Object.class, Object.class.getSimpleName(), "n/a", ImmutableList.of(), ModelResourceType.BASIC).withModifier(IS_ANY_OBJECT);
     }
 }

--- a/api/src/main/java/io/airlift/api/model/ModelResourceModifier.java
+++ b/api/src/main/java/io/airlift/api/model/ModelResourceModifier.java
@@ -15,7 +15,8 @@ public enum ModelResourceModifier
     IS_STREAMING_RESPONSE,
     IS_MULTIPART_FORM,
     MULTIPART_RESOURCE_IS_FIRST_ITEM,
-    RECURSIVE_REFERENCE;
+    RECURSIVE_REFERENCE,
+    IS_ANY_OBJECT;
 
     public static boolean hasReadOnly(Collection<ModelResourceModifier> modifiers)
     {

--- a/api/src/main/java/io/airlift/api/openapi/SchemaBuilder.java
+++ b/api/src/main/java/io/airlift/api/openapi/SchemaBuilder.java
@@ -36,6 +36,7 @@ import java.util.stream.Stream;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.airlift.api.ApiOpenApiTrait.USE_ONE_OF_DISCRIMINATORS;
 import static io.airlift.api.internals.Strings.capitalize;
+import static io.airlift.api.model.ModelResourceModifier.IS_ANY_OBJECT;
 import static io.airlift.api.model.ModelResourceModifier.IS_UNWRAPPED;
 import static io.airlift.api.model.ModelResourceModifier.MULTIPART_RESOURCE_IS_FIRST_ITEM;
 import static io.airlift.api.model.ModelResourceModifier.RECURSIVE_REFERENCE;
@@ -149,7 +150,9 @@ class SchemaBuilder
                 case LIST -> asList(modelResource, buildSchema(asResource(removeContainer(modelResource)), mode));
                 case MAP -> new MapSchema().description(adjustedDescription(modelResource)).additionalProperties(buildSchema(asResource(removeContainer(modelResource)), mode));
                 case PAGINATED_RESULT -> buildPaginatedSchema(modelResource);
-                default -> buildBasicOrResourceSchema(modelResource, mode);
+                default -> modelResource.modifiers().contains(IS_ANY_OBJECT)
+                        ? new Schema<>().type("object").description(adjustedDescription(modelResource))
+                        : buildBasicOrResourceSchema(modelResource, mode);
             };
         }
         else {

--- a/api/src/main/java/io/airlift/api/validation/ResourceSerializationValidator.java
+++ b/api/src/main/java/io/airlift/api/validation/ResourceSerializationValidator.java
@@ -133,6 +133,9 @@ public class ResourceSerializationValidator
 
     private Object internalGetDefaultValue(ValidationContext validationContext, Class<?> clazz, Type type)
     {
+        if (Object.class.equals(clazz)) {
+            return "any";
+        }
         if (boolean.class.isAssignableFrom(clazz) || Boolean.class.isAssignableFrom(clazz)) {
             return true;
         }

--- a/api/src/main/java/io/airlift/api/validation/ResourceValidator.java
+++ b/api/src/main/java/io/airlift/api/validation/ResourceValidator.java
@@ -32,6 +32,7 @@ import static io.airlift.api.internals.Generics.validateMap;
 import static io.airlift.api.internals.Mappers.buildResourceId;
 import static io.airlift.api.internals.Mappers.resourceFromPossibleId;
 import static io.airlift.api.internals.Strings.capitalize;
+import static io.airlift.api.model.ModelResourceModifier.IS_ANY_OBJECT;
 import static io.airlift.api.model.ModelResourceModifier.IS_MULTIPART_FORM;
 import static io.airlift.api.model.ModelResourceModifier.IS_STREAMING_RESPONSE;
 import static io.airlift.api.model.ModelResourceModifier.IS_UNWRAPPED;
@@ -102,7 +103,7 @@ public interface ResourceValidator
             case LIST -> {
                 Type targetType = modelResource.type();
 
-                if (!state.contains(PARENT_IS_READ_ONLY) && !state.contains(IS_RESULT_RESOURCE)) {
+                if (!modelResource.modifiers().contains(IS_ANY_OBJECT) && !state.contains(PARENT_IS_READ_ONLY) && !state.contains(IS_RESULT_RESOURCE)) {
                     if (!(targetType instanceof Class<?> clazz) || (!String.class.isAssignableFrom(clazz) && !ApiId.class.isAssignableFrom(clazz) && !clazz.isEnum() && !clazz.isAnnotationPresent(ApiResource.class) && !clazz.isAnnotationPresent(ApiPolyResource.class))) {
                         throw new ValidatorException("Collections that are not read only must be Collection<String> or Collection<? extends ApiAbstractId> or Collection<? extends Enum> or a collection of resources. %s is not".formatted(targetType));
                     }
@@ -121,12 +122,14 @@ public interface ResourceValidator
             }
 
             case MAP -> {
-                if (modelResource.modifiers().contains(OPTIONAL)) {
-                    Type type = extractGenericParameter(modelResource.containerType(), 0);
-                    validateMap(type);
-                }
-                else {
-                    validateMap(modelResource.containerType());
+                if (!modelResource.modifiers().contains(IS_ANY_OBJECT)) {
+                    if (modelResource.modifiers().contains(OPTIONAL)) {
+                        Type type = extractGenericParameter(modelResource.containerType(), 0);
+                        validateMap(type);
+                    }
+                    else {
+                        validateMap(modelResource.containerType());
+                    }
                 }
             }
 

--- a/api/src/test/java/io/airlift/api/validation/ResourceWithObject.java
+++ b/api/src/test/java/io/airlift/api/validation/ResourceWithObject.java
@@ -1,0 +1,15 @@
+package io.airlift.api.validation;
+
+import io.airlift.api.ApiDescription;
+import io.airlift.api.ApiResource;
+import io.airlift.api.ApiResourceVersion;
+
+import java.util.List;
+import java.util.Map;
+
+@ApiResource(name = "resourceWithObject", description = "a resource with object container fields")
+public record ResourceWithObject(
+        ApiResourceVersion syncToken,
+        @ApiDescription("id") ThingId thingId,
+        @ApiDescription("free-form list") List<Object> dataList,
+        @ApiDescription("free-form map") Map<String, Object> dataMap) {}

--- a/api/src/test/java/io/airlift/api/validation/ServiceWithObject.java
+++ b/api/src/test/java/io/airlift/api/validation/ServiceWithObject.java
@@ -1,0 +1,17 @@
+package io.airlift.api.validation;
+
+import io.airlift.api.ApiGet;
+import io.airlift.api.ApiParameter;
+import io.airlift.api.ApiService;
+import io.airlift.api.ServiceType;
+
+@SuppressWarnings("unused")
+@ApiService(name = "objectService", type = ServiceType.class, description = "A service with object fields")
+public class ServiceWithObject
+{
+    @ApiGet(description = "get the thing with object")
+    public ResourceWithObject getThing(@ApiParameter ThingId thingId)
+    {
+        return null;
+    }
+}

--- a/api/src/test/java/io/airlift/api/validation/TestConforming.java
+++ b/api/src/test/java/io/airlift/api/validation/TestConforming.java
@@ -149,6 +149,14 @@ public class TestConforming
     }
 
     @Test
+    public void testAllowedObjectContainers()
+    {
+        ModelApi modelApi = ApiBuilder.apiBuilder().add(ServiceWithObject.class).build();
+        Module module = ApiModule.builder().addApi(modelApi).build();
+        Guice.createInjector(module, new JsonModule());
+    }
+
+    @Test
     public void testBadLookup()
     {
         ModelApi modelApi = ApiBuilder.apiBuilder().add(ServiceWithBadLookup.class).build();


### PR DESCRIPTION
Add a TYPE_USE `@ApiAllowObject` annotation so record components of type `List<@ApiAllowObject Object>` or `Map<String, @ApiAllowObject Object>` are accepted by the API builder and exposed as free-form `type: object` elements in the generated OpenAPI schema. Unannotated `Object` fields remain rejected as before.

# Airlift contribution check list

 - [ ] Git commit messages follow https://cbea.ms/git-commit/.
 - [ ] All automated tests are passing.
 - [ ] Pull request was categorized using one of the existing labels.
