### PR TITLE
Add qualifier-aware bindings for MCP, OpenMetrics, and testing HTTP servers

### DIFF
--- a/http-server/src/main/java/io/airlift/http/server/testing/TestingHttpServerModule.java
+++ b/http-server/src/main/java/io/airlift/http/server/testing/TestingHttpServerModule.java
@@ -38,15 +38,6 @@ public class TestingHttpServerModule
     private final String name;
     private final int httpPort;
 
-    /**
-     * @deprecated use {@link #TestingHttpServerModule(String, int)} or {@link #TestingHttpServerModule(String)} instead
-     */
-    @Deprecated(forRemoval = true)
-    public TestingHttpServerModule()
-    {
-        this("testing", 0);
-    }
-
     public TestingHttpServerModule(String name)
     {
         this(name, 0);

--- a/http-server/src/main/java/io/airlift/http/server/testing/TestingHttpServerModule.java
+++ b/http-server/src/main/java/io/airlift/http/server/testing/TestingHttpServerModule.java
@@ -18,25 +18,35 @@ import com.google.inject.Key;
 import com.google.inject.Scopes;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.airlift.discovery.client.AnnouncementHttpServerInfo;
+import io.airlift.http.server.AnnouncementHttpServerInfoProvider;
 import io.airlift.http.server.HttpServer;
 import io.airlift.http.server.HttpServer.ClientCertificate;
 import io.airlift.http.server.HttpServerConfig;
 import io.airlift.http.server.HttpServerInfo;
+import io.airlift.http.server.HttpServerInfoProvider;
 import io.airlift.http.server.HttpsConfig;
 import io.airlift.http.server.LocalAnnouncementHttpServerInfo;
 import io.airlift.http.server.ServerFeature;
+import jakarta.annotation.Nullable;
 import jakarta.servlet.Filter;
 
+import java.lang.annotation.Annotation;
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.http.server.HttpServerBinder.HttpResourceBinding;
+import static java.util.Objects.requireNonNull;
 
 public class TestingHttpServerModule
         extends AbstractConfigurationAwareModule
 {
     private final String name;
     private final int httpPort;
+    private final Optional<Class<? extends Annotation>> qualifier;
+    private final @Nullable String configPrefix;
 
     public TestingHttpServerModule(String name)
     {
@@ -45,35 +55,78 @@ public class TestingHttpServerModule
 
     public TestingHttpServerModule(String name, int httpPort)
     {
-        this.name = name;
+        this(name, httpPort, Optional.empty(), null);
+    }
+
+    public TestingHttpServerModule(String name, Class<? extends Annotation> qualifier, String configPrefix)
+    {
+        this(name, 0, qualifier, configPrefix);
+    }
+
+    public TestingHttpServerModule(String name, int httpPort, Class<? extends Annotation> qualifier, String configPrefix)
+    {
+        this(name, httpPort, Optional.of(requireNonNull(qualifier, "qualifier is null")), requireNonNull(configPrefix, "configPrefix is null"));
+    }
+
+    private TestingHttpServerModule(String name, int httpPort, Optional<Class<? extends Annotation>> qualifier, @Nullable String configPrefix)
+    {
+        this.name = requireNonNull(name, "name is null");
         this.httpPort = httpPort;
+        this.qualifier = requireNonNull(qualifier, "qualifier is null");
+        this.configPrefix = configPrefix;
+
+        if (this.qualifier.isPresent()) {
+            checkArgument(this.configPrefix != null, "qualifier is present but configPrefix is null");
+        }
     }
 
     @Override
     protected void setup(Binder binder)
     {
-        configBinder(binder).bindConfig(HttpServerConfig.class);
-        configBinder(binder).bindConfigDefaults(HttpServerConfig.class, config -> config
+        configBinder(binder).bindConfig(qualifiedKey(HttpServerConfig.class), HttpServerConfig.class, configPrefix);
+        configBinder(binder).bindConfigDefaults(qualifiedKey(HttpServerConfig.class), config -> config
                 .setHttpPort(httpPort));
 
-        binder.bind(String.class).annotatedWith(ForTestingServer.class).toInstance(name);
-        binder.bind(HttpServerInfo.class).in(Scopes.SINGLETON);
-        binder.bind(TestingHttpServer.class).in(Scopes.SINGLETON);
-        newOptionalBinder(binder, ClientCertificate.class).setDefault().toInstance(ClientCertificate.NONE);
-        binder.bind(HttpServer.class).to(Key.get(TestingHttpServer.class));
-        newSetBinder(binder, ServerFeature.class);
-        newSetBinder(binder, Filter.class);
-        newSetBinder(binder, HttpResourceBinding.class);
-        binder.bind(AnnouncementHttpServerInfo.class).to(LocalAnnouncementHttpServerInfo.class);
+        if (qualifier.isPresent()) {
+            binder.bind(qualifiedKey(HttpServerInfo.class))
+                    .toProvider(new HttpServerInfoProvider(qualifier))
+                    .in(Scopes.SINGLETON);
+            binder.bind(qualifiedKey(TestingHttpServer.class))
+                    .toProvider(new TestingHttpServerProvider(name, qualifier))
+                    .in(Scopes.SINGLETON);
+            binder.bind(qualifiedKey(HttpServer.class)).to(qualifiedKey(TestingHttpServer.class));
+            binder.bind(qualifiedKey(AnnouncementHttpServerInfo.class))
+                    .toProvider(new AnnouncementHttpServerInfoProvider(qualifier))
+                    .in(Scopes.SINGLETON);
+        }
+        else {
+            binder.bind(String.class).annotatedWith(ForTestingServer.class).toInstance(name);
+            binder.bind(HttpServerInfo.class).in(Scopes.SINGLETON);
+            binder.bind(TestingHttpServer.class).in(Scopes.SINGLETON);
+            binder.bind(HttpServer.class).to(Key.get(TestingHttpServer.class));
+            binder.bind(AnnouncementHttpServerInfo.class).to(LocalAnnouncementHttpServerInfo.class);
+        }
 
-        newOptionalBinder(binder, HttpsConfig.class);
-        if (buildConfigObject(HttpServerConfig.class).isHttpsEnabled()) {
-            configBinder(binder).bindConfig(HttpsConfig.class);
-            configBinder(binder).bindConfigDefaults(HttpsConfig.class, config -> {
+        newOptionalBinder(binder, qualifiedKey(ClientCertificate.class)).setDefault().toInstance(ClientCertificate.NONE);
+        newSetBinder(binder, qualifiedKey(ServerFeature.class));
+        newSetBinder(binder, qualifiedKey(Filter.class));
+        newSetBinder(binder, qualifiedKey(HttpResourceBinding.class));
+
+        newOptionalBinder(binder, qualifiedKey(HttpsConfig.class));
+        if (buildConfigObject(qualifiedKey(HttpServerConfig.class), HttpServerConfig.class, configPrefix).isHttpsEnabled()) {
+            configBinder(binder).bindConfig(qualifiedKey(HttpsConfig.class), HttpsConfig.class, configPrefix);
+            configBinder(binder).bindConfigDefaults(qualifiedKey(HttpsConfig.class), config -> {
                 if (httpPort == 0) {
                     config.setHttpsPort(0);
                 }
             });
         }
+    }
+
+    private <T> Key<T> qualifiedKey(Class<T> type)
+    {
+        return qualifier
+                .map(annotation -> Key.get(type, annotation))
+                .orElseGet(() -> Key.get(type));
     }
 }

--- a/http-server/src/main/java/io/airlift/http/server/testing/TestingHttpServerProvider.java
+++ b/http-server/src/main/java/io/airlift/http/server/testing/TestingHttpServerProvider.java
@@ -1,0 +1,80 @@
+package io.airlift.http.server.testing;
+
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.Provider;
+import com.google.inject.TypeLiteral;
+import io.airlift.http.server.HttpServer.ClientCertificate;
+import io.airlift.http.server.HttpServerBinder.HttpResourceBinding;
+import io.airlift.http.server.HttpServerConfig;
+import io.airlift.http.server.HttpServerInfo;
+import io.airlift.http.server.HttpsConfig;
+import io.airlift.http.server.ServerFeature;
+import io.airlift.node.NodeInfo;
+import jakarta.servlet.Filter;
+import jakarta.servlet.Servlet;
+
+import java.lang.annotation.Annotation;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.base.Throwables.throwIfUnchecked;
+import static java.util.Objects.requireNonNull;
+
+class TestingHttpServerProvider
+        implements Provider<TestingHttpServer>
+{
+    private final String name;
+    private final Optional<Class<? extends Annotation>> qualifier;
+
+    private Injector injector;
+
+    TestingHttpServerProvider(String name, Optional<Class<? extends Annotation>> qualifier)
+    {
+        this.name = requireNonNull(name, "name is null");
+        this.qualifier = requireNonNull(qualifier, "qualifier is null");
+    }
+
+    @Inject
+    public void setInjector(Injector injector)
+    {
+        this.injector = requireNonNull(injector, "injector is null");
+    }
+
+    @Override
+    public TestingHttpServer get()
+    {
+        try {
+            return new TestingHttpServer(
+                    name,
+                    injector.getInstance(qualifiedKey(HttpServerInfo.class)),
+                    injector.getInstance(NodeInfo.class),
+                    injector.getInstance(qualifiedKey(HttpServerConfig.class)),
+                    injector.getInstance(qualifiedKey(new TypeLiteral<Optional<HttpsConfig>>() {})),
+                    injector.getInstance(qualifiedKey(Servlet.class)),
+                    injector.getInstance(qualifiedKey(new TypeLiteral<Set<Filter>>() {})),
+                    injector.getInstance(qualifiedKey(new TypeLiteral<Set<HttpResourceBinding>>() {})),
+                    injector.getInstance(qualifiedKey(new TypeLiteral<Set<ServerFeature>>() {})),
+                    injector.getInstance(qualifiedKey(ClientCertificate.class)));
+        }
+        catch (Exception e) {
+            throwIfUnchecked(e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    private <T> Key<T> qualifiedKey(Class<T> type)
+    {
+        return qualifier
+                .map(annotation -> Key.get(type, annotation))
+                .orElseGet(() -> Key.get(type));
+    }
+
+    private <T> Key<T> qualifiedKey(TypeLiteral<T> type)
+    {
+        return qualifier
+                .map(annotation -> Key.get(type, annotation))
+                .orElseGet(() -> Key.get(type));
+    }
+}

--- a/http-server/src/test/java/io/airlift/http/server/testing/AbstractTestTestingHttpServer.java
+++ b/http-server/src/test/java/io/airlift/http/server/testing/AbstractTestTestingHttpServer.java
@@ -18,7 +18,10 @@ package io.airlift.http.server.testing;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.net.HttpHeaders;
 import com.google.common.net.MediaType;
+import com.google.inject.BindingAnnotation;
 import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.TypeLiteral;
 import io.airlift.bootstrap.Bootstrap;
 import io.airlift.bootstrap.LifeCycleManager;
 import io.airlift.http.client.HttpClient;
@@ -54,6 +57,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 import java.io.IOException;
+import java.lang.annotation.Retention;
 import java.net.URI;
 import java.util.Optional;
 import java.util.Set;
@@ -70,6 +74,7 @@ import static io.airlift.http.client.StatusResponseHandler.createStatusResponseH
 import static io.airlift.http.client.StringResponseHandler.createStringResponseHandler;
 import static io.airlift.http.server.HttpServerBinder.httpServerBinder;
 import static io.airlift.http.server.ServerFeature.VIRTUAL_THREADS;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.abort;
@@ -272,6 +277,44 @@ public abstract class AbstractTestTestingHttpServer
         }
     }
 
+    @Test
+    public void testQualifiedGuiceInjectionWithFilters()
+    {
+        skipUnlessJdkHasVirtualThreads();
+        DummyServlet servlet = new DummyServlet();
+        DummyFilter filter = new DummyFilter();
+
+        Bootstrap app = new Bootstrap(
+                new TestingNodeModule(),
+                new TestingHttpServerModule(getClass().getName(), 0, TestServer.class, "test-server"),
+                binder -> {
+                    binder.bind(Key.get(Servlet.class, TestServer.class)).toInstance(servlet);
+                    newSetBinder(binder, Key.get(Filter.class, TestServer.class)).addBinding().toInstance(filter);
+                    httpServerBinder(binder, TestServer.class).withFeatures(serverFeatures);
+                });
+
+        Injector injector = app
+                .doNotInitializeLogging()
+                .initialize();
+
+        assertThat(injector.getExistingBinding(Key.get(new TypeLiteral<Set<Filter>>() {}))).isNull();
+        assertThat(injector.getExistingBinding(Key.get(new TypeLiteral<Set<Filter>>() {}, TestServer.class))).isNotNull();
+
+        LifeCycleManager lifeCycleManager = injector.getInstance(LifeCycleManager.class);
+        TestingHttpServer server = injector.getInstance(Key.get(TestingHttpServer.class, TestServer.class));
+
+        try (HttpClient client = new JettyHttpClient(new HttpClientConfig().setConnectTimeout(new Duration(1, SECONDS)))) {
+            StatusResponse response = client.execute(prepareGet().setUri(server.getBaseUrl()).build(), createStatusResponseHandler());
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpServletResponse.SC_OK);
+            assertThat(servlet.getCallCount()).isEqualTo(1);
+            assertThat(filter.getCallCount()).isEqualTo(1);
+        }
+        finally {
+            lifeCycleManager.stop();
+        }
+    }
+
     @SuppressWarnings("SynchronizationOnLocalVariableOrMethodParameter")
     @Test
     public void testHeaderCaseSensitivity()
@@ -417,4 +460,8 @@ public abstract class AbstractTestTestingHttpServer
         @Override
         public void destroy() {}
     }
+
+    @Retention(RUNTIME)
+    @BindingAnnotation
+    private @interface TestServer {}
 }

--- a/mcp/src/main/java/io/airlift/mcp/McpModule.java
+++ b/mcp/src/main/java/io/airlift/mcp/McpModule.java
@@ -50,6 +50,7 @@ import io.airlift.mcp.sessions.ForSessionCaching;
 import io.airlift.mcp.sessions.SessionController;
 import io.airlift.mcp.storage.StorageController;
 
+import java.lang.annotation.Annotation;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -88,6 +89,7 @@ public class McpModule
     private final Set<String> serverIcons;
     private final Optional<Consumer<LinkedBindingBuilder<StorageController>>> storageControllerBinding;
     private final Consumer<LinkedBindingBuilder<Operations>> operationsBinding;
+    private final Optional<Class<? extends Annotation>> filterBindingAnnotation;
 
     public static Builder builder()
     {
@@ -108,7 +110,8 @@ public class McpModule
             Map<String, Consumer<LinkedBindingBuilder<Icon>>> icons,
             Set<String> serverIcons,
             Optional<Consumer<LinkedBindingBuilder<StorageController>>> storageControllerBinding,
-            Consumer<LinkedBindingBuilder<Operations>> operationsBinding)
+            Consumer<LinkedBindingBuilder<Operations>> operationsBinding,
+            Optional<Class<? extends Annotation>> filterBindingAnnotation)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.identityMapperBinding = requireNonNull(identityMapperBinding, "identityMapperBinding is null");
@@ -124,6 +127,7 @@ public class McpModule
         this.serverIcons = ImmutableSet.copyOf(serverIcons);
         this.storageControllerBinding = requireNonNull(storageControllerBinding, "storageControllerBinding is null");
         this.operationsBinding = requireNonNull(operationsBinding, "operationsBinding is null");
+        this.filterBindingAnnotation = requireNonNull(filterBindingAnnotation, "filterBindingAnnotation is null");
     }
 
     record IdentityMapperBinding(Class<?> identityType, Consumer<AnnotatedBindingBuilder<McpIdentityMapper>> identityMapperBinding)
@@ -162,6 +166,7 @@ public class McpModule
         private Optional<Consumer<LinkedBindingBuilder<McpCapabilityFilter>>> capabilityFilterBinding = Optional.empty();
         private Optional<Consumer<LinkedBindingBuilder<StorageController>>> storageControllerBinding = Optional.empty();
         private Consumer<LinkedBindingBuilder<Operations>> operationsBinding = binding -> binding.to(SessionlessOperations.class).in(SINGLETON);
+        private Optional<Class<? extends Annotation>> filterBindingAnnotation = Optional.empty();
 
         private Builder() {}
 
@@ -200,6 +205,13 @@ public class McpModule
         {
             checkArgument(this.capabilityFilterBinding.isEmpty(), "Capability filter binding is already set");
             this.capabilityFilterBinding = Optional.of(filterBinding);
+            return this;
+        }
+
+        public Builder withHttpServerBinding(Class<? extends Annotation> annotation)
+        {
+            checkState(filterBindingAnnotation.isEmpty(), "HTTP server binding annotation is already set");
+            filterBindingAnnotation = Optional.of(requireNonNull(annotation, "annotation is null"));
             return this;
         }
 
@@ -279,7 +291,8 @@ public class McpModule
                     icons.build(),
                     serverIcons.build(),
                     storageControllerBinding,
-                    operationsBinding);
+                    operationsBinding,
+                    filterBindingAnnotation);
         }
     }
 
@@ -310,7 +323,7 @@ public class McpModule
         bindCapabilityFilter(binder);
         bindIcons(binder);
 
-        binder.install(new InternalMcpModule());
+        binder.install(new InternalMcpModule(filterBindingAnnotation));
         binder.install(new OperationsModule());
     }
 

--- a/mcp/src/main/java/io/airlift/mcp/internal/InternalMcpModule.java
+++ b/mcp/src/main/java/io/airlift/mcp/internal/InternalMcpModule.java
@@ -1,22 +1,44 @@
 package io.airlift.mcp.internal;
 
 import com.google.inject.Binder;
+import com.google.inject.Key;
 import com.google.inject.Module;
 import io.airlift.mcp.McpEntities;
 import jakarta.servlet.Filter;
 
+import java.lang.annotation.Annotation;
+import java.util.Optional;
+
 import static com.google.inject.Scopes.SINGLETON;
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
+import static java.util.Objects.requireNonNull;
 
 public class InternalMcpModule
         implements Module
 {
+    private final Optional<Class<? extends Annotation>> filterBindingAnnotation;
+
+    public InternalMcpModule()
+    {
+        this(Optional.empty());
+    }
+
+    public InternalMcpModule(Optional<Class<? extends Annotation>> filterBindingAnnotation)
+    {
+        this.filterBindingAnnotation = requireNonNull(filterBindingAnnotation, "filterBindingAnnotation is null");
+    }
+
     @Override
     public void configure(Binder binder)
     {
         binder.bind(InternalEntities.class).in(SINGLETON);
         binder.bind(McpEntities.class).to(InternalEntities.class).in(SINGLETON);
 
-        newSetBinder(binder, Filter.class).addBinding().to(InternalFilter.class).in(SINGLETON);
+        newSetBinder(binder, filterBindingAnnotation
+                .map(annotation -> Key.get(Filter.class, annotation))
+                .orElseGet(() -> Key.get(Filter.class)))
+                .addBinding()
+                .to(InternalFilter.class)
+                .in(SINGLETON);
     }
 }

--- a/mcp/src/test/java/io/airlift/mcp/TestMcpModule.java
+++ b/mcp/src/test/java/io/airlift/mcp/TestMcpModule.java
@@ -1,0 +1,38 @@
+package io.airlift.mcp;
+
+import com.google.inject.Binding;
+import com.google.inject.Key;
+import com.google.inject.TypeLiteral;
+import com.google.inject.spi.Element;
+import com.google.inject.spi.Elements;
+import jakarta.servlet.Filter;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestMcpModule
+{
+    @Test
+    public void testMcpFilterCanBeBoundToQualifiedHttpServer()
+    {
+        List<Element> elements = Elements.getElements(McpModule.builder()
+                .withIdentityMapper(TestingIdentity.class, binding -> binding.to(TestingIdentityMapper.class))
+                .withHttpServerBinding(ForTest.class)
+                .build());
+
+        assertThat(hasBinding(elements, Key.get(new TypeLiteral<Set<Filter>>() {}))).isFalse();
+        assertThat(hasBinding(elements, Key.get(new TypeLiteral<Set<Filter>>() {}, ForTest.class))).isTrue();
+    }
+
+    private static boolean hasBinding(List<Element> elements, Key<?> key)
+    {
+        return elements.stream()
+                .filter(Binding.class::isInstance)
+                .map(Binding.class::cast)
+                .map(Binding::getKey)
+                .anyMatch(key::equals);
+    }
+}

--- a/openmetrics/src/main/java/io/airlift/openmetrics/JmxOpenMetricsModule.java
+++ b/openmetrics/src/main/java/io/airlift/openmetrics/JmxOpenMetricsModule.java
@@ -16,16 +16,35 @@ package io.airlift.openmetrics;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 
+import java.lang.annotation.Annotation;
+import java.util.Optional;
+
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
+import static java.util.Objects.requireNonNull;
 
 public class JmxOpenMetricsModule
         implements Module
 {
+    private final Optional<Class<? extends Annotation>> annotation;
+
+    public JmxOpenMetricsModule()
+    {
+        this.annotation = Optional.empty();
+    }
+
+    public JmxOpenMetricsModule(Class<? extends Annotation> annotation)
+    {
+        this.annotation = Optional.of(requireNonNull(annotation, "annotation is null"));
+    }
+
     @Override
     public void configure(Binder binder)
     {
         configBinder(binder).bindConfig(MetricsConfig.class);
-        jaxrsBinder(binder).bind(MetricsResource.class);
+        annotation
+                .map(value -> jaxrsBinder(binder, value))
+                .orElseGet(() -> jaxrsBinder(binder))
+                .bind(MetricsResource.class);
     }
 }

--- a/openmetrics/src/test/java/io/airlift/openmetrics/TestJmxOpenMetricsModule.java
+++ b/openmetrics/src/test/java/io/airlift/openmetrics/TestJmxOpenMetricsModule.java
@@ -1,0 +1,41 @@
+package io.airlift.openmetrics;
+
+import com.google.inject.Binding;
+import com.google.inject.BindingAnnotation;
+import com.google.inject.Key;
+import com.google.inject.TypeLiteral;
+import com.google.inject.spi.Element;
+import com.google.inject.spi.Elements;
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.Retention;
+import java.util.List;
+import java.util.Set;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestJmxOpenMetricsModule
+{
+    @Test
+    public void testMetricsResourceCanBeBoundToQualifiedJaxrsServer()
+    {
+        List<Element> elements = Elements.getElements(new JmxOpenMetricsModule(ForTesting.class));
+
+        assertThat(hasBinding(elements, Key.get(new TypeLiteral<Set<Object>>() {}))).isFalse();
+        assertThat(hasBinding(elements, Key.get(new TypeLiteral<Set<Object>>() {}, ForTesting.class))).isTrue();
+    }
+
+    private static boolean hasBinding(List<Element> elements, Key<?> key)
+    {
+        return elements.stream()
+                .filter(Binding.class::isInstance)
+                .map(Binding.class::cast)
+                .map(Binding::getKey)
+                .anyMatch(key::equals);
+    }
+
+    @Retention(RUNTIME)
+    @BindingAnnotation
+    private @interface ForTesting {}
+}


### PR DESCRIPTION
Adds support for binding higher-level HTTP-facing Airlift modules to explicit server annotations, while preserving existing unqualified/default behavior.

# Airlift contribution check list

 - [X] Git commit messages follow https://cbea.ms/git-commit/.
 - [ ] All automated tests are passing.
 - [X] Pull request was categorized using one of the existing labels.
