### PR TITLE
[API] Allow POST API streaming responses

### DIFF
--- a/api/docs/streaming.md
+++ b/api/docs/streaming.md
@@ -2,30 +2,42 @@
 
 # API Builder: Streaming Responses
 
-`@ApiGet` methods can stream responses by returning a `ApiTextStreamResponse`, `ApiByteStreamResponse`, or `ApiOutputStreamResponse` instance. The instance must be
-parameterized with a [resource](resources.md) that it represents.
+`@ApiGet` and `@ApiCreate` methods can stream responses by returning an `ApiTextStreamResponse`, `ApiByteStreamResponse`, or `ApiOutputStreamResponse` instance. The instance must be
+parameterized with a [resource](resources.md) that it represents. `@ApiCustom` methods can also stream responses when their `type` is `GET` or `CREATE`.
 
 E.g.
 
 ```java
 @ApiGet(...)
-public ApiTextStreamResponse≤MyResource> myStreamedResponse(...)
+public ApiTextStreamResponse<MyResource> myStreamedResponse(...)
 {
     return new ApiTextStreamResponse<>(myTextStream);
 }
 
 @ApiGet(...)
-public ApiByteStreamResponse≤MyResource> myStreamedResponse(...)
+public ApiByteStreamResponse<MyResource> myStreamedResponse(...)
 {
     return new ApiByteStreamResponse<>(myByteStream);
 }
 
 @ApiGet(...)
-public ApiOutputStreamResponse≤MyResource> myStreamedResponse(...)
+public ApiOutputStreamResponse<MyResource> myStreamedResponse(...)
 {
     Consumer<OutputStream> consumer = outputStream -> {
         // write to the output stream
     };
     return new ApiOutputStreamResponse<>(consumer);
+}
+
+@ApiCreate(...)
+public ApiTextStreamResponse<MyResource> myPostStreamedResponse(MyCreateRequest request)
+{
+    return new ApiTextStreamResponse<>(myTextStream);
+}
+
+@ApiCustom(type = CREATE, verb = "stream", ...)
+public ApiByteStreamResponse<MyResource> myPostCustomStreamedResponse(MyCreateRequest request)
+{
+    return new ApiByteStreamResponse<>(myByteStream);
 }
 ```

--- a/api/src/main/java/io/airlift/api/binding/JaxrsResourceBuilder.java
+++ b/api/src/main/java/io/airlift/api/binding/JaxrsResourceBuilder.java
@@ -111,7 +111,7 @@ class JaxrsResourceBuilder
             case LIST, DELETE -> methodBuilder.produces(APPLICATION_JSON_TYPE);
             case CREATE, UPDATE -> {
                 boolean isMultiPartForm = method.requestBody().map(requestBody -> requestBody.modifiers().contains(IS_MULTIPART_FORM)).orElse(false);
-                methodBuilder.consumes(isMultiPartForm ? MULTIPART_FORM_DATA_TYPE : APPLICATION_JSON_TYPE).produces(APPLICATION_JSON_TYPE);
+                methodBuilder.consumes(isMultiPartForm ? MULTIPART_FORM_DATA_TYPE : APPLICATION_JSON_TYPE).produces(getResponseType(method.returnType()));
             }
         }
         methodBuilder.handledBy(service.serviceClass(), method.method());

--- a/api/src/main/java/io/airlift/api/builders/MethodBuilder.java
+++ b/api/src/main/java/io/airlift/api/builders/MethodBuilder.java
@@ -421,7 +421,7 @@ public class MethodBuilder
     private ModelResource buildResultResource(Method method, ApiType apiType)
     {
         boolean allowVoidResult = (apiType != ApiType.GET) && (apiType != ApiType.LIST);
-        boolean allowStreamingResult = (apiType == ApiType.GET);
+        boolean allowStreamingResult = (apiType == ApiType.GET) || (apiType == ApiType.CREATE);
 
         Type resource = method.getGenericReturnType();
 
@@ -447,7 +447,7 @@ public class MethodBuilder
         }
 
         if (validatedResource.modifiers().contains(IS_STREAMING_RESPONSE) && !allowStreamingResult) {
-            throw new ValidatorException("%s is only allowed for @%s".formatted(ApiStreamResponse.class.getSimpleName(), ApiGet.class.getSimpleName()));
+            throw new ValidatorException("%s is only allowed for @%s or @%s".formatted(ApiStreamResponse.class.getSimpleName(), ApiGet.class.getSimpleName(), ApiCreate.class.getSimpleName()));
         }
 
         if (validatedResource.modifiers().contains(IS_MULTIPART_FORM)) {

--- a/api/src/test/java/io/airlift/api/servertests/streaming/StreamingRequest.java
+++ b/api/src/test/java/io/airlift/api/servertests/streaming/StreamingRequest.java
@@ -1,0 +1,7 @@
+package io.airlift.api.servertests.streaming;
+
+import io.airlift.api.ApiDescription;
+import io.airlift.api.ApiResource;
+
+@ApiResource(name = "streamer", openApiAlternateName = "newStreamer", description = "new streamer")
+public record StreamingRequest(@ApiDescription("ok") String something) {}

--- a/api/src/test/java/io/airlift/api/servertests/streaming/StreamingService.java
+++ b/api/src/test/java/io/airlift/api/servertests/streaming/StreamingService.java
@@ -1,8 +1,10 @@
 package io.airlift.api.servertests.streaming;
 
+import com.google.inject.Inject;
 import io.airlift.api.ApiCustom;
 import io.airlift.api.ApiGet;
 import io.airlift.api.ApiParameter;
+import io.airlift.api.ApiQuotaController;
 import io.airlift.api.ApiResponseHeaders;
 import io.airlift.api.ApiService;
 import io.airlift.api.ApiStreamResponse.ApiByteStreamResponse;
@@ -10,18 +12,30 @@ import io.airlift.api.ApiStreamResponse.ApiOutputStreamResponse;
 import io.airlift.api.ApiStreamResponse.ApiTextStreamResponse;
 import io.airlift.api.ServiceType;
 import io.airlift.api.responses.ApiException;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Request;
 
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.function.Consumer;
 
+import static io.airlift.api.ApiType.CREATE;
 import static io.airlift.api.ApiType.GET;
 import static io.airlift.api.ApiType.LIST;
+import static java.util.Objects.requireNonNull;
 
 @ApiService(type = ServiceType.class, name = "streaming", description = "Does streaming things")
 public class StreamingService
 {
+    private final ApiQuotaController quotaController;
+
+    @Inject
+    public StreamingService(ApiQuotaController quotaController)
+    {
+        this.quotaController = requireNonNull(quotaController, "quotaController is null");
+    }
+
     @ApiGet(description = "streaming")
     public ApiByteStreamResponse<StreamingResource> streamBytes()
     {
@@ -48,6 +62,13 @@ public class StreamingService
 
         responseHeaders.headers().put("Content-Disposition", "attachment; filename=\"foo.bar\"");
         return new ApiOutputStreamResponse<>(consumer);
+    }
+
+    @ApiCustom(type = CREATE, verb = "post", description = "yep", quotas = "STREAMING")
+    public ApiTextStreamResponse<StreamingResource> streamPost(@Context Request request, StreamingRequest streamingRequest)
+    {
+        quotaController.recordQuotaUsage(request, "STREAMING");
+        return new ApiTextStreamResponse<>("This is streaming post: " + streamingRequest.something());
     }
 
     @ApiCustom(type = LIST, verb = "bad", description = "bad")

--- a/api/src/test/java/io/airlift/api/servertests/streaming/TestStreaming.java
+++ b/api/src/test/java/io/airlift/api/servertests/streaming/TestStreaming.java
@@ -11,11 +11,15 @@ import org.junit.jupiter.api.Test;
 import java.net.URI;
 import java.util.Optional;
 
+import static io.airlift.http.client.HeaderNames.ACCEPT;
 import static io.airlift.http.client.HeaderNames.CONTENT_DISPOSITION;
 import static io.airlift.http.client.HeaderNames.CONTENT_TYPE;
+import static io.airlift.http.client.JsonBodyGenerator.jsonBodyGenerator;
 import static io.airlift.http.client.Request.Builder.prepareGet;
+import static io.airlift.http.client.Request.Builder.preparePost;
 import static io.airlift.http.client.StatusResponseHandler.createStatusResponseHandler;
 import static io.airlift.http.client.StringResponseHandler.createStringResponseHandler;
+import static io.airlift.json.JsonCodec.jsonCodec;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestStreaming
@@ -41,6 +45,23 @@ public class TestStreaming
         assertThat(stringResponse.getHeader(CONTENT_TYPE)).hasValue(MediaType.APPLICATION_OCTET_STREAM);
         assertThat(stringResponse.getHeader(CONTENT_DISPOSITION)).hasValue("attachment; filename=\"foo.bar\"");
         assertThat(stringResponse.getBody()).isEqualTo("This is streaming output");
+    }
+
+    @Test
+    public void testStreamingPost()
+    {
+        URI uri = UriBuilder.fromUri(baseUri).path("public/api/v1/streamer:post").build();
+        Request request = preparePost()
+                .setUri(uri)
+                .setHeader(ACCEPT, MediaType.TEXT_PLAIN)
+                .setHeader(CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .setBodyGenerator(jsonBodyGenerator(jsonCodec(StreamingRequest.class), new StreamingRequest("payload")))
+                .build();
+
+        StringResponse stringResponse = httpClient.execute(request, createStringResponseHandler());
+        assertThat(stringResponse.getStatusCode()).isEqualTo(200);
+        assertThat(stringResponse.getHeader(CONTENT_TYPE)).hasValue(MediaType.TEXT_PLAIN + ";charset=iso-8859-1");
+        assertThat(stringResponse.getBody()).isEqualTo("This is streaming post: payload");
     }
 
     @Test

--- a/api/src/test/java/io/airlift/api/validation/BadServiceWithStreamResponse1.java
+++ b/api/src/test/java/io/airlift/api/validation/BadServiceWithStreamResponse1.java
@@ -1,6 +1,6 @@
 package io.airlift.api.validation;
 
-import io.airlift.api.ApiCreate;
+import io.airlift.api.ApiDelete;
 import io.airlift.api.ApiService;
 import io.airlift.api.ApiStreamResponse.ApiTextStreamResponse;
 import io.airlift.api.ServiceType;
@@ -8,7 +8,7 @@ import io.airlift.api.ServiceType;
 @ApiService(type = ServiceType.class, name = "stream response service", description = "stream response")
 public class BadServiceWithStreamResponse1
 {
-    @ApiCreate(description = "streaming", quotas = "something")
+    @ApiDelete(description = "streaming")
     public ApiTextStreamResponse<Food> test()
     {
         return null;

--- a/api/src/test/java/io/airlift/api/validation/ServiceWithCreateStreamResponse.java
+++ b/api/src/test/java/io/airlift/api/validation/ServiceWithCreateStreamResponse.java
@@ -1,0 +1,16 @@
+package io.airlift.api.validation;
+
+import io.airlift.api.ApiCreate;
+import io.airlift.api.ApiService;
+import io.airlift.api.ApiStreamResponse.ApiTextStreamResponse;
+import io.airlift.api.ServiceType;
+
+@ApiService(type = ServiceType.class, name = "create stream response service", description = "stream response")
+public class ServiceWithCreateStreamResponse
+{
+    @ApiCreate(description = "streaming", quotas = "something")
+    public ApiTextStreamResponse<Food> test()
+    {
+        return null;
+    }
+}

--- a/api/src/test/java/io/airlift/api/validation/TestConforming.java
+++ b/api/src/test/java/io/airlift/api/validation/TestConforming.java
@@ -174,9 +174,12 @@ public class TestConforming
         ModelServices services = ApiBuilder.apiBuilder().add(ServiceWithStreamResponse.class).build().modelServices();
         assertThat(services.errors()).hasSize(0);
 
+        services = ApiBuilder.apiBuilder().add(ServiceWithCreateStreamResponse.class).build().modelServices();
+        assertThat(services.errors()).hasSize(0);
+
         services = ApiBuilder.apiBuilder().add(BadServiceWithStreamResponse1.class).build().modelServices();
         assertThat(services.errors()).hasSize(1).first()
-                .matches(s -> s.startsWith("ApiStreamResponse is only allowed for @ApiGet"));
+                .matches(s -> s.startsWith("ApiStreamResponse is only allowed for @ApiGet or @ApiCreate"));
 
         services = ApiBuilder.apiBuilder().add(BadServiceWithStreamResponse2.class).build().modelServices();
         assertThat(services.errors()).anyMatch(s -> s.startsWith("ApiStreamResponse cannot be a parameter"));


### PR DESCRIPTION
## Summary

- Allows `ApiStreamResponse` results on `CREATE`/POST API methods.
- Advertises streaming media types for non-GET API bindings.
- Adds validation and server coverage for POST streaming responses.
