### PR TITLE
Extract OpenMetricsCollector from MetricsResource

### DIFF
--- a/openmetrics/src/main/java/io/airlift/openmetrics/JmxOpenMetricsModule.java
+++ b/openmetrics/src/main/java/io/airlift/openmetrics/JmxOpenMetricsModule.java
@@ -19,6 +19,7 @@ import com.google.inject.Module;
 import java.lang.annotation.Annotation;
 import java.util.Optional;
 
+import static com.google.inject.Scopes.SINGLETON;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
 import static java.util.Objects.requireNonNull;
@@ -42,6 +43,7 @@ public class JmxOpenMetricsModule
     public void configure(Binder binder)
     {
         configBinder(binder).bindConfig(MetricsConfig.class);
+        binder.bind(OpenMetricsCollector.class).in(SINGLETON);
         annotation
                 .map(value -> jaxrsBinder(binder, value))
                 .orElseGet(() -> jaxrsBinder(binder))

--- a/openmetrics/src/main/java/io/airlift/openmetrics/MetricsResource.java
+++ b/openmetrics/src/main/java/io/airlift/openmetrics/MetricsResource.java
@@ -14,43 +14,17 @@
 package io.airlift.openmetrics;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.CharMatcher;
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
-import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
-import io.airlift.log.Logger;
-import io.airlift.node.NodeInfo;
 import io.airlift.openmetrics.types.CompositeMetric;
-import io.airlift.openmetrics.types.Counter;
-import io.airlift.openmetrics.types.Gauge;
 import io.airlift.openmetrics.types.Metric;
-import io.airlift.openmetrics.types.Summary;
-import io.airlift.stats.CounterStat;
-import io.airlift.stats.TimeDistribution;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
-import org.weakref.jmx.MBeanExporter;
-import org.weakref.jmx.ManagedClass;
 
-import javax.management.InstanceNotFoundException;
-import javax.management.IntrospectionException;
-import javax.management.JMException;
-import javax.management.MBeanAttributeInfo;
-import javax.management.MBeanInfo;
-import javax.management.MBeanServer;
-import javax.management.MalformedObjectNameException;
-import javax.management.ObjectName;
-import javax.management.ReflectionException;
-import javax.management.openmbean.CompositeData;
-
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -64,266 +38,31 @@ import static java.util.stream.Collectors.toList;
 @Path("/metrics")
 public class MetricsResource
 {
-    private static final Logger log = Logger.get(MetricsResource.class);
     private static final String OPENMETRICS_CONTENT_TYPE = "application/openmetrics-text; version=1.0.0; charset=utf-8";
-    private static final String ATTRIBUTE_SEPARATOR = "_ATTRIBUTE_";
-    private static final String TYPE_SEPARATOR = "_TYPE_";
-    private static final String NAME_SEPARATOR = "_NAME_";
-    private static final CharMatcher NON_ALLOWED_LABEL_CHARACTERS = CharMatcher
-            .inRange('a', 'z')
-            .or(CharMatcher.inRange('A', 'Z'))
-            .or(CharMatcher.inRange('0', '9'))
-            .or(CharMatcher.anyOf("_"))
-            .negate()
-            .precomputed();
 
-    private final MBeanServer mbeanServer;
-    private final MBeanExporter mbeanExporter;
-
-    private final List<ObjectName> allMetricsObjectNames;
-    private final Map<String, String> labels;
+    private final OpenMetricsCollector collector;
 
     @Inject
-    public MetricsResource(MBeanServer mbeanServer, MBeanExporter mbeanExporter, MetricsConfig metricsConfig, NodeInfo nodeInfo)
+    public MetricsResource(OpenMetricsCollector collector)
     {
-        this.mbeanServer = requireNonNull(mbeanServer, "mbeanServer is null");
-        this.mbeanExporter = requireNonNull(mbeanExporter, "mbeanExporter is null");
-        this.allMetricsObjectNames = metricsConfig.getJmxObjectNames();
-        this.labels = nodeInfo.getAnnotations();
+        this.collector = requireNonNull(collector, "collector is null");
     }
 
     @GET
     @Produces(OPENMETRICS_CONTENT_TYPE)
     public String getMetrics(@QueryParam("name[]") List<String> filter)
     {
-        List<Metric> metrics = new ArrayList<>();
-        Supplier<List<Metric>> managedMetrics = Suppliers.memoize(this::getManagedMetrics);
-        if (filter != null && !filter.isEmpty()) {
-            for (String metricName : filter) {
-                findMetric(managedMetrics, metricName).ifPresent(metrics::add);
-            }
-        }
-        else {
-            metrics.addAll(managedMetrics.get());
-            for (ObjectName metricObjectNames : allMetricsObjectNames) {
-                mbeanServer.queryNames(metricObjectNames, null).forEach(objectName -> metrics.addAll(inferAttributesForObjectName(objectName)));
-            }
-        }
+        List<Metric> metrics = collector.collect(filter);
         StringBuilder body = new StringBuilder();
         metricExpositions(body, metrics);
         body.append("# EOF\n");
         return body.toString();
     }
 
-    private Set<ObjectName> objectNamesFromMetricName(String metricName)
-            throws MalformedObjectNameException
-    {
-        int nameStart = metricName.indexOf(NAME_SEPARATOR);
-        int typeStart = metricName.indexOf(TYPE_SEPARATOR);
-        int attributeStart = metricName.indexOf(ATTRIBUTE_SEPARATOR);
-
-        String domain;
-
-        if (nameStart != -1) {
-            domain = metricName.substring(0, nameStart).replace("_", ".");
-        }
-        else if (typeStart != -1) {
-            domain = metricName.substring(0, typeStart).replace("_", ".");
-        }
-        else {
-            domain = metricName.substring(0, attributeStart).replace("_", ".");
-        }
-
-        StringBuilder objectNameBuilder = new StringBuilder(domain).append(":");
-
-        if (nameStart != -1) {
-            objectNameBuilder.append("name=")
-                    .append(metricName, nameStart + NAME_SEPARATOR.length(), typeStart == -1 ? attributeStart : typeStart)
-                    .append(",");
-        }
-        if (typeStart != -1) {
-            objectNameBuilder.append("type=")
-                    .append(metricName.substring(typeStart + TYPE_SEPARATOR.length(), attributeStart).replace("_", "$"))
-                    .append(",");
-        }
-
-        return mbeanServer.queryNames(ObjectName.getInstance(objectNameBuilder.append("*").toString()), null);
-    }
-
-    private String attributeNameFromMetricName(String metricName)
-    {
-        int attributeNameStart = metricName.indexOf(ATTRIBUTE_SEPARATOR);
-        if (attributeNameStart == -1) {
-            throw new RuntimeException("Metric name invalid, no attribute separator %s".formatted(metricName));
-        }
-        return metricName.substring(attributeNameStart + ATTRIBUTE_SEPARATOR.length()).replace("_", ".");
-    }
-
-    private String mBeanNameToMetricName(ObjectName objectName, String attributeName)
-    {
-        if (objectName.getDomain().contains("_")) {
-            log.warn("Unable to expose JMX metric with domain name %s, package names with underscores are unsupported.", objectName.getDomain());
-            throw new RuntimeException("Bad domain name %s".formatted(objectName.getDomain()));
-        }
-
-        StringBuilder metricNameBuilder = new StringBuilder("JMX_")
-                .append(objectName.getDomain());
-
-        if (objectName.getKeyProperty("name") != null) {
-            metricNameBuilder.append(NAME_SEPARATOR)
-                    .append(objectName.getKeyProperty("name"));
-        }
-
-        if (objectName.getKeyProperty("type") != null) {
-            metricNameBuilder.append(TYPE_SEPARATOR)
-                    .append(objectName.getKeyProperty("type"));
-        }
-
-        metricNameBuilder.append(ATTRIBUTE_SEPARATOR)
-                .append(attributeName);
-
-        return sanitizeMetricName(metricNameBuilder.toString());
-    }
-
-    private Optional<Metric> findMetric(Supplier<List<Metric>> managedMetricsSupplier, String metricName)
-    {
-        if (metricName.startsWith("JMX_")) {
-            final String jmxMetricName = metricName.substring(4);
-            try {
-                String attributeName = attributeNameFromMetricName(jmxMetricName);
-                return objectNamesFromMetricName(jmxMetricName).stream()
-                        .map(objectName -> getMetric(objectName, attributeName, jmxMetricName, ""))
-                        .flatMap(Optional::stream)
-                        .findFirst();
-            }
-            catch (MalformedObjectNameException e) {
-                log.warn(e, "Unable to retrieve metric %s.", metricName);
-                return Optional.empty();
-            }
-        }
-        else {
-            return managedMetricsSupplier.get()
-                    .stream()
-                    .filter(metric -> metric.metricName().equals(metricName))
-                    .findFirst();
-        }
-    }
-
-    private Optional<Metric> getMetric(ObjectName objectName, String attributeName, String metricName, String description)
-    {
-        try {
-            Object attributeValue = mbeanServer.getAttribute(objectName, attributeName);
-            return switch (attributeValue) {
-                case Number number -> Optional.of(Gauge.from(metricName, number, labels, description));
-                case CompositeData compositeData -> Optional.of(CompositeMetric.from(metricName, compositeData, labels, description));
-                case null, default -> Optional.empty();
-            };
-        }
-        catch (JMException ex) {
-            log.debug(ex, "Unable to get metric for ObjectName %s and Attribute %s.", objectName.getCanonicalName(), attributeName);
-            return Optional.empty();
-        }
-    }
-
-    private List<Metric> inferAttributesForObjectName(ObjectName objectName)
-    {
-        List<Metric> metrics = new ArrayList<>();
-        try {
-            MBeanInfo mbeanInfo = mbeanServer.getMBeanInfo(objectName);
-            for (MBeanAttributeInfo mBeanAttributeInfo : mbeanInfo.getAttributes()) {
-                String attributeName = mBeanAttributeInfo.getName();
-                String description = mBeanAttributeInfo.getDescription();
-                try {
-                    getMetric(objectName, attributeName, mBeanNameToMetricName(objectName, attributeName), description)
-                            .ifPresent(metrics::add);
-                }
-                catch (RuntimeException e) {
-                    log.debug(e, "Unable to get Metric for ObjectName %s and Attribute %s, skipping", objectName.getCanonicalName(), attributeName);
-                }
-            }
-        }
-        catch (InstanceNotFoundException | IntrospectionException | ReflectionException e) {
-            log.debug(e, "Unable to get MBeanInfo for object %s, skipping", objectName.getCanonicalName());
-        }
-        return metrics;
-    }
-
     @VisibleForTesting
     static String sanitizeMetricName(String name)
     {
-        return NON_ALLOWED_LABEL_CHARACTERS.collapseFrom(name, '_');
-    }
-
-    private List<Metric> getMetricsRecursively(String prefix, ManagedClass managedClass)
-    {
-        String metricName = sanitizeMetricName(prefix);
-
-        ImmutableList.Builder<Metric> metrics = ImmutableList.builder();
-
-        for (String attributeName : managedClass.getAttributeNames()) {
-            try {
-                String metricAndAttribute = managedClass.isAttributeFlatten(attributeName) ? metricName : metricName + "_" + attributeName;
-                String attributeDescription = managedClass.getAttributeDescription(attributeName);
-
-                if (managedClass.getChildren().get(attributeName) instanceof ManagedClass child) {
-                    // The managed class is directly translatable to an openmetrics type, don't recurse any further
-                    Optional<Metric> metricFromTarget = getMetricFromTarget(child, metricAndAttribute, attributeDescription);
-                    if (metricFromTarget.isPresent()) {
-                        metrics.add(metricFromTarget.orElseThrow());
-                    }
-                    else {
-                        // Recurse this nested child
-                        metrics.addAll(getMetricsRecursively(metricAndAttribute, child));
-                    }
-                }
-                else {
-                    // Attempt to infer a numeric gauge
-                    Object attributeValue = managedClass.invokeAttribute(attributeName);
-                    if (attributeValue instanceof Number) {
-                        metrics.add(Gauge.from(metricAndAttribute, (Number) attributeValue, labels, attributeDescription));
-                    }
-                    if (attributeValue instanceof Boolean) {
-                        metrics.add(Gauge.from(metricAndAttribute, (Boolean) attributeValue ? 1 : 0, labels, attributeDescription));
-                    }
-                }
-            }
-            catch (ReflectiveOperationException e) {
-                log.debug("Unable to invoke getter for managed attribute : " + attributeName);
-            }
-        }
-
-        return metrics.build();
-    }
-
-    private Optional<Metric> getMetricFromTarget(ManagedClass managedClass, String metricName, String description)
-    {
-        Object target;
-        try {
-            target = managedClass.getTarget();
-        }
-        catch (IllegalStateException ignored) {
-            return Optional.empty();
-        }
-
-        if (target instanceof CounterStat counterStat) {
-            return Optional.of(Counter.from(metricName, counterStat, labels, description));
-        }
-
-        if (target instanceof TimeDistribution timeDistribution) {
-            return Optional.of(Summary.from(metricName, timeDistribution, labels, description));
-        }
-
-        return Optional.empty();
-    }
-
-    private List<Metric> getManagedMetrics()
-    {
-        Map<String, ManagedClass> managedClasses = this.mbeanExporter.getManagedClasses();
-
-        return managedClasses.entrySet().stream()
-                .map(entry -> getMetricsRecursively(entry.getKey(), entry.getValue()))
-                .flatMap(List::stream)
-                .collect(toImmutableList());
+        return OpenMetricsCollector.sanitizeMetricName(name);
     }
 
     /**
@@ -352,8 +91,8 @@ public class MetricsResource
             checkState(metricTypes.size() == 1, "Metric family %s contains mixed metric types: %s", metricName, metricTypes);
 
             builder.append(metricFamily.getFirst().getMetricDescriptor());
-            for (int i = 0; i < metricFamily.size(); i++) {
-                builder.append(metricFamily.get(i).getMetricExposition());
+            for (Metric metric : metricFamily) {
+                builder.append(metric.getMetricExposition());
             }
         });
     }

--- a/openmetrics/src/main/java/io/airlift/openmetrics/OpenMetricsCollector.java
+++ b/openmetrics/src/main/java/io/airlift/openmetrics/OpenMetricsCollector.java
@@ -1,0 +1,326 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.openmetrics;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.CharMatcher;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import io.airlift.log.Logger;
+import io.airlift.node.NodeInfo;
+import io.airlift.openmetrics.types.CompositeMetric;
+import io.airlift.openmetrics.types.Counter;
+import io.airlift.openmetrics.types.Gauge;
+import io.airlift.openmetrics.types.Metric;
+import io.airlift.openmetrics.types.Summary;
+import io.airlift.stats.CounterStat;
+import io.airlift.stats.TimeDistribution;
+import org.weakref.jmx.MBeanExporter;
+import org.weakref.jmx.ManagedClass;
+
+import javax.management.InstanceNotFoundException;
+import javax.management.IntrospectionException;
+import javax.management.JMException;
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanInfo;
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import javax.management.ReflectionException;
+import javax.management.openmbean.CompositeData;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Collects the structured OpenMetrics values rendered by {@link MetricsResource}.
+ */
+public class OpenMetricsCollector
+{
+    private static final Logger log = Logger.get(OpenMetricsCollector.class);
+    private static final String ATTRIBUTE_SEPARATOR = "_ATTRIBUTE_";
+    private static final String TYPE_SEPARATOR = "_TYPE_";
+    private static final String NAME_SEPARATOR = "_NAME_";
+    private static final CharMatcher NON_ALLOWED_LABEL_CHARACTERS = CharMatcher
+            .inRange('a', 'z')
+            .or(CharMatcher.inRange('A', 'Z'))
+            .or(CharMatcher.inRange('0', '9'))
+            .or(CharMatcher.anyOf("_"))
+            .negate()
+            .precomputed();
+
+    private final MBeanServer mbeanServer;
+    private final MBeanExporter mbeanExporter;
+    private final List<ObjectName> allMetricsObjectNames;
+    private final Map<String, String> labels;
+
+    @Inject
+    public OpenMetricsCollector(MBeanServer mbeanServer, MBeanExporter mbeanExporter, MetricsConfig metricsConfig, NodeInfo nodeInfo)
+    {
+        this.mbeanServer = requireNonNull(mbeanServer, "mbeanServer is null");
+        this.mbeanExporter = requireNonNull(mbeanExporter, "mbeanExporter is null");
+        requireNonNull(metricsConfig, "metricsConfig is null");
+        requireNonNull(nodeInfo, "nodeInfo is null");
+        this.allMetricsObjectNames = metricsConfig.getJmxObjectNames();
+        this.labels = nodeInfo.getAnnotations();
+    }
+
+    public List<Metric> collect()
+    {
+        ImmutableList.Builder<Metric> metrics = ImmutableList.builder();
+        metrics.addAll(getManagedMetrics());
+        for (ObjectName metricObjectNames : allMetricsObjectNames) {
+            mbeanServer.queryNames(metricObjectNames, null).forEach(objectName -> metrics.addAll(inferAttributesForObjectName(objectName)));
+        }
+        return metrics.build();
+    }
+
+    public List<Metric> collect(List<String> filters)
+    {
+        if (filters == null || filters.isEmpty()) {
+            return collect();
+        }
+
+        ImmutableList.Builder<Metric> metrics = ImmutableList.builder();
+        Supplier<List<Metric>> managedMetrics = Suppliers.memoize(this::getManagedMetrics);
+        for (String metricName : filters) {
+            findMetric(managedMetrics, metricName).ifPresent(metrics::add);
+        }
+        return metrics.build();
+    }
+
+    public Optional<Metric> findMetric(String metricName)
+    {
+        return findMetric(Suppliers.memoize(this::getManagedMetrics), metricName);
+    }
+
+    private Set<ObjectName> objectNamesFromMetricName(String metricName)
+            throws MalformedObjectNameException
+    {
+        int nameStart = metricName.indexOf(NAME_SEPARATOR);
+        int typeStart = metricName.indexOf(TYPE_SEPARATOR);
+        int attributeStart = metricName.indexOf(ATTRIBUTE_SEPARATOR);
+
+        String domain;
+
+        if (nameStart != -1) {
+            domain = metricName.substring(0, nameStart).replace("_", ".");
+        }
+        else if (typeStart != -1) {
+            domain = metricName.substring(0, typeStart).replace("_", ".");
+        }
+        else {
+            domain = metricName.substring(0, attributeStart).replace("_", ".");
+        }
+
+        StringBuilder objectNameBuilder = new StringBuilder(domain).append(":");
+
+        if (nameStart != -1) {
+            objectNameBuilder.append("name=")
+                    .append(metricName, nameStart + NAME_SEPARATOR.length(), typeStart == -1 ? attributeStart : typeStart)
+                    .append(",");
+        }
+        if (typeStart != -1) {
+            objectNameBuilder.append("type=")
+                    .append(metricName.substring(typeStart + TYPE_SEPARATOR.length(), attributeStart).replace("_", "$"))
+                    .append(",");
+        }
+
+        return mbeanServer.queryNames(ObjectName.getInstance(objectNameBuilder.append("*").toString()), null);
+    }
+
+    private String attributeNameFromMetricName(String metricName)
+    {
+        int attributeNameStart = metricName.indexOf(ATTRIBUTE_SEPARATOR);
+        if (attributeNameStart == -1) {
+            throw new RuntimeException("Metric name invalid, no attribute separator %s".formatted(metricName));
+        }
+        return metricName.substring(attributeNameStart + ATTRIBUTE_SEPARATOR.length()).replace("_", ".");
+    }
+
+    private String mBeanNameToMetricName(ObjectName objectName, String attributeName)
+    {
+        if (objectName.getDomain().contains("_")) {
+            log.warn("Unable to expose JMX metric with domain name %s, package names with underscores are unsupported.", objectName.getDomain());
+            throw new RuntimeException("Bad domain name %s".formatted(objectName.getDomain()));
+        }
+
+        StringBuilder metricNameBuilder = new StringBuilder("JMX_")
+                .append(objectName.getDomain());
+
+        if (objectName.getKeyProperty("name") != null) {
+            metricNameBuilder.append(NAME_SEPARATOR)
+                    .append(objectName.getKeyProperty("name"));
+        }
+
+        if (objectName.getKeyProperty("type") != null) {
+            metricNameBuilder.append(TYPE_SEPARATOR)
+                    .append(objectName.getKeyProperty("type"));
+        }
+
+        metricNameBuilder.append(ATTRIBUTE_SEPARATOR)
+                .append(attributeName);
+
+        return sanitizeMetricName(metricNameBuilder.toString());
+    }
+
+    private Optional<Metric> findMetric(Supplier<List<Metric>> managedMetricsSupplier, String metricName)
+    {
+        if (metricName.startsWith("JMX_")) {
+            final String jmxMetricName = metricName.substring(4);
+            try {
+                String attributeName = attributeNameFromMetricName(jmxMetricName);
+                return objectNamesFromMetricName(jmxMetricName).stream()
+                        .map(objectName -> getMetric(objectName, attributeName, jmxMetricName, ""))
+                        .flatMap(Optional::stream)
+                        .findFirst();
+            }
+            catch (MalformedObjectNameException e) {
+                log.warn(e, "Unable to retrieve metric %s.", metricName);
+                return Optional.empty();
+            }
+        }
+        else {
+            return managedMetricsSupplier.get()
+                    .stream()
+                    .filter(metric -> metric.metricName().equals(metricName))
+                    .findFirst();
+        }
+    }
+
+    private Optional<Metric> getMetric(ObjectName objectName, String attributeName, String metricName, String description)
+    {
+        try {
+            Object attributeValue = mbeanServer.getAttribute(objectName, attributeName);
+            return switch (attributeValue) {
+                case Number number -> Optional.of(Gauge.from(metricName, number, labels, description));
+                case CompositeData compositeData -> Optional.of(CompositeMetric.from(metricName, compositeData, labels, description));
+                case null, default -> Optional.empty();
+            };
+        }
+        catch (JMException ex) {
+            log.debug(ex, "Unable to get metric for ObjectName %s and Attribute %s.", objectName.getCanonicalName(), attributeName);
+            return Optional.empty();
+        }
+    }
+
+    private List<Metric> inferAttributesForObjectName(ObjectName objectName)
+    {
+        List<Metric> metrics = new ArrayList<>();
+        try {
+            MBeanInfo mbeanInfo = mbeanServer.getMBeanInfo(objectName);
+            for (MBeanAttributeInfo mBeanAttributeInfo : mbeanInfo.getAttributes()) {
+                String attributeName = mBeanAttributeInfo.getName();
+                String description = mBeanAttributeInfo.getDescription();
+                try {
+                    getMetric(objectName, attributeName, mBeanNameToMetricName(objectName, attributeName), description)
+                            .ifPresent(metrics::add);
+                }
+                catch (RuntimeException e) {
+                    log.debug(e, "Unable to get Metric for ObjectName %s and Attribute %s, skipping", objectName.getCanonicalName(), attributeName);
+                }
+            }
+        }
+        catch (InstanceNotFoundException | IntrospectionException | ReflectionException e) {
+            log.debug(e, "Unable to get MBeanInfo for object %s, skipping", objectName.getCanonicalName());
+        }
+        return metrics;
+    }
+
+    @VisibleForTesting
+    static String sanitizeMetricName(String name)
+    {
+        return NON_ALLOWED_LABEL_CHARACTERS.collapseFrom(name, '_');
+    }
+
+    private List<Metric> getMetricsRecursively(String prefix, ManagedClass managedClass)
+    {
+        String metricName = sanitizeMetricName(prefix);
+
+        ImmutableList.Builder<Metric> metrics = ImmutableList.builder();
+
+        for (String attributeName : managedClass.getAttributeNames()) {
+            try {
+                String metricAndAttribute = managedClass.isAttributeFlatten(attributeName) ? metricName : metricName + "_" + attributeName;
+                String attributeDescription = managedClass.getAttributeDescription(attributeName);
+
+                if (managedClass.getChildren().get(attributeName) instanceof ManagedClass child) {
+                    // The managed class is directly translatable to an openmetrics type, don't recurse any further
+                    Optional<Metric> metricFromTarget = getMetricFromTarget(child, metricAndAttribute, attributeDescription);
+                    if (metricFromTarget.isPresent()) {
+                        metrics.add(metricFromTarget.orElseThrow());
+                    }
+                    else {
+                        // Recurse this nested child
+                        metrics.addAll(getMetricsRecursively(metricAndAttribute, child));
+                    }
+                }
+                else {
+                    // Attempt to infer a numeric gauge
+                    Object attributeValue = managedClass.invokeAttribute(attributeName);
+                    if (attributeValue instanceof Number) {
+                        metrics.add(Gauge.from(metricAndAttribute, (Number) attributeValue, labels, attributeDescription));
+                    }
+                    if (attributeValue instanceof Boolean) {
+                        metrics.add(Gauge.from(metricAndAttribute, (Boolean) attributeValue ? 1 : 0, labels, attributeDescription));
+                    }
+                }
+            }
+            catch (ReflectiveOperationException e) {
+                log.debug("Unable to invoke getter for managed attribute : " + attributeName);
+            }
+        }
+
+        return metrics.build();
+    }
+
+    private Optional<Metric> getMetricFromTarget(ManagedClass managedClass, String metricName, String description)
+    {
+        Object target;
+        try {
+            target = managedClass.getTarget();
+        }
+        catch (IllegalStateException ignored) {
+            return Optional.empty();
+        }
+
+        if (target instanceof CounterStat counterStat) {
+            return Optional.of(Counter.from(metricName, counterStat, labels, description));
+        }
+
+        if (target instanceof TimeDistribution timeDistribution) {
+            return Optional.of(Summary.from(metricName, timeDistribution, labels, description));
+        }
+
+        return Optional.empty();
+    }
+
+    private List<Metric> getManagedMetrics()
+    {
+        Map<String, ManagedClass> managedClasses = this.mbeanExporter.getManagedClasses();
+
+        return managedClasses.entrySet().stream()
+                .map(entry -> getMetricsRecursively(entry.getKey(), entry.getValue()))
+                .flatMap(List::stream)
+                .collect(toImmutableList());
+    }
+}

--- a/openmetrics/src/test/java/io/airlift/openmetrics/TestOpenMetricsCollector.java
+++ b/openmetrics/src/test/java/io/airlift/openmetrics/TestOpenMetricsCollector.java
@@ -1,0 +1,296 @@
+package io.airlift.openmetrics;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.node.NodeInfo;
+import io.airlift.openmetrics.types.CompositeMetric;
+import io.airlift.openmetrics.types.Counter;
+import io.airlift.openmetrics.types.Gauge;
+import io.airlift.openmetrics.types.Metric;
+import io.airlift.openmetrics.types.Summary;
+import io.airlift.stats.CounterStat;
+import io.airlift.stats.TimeDistribution;
+import io.airlift.testing.TestingTicker;
+import org.junit.jupiter.api.Test;
+import org.weakref.jmx.MBeanExporter;
+import org.weakref.jmx.Managed;
+import org.weakref.jmx.Nested;
+
+import javax.management.MBeanServer;
+import javax.management.MBeanServerFactory;
+import javax.management.ObjectName;
+import javax.management.StandardMBean;
+import javax.management.openmbean.CompositeData;
+import javax.management.openmbean.CompositeDataSupport;
+import javax.management.openmbean.CompositeType;
+import javax.management.openmbean.OpenType;
+import javax.management.openmbean.SimpleType;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.airlift.node.NodeConfig.AddressSource.IP;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+public class TestOpenMetricsCollector
+{
+    @Test
+    public void testCollectManagedNumericGauge()
+            throws Exception
+    {
+        OpenMetricsCollector collector = createTestingCollector();
+
+        assertThat(collector.collect())
+                .filteredOn(Gauge.class::isInstance)
+                .map(Gauge.class::cast)
+                .anySatisfy(metric -> {
+                    assertThat(metric.metricName()).endsWith("_NumericGauge");
+                    assertThat(metric.value()).isEqualTo(7.0);
+                    assertThat(metric.labels()).isEqualTo(ImmutableMap.of("region", "b", "team", "a"));
+                    assertThat(metric.help()).isEqualTo("numeric gauge");
+                });
+    }
+
+    @Test
+    public void testCollectManagedCounterStat()
+            throws Exception
+    {
+        OpenMetricsCollector collector = createTestingCollector();
+
+        assertThat(collector.collect())
+                .filteredOn(Counter.class::isInstance)
+                .map(Counter.class::cast)
+                .anySatisfy(metric -> {
+                    assertThat(metric.metricName()).endsWith("_Requests");
+                    assertThat(metric.value()).isEqualTo(11);
+                    assertThat(metric.labels()).isEqualTo(ImmutableMap.of("region", "b", "team", "a"));
+                    assertThat(metric.help()).isEqualTo("request counter");
+                });
+    }
+
+    @Test
+    public void testCollectManagedTimeDistribution()
+            throws Exception
+    {
+        OpenMetricsCollector collector = createTestingCollector();
+
+        assertThat(collector.collect())
+                .filteredOn(Summary.class::isInstance)
+                .map(Summary.class::cast)
+                .anySatisfy(metric -> {
+                    assertThat(metric.metricName()).endsWith("_Latency");
+                    assertThat(metric.count()).isEqualTo(2);
+                    assertThat(metric.labels()).isEqualTo(ImmutableMap.of("region", "b", "team", "a"));
+                    assertThat(metric.help()).isEqualTo("request latency");
+                });
+    }
+
+    @Test
+    public void testCollectConfiguredJmxNumericAttribute()
+            throws Exception
+    {
+        OpenMetricsCollector collector = createTestingCollector();
+
+        assertThat(collector.collect())
+                .filteredOn(Gauge.class::isInstance)
+                .map(Gauge.class::cast)
+                .anySatisfy(metric -> {
+                    assertThat(metric.metricName()).isEqualTo("JMX_io_airlift_openmetrics_test_NAME_configured_TYPE_Test_ATTRIBUTE_Count");
+                    assertThat(metric.value()).isEqualTo(23.0);
+                    assertThat(metric.labels()).isEqualTo(ImmutableMap.of("region", "b", "team", "a"));
+                });
+    }
+
+    @Test
+    public void testCollectConfiguredJmxCompositeAttribute()
+            throws Exception
+    {
+        OpenMetricsCollector collector = createTestingCollector();
+
+        Optional<CompositeMetric> memoryMetric = collector.collect().stream()
+                .filter(CompositeMetric.class::isInstance)
+                .map(CompositeMetric.class::cast)
+                .filter(metric -> metric.metricName().equals("JMX_io_airlift_openmetrics_test_NAME_configured_TYPE_Test_ATTRIBUTE_Memory"))
+                .findFirst();
+
+        assertThat(memoryMetric).isPresent();
+        assertThat(memoryMetric.orElseThrow().labels()).isEqualTo(ImmutableMap.of("region", "b", "team", "a"));
+        assertThat(memoryMetric.orElseThrow().subMetrics())
+                .filteredOn(Gauge.class::isInstance)
+                .map(Gauge.class::cast)
+                .extracting(Gauge::metricName, Gauge::value)
+                .contains(
+                        tuple("JMX_io_airlift_openmetrics_test_NAME_configured_TYPE_Test_ATTRIBUTE_Memory_committed", 200.0),
+                        tuple("JMX_io_airlift_openmetrics_test_NAME_configured_TYPE_Test_ATTRIBUTE_Memory_max", 1000.0),
+                        tuple("JMX_io_airlift_openmetrics_test_NAME_configured_TYPE_Test_ATTRIBUTE_Memory_used", 100.0));
+    }
+
+    @Test
+    public void testResourceOutputMatchesCollectorRendering()
+            throws Exception
+    {
+        OpenMetricsCollector collector = createTestingCollector();
+        MetricsResource resource = new MetricsResource(collector);
+
+        StringBuilder expected = new StringBuilder();
+        MetricsResource.metricExpositions(expected, collector.collect());
+        expected.append("# EOF\n");
+
+        assertThat(resource.getMetrics(ImmutableList.of())).isEqualTo(expected.toString());
+    }
+
+    @Test
+    public void testFilteredMetricLookupCompatibility()
+            throws Exception
+    {
+        OpenMetricsCollector collector = createTestingCollector();
+        MetricsResource resource = new MetricsResource(collector);
+        String managedMetricName = collector.collect().stream()
+                .map(Metric::metricName)
+                .filter(name -> name.endsWith("_NumericGauge"))
+                .findFirst()
+                .orElseThrow();
+        String jmxMetricName = "JMX_io_airlift_openmetrics_test_NAME_configured_TYPE_Test_ATTRIBUTE_Count";
+
+        assertThat(collector.collect(ImmutableList.of(managedMetricName)))
+                .extracting(Metric::metricName)
+                .containsExactly(managedMetricName);
+        assertThat(resource.getMetrics(ImmutableList.of(managedMetricName)))
+                .isEqualTo(renderWithEof(collector.collect(ImmutableList.of(managedMetricName))));
+
+        Metric filteredJmxMetric = collector.findMetric(jmxMetricName).orElseThrow();
+        assertThat(filteredJmxMetric.metricName()).isEqualTo("io_airlift_openmetrics_test_NAME_configured_TYPE_Test_ATTRIBUTE_Count");
+        assertThat(resource.getMetrics(ImmutableList.of(jmxMetricName)))
+                .isEqualTo(renderWithEof(collector.collect(ImmutableList.of(jmxMetricName))));
+    }
+
+    private static String renderWithEof(List<Metric> metrics)
+    {
+        StringBuilder builder = new StringBuilder();
+        MetricsResource.metricExpositions(builder, metrics);
+        builder.append("# EOF\n");
+        return builder.toString();
+    }
+
+    private static OpenMetricsCollector createTestingCollector()
+            throws Exception
+    {
+        MBeanServer mbeanServer = MBeanServerFactory.newMBeanServer();
+        MBeanExporter mbeanExporter = new MBeanExporter(mbeanServer);
+
+        ManagedMetrics managedMetrics = new ManagedMetrics();
+        managedMetrics.getRequests().update(11);
+        managedMetrics.getLatency().add(100);
+        managedMetrics.getLatency().add(200);
+        managedMetrics.forceLatencyMerge();
+        mbeanExporter.export(new ObjectName("io.airlift.openmetrics.test:name=managed"), managedMetrics);
+
+        ObjectName configuredObjectName = new ObjectName("io.airlift.openmetrics.test:name=configured,type=Test");
+        mbeanServer.registerMBean(new StandardMBean(new ConfiguredMetrics(), ConfiguredMetricsMBean.class), configuredObjectName);
+
+        MetricsConfig metricsConfig = new MetricsConfig().setJmxObjectNames(ImmutableList.of(configuredObjectName));
+        NodeInfo nodeInfo = new NodeInfo(
+                "test",
+                "pool",
+                "nodeInfo",
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                IP,
+                null,
+                ImmutableMap.of("team", "a", "region", "b"),
+                false);
+
+        return new OpenMetricsCollector(mbeanServer, mbeanExporter, metricsConfig, nodeInfo);
+    }
+
+    public static class ManagedMetrics
+    {
+        private final CounterStat requests = new CounterStat();
+        private final TestingTicker ticker = new TestingTicker();
+        private final TimeDistribution latency = new TimeDistribution(ticker);
+
+        @Managed(description = "numeric gauge")
+        public int getNumericGauge()
+        {
+            return 7;
+        }
+
+        @Managed(description = "request counter")
+        @Nested
+        public CounterStat getRequests()
+        {
+            return requests;
+        }
+
+        @Managed(description = "request latency")
+        @Nested
+        public TimeDistribution getLatency()
+        {
+            return latency;
+        }
+
+        private void forceLatencyMerge()
+        {
+            ticker.increment(1, SECONDS);
+            latency.getCount();
+        }
+    }
+
+    public interface ConfiguredMetricsMBean
+    {
+        int getCount();
+
+        CompositeData getMemory();
+
+        String getUnsupported();
+    }
+
+    public static class ConfiguredMetrics
+            implements ConfiguredMetricsMBean
+    {
+        @Override
+        public int getCount()
+        {
+            return 23;
+        }
+
+        @Override
+        public CompositeData getMemory()
+        {
+            return createMemoryUsageCompositeData(100, 200, 1000);
+        }
+
+        @Override
+        public String getUnsupported()
+        {
+            return "ignored";
+        }
+    }
+
+    private static CompositeData createMemoryUsageCompositeData(long used, long committed, long max)
+    {
+        try {
+            String[] itemNames = {"used", "committed", "max"};
+            OpenType<?>[] itemTypes = {SimpleType.LONG, SimpleType.LONG, SimpleType.LONG};
+            CompositeType compositeType = new CompositeType("MemoryUsage", "Memory Usage", itemNames, itemNames, itemTypes);
+
+            Map<String, Object> values = ImmutableMap.<String, Object>builder()
+                    .put("used", used)
+                    .put("committed", committed)
+                    .put("max", max)
+                    .buildOrThrow();
+
+            return new CompositeDataSupport(compositeType, values);
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
The extracts the metrics collection from the resource code, so metrics can be inspected directly without going through the resource endpoint.

Add more complete test coverage for metrics collection.

# Airlift contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [x] All automated tests are passing.
 - [x] Pull request was categorized using one of the existing labels.
