### PR TITLE
[MCP] Fix MCP optional parameter schemas

### DIFF
--- a/mcp/src/main/java/io/airlift/mcp/model/JsonSchemaBuilder.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/JsonSchemaBuilder.java
@@ -32,6 +32,7 @@ import java.util.function.BiConsumer;
 import java.util.stream.Stream;
 
 import static io.airlift.mcp.reflection.ReflectionHelper.listArgument;
+import static io.airlift.mcp.reflection.ReflectionHelper.schemaType;
 import static java.util.Objects.requireNonNull;
 
 public class JsonSchemaBuilder
@@ -117,7 +118,7 @@ public class JsonSchemaBuilder
         return buildObject(description, (properties, required) -> parameters.stream()
                 .flatMap(methodParameter -> (methodParameter instanceof ObjectParameter objectParameter) ? Stream.of(objectParameter) : Stream.empty())
                 .forEach(objectParameter -> {
-                    ObjectNode objectNode = generator.generateSchema(objectParameter.genericType());
+                    ObjectNode objectNode = generator.generateSchema(schemaType(objectParameter));
                     objectParameter.description().ifPresent(value -> objectNode.put("description", value));
                     properties.set(objectParameter.name(), objectNode);
 

--- a/mcp/src/main/java/io/airlift/mcp/reflection/ReflectionHelper.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/ReflectionHelper.java
@@ -39,6 +39,7 @@ import java.util.function.Predicate;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.mcp.McpException.exception;
 import static io.airlift.mcp.model.JsonRpcErrorCode.INVALID_PARAMS;
@@ -179,6 +180,16 @@ public interface ReflectionHelper
         }
 
         return Optional.empty();
+    }
+
+    static Type schemaType(ObjectParameter objectParameter)
+    {
+        if (Optional.class.equals(objectParameter.rawType())) {
+            verify(!objectParameter.required(), "Optional parameter must not be required: %s", objectParameter.name());
+            return optionalArgument(objectParameter.genericType()).orElse(objectParameter.genericType());
+        }
+
+        return objectParameter.genericType();
     }
 
     static Class<?> requiredArgument(Type type)

--- a/mcp/src/test/java/io/airlift/mcp/TestJsonSchemaBuilder.java
+++ b/mcp/src/test/java/io/airlift/mcp/TestJsonSchemaBuilder.java
@@ -9,6 +9,8 @@ import io.airlift.mcp.reflection.MethodParameter;
 import io.airlift.mcp.reflection.MethodParameter.ObjectParameter;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.List;
@@ -294,6 +296,39 @@ public class TestJsonSchemaBuilder
     }
 
     @Test
+    public void testBuildWithOptionalMethodParametersUsesValueSchema()
+    {
+        List<MethodParameter> parameters = ImmutableList.of(
+                new ObjectParameter("requiredName", String.class, String.class, Optional.empty(), Optional.empty(), true),
+                new ObjectParameter("label", Optional.class, optionalParameterType(0), Optional.of("Optional label"), Optional.empty(), false),
+                new ObjectParameter("tags", Optional.class, optionalParameterType(1), Optional.empty(), Optional.empty(), false),
+                new ObjectParameter("attributes", Optional.class, optionalParameterType(2), Optional.empty(), Optional.empty(), false));
+
+        ObjectNode schema = jsonSchemaBuilder.build(Optional.empty(), parameters);
+        ObjectNode properties = (ObjectNode) schema.get("properties");
+
+        ObjectNode labelSchema = (ObjectNode) properties.get("label");
+        assertThat(labelSchema.get("type").asText()).isEqualTo("string");
+        assertThat(labelSchema.has("properties")).isFalse();
+        assertThat(labelSchema.get("description").asText()).isEqualTo("Optional label");
+
+        ObjectNode tagsSchema = (ObjectNode) properties.get("tags");
+        assertThat(tagsSchema.get("type").asText()).isEqualTo("array");
+        assertThat(tagsSchema.has("properties")).isFalse();
+        assertThat(tagsSchema.get("items").get("type").asText()).isEqualTo("string");
+
+        ObjectNode attributesSchema = (ObjectNode) properties.get("attributes");
+        assertThat(attributesSchema.get("type").asText()).isEqualTo("object");
+        assertThat(attributesSchema.has("properties")).isFalse();
+
+        ArrayNode required = (ArrayNode) schema.get("required");
+        List<String> requiredFields = StreamSupport.stream(required.spliterator(), false)
+                .map(JsonNode::asText)
+                .toList();
+        assertThat(requiredFields).containsExactly("requiredName");
+    }
+
+    @Test
     public void testBuildWithMethodParametersAndDescription()
     {
         List<MethodParameter> parameters = ImmutableList.of(
@@ -365,5 +400,23 @@ public class TestJsonSchemaBuilder
     {
         ObjectNode objectNode = jsonSchemaBuilder.build(description, type);
         assertThat(objectNode.toString()).isEqualTo(expected);
+    }
+
+    @SuppressWarnings("unused")
+    private static void optionalParameterTypes(
+            Optional<String> label,
+            Optional<List<String>> tags,
+            Optional<Map<String, String>> attributes)
+    {}
+
+    private static Type optionalParameterType(int index)
+    {
+        try {
+            Method method = TestJsonSchemaBuilder.class.getDeclaredMethod("optionalParameterTypes", Optional.class, Optional.class, Optional.class);
+            return method.getGenericParameterTypes()[index];
+        }
+        catch (ReflectiveOperationException e) {
+            throw new AssertionError(e);
+        }
     }
 }

--- a/mcp/src/test/java/io/airlift/mcp/TestMcp.java
+++ b/mcp/src/test/java/io/airlift/mcp/TestMcp.java
@@ -372,26 +372,33 @@ public abstract class TestMcp
     public void testToolEmbeddedStructuredContent()
     {
         ListToolsResult listToolsResult = client1.mcpClient().listTools();
-        assertThat(listToolsResult.tools())
-                .filteredOn(tool -> tool.name().equals("addFirstTwoAndAllThree"))
-                .hasSize(1)
-                .first()
-                .extracting(Tool::outputSchema)
-                .satisfies(outputSchema -> {
-                    assertThat(outputSchema.get("type")).isEqualTo("object");
+        Tool addFirstTwoAndAllThree = listToolsResult.tools().stream()
+                .filter(tool -> tool.name().equals("addFirstTwoAndAllThree"))
+                .findFirst()
+                .orElseThrow();
 
-                    assertThat(outputSchema.get("required"))
-                            .isNotNull()
-                            .asInstanceOf(type(List.class))
-                            .satisfies(list -> assertThat(list).containsExactlyInAnyOrder("firstTwo", "allThree"));
+        assertThat(addFirstTwoAndAllThree.inputSchema().required()).containsExactlyInAnyOrder("a", "b");
+        Map<String, Object> inputProperties = addFirstTwoAndAllThree.inputSchema().properties();
+        assertThat(inputProperties.keySet()).containsExactlyInAnyOrder("a", "b", "c");
 
-                    assertThat(outputSchema.get("properties")).isNotNull();
-                    Map<String, Object> properties = (Map<String, Object>) outputSchema.get("properties");
-                    assertThat(properties.keySet()).containsExactlyInAnyOrder("firstTwo", "allThree");
+        Map<String, Object> optionalParameterSchema = (Map<String, Object>) inputProperties.get("c");
+        assertThat(optionalParameterSchema.get("type")).isEqualTo("integer");
+        assertThat(optionalParameterSchema).doesNotContainKey("properties");
 
-                    assertThat(((Map<String, Object>) properties.get("firstTwo")).get("type")).isEqualTo("integer");
-                    assertThat(((Map<String, Object>) properties.get("allThree")).get("type")).isEqualTo("integer");
-                });
+        Map<String, Object> outputSchema = addFirstTwoAndAllThree.outputSchema();
+        assertThat(outputSchema.get("type")).isEqualTo("object");
+
+        assertThat(outputSchema.get("required"))
+                .isNotNull()
+                .asInstanceOf(type(List.class))
+                .satisfies(list -> assertThat(list).containsExactlyInAnyOrder("firstTwo", "allThree"));
+
+        assertThat(outputSchema.get("properties")).isNotNull();
+        Map<String, Object> properties = (Map<String, Object>) outputSchema.get("properties");
+        assertThat(properties.keySet()).containsExactlyInAnyOrder("firstTwo", "allThree");
+
+        assertThat(((Map<String, Object>) properties.get("firstTwo")).get("type")).isEqualTo("integer");
+        assertThat(((Map<String, Object>) properties.get("allThree")).get("type")).isEqualTo("integer");
 
         CallToolRequest callToolRequest = new CallToolRequest("addFirstTwoAndAllThree", ImmutableMap.of("a", 1, "b", 2, "c", 3));
         CallToolResult twoAndThreeCallToolResult = client1.mcpClient().callTool(callToolRequest);


### PR DESCRIPTION
Generating schemas from Optional<T> exposes a synthetic object with a value field. Clients follow that schema and send wrapper objects that the method binding does not expect.

Build method parameter schemas from the Optional payload type so clients send the same shape that the runtime accepts.

<!-- Thank you for submitting pull request to Airlift -->

# Airlift contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [ ] All automated tests are passing.
 - [ ] Pull request was categorized using one of the existing labels.
