### PR TITLE
[API] Add ApiUuidId

### DIFF
--- a/api/src/main/java/io/airlift/api/ApiId.java
+++ b/api/src/main/java/io/airlift/api/ApiId.java
@@ -80,7 +80,9 @@ public abstract class ApiId<RESOURCE, INTERNALID>
     @SuppressWarnings("rawtypes")
     private Optional<Constructor<?>> validateAndGetInternalConstructor(Class<? extends ApiId> clazz)
     {
-        if (ApiEnumId.class.isAssignableFrom(clazz) || ApiStringId.class.isAssignableFrom(clazz)) {
+        if (ApiEnumId.class.isAssignableFrom(clazz) ||
+                ApiStringId.class.isAssignableFrom(clazz) ||
+                ApiUuidId.class.isAssignableFrom(clazz)) {
             return Optional.empty();
         }
 

--- a/api/src/main/java/io/airlift/api/ApiUuidId.java
+++ b/api/src/main/java/io/airlift/api/ApiUuidId.java
@@ -1,0 +1,43 @@
+package io.airlift.api;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.UUID;
+
+import static io.airlift.api.responses.ApiException.badRequest;
+import static java.util.Objects.requireNonNull;
+
+public abstract class ApiUuidId<RESOURCE>
+        extends ApiId<RESOURCE, UUID>
+{
+    protected ApiUuidId(UUID id)
+    {
+        super(requireNonNull(id, "id is null"));
+    }
+
+    protected ApiUuidId(String id)
+    {
+        super(id);
+    }
+
+    public UUID value()
+    {
+        return toInternal();
+    }
+
+    @Override
+    public UUID toInternal()
+    {
+        try {
+            return UUID.fromString(id);
+        }
+        catch (IllegalArgumentException e) {
+            throw badRequest("Invalid id: " + id, ImmutableList.of("id"));
+        }
+    }
+
+    protected static UUID defaultUuidValue()
+    {
+        return new UUID(0L, 0L);
+    }
+}

--- a/api/src/main/java/io/airlift/api/internals/Generics.java
+++ b/api/src/main/java/io/airlift/api/internals/Generics.java
@@ -3,10 +3,12 @@ package io.airlift.api.internals;
 import com.google.common.reflect.TypeResolver;
 import com.google.common.reflect.TypeToken;
 import io.airlift.api.ApiStringId;
+import io.airlift.api.ApiUuidId;
 import io.airlift.api.validation.ValidatorException;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.UUID;
 
 public interface Generics
 {
@@ -17,6 +19,9 @@ public interface Generics
         if (type instanceof ParameterizedType parameterizedType) {
             if (parameterizedType.getRawType().equals(ApiStringId.class) && (index == 1)) {
                 return String.class;
+            }
+            if (parameterizedType.getRawType().equals(ApiUuidId.class) && (index == 1)) {
+                return UUID.class;
             }
 
             if (parameterizedType.getActualTypeArguments().length <= index) {

--- a/api/src/main/java/io/airlift/api/validation/ValidationContext.java
+++ b/api/src/main/java/io/airlift/api/validation/ValidationContext.java
@@ -13,6 +13,7 @@ import io.airlift.api.ApiStreamResponse.ApiByteStreamResponse;
 import io.airlift.api.ApiStreamResponse.ApiOutputStreamResponse;
 import io.airlift.api.ApiStreamResponse.ApiTextStreamResponse;
 import io.airlift.api.ApiStringId;
+import io.airlift.api.ApiUuidId;
 import io.airlift.api.model.ModelResource;
 import io.airlift.log.Logger;
 import jakarta.ws.rs.core.MediaType;
@@ -25,6 +26,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -135,6 +137,9 @@ public class ValidationContext
             if (parameterizedType.getRawType().equals(ApiStringId.class) && (index == 1)) {
                 return String.class;
             }
+            if (parameterizedType.getRawType().equals(ApiUuidId.class) && (index == 1)) {
+                return UUID.class;
+            }
 
             if (parameterizedType.getActualTypeArguments().length <= index) {
                 throw new ValidatorException("%s does not have expected (%d) number of parameters".formatted(type, index + 1));
@@ -213,7 +218,7 @@ public class ValidationContext
             throw new ValidatorException("ID's resource type parameter is not a valid resource type: %s".formatted(resourceType));
         }
 
-        if (!ApiEnumId.class.isAssignableFrom(idClass)) {
+        if (!ApiEnumId.class.isAssignableFrom(idClass) && !ApiStringId.class.isAssignableFrom(idClass) && !ApiUuidId.class.isAssignableFrom(idClass)) {
             Class<?> internalIdType = extractGenericParameterAsClass(idClass.getGenericSuperclass(), 1);
             try {
                 internalIdType.getConstructor(String.class);

--- a/api/src/test/java/io/airlift/api/validation/ResourceWithAllTypes.java
+++ b/api/src/test/java/io/airlift/api/validation/ResourceWithAllTypes.java
@@ -5,6 +5,7 @@ import io.airlift.api.ApiDescription;
 import io.airlift.api.ApiReadOnly;
 import io.airlift.api.ApiResource;
 import io.airlift.api.ApiStringId;
+import io.airlift.api.ApiUuidId;
 
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -44,9 +45,14 @@ public record ResourceWithAllTypes(
         @ApiDescription("A type") Set<SimpleResource> sSimpleResource,
         @ApiDescription("A type") Optional<SimpleResource> oSimpleResource,
         @ApiDescription("A type") Optional<UUID> oUuid,
+        @ApiDescription("A type") SimpleId nameId,
         @ApiDescription("A type") List<SimpleId> listOfNameIds,
         @ApiDescription("A type") Optional<List<SimpleId>> maybeNameIds,
         @ApiDescription("A type") Optional<SimpleId> maybeNameId,
+        @ApiDescription("A type") SimpleUuidId uuidId,
+        @ApiDescription("A type") List<SimpleUuidId> listOfUuidIds,
+        @ApiDescription("A type") Optional<List<SimpleUuidId>> maybeUuidIds,
+        @ApiDescription("A type") Optional<SimpleUuidId> maybeUuidId,
         @ApiDescription("A type") PolyInPoly pp,
         @ApiDescription("A type") Optional<PolyInPoly> ppo)
 {
@@ -61,6 +67,10 @@ public record ResourceWithAllTypes(
     @ApiReadOnly
     public record SimpleResource(@ApiDescription("A name") String name) {}
 
+    @ApiResource(name = "uuid", description = "A UUID")
+    @ApiReadOnly
+    public record UuidResource(@ApiDescription("A UUID") UUID uuid) {}
+
     public static class SimpleId
             extends ApiStringId<SimpleResource>
     {
@@ -71,6 +81,26 @@ public record ResourceWithAllTypes(
 
         @JsonCreator
         public SimpleId(String id)
+        {
+            super(id);
+        }
+    }
+
+    public static class SimpleUuidId
+            extends ApiUuidId<UuidResource>
+    {
+        public SimpleUuidId()
+        {
+            super(defaultUuidValue());
+        }
+
+        public SimpleUuidId(UUID id)
+        {
+            super(id);
+        }
+
+        @JsonCreator
+        public SimpleUuidId(String id)
         {
             super(id);
         }

--- a/api/src/test/java/io/airlift/api/validation/TestConforming.java
+++ b/api/src/test/java/io/airlift/api/validation/TestConforming.java
@@ -12,17 +12,25 @@ import io.airlift.api.binding.PolyResourceModule;
 import io.airlift.api.builders.ApiBuilder;
 import io.airlift.api.model.ModelApi;
 import io.airlift.api.model.ModelResource;
+import io.airlift.api.model.ModelResourceType;
 import io.airlift.api.model.ModelServiceMetadata;
 import io.airlift.api.model.ModelServiceType;
 import io.airlift.api.model.ModelServices;
+import io.airlift.api.responses.ApiBadRequest;
 import io.airlift.json.JsonModule;
+import jakarta.ws.rs.WebApplicationException;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 import static io.airlift.api.builders.ResourceBuilder.resourceBuilder;
 import static io.airlift.api.internals.Mappers.buildHeaderName;
+import static io.airlift.api.model.ModelResourceModifier.OPTIONAL;
 import static io.airlift.api.model.ModelResourceModifier.RECURSIVE_REFERENCE;
+import static io.airlift.api.model.ModelResourceType.BASIC;
+import static io.airlift.api.model.ModelResourceType.LIST;
 import static io.airlift.api.validation.ResourceValidator.validateResource;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -146,6 +154,35 @@ public class TestConforming
         ModelApi modelApi = ApiBuilder.apiBuilder().add(ServiceWithAllTypes.class).build();
         Module module = ApiModule.builder().addApi(modelApi).build();
         Guice.createInjector(module, new JsonModule());
+
+        ModelResource allTypes = resourceBuilder(ResourceWithAllTypes.class).build();
+        assertIdComponent(allTypes, "nameId", ResourceWithAllTypes.SimpleId.class, BASIC, false);
+        assertIdComponent(allTypes, "listOfNameIds", ResourceWithAllTypes.SimpleId.class, LIST, false);
+        assertIdComponent(allTypes, "maybeNameIds", ResourceWithAllTypes.SimpleId.class, LIST, true);
+        assertIdComponent(allTypes, "maybeNameId", ResourceWithAllTypes.SimpleId.class, BASIC, true);
+        assertIdComponent(allTypes, "uuidId", ResourceWithAllTypes.SimpleUuidId.class, BASIC, false);
+        assertIdComponent(allTypes, "listOfUuidIds", ResourceWithAllTypes.SimpleUuidId.class, LIST, false);
+        assertIdComponent(allTypes, "maybeUuidIds", ResourceWithAllTypes.SimpleUuidId.class, LIST, true);
+        assertIdComponent(allTypes, "maybeUuidId", ResourceWithAllTypes.SimpleUuidId.class, BASIC, true);
+    }
+
+    @Test
+    public void testApiUuidId()
+    {
+        UUID uuid = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        ResourceWithAllTypes.SimpleUuidId id = new ResourceWithAllTypes.SimpleUuidId(uuid);
+
+        assertThat(id).hasToString(uuid.toString());
+        assertThat(id.value()).isEqualTo(uuid);
+        assertThat(id.toInternal()).isEqualTo(uuid);
+        assertThat(new ResourceWithAllTypes.SimpleUuidId().toInternal()).isEqualTo(new UUID(0L, 0L));
+        assertThat(new ResourceWithAllTypes.SimpleUuidId(uuid.toString()).toInternal()).isEqualTo(uuid);
+        assertThatThrownBy(() -> new ResourceWithAllTypes.SimpleUuidId((UUID) null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("id is null");
+        assertThatThrownBy(() -> new ResourceWithAllTypes.SimpleUuidId("invalid").toInternal())
+                .isInstanceOfSatisfying(WebApplicationException.class, exception -> assertThat(exception.getResponse().getEntity())
+                        .isEqualTo(new ApiBadRequest(Optional.of("Invalid id: invalid"), Optional.of(ImmutableList.of("id")))));
     }
 
     @Test
@@ -240,5 +277,22 @@ public class TestConforming
 
         ResourceSerializationValidator serializationValidator = new ResourceSerializationValidator(ImmutableSet.of(RecursiveResource.class));
         serializationValidator.validateSerialization(jsonMapper);
+    }
+
+    private static void assertIdComponent(ModelResource resource, String name, Class<?> type, ModelResourceType resourceType, boolean optional)
+    {
+        ModelResource component = resource.components().stream()
+                .filter(candidate -> candidate.name().equals(name))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(component.type()).isEqualTo(type);
+        assertThat(component.resourceType()).isEqualTo(resourceType);
+        if (optional) {
+            assertThat(component.modifiers()).contains(OPTIONAL);
+        }
+        else {
+            assertThat(component.modifiers()).doesNotContain(OPTIONAL);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Add `ApiUuidId` as a UUID-backed `ApiId` helper with a zero-UUID default constructor.
- Teach API generic validation helpers to recognize UUID-backed IDs.
- Cover UUID ID conversion and validation in the API conforming tests.