### PR TITLE
[API] Support ApiJson API types

### DIFF
--- a/api/docs/enforcement.md
+++ b/api/docs/enforcement.md
@@ -24,10 +24,15 @@ etc. will cause the application to abort. Note: all errors are reported (i.e. th
     - Enumerations
     - Other API resources
     - `ApiId` subclasses
-  - `Optional` of basic types 
+  - _JSON Types_
+    - `ApiJsonNode` for arbitrary JSON values
+    - `ApiJsonObject` for JSON objects
+    - `ApiJsonList` for JSON arrays
+    - Raw Jackson tree types such as `JsonNode`, `ObjectNode`, and `ArrayNode` must be wrapped in the corresponding `ApiJson` type
+  - `Optional` of basic or JSON types
   - `ApiResourceVersion`
-  - Collections (List, Set, etc.) may only be `? extends Collection<String>`, `? extends Collection<? extends ApiId>`, `? extends Collection<? extends Enum>` or `? extends Collection<? is a resource>`.
-  - `Map<String, String>`
+  - Collections (List, Set, etc.) may only be `? extends Collection<String>`, `? extends Collection<? extends ApiId>`, `? extends Collection<? extends Enum>`, `Collection<ApiJsonNode>`, `Collection<ApiJsonObject>`, `Collection<ApiJsonList>`, or collections whose element type is an API resource.
+  - Maps may only be `Map<String, String>`, `Map<String, ApiJsonNode>`, `Map<String, ApiJsonObject>`, or `Map<String, ApiJsonList>`
 - Must be annotated with `@ApiResource` - `@ApiResource` requires both a resource name and a publicly displayable description
 - Each component/field of the record must have an `@ApiDescription` annotation (except `ApiResourceVersion`) with a publicly displayable description of the component/field
 - Components/fields that cannot be updated should be annotated with `@ApiReadOnly`
@@ -36,6 +41,8 @@ etc. will cause the application to abort. Note: all errors are reported (i.e. th
   - Fields must be named to match the associated resource. E.g. if the `ApiId` is for a resource named `foo` the field must be named `fooId`.
   - Collections of `ApiId` must end with the id name plus `s`. For example: `myResourceIds`.
   - Optionals of `ApiId` must end with the id name. For example: `optionalResourceId`.
+- `ApiJson` types cannot be used as API ID targets or path parameters
+- Fields whose names are exposed as query parameters via `ApiFilter`, `ApiFilterList`, or `ApiOrderBy` cannot be `ApiJson` types
 - Enumerations must be capitalized camel case
 - Resource names must be unique for generating the [OpenApi](openapi.md) spec. By default, the
 `@ApiResource` name attribute is used. If this value is not unique, use the `openApiAlternateName` attribute to 

--- a/api/src/main/java/io/airlift/api/ApiJson.java
+++ b/api/src/main/java/io/airlift/api/ApiJson.java
@@ -1,0 +1,13 @@
+package io.airlift.api;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.JsonNode;
+
+public sealed interface ApiJson<T extends JsonNode>
+        permits ApiJsonList,
+                ApiJsonNode,
+                ApiJsonObject
+{
+    @JsonValue
+    T value();
+}

--- a/api/src/main/java/io/airlift/api/ApiJsonList.java
+++ b/api/src/main/java/io/airlift/api/ApiJsonList.java
@@ -1,0 +1,17 @@
+package io.airlift.api;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+
+import static com.fasterxml.jackson.annotation.JsonCreator.Mode.DELEGATING;
+import static java.util.Objects.requireNonNull;
+
+public record ApiJsonList(ArrayNode value)
+        implements ApiJson<ArrayNode>
+{
+    @JsonCreator(mode = DELEGATING)
+    public ApiJsonList
+    {
+        requireNonNull(value, "value is null");
+    }
+}

--- a/api/src/main/java/io/airlift/api/ApiJsonNode.java
+++ b/api/src/main/java/io/airlift/api/ApiJsonNode.java
@@ -1,0 +1,17 @@
+package io.airlift.api;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import static com.fasterxml.jackson.annotation.JsonCreator.Mode.DELEGATING;
+import static java.util.Objects.requireNonNull;
+
+public record ApiJsonNode(JsonNode value)
+        implements ApiJson<JsonNode>
+{
+    @JsonCreator(mode = DELEGATING)
+    public ApiJsonNode
+    {
+        requireNonNull(value, "value is null");
+    }
+}

--- a/api/src/main/java/io/airlift/api/ApiJsonObject.java
+++ b/api/src/main/java/io/airlift/api/ApiJsonObject.java
@@ -1,0 +1,17 @@
+package io.airlift.api;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import static com.fasterxml.jackson.annotation.JsonCreator.Mode.DELEGATING;
+import static java.util.Objects.requireNonNull;
+
+public record ApiJsonObject(ObjectNode value)
+        implements ApiJson<ObjectNode>
+{
+    @JsonCreator(mode = DELEGATING)
+    public ApiJsonObject
+    {
+        requireNonNull(value, "value is null");
+    }
+}

--- a/api/src/main/java/io/airlift/api/binding/JaxrsMapper.java
+++ b/api/src/main/java/io/airlift/api/binding/JaxrsMapper.java
@@ -33,6 +33,7 @@ import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_NULL
 import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES;
 import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_NUMBERS_FOR_ENUMS;
 import static com.fasterxml.jackson.databind.SerializationFeature.FAIL_ON_UNWRAPPED_TYPE_IDENTIFIERS;
+import static io.airlift.api.internals.ApiJsonTypes.isApiJsonType;
 import static io.airlift.api.responses.ApiException.badRequest;
 import static java.util.Objects.requireNonNull;
 
@@ -63,7 +64,7 @@ public class JaxrsMapper
     @Override
     public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType)
     {
-        return JaxrsUtil.isApiResource(type) || ApiPatch.class.isAssignableFrom(type);
+        return JaxrsUtil.isApiResource(type) || isApiJsonType(type) || ApiPatch.class.isAssignableFrom(type);
     }
 
     @Override

--- a/api/src/main/java/io/airlift/api/builders/MethodBuilder.java
+++ b/api/src/main/java/io/airlift/api/builders/MethodBuilder.java
@@ -69,6 +69,7 @@ import static io.airlift.api.ApiPagination.DEFAULT_PAGE_SIZE;
 import static io.airlift.api.ApiPagination.PAGE_SIZE_QUERY_PARAMETER_NAME;
 import static io.airlift.api.ApiPagination.PAGE_TOKEN_QUERY_PARAMETER_NAME;
 import static io.airlift.api.ApiValidateOnly.VALIDATE_ONLY_PARAMETER_NAME;
+import static io.airlift.api.internals.ApiJsonTypes.isApiJsonType;
 import static io.airlift.api.internals.Generics.extractGenericParameter;
 import static io.airlift.api.internals.Mappers.buildHeaderName;
 import static io.airlift.api.internals.Mappers.openApiName;
@@ -328,7 +329,12 @@ public class MethodBuilder
             }
             if (apiParameter != null) {
                 if (ApiId.class.isAssignableFrom(parameter.getType())) {
-                    ModelResource modelResource = resourceBuilder.apply(resourceFromPossibleId(parameter.getType())).build();
+                    Type resourceType = resourceFromPossibleId(parameter.getType());
+                    if (isApiJsonType(resourceType)) {
+                        throw new ValidatorException("ApiJson types cannot be used as API path parameters");
+                    }
+
+                    ModelResource modelResource = resourceBuilder.apply(resourceType).build();
 
                     if (apiParameter.allowedValues().length > 0) {
                         modelResource = modelResource.withLimitedValues(ImmutableSet.copyOf(apiParameter.allowedValues()));

--- a/api/src/main/java/io/airlift/api/builders/ResourceBuilder.java
+++ b/api/src/main/java/io/airlift/api/builders/ResourceBuilder.java
@@ -41,6 +41,9 @@ import java.util.stream.Stream;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static io.airlift.api.internals.ApiJsonTypes.apiJsonResourceDescription;
+import static io.airlift.api.internals.ApiJsonTypes.apiJsonResourceName;
+import static io.airlift.api.internals.ApiJsonTypes.isApiJsonType;
 import static io.airlift.api.internals.Generics.extractGenericParameter;
 import static io.airlift.api.internals.Generics.typeResolver;
 import static io.airlift.api.internals.Mappers.openApiName;
@@ -172,7 +175,12 @@ public class ResourceBuilder
         if (typeToken.isSubtypeOf(Map.class)) {
             Type keyType = extractGenericParameter(typeToken.getType(), 0);
             Type valueType = extractGenericParameter(typeToken.getType(), 1);
-            if (String.class.equals(keyType) && Object.class.equals(valueType)) {
+            if (keyType.equals(String.class) && (valueType.equals(String.class) || isApiJsonType(valueType))) {
+                return internalBuildAndAdd(componentName, valueType)
+                        .asResourceType(ModelResourceType.MAP)
+                        .withContainerType(resource);
+            }
+            if (keyType.equals(String.class) && valueType.equals(Object.class)) {
                 return anyObjectLeafResource()
                         .asResourceType(ModelResourceType.MAP)
                         .withContainerType(resource);
@@ -190,6 +198,15 @@ public class ResourceBuilder
                 }
             }
             return modelResource;
+        }
+
+        if (isApiJsonType(typeToken.getType())) {
+            return new ModelResource(
+                    typeToken.getRawType(),
+                    apiJsonResourceName(typeToken.getType()),
+                    apiJsonResourceDescription(typeToken.getType()),
+                    ImmutableList.of(),
+                    ModelResourceType.JSON);
         }
 
         if (typeToken.isSubtypeOf(ApiStreamResponse.class)) {

--- a/api/src/main/java/io/airlift/api/internals/ApiJsonTypes.java
+++ b/api/src/main/java/io/airlift/api/internals/ApiJsonTypes.java
@@ -1,0 +1,80 @@
+package io.airlift.api.internals;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.reflect.TypeToken;
+import io.airlift.api.ApiJson;
+import io.airlift.api.ApiJsonList;
+import io.airlift.api.ApiJsonNode;
+import io.airlift.api.ApiJsonObject;
+
+import java.lang.reflect.Type;
+
+import static io.airlift.api.internals.Generics.typeResolver;
+
+public final class ApiJsonTypes
+{
+    private ApiJsonTypes() {}
+
+    public static boolean isApiJsonType(Type type)
+    {
+        Class<?> clazz = rawClass(type);
+        return ApiJson.class.isAssignableFrom(clazz);
+    }
+
+    public static String apiJsonResourceName(Type type)
+    {
+        Class<?> clazz = rawClass(type);
+        if (ApiJsonNode.class.isAssignableFrom(clazz)) {
+            return "json";
+        }
+        if (ApiJsonObject.class.isAssignableFrom(clazz)) {
+            return "jsonObject";
+        }
+        if (ApiJsonList.class.isAssignableFrom(clazz)) {
+            return "jsonList";
+        }
+        throw unsupportedType(clazz);
+    }
+
+    public static String apiJsonResourceDescription(Type type)
+    {
+        Class<?> clazz = rawClass(type);
+        if (ApiJsonNode.class.isAssignableFrom(clazz)) {
+            return "An arbitrary JSON value.";
+        }
+        if (ApiJsonObject.class.isAssignableFrom(clazz)) {
+            return "A JSON object.";
+        }
+        if (ApiJsonList.class.isAssignableFrom(clazz)) {
+            return "A JSON array.";
+        }
+        throw unsupportedType(clazz);
+    }
+
+    public static Class<? extends JsonNode> jacksonJsonType(Type type)
+    {
+        Class<?> clazz = rawClass(type);
+        if (ApiJsonNode.class.isAssignableFrom(clazz)) {
+            return JsonNode.class;
+        }
+        if (ApiJsonObject.class.isAssignableFrom(clazz)) {
+            return ObjectNode.class;
+        }
+        if (ApiJsonList.class.isAssignableFrom(clazz)) {
+            return ArrayNode.class;
+        }
+        throw unsupportedType(clazz);
+    }
+
+    private static IllegalArgumentException unsupportedType(Class<?> clazz)
+    {
+        return new IllegalArgumentException("Unsupported ApiJson type: " + clazz.getName());
+    }
+
+    private static Class<?> rawClass(Type type)
+    {
+        return TypeToken.of(typeResolver.resolveType(type)).getRawType();
+    }
+}

--- a/api/src/main/java/io/airlift/api/internals/Generics.java
+++ b/api/src/main/java/io/airlift/api/internals/Generics.java
@@ -10,6 +10,8 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.UUID;
 
+import static io.airlift.api.internals.ApiJsonTypes.isApiJsonType;
+
 public interface Generics
 {
     TypeResolver typeResolver = new TypeResolver();
@@ -38,8 +40,9 @@ public interface Generics
 
         Type keyType = extractGenericParameter(typeToken.getType(), 0);
         Type valueType = extractGenericParameter(typeToken.getType(), 1);
-        if (!(keyType.equals(String.class)) || !(valueType.equals(String.class))) {
-            throw new ValidatorException("Maps in resources must be Map<String, String>. %s is not".formatted(typeToken.getType()));
+        if (keyType.equals(String.class) && (valueType.equals(String.class) || isApiJsonType(valueType))) {
+            return;
         }
+        throw new ValidatorException("Maps in resources must be Map<String, String>, Map<String, ApiJsonNode>, Map<String, ApiJsonObject>, or Map<String, ApiJsonList>. %s is not".formatted(typeToken.getType()));
     }
 }

--- a/api/src/main/java/io/airlift/api/internals/Mappers.java
+++ b/api/src/main/java/io/airlift/api/internals/Mappers.java
@@ -113,6 +113,10 @@ public interface Mappers
     static String buildResourceName(Type resourceType)
     {
         Class<?> resourceClass = TypeToken.of(resourceType).getRawType();
+        if (ApiJsonTypes.isApiJsonType(resourceClass)) {
+            return ApiJsonTypes.apiJsonResourceName(resourceClass);
+        }
+
         ApiPolyResource apiPolyResource = resourceClass.getAnnotation(ApiPolyResource.class);
         if (apiPolyResource != null) {
             return apiPolyResource.name();

--- a/api/src/main/java/io/airlift/api/model/ModelResourceType.java
+++ b/api/src/main/java/io/airlift/api/model/ModelResourceType.java
@@ -7,4 +7,5 @@ public enum ModelResourceType
     LIST,
     PAGINATED_RESULT,
     MAP,
+    JSON,
 }

--- a/api/src/main/java/io/airlift/api/openapi/SchemaBuilder.java
+++ b/api/src/main/java/io/airlift/api/openapi/SchemaBuilder.java
@@ -1,5 +1,8 @@
 package io.airlift.api.openapi;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.reflect.TypeToken;
 import io.airlift.api.ApiId;
@@ -35,6 +38,8 @@ import java.util.stream.Stream;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.airlift.api.ApiOpenApiTrait.USE_ONE_OF_DISCRIMINATORS;
+import static io.airlift.api.internals.ApiJsonTypes.isApiJsonType;
+import static io.airlift.api.internals.ApiJsonTypes.jacksonJsonType;
 import static io.airlift.api.internals.Strings.capitalize;
 import static io.airlift.api.model.ModelResourceModifier.IS_ANY_OBJECT;
 import static io.airlift.api.model.ModelResourceModifier.IS_UNWRAPPED;
@@ -150,6 +155,7 @@ class SchemaBuilder
                 case LIST -> asList(modelResource, buildSchema(asResource(removeContainer(modelResource)), mode));
                 case MAP -> new MapSchema().description(adjustedDescription(modelResource)).additionalProperties(buildSchema(asResource(removeContainer(modelResource)), mode));
                 case PAGINATED_RESULT -> buildPaginatedSchema(modelResource);
+                case JSON -> buildApiJsonSchema(modelResource);
                 default -> modelResource.modifiers().contains(IS_ANY_OBJECT)
                         ? new Schema<>().type("object").description(adjustedDescription(modelResource))
                         : buildBasicOrResourceSchema(modelResource, mode);
@@ -291,7 +297,9 @@ class SchemaBuilder
 
     private Schema<?> buildBasicOrResourceSchema(ModelResource modelResource, BuildSchemaMode mode)
     {
-        return buildBasicSchema(modelResource).orElseGet(() -> buildResourceSchema(modelResource, mode));
+        return buildBasicSchema(modelResource)
+                .or(() -> buildApiJsonSchemaIfPresent(modelResource))
+                .orElseGet(() -> buildResourceSchema(modelResource, mode));
     }
 
     private Schema<?> buildResourceSchema(ModelResource modelResource, BuildSchemaMode mode)
@@ -341,6 +349,34 @@ class SchemaBuilder
         Optional<Schema<?>> schema = buildBasicSchema(TypeToken.of(modelResource.type()).getRawType());
         schema.ifPresent(s -> s.description(adjustedDescription(modelResource)));
         return schema;
+    }
+
+    private Optional<Schema<?>> buildApiJsonSchemaIfPresent(ModelResource modelResource)
+    {
+        return Optional.of(modelResource)
+                .filter(resource -> isApiJsonType(resource.type()))
+                .map(this::buildApiJsonSchema);
+    }
+
+    private Schema<?> buildApiJsonSchema(ModelResource modelResource)
+    {
+        Schema<?> schema = buildApiJsonSchema(TypeToken.of(modelResource.type()).getRawType());
+        return schema.description(adjustedDescription(modelResource));
+    }
+
+    private static Schema<?> buildApiJsonSchema(Class<?> clazz)
+    {
+        Class<?> jsonType = jacksonJsonType(clazz);
+        if (ObjectNode.class.isAssignableFrom(jsonType)) {
+            return new MapSchema().additionalProperties(true);
+        }
+        if (ArrayNode.class.isAssignableFrom(jsonType)) {
+            return new ArraySchema().items(new Schema<>());
+        }
+        if (JsonNode.class.isAssignableFrom(jsonType)) {
+            return new Schema<>().nullable(true);
+        }
+        throw new IllegalArgumentException("Unsupported ApiJson type: " + clazz.getName());
     }
 
     private void buildPolySchema(Schema<?> schema, ModelPolyResource polyResource, BuildSchemaMode mode)

--- a/api/src/main/java/io/airlift/api/validation/MethodValidator.java
+++ b/api/src/main/java/io/airlift/api/validation/MethodValidator.java
@@ -29,18 +29,24 @@ import jakarta.ws.rs.core.Context;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
+import java.lang.reflect.Type;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
 import static io.airlift.api.builders.MethodBuilder.OPTIONAL_PARAMETER_MAP;
+import static io.airlift.api.internals.ApiJsonTypes.isApiJsonType;
+import static io.airlift.api.model.ModelOptionalParameter.Location.QUERY;
 import static io.airlift.api.model.ModelOptionalParameter.Metadata.MULTIPLE_ALLOWED;
 import static io.airlift.api.model.ModelOptionalParameter.Metadata.REQUIRES_ALLOWED_VALUES;
 import static io.airlift.api.model.ModelResourceModifier.HAS_RESOURCE_ID;
 import static io.airlift.api.model.ModelResourceModifier.HAS_VERSION;
 import static io.airlift.api.model.ModelResourceModifier.PATCH;
+import static io.airlift.api.model.ModelResourceType.JSON;
 import static java.util.function.Predicate.not;
+import static java.util.stream.Collectors.toUnmodifiableSet;
 
 public interface MethodValidator
 {
@@ -105,7 +111,63 @@ public interface MethodValidator
             }
         }
 
+        validateApiJsonResourcesNotUsedAsQueryParameters(modelMethod);
         validateQuotas(modelMethod, serviceTraits);
+    }
+
+    private static void validateApiJsonResourcesNotUsedAsQueryParameters(ModelMethod modelMethod)
+    {
+        Set<String> apiJsonResourceNames = Stream.concat(Stream.of(modelMethod.returnType()), modelMethod.requestBody().stream())
+                .flatMap(resource -> apiJsonResourceNames(resource, new HashSet<>()))
+                .collect(toUnmodifiableSet());
+        if (apiJsonResourceNames.isEmpty()) {
+            return;
+        }
+
+        Set<String> queryParameterNames = modelMethod.optionalParameters().stream()
+                .flatMap(MethodValidator::resourceQueryParameterNames)
+                .collect(toUnmodifiableSet());
+
+        apiJsonResourceNames.stream()
+                .filter(queryParameterNames::contains)
+                .findFirst()
+                .ifPresent(name -> {
+                    throw new ValidatorException("ApiJson field %s cannot be used as an API query parameter".formatted(name));
+                });
+    }
+
+    private static Stream<String> apiJsonResourceNames(ModelResource modelResource, Set<Type> visited)
+    {
+        if ((modelResource.resourceType() == JSON) ||
+                (((modelResource.resourceType() == ModelResourceType.LIST) ||
+                        (modelResource.resourceType() == ModelResourceType.MAP)) &&
+                        isApiJsonType(modelResource.type()))) {
+            return Stream.of(modelResource.name());
+        }
+        if (!visited.add(modelResource.type())) {
+            return Stream.empty();
+        }
+
+        Stream<ModelResource> directComponents = modelResource.components().stream();
+        Stream<ModelResource> polySubResources = modelResource.polyResource().stream()
+                .flatMap(polyResource -> polyResource.subResources().stream());
+
+        return Stream.concat(directComponents, polySubResources)
+                .flatMap(component -> apiJsonResourceNames(component, visited));
+    }
+
+    private static Stream<String> resourceQueryParameterNames(ModelOptionalParameter optionalParameter)
+    {
+        if (optionalParameter.location() != QUERY) {
+            return Stream.empty();
+        }
+        if (optionalParameter.type().equals(ApiFilter.class) || optionalParameter.type().equals(ApiFilterList.class)) {
+            return optionalParameter.externalParameters().stream().map(ModelOptionalParameter.ExternalParameter::name);
+        }
+        if (optionalParameter.type().equals(ApiOrderBy.class)) {
+            return optionalParameter.limitedValues().stream();
+        }
+        return Stream.empty();
     }
 
     private static void validateOptionalParameter(ModelMethod method, Parameter parameter, Collection<Class<?>> allowedParameterTypes, ApiParameter apiParameter)

--- a/api/src/main/java/io/airlift/api/validation/ResourceSerializationValidator.java
+++ b/api/src/main/java/io/airlift/api/validation/ResourceSerializationValidator.java
@@ -2,10 +2,15 @@ package io.airlift.api.validation;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.api.ApiId;
+import io.airlift.api.ApiJson;
+import io.airlift.api.ApiJsonList;
+import io.airlift.api.ApiJsonNode;
+import io.airlift.api.ApiJsonObject;
 import io.airlift.api.ApiPatch;
 import io.airlift.api.ApiPolyResource;
 
@@ -24,6 +29,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
+import static io.airlift.api.internals.ApiJsonTypes.isApiJsonType;
 import static java.util.Objects.requireNonNull;
 
 public class ResourceSerializationValidator
@@ -72,6 +78,9 @@ public class ResourceSerializationValidator
 
         if (!clazz.isRecord()) {
             throw new ValidatorException("Resource %s is not a record".formatted(clazz.getName()));
+        }
+        if (isApiJsonType(clazz)) {
+            return getDefaultApiJson(clazz);
         }
 
         validationContext.addValidatingResources(type);
@@ -215,6 +224,20 @@ public class ResourceSerializationValidator
             catch (Exception e) {
                 throw new ValidatorException("Could not create default value for ApiAbstractId %s".formatted(clazz.getName()));
             }
+        }
+        throw new ValidatorException("Could not create default value for %s".formatted(clazz.getName()));
+    }
+
+    private ApiJson<?> getDefaultApiJson(Class<?> clazz)
+    {
+        if (ApiJsonNode.class.isAssignableFrom(clazz)) {
+            return new ApiJsonNode(JsonNodeFactory.instance.objectNode().put("field", "value"));
+        }
+        if (ApiJsonObject.class.isAssignableFrom(clazz)) {
+            return new ApiJsonObject(JsonNodeFactory.instance.objectNode().put("field", "value"));
+        }
+        if (ApiJsonList.class.isAssignableFrom(clazz)) {
+            return new ApiJsonList(JsonNodeFactory.instance.arrayNode().add("value"));
         }
         throw new ValidatorException("Could not create default value for %s".formatted(clazz.getName()));
     }

--- a/api/src/main/java/io/airlift/api/validation/ResourceValidator.java
+++ b/api/src/main/java/io/airlift/api/validation/ResourceValidator.java
@@ -28,6 +28,7 @@ import static io.airlift.api.ApiServiceTrait.ALLOW_OBJECT_ELEMENTS;
 import static io.airlift.api.ApiServiceTrait.DESCRIPTIONS_REQUIRED;
 import static io.airlift.api.binding.JaxrsUtil.isApiResource;
 import static io.airlift.api.builders.ResourceBuilder.isBasic;
+import static io.airlift.api.internals.ApiJsonTypes.isApiJsonType;
 import static io.airlift.api.internals.Generics.extractGenericParameter;
 import static io.airlift.api.internals.Generics.validateMap;
 import static io.airlift.api.internals.Mappers.buildResourceId;
@@ -107,8 +108,8 @@ public interface ResourceValidator
                 }
                 else if (!state.contains(PARENT_IS_READ_ONLY) && !state.contains(IS_RESULT_RESOURCE)) {
                     Type targetType = modelResource.type();
-                    if (!(targetType instanceof Class<?> clazz) || (!String.class.isAssignableFrom(clazz) && !ApiId.class.isAssignableFrom(clazz) && !clazz.isEnum() && !clazz.isAnnotationPresent(ApiResource.class) && !clazz.isAnnotationPresent(ApiPolyResource.class))) {
-                        throw new ValidatorException("Collections that are not read only must be Collection<String> or Collection<? extends ApiAbstractId> or Collection<? extends Enum> or a collection of resources. %s is not".formatted(targetType));
+                    if (!isAllowedCollectionType(targetType)) {
+                        throw new ValidatorException("Collections that are not read only must contain strings, API IDs, enums, ApiJson types, or resources. %s is not".formatted(targetType));
                     }
                 }
 
@@ -155,6 +156,20 @@ public interface ResourceValidator
 
             case RESOURCE -> validateDeclaredResource(context, service, modelResource, state);
         }
+    }
+
+    private static boolean isAllowedCollectionType(Type type)
+    {
+        if (!(type instanceof Class<?> clazz)) {
+            return false;
+        }
+
+        return String.class.isAssignableFrom(clazz) ||
+                ApiId.class.isAssignableFrom(clazz) ||
+                clazz.isEnum() ||
+                clazz.isAnnotationPresent(ApiResource.class) ||
+                clazz.isAnnotationPresent(ApiPolyResource.class) ||
+                isApiJsonType(clazz);
     }
 
     private static void validateDeclaredResource(ValidationContext context, ModelServiceMetadata service, ModelResource modelResource, ResourceValidationState state)
@@ -273,7 +288,12 @@ TODO why this?
         }
 
         else if (ApiId.class.isAssignableFrom(rawType)) {
-            String id = buildResourceId(resourceFromPossibleId(rawType));
+            Type resourceType = resourceFromPossibleId(rawType);
+            if (isApiJsonType(resourceType)) {
+                throw new ValidatorException("ApiJson types cannot be used as API ID fields");
+            }
+
+            String id = buildResourceId(resourceType);
             if (isCollection || isOptional) {
                 String idSuffix = isCollection ? (id + "s") : id;
                 String capitalizedIdSuffix = capitalize(idSuffix);

--- a/api/src/main/java/io/airlift/api/validation/ValidationContext.java
+++ b/api/src/main/java/io/airlift/api/validation/ValidationContext.java
@@ -18,7 +18,6 @@ import io.airlift.api.model.ModelResource;
 import io.airlift.log.Logger;
 import jakarta.ws.rs.core.MediaType;
 
-import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.net.URI;
 import java.util.Collection;
@@ -26,13 +25,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.Throwables.getRootCause;
 import static com.google.common.base.Throwables.getStackTraceAsString;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.airlift.api.internals.Generics.extractGenericParameter;
 import static io.airlift.api.internals.Generics.typeResolver;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM_TYPE;
 import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
@@ -116,11 +115,7 @@ public class ValidationContext
 
     public Class<?> extractGenericParameterAsClass(Type type, int index)
     {
-        Type parameter = extractGenericParameter(type, index);
-        if (parameter instanceof Class<?> clazz) {
-            return clazz;
-        }
-        throw new ValidatorException("Expected %s's type argument to be a class".formatted(type));
+        return genericParameterAsClass(extractGenericParameter(type, index));
     }
 
     public Class<?> genericParameterAsClass(Type parameter)
@@ -129,24 +124,6 @@ public class ValidationContext
             return clazz;
         }
         throw new ValidatorException("Expected type %s to be a class".formatted(parameter));
-    }
-
-    public Type extractGenericParameter(Type type, int index)
-    {
-        if (type instanceof ParameterizedType parameterizedType) {
-            if (parameterizedType.getRawType().equals(ApiStringId.class) && (index == 1)) {
-                return String.class;
-            }
-            if (parameterizedType.getRawType().equals(ApiUuidId.class) && (index == 1)) {
-                return UUID.class;
-            }
-
-            if (parameterizedType.getActualTypeArguments().length <= index) {
-                throw new ValidatorException("%s does not have expected (%d) number of parameters".formatted(type, index + 1));
-            }
-            return typeResolver.resolveType(parameterizedType.getActualTypeArguments()[index]);
-        }
-        throw new ValidatorException("Expected %s to be parameterized type".formatted(type));
     }
 
     public static boolean isForcedReadOnly(Type type)

--- a/api/src/test/java/io/airlift/api/TestApiJson.java
+++ b/api/src/test/java/io/airlift/api/TestApiJson.java
@@ -1,0 +1,42 @@
+package io.airlift.api;
+
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestApiJson
+{
+    private static final JsonMapper JSON_MAPPER = JsonMapper.builder().build();
+
+    @Test
+    public void testApiJsonNodeSerializesWrappedJsonValue()
+            throws Exception
+    {
+        ApiJsonNode jsonNode = new ApiJsonNode(JSON_MAPPER.readTree("{\"field\":\"value\"}"));
+
+        assertThat(JSON_MAPPER.writeValueAsString(jsonNode)).isEqualTo("{\"field\":\"value\"}");
+    }
+
+    @Test
+    public void testApiJsonNodeDeserializesArbitraryJsonValue()
+            throws Exception
+    {
+        assertThat(JSON_MAPPER.readValue("\"value\"", ApiJsonNode.class).value().asText()).isEqualTo("value");
+    }
+
+    @Test
+    public void testStructuredTypesUseTheirJsonShape()
+            throws Exception
+    {
+        ApiJsonObject jsonObject = JSON_MAPPER.readValue("{\"field\":\"value\"}", ApiJsonObject.class);
+        assertThat(jsonObject.value()).isInstanceOf(ObjectNode.class);
+        assertThat(JSON_MAPPER.writeValueAsString(jsonObject)).isEqualTo("{\"field\":\"value\"}");
+
+        ApiJsonList jsonList = JSON_MAPPER.readValue("[\"value\"]", ApiJsonList.class);
+        assertThat(jsonList.value()).isInstanceOf(ArrayNode.class);
+        assertThat(JSON_MAPPER.writeValueAsString(jsonList)).isEqualTo("[\"value\"]");
+    }
+}

--- a/api/src/test/java/io/airlift/api/internals/TestApiJsonTypes.java
+++ b/api/src/test/java/io/airlift/api/internals/TestApiJsonTypes.java
@@ -1,0 +1,63 @@
+package io.airlift.api.internals;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.airlift.api.ApiJsonList;
+import io.airlift.api.ApiJsonNode;
+import io.airlift.api.ApiJsonObject;
+import org.junit.jupiter.api.Test;
+
+import static io.airlift.api.internals.ApiJsonTypes.apiJsonResourceDescription;
+import static io.airlift.api.internals.ApiJsonTypes.apiJsonResourceName;
+import static io.airlift.api.internals.ApiJsonTypes.isApiJsonType;
+import static io.airlift.api.internals.ApiJsonTypes.jacksonJsonType;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestApiJsonTypes
+{
+    @Test
+    public void testApiJsonTypeDetection()
+    {
+        assertThat(isApiJsonType(ApiJsonNode.class)).isTrue();
+        assertThat(isApiJsonType(ApiJsonObject.class)).isTrue();
+        assertThat(isApiJsonType(ApiJsonList.class)).isTrue();
+        assertThat(isApiJsonType(String.class)).isFalse();
+    }
+
+    @Test
+    public void testApiJsonResourceNames()
+    {
+        assertThat(apiJsonResourceName(ApiJsonNode.class)).isEqualTo("json");
+        assertThat(apiJsonResourceName(ApiJsonObject.class)).isEqualTo("jsonObject");
+        assertThat(apiJsonResourceName(ApiJsonList.class)).isEqualTo("jsonList");
+    }
+
+    @Test
+    public void testApiJsonResourceDescriptions()
+    {
+        assertThat(apiJsonResourceDescription(ApiJsonNode.class)).isEqualTo("An arbitrary JSON value.");
+        assertThat(apiJsonResourceDescription(ApiJsonObject.class)).isEqualTo("A JSON object.");
+        assertThat(apiJsonResourceDescription(ApiJsonList.class)).isEqualTo("A JSON array.");
+    }
+
+    @Test
+    public void testJacksonJsonTypes()
+    {
+        assertThat(jacksonJsonType(ApiJsonNode.class)).isEqualTo(JsonNode.class);
+        assertThat(jacksonJsonType(ApiJsonObject.class)).isEqualTo(ObjectNode.class);
+        assertThat(jacksonJsonType(ApiJsonList.class)).isEqualTo(ArrayNode.class);
+    }
+
+    @Test
+    public void testUnsupportedJsonType()
+    {
+        assertThatThrownBy(() -> apiJsonResourceDescription(String.class))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Unsupported ApiJson type: java.lang.String");
+        assertThatThrownBy(() -> jacksonJsonType(String.class))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Unsupported ApiJson type: java.lang.String");
+    }
+}

--- a/api/src/test/java/io/airlift/api/openapi/TestApiJsonSchemas.java
+++ b/api/src/test/java/io/airlift/api/openapi/TestApiJsonSchemas.java
@@ -1,0 +1,64 @@
+package io.airlift.api.openapi;
+
+import com.google.common.reflect.TypeToken;
+import io.airlift.api.ApiJsonList;
+import io.airlift.api.ApiJsonNode;
+import io.airlift.api.ApiJsonObject;
+import io.airlift.api.model.ModelResource;
+import io.airlift.api.openapi.models.Schema;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.airlift.api.builders.ResourceBuilder.resourceBuilder;
+import static io.airlift.api.openapi.SchemaBuilder.BuildSchemaMode.STANDARD;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestApiJsonSchemas
+{
+    @Test
+    public void testJsonNodeIsUnconstrained()
+    {
+        Schema<?> schema = buildSchema(ApiJsonNode.class);
+
+        assertThat(schema.getType()).isNull();
+        assertThat(schema.getNullable()).isTrue();
+        assertThat(schema.getProperties()).isNull();
+        assertThat(schema.getItems()).isNull();
+        assertThat(schema.getDescription()).isEqualTo("An arbitrary JSON value.");
+    }
+
+    @Test
+    public void testStructuredJsonTypesUseTheirJsonShape()
+    {
+        Schema<?> objectSchema = buildSchema(ApiJsonObject.class);
+        assertThat(objectSchema.getType()).isEqualTo("object");
+        assertThat(objectSchema.getAdditionalProperties()).isEqualTo(true);
+        assertThat(objectSchema.getDescription()).isEqualTo("A JSON object.");
+
+        Schema<?> arraySchema = buildSchema(ApiJsonList.class);
+        assertThat(arraySchema.getType()).isEqualTo("array");
+        assertThat(arraySchema.getItems()).isNotNull();
+        assertThat(arraySchema.getItems().getType()).isNull();
+        assertThat(arraySchema.getDescription()).isEqualTo("A JSON array.");
+    }
+
+    @Test
+    public void testMapWithJsonNodeAllowsArbitraryJsonValues()
+    {
+        ModelResource modelResource = resourceBuilder(new TypeToken<Map<String, ApiJsonNode>>() {}.getType()).build();
+
+        Schema<?> schema = new SchemaBuilder(false).buildSchema(modelResource, STANDARD);
+
+        assertThat(schema.getType()).isEqualTo("object");
+        assertThat(schema.getAdditionalProperties()).isInstanceOfSatisfying(Schema.class, additionalProperties -> {
+            assertThat(additionalProperties.getType()).isNull();
+            assertThat(additionalProperties.getNullable()).isTrue();
+        });
+    }
+
+    private static Schema<?> buildSchema(Class<?> clazz)
+    {
+        return new SchemaBuilder(false).buildSchema(resourceBuilder(clazz).build(), STANDARD);
+    }
+}

--- a/api/src/test/java/io/airlift/api/validation/ResourceWithAllTypes.java
+++ b/api/src/test/java/io/airlift/api/validation/ResourceWithAllTypes.java
@@ -2,6 +2,9 @@ package io.airlift.api.validation;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import io.airlift.api.ApiDescription;
+import io.airlift.api.ApiJsonList;
+import io.airlift.api.ApiJsonNode;
+import io.airlift.api.ApiJsonObject;
 import io.airlift.api.ApiReadOnly;
 import io.airlift.api.ApiResource;
 import io.airlift.api.ApiStringId;
@@ -27,6 +30,12 @@ public record ResourceWithAllTypes(
         @ApiDescription("A type") LocalDate localDate,
         @ApiDescription("A type") BigDecimal bigDecimal,
         @ApiDescription("A type") UUID uuid,
+        @ApiDescription("A type") ApiJsonNode json,
+        @ApiDescription("A type") ApiJsonObject jsonObject,
+        @ApiDescription("A type") ApiJsonList jsonList,
+        @ApiDescription("A type") Map<String, ApiJsonNode> jsonMap,
+        @ApiDescription("A type") List<ApiJsonNode> jsonNodeList,
+        @ApiDescription("A type") Optional<ApiJsonNode> oJson,
         @ApiDescription("A type") Stuff e,
         @ApiDescription("A type") Map<String, String> m,
         @ApiDescription("A type") List<Stuff> le,

--- a/api/src/test/java/io/airlift/api/validation/TestConforming.java
+++ b/api/src/test/java/io/airlift/api/validation/TestConforming.java
@@ -1,12 +1,31 @@
 package io.airlift.api.validation;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.IntNode;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Module;
+import io.airlift.api.ApiDescription;
+import io.airlift.api.ApiFilter;
+import io.airlift.api.ApiGet;
+import io.airlift.api.ApiJsonNode;
+import io.airlift.api.ApiList;
+import io.airlift.api.ApiOrderBy;
+import io.airlift.api.ApiParameter;
+import io.airlift.api.ApiPolyResource;
+import io.airlift.api.ApiResource;
+import io.airlift.api.ApiService;
 import io.airlift.api.ApiServiceTrait;
+import io.airlift.api.ApiStringId;
+import io.airlift.api.ServiceType;
 import io.airlift.api.binding.ApiModule;
 import io.airlift.api.binding.PolyResourceModule;
 import io.airlift.api.builders.ApiBuilder;
@@ -203,12 +222,180 @@ public class TestConforming
     }
 
     @Test
+    public void testJsonNodeIdResourceDisallowed()
+    {
+        ModelServices services = ApiBuilder.apiBuilder().add(ServiceWithJsonNodeIdParameter.class).build().modelServices();
+        assertThat(services.errors()).anyMatch(error -> error.contains("ApiJson types cannot be used as API path parameters"));
+    }
+
+    @Test
+    public void testResourceWithJsonNodeFieldCanHaveIdParameter()
+    {
+        ModelServices services = ApiBuilder.apiBuilder().add(ServiceWithJsonNodeFieldIdParameter.class).build().modelServices();
+        assertThat(services.errors()).isEmpty();
+    }
+
+    @Test
+    public void testJsonNodeIdFieldDisallowed()
+    {
+        ValidationContext validationContext = new ValidationContext();
+        validateResource(validationContext, METADATA, resourceBuilder(ResourceWithJsonNodeIdField.class).build());
+        assertThat(validationContext.errors()).anyMatch(error -> error.contains("ApiJson types cannot be used as API ID fields"));
+    }
+
+    @Test
+    public void testJsonNodeFilterFieldDisallowed()
+    {
+        ModelServices services = ApiBuilder.apiBuilder().add(ServiceWithJsonNodeFilter.class).build().modelServices();
+        assertThat(services.errors()).anyMatch(error -> error.contains("ApiJson field json cannot be used as an API query parameter"));
+    }
+
+    @Test
+    public void testJsonNodeOrderByFieldDisallowed()
+    {
+        ModelServices services = ApiBuilder.apiBuilder().add(ServiceWithJsonNodeOrderBy.class).build().modelServices();
+        assertThat(services.errors()).anyMatch(error -> error.contains("ApiJson field json cannot be used as an API query parameter"));
+    }
+
+    @Test
+    public void testJsonNodeFilterFieldInPolyResourceDisallowed()
+    {
+        ModelServices services = ApiBuilder.apiBuilder().add(ServiceWithPolyJsonNodeFilter.class).build().modelServices();
+        assertThat(services.errors()).anyMatch(error -> error.contains("ApiJson field json cannot be used as an API query parameter"));
+    }
+
+    @Test
+    public void testRawJacksonNodeFieldsDisallowed()
+    {
+        assertJacksonNodeResourceTypeDisallowed(ResourceWithJacksonJsonNodeField.class);
+        assertJacksonNodeResourceTypeDisallowed(ResourceWithObjectNodeField.class);
+        assertJacksonNodeResourceTypeDisallowed(ResourceWithArrayNodeField.class);
+        assertJacksonNodeResourceTypeDisallowed(ResourceWithTextNodeField.class);
+        assertJacksonNodeResourceTypeDisallowed(ResourceWithIntNodeField.class);
+        assertJacksonNodeResourceTypeDisallowed(ResourceWithNullNodeField.class);
+    }
+
+    private static void assertJacksonNodeResourceTypeDisallowed(Class<?> resourceType)
+    {
+        assertThatThrownBy(() -> resourceBuilder(resourceType).build())
+                .isInstanceOf(ValidatorException.class)
+                .hasMessageContaining("not a valid resource type");
+    }
+
+    @Test
     public void testBadLookup()
     {
         ModelApi modelApi = ApiBuilder.apiBuilder().add(ServiceWithBadLookup.class).build();
         Module module = ApiModule.builder().addApi(modelApi).build();
         assertThatThrownBy(() -> Guice.createInjector(module)).hasMessageContaining("There are Ids used in service methods that are annotated with ApiIdSupportsLookup but missing a binding of ApiIdLookup");
     }
+
+    @ApiService(type = ServiceType.class, name = "json node id service", description = "json node id")
+    public static class ServiceWithJsonNodeIdParameter
+    {
+        @ApiGet(description = "json node id")
+        public ResourceWithAllTypes get(@ApiParameter JsonNodeId id)
+        {
+            return null;
+        }
+    }
+
+    public static class JsonNodeId
+            extends ApiStringId<ApiJsonNode>
+    {
+        @JsonCreator
+        public JsonNodeId(String id)
+        {
+            super(id);
+        }
+    }
+
+    @ApiService(type = ServiceType.class, name = "json node field id service", description = "json node field id")
+    public static class ServiceWithJsonNodeFieldIdParameter
+    {
+        @ApiGet(description = "json node field id")
+        public ResourceWithJsonNodeFieldWithId get(@ApiParameter JsonNodeFieldResourceId id)
+        {
+            return null;
+        }
+    }
+
+    public static class JsonNodeFieldResourceId
+            extends ApiStringId<ResourceWithJsonNodeFieldWithId>
+    {
+        @JsonCreator
+        public JsonNodeFieldResourceId(String id)
+        {
+            super(id);
+        }
+    }
+
+    @ApiResource(name = "jsonNodeFieldWithId", description = "json node field with id")
+    public record ResourceWithJsonNodeFieldWithId(
+            @ApiDescription("id") JsonNodeFieldResourceId jsonNodeFieldWithIdId,
+            @ApiDescription("json") ApiJsonNode json) {}
+
+    @ApiResource(name = "jsonNodeIdField", description = "json node id field")
+    public record ResourceWithJsonNodeIdField(@ApiDescription("id") JsonNodeId jsonId) {}
+
+    @ApiService(type = ServiceType.class, name = "json node filter service", description = "json node filter")
+    public static class ServiceWithJsonNodeFilter
+    {
+        @ApiList(description = "json node filter")
+        public List<ResourceWithJsonNodeField> list(@ApiParameter ApiFilter json)
+        {
+            return null;
+        }
+    }
+
+    @ApiService(type = ServiceType.class, name = "json node order by service", description = "json node order by")
+    public static class ServiceWithJsonNodeOrderBy
+    {
+        @ApiList(description = "json node order by")
+        public List<ResourceWithJsonNodeField> list(@ApiParameter(allowedValues = "json") ApiOrderBy orderBy)
+        {
+            return null;
+        }
+    }
+
+    @ApiService(type = ServiceType.class, name = "poly json node filter service", description = "poly json node filter")
+    public static class ServiceWithPolyJsonNodeFilter
+    {
+        @ApiList(description = "poly json node filter")
+        public List<PolyResourceWithJsonNodeField> list(@ApiParameter ApiFilter json)
+        {
+            return null;
+        }
+    }
+
+    @ApiPolyResource(key = "type", name = "polyJsonNodeField", description = "poly json node field")
+    public sealed interface PolyResourceWithJsonNodeField
+    {
+        @ApiResource(name = "polyJsonNode", description = "poly json node")
+        record PolyJsonNode(@ApiDescription("json") ApiJsonNode json)
+                implements PolyResourceWithJsonNodeField {}
+    }
+
+    @ApiResource(name = "jsonNodeField", description = "json node field")
+    public record ResourceWithJsonNodeField(@ApiDescription("json") ApiJsonNode json) {}
+
+    @ApiResource(name = "jacksonJsonNodeField", description = "jackson json node field")
+    public record ResourceWithJacksonJsonNodeField(@ApiDescription("json") JsonNode json) {}
+
+    @ApiResource(name = "objectNodeField", description = "object node field")
+    public record ResourceWithObjectNodeField(@ApiDescription("object") ObjectNode object) {}
+
+    @ApiResource(name = "arrayNodeField", description = "array node field")
+    public record ResourceWithArrayNodeField(@ApiDescription("array") ArrayNode array) {}
+
+    @ApiResource(name = "textNodeField", description = "text node field")
+    public record ResourceWithTextNodeField(@ApiDescription("text") TextNode text) {}
+
+    @ApiResource(name = "intNodeField", description = "int node field")
+    public record ResourceWithIntNodeField(@ApiDescription("int") IntNode integer) {}
+
+    @ApiResource(name = "nullNodeField", description = "null node field")
+    public record ResourceWithNullNodeField(@ApiDescription("null") NullNode nullNode) {}
 
     @Test
     public void testPolyResourceWithReusedKey()


### PR DESCRIPTION
Summary

- Add an `ApiJson` wrapper base with `ApiJsonNode`, `ApiJsonObject`, and `ApiJsonList` API types that serialize as their wrapped JSON values.
- Teach API Builder resource modeling, validation, request handling, serialization defaults, and OpenAPI schema generation to support ApiJson fields, optionals, collections, maps, and request/response bodies.
- Reject ApiJson types where they would be exposed through paths, IDs, filters, order-by query parameters, or raw Jackson node declarations.