### PR TITLE
Allow Object element type via ApiServiceTrait

### DIFF
--- a/api/src/main/java/io/airlift/api/ApiServiceTrait.java
+++ b/api/src/main/java/io/airlift/api/ApiServiceTrait.java
@@ -7,4 +7,5 @@ public enum ApiServiceTrait
     QUOTAS_REQUIRED,
     ENUMS_AS_STRINGS,
     DESCRIPTIONS_REQUIRED,
+    ALLOW_OBJECT_ELEMENTS,
 }

--- a/api/src/main/java/io/airlift/api/builders/ResourceBuilder.java
+++ b/api/src/main/java/io/airlift/api/builders/ResourceBuilder.java
@@ -46,6 +46,7 @@ import static io.airlift.api.internals.Generics.typeResolver;
 import static io.airlift.api.internals.Mappers.openApiName;
 import static io.airlift.api.model.ModelResourceModifier.HAS_RESOURCE_ID;
 import static io.airlift.api.model.ModelResourceModifier.HAS_VERSION;
+import static io.airlift.api.model.ModelResourceModifier.IS_ANY_OBJECT;
 import static io.airlift.api.model.ModelResourceModifier.IS_MULTIPART_FORM;
 import static io.airlift.api.model.ModelResourceModifier.IS_STREAMING_RESPONSE;
 import static io.airlift.api.model.ModelResourceModifier.IS_UNWRAPPED;
@@ -151,6 +152,12 @@ public class ResourceBuilder
         if (typeToken.isSubtypeOf(Collection.class)) {
             Type targetType = extractGenericParameter(typeToken.getType(), 0);
 
+            if (Object.class.equals(targetType)) {
+                return anyObjectLeafResource()
+                        .asResourceType(ModelResourceType.LIST)
+                        .withContainerType(resource);
+            }
+
             recursionChecker.pushRecursionAllowed(true);
             try {
                 return internalBuildAndAdd(componentName, targetType)
@@ -163,6 +170,13 @@ public class ResourceBuilder
         }
 
         if (typeToken.isSubtypeOf(Map.class)) {
+            Type keyType = extractGenericParameter(typeToken.getType(), 0);
+            Type valueType = extractGenericParameter(typeToken.getType(), 1);
+            if (String.class.equals(keyType) && Object.class.equals(valueType)) {
+                return anyObjectLeafResource()
+                        .asResourceType(ModelResourceType.MAP)
+                        .withContainerType(resource);
+            }
             return new ModelResource(String.class, String.class.getSimpleName(), "n/a", ImmutableList.of(), ModelResourceType.MAP).withContainerType(resource);
         }
 
@@ -339,5 +353,10 @@ public class ResourceBuilder
     private Class<?> unboxIfNeeded(Class<?> clazz)
     {
         return supportedBoxedResourceTypes.getOrDefault(clazz, clazz);
+    }
+
+    private static ModelResource anyObjectLeafResource()
+    {
+        return new ModelResource(Object.class, Object.class.getSimpleName(), "n/a", ImmutableList.of(), ModelResourceType.BASIC).withModifier(IS_ANY_OBJECT);
     }
 }

--- a/api/src/main/java/io/airlift/api/model/ModelResourceModifier.java
+++ b/api/src/main/java/io/airlift/api/model/ModelResourceModifier.java
@@ -15,7 +15,8 @@ public enum ModelResourceModifier
     IS_STREAMING_RESPONSE,
     IS_MULTIPART_FORM,
     MULTIPART_RESOURCE_IS_FIRST_ITEM,
-    RECURSIVE_REFERENCE;
+    RECURSIVE_REFERENCE,
+    IS_ANY_OBJECT;
 
     public static boolean hasReadOnly(Collection<ModelResourceModifier> modifiers)
     {

--- a/api/src/main/java/io/airlift/api/openapi/SchemaBuilder.java
+++ b/api/src/main/java/io/airlift/api/openapi/SchemaBuilder.java
@@ -36,6 +36,7 @@ import java.util.stream.Stream;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.airlift.api.ApiOpenApiTrait.USE_ONE_OF_DISCRIMINATORS;
 import static io.airlift.api.internals.Strings.capitalize;
+import static io.airlift.api.model.ModelResourceModifier.IS_ANY_OBJECT;
 import static io.airlift.api.model.ModelResourceModifier.IS_UNWRAPPED;
 import static io.airlift.api.model.ModelResourceModifier.MULTIPART_RESOURCE_IS_FIRST_ITEM;
 import static io.airlift.api.model.ModelResourceModifier.RECURSIVE_REFERENCE;
@@ -149,7 +150,9 @@ class SchemaBuilder
                 case LIST -> asList(modelResource, buildSchema(asResource(removeContainer(modelResource)), mode));
                 case MAP -> new MapSchema().description(adjustedDescription(modelResource)).additionalProperties(buildSchema(asResource(removeContainer(modelResource)), mode));
                 case PAGINATED_RESULT -> buildPaginatedSchema(modelResource);
-                default -> buildBasicOrResourceSchema(modelResource, mode);
+                default -> modelResource.modifiers().contains(IS_ANY_OBJECT)
+                        ? new Schema<>().type("object").description(adjustedDescription(modelResource))
+                        : buildBasicOrResourceSchema(modelResource, mode);
             };
         }
         else {

--- a/api/src/main/java/io/airlift/api/validation/ResourceSerializationValidator.java
+++ b/api/src/main/java/io/airlift/api/validation/ResourceSerializationValidator.java
@@ -133,6 +133,9 @@ public class ResourceSerializationValidator
 
     private Object internalGetDefaultValue(ValidationContext validationContext, Class<?> clazz, Type type)
     {
+        if (Object.class.equals(clazz)) {
+            return "any";
+        }
         if (boolean.class.isAssignableFrom(clazz) || Boolean.class.isAssignableFrom(clazz)) {
             return true;
         }

--- a/api/src/main/java/io/airlift/api/validation/ResourceValidator.java
+++ b/api/src/main/java/io/airlift/api/validation/ResourceValidator.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import static io.airlift.api.ApiResourceVersion.PUBLIC_NAME;
+import static io.airlift.api.ApiServiceTrait.ALLOW_OBJECT_ELEMENTS;
 import static io.airlift.api.ApiServiceTrait.DESCRIPTIONS_REQUIRED;
 import static io.airlift.api.binding.JaxrsUtil.isApiResource;
 import static io.airlift.api.builders.ResourceBuilder.isBasic;
@@ -32,6 +33,7 @@ import static io.airlift.api.internals.Generics.validateMap;
 import static io.airlift.api.internals.Mappers.buildResourceId;
 import static io.airlift.api.internals.Mappers.resourceFromPossibleId;
 import static io.airlift.api.internals.Strings.capitalize;
+import static io.airlift.api.model.ModelResourceModifier.IS_ANY_OBJECT;
 import static io.airlift.api.model.ModelResourceModifier.IS_MULTIPART_FORM;
 import static io.airlift.api.model.ModelResourceModifier.IS_STREAMING_RESPONSE;
 import static io.airlift.api.model.ModelResourceModifier.IS_UNWRAPPED;
@@ -100,9 +102,11 @@ public interface ResourceValidator
 
         switch (modelResource.resourceType()) {
             case LIST -> {
-                Type targetType = modelResource.type();
-
-                if (!state.contains(PARENT_IS_READ_ONLY) && !state.contains(IS_RESULT_RESOURCE)) {
+                if (modelResource.modifiers().contains(IS_ANY_OBJECT)) {
+                    requireAllowObjectElementsTrait(service, modelResource);
+                }
+                else if (!state.contains(PARENT_IS_READ_ONLY) && !state.contains(IS_RESULT_RESOURCE)) {
+                    Type targetType = modelResource.type();
                     if (!(targetType instanceof Class<?> clazz) || (!String.class.isAssignableFrom(clazz) && !ApiId.class.isAssignableFrom(clazz) && !clazz.isEnum() && !clazz.isAnnotationPresent(ApiResource.class) && !clazz.isAnnotationPresent(ApiPolyResource.class))) {
                         throw new ValidatorException("Collections that are not read only must be Collection<String> or Collection<? extends ApiAbstractId> or Collection<? extends Enum> or a collection of resources. %s is not".formatted(targetType));
                     }
@@ -115,13 +119,16 @@ public interface ResourceValidator
                     throw new ValidatorException("%s cannot be used in collections".formatted(ApiStreamResponse.class));
                 }
 
-                if (isApiResource(targetType)) {
+                if (isApiResource(modelResource.type())) {
                     validateDeclaredResource(context, service, modelResource, state);
                 }
             }
 
             case MAP -> {
-                if (modelResource.modifiers().contains(OPTIONAL)) {
+                if (modelResource.modifiers().contains(IS_ANY_OBJECT)) {
+                    requireAllowObjectElementsTrait(service, modelResource);
+                }
+                else if (modelResource.modifiers().contains(OPTIONAL)) {
                     Type type = extractGenericParameter(modelResource.containerType(), 0);
                     validateMap(type);
                 }
@@ -315,5 +322,12 @@ TODO why this?
             throw new ValidatorException("\"%s %s\" is not a valid resource type".formatted(type, name.orElseThrow()));
         }
         throw new ValidatorException("%s is not a valid resource type".formatted(type));
+    }
+
+    private static void requireAllowObjectElementsTrait(ModelServiceMetadata service, ModelResource modelResource)
+    {
+        if (!service.type().serviceTraits().contains(ALLOW_OBJECT_ELEMENTS)) {
+            throw new ValidatorException("%s requires service trait %s".formatted(modelResource.containerType(), ALLOW_OBJECT_ELEMENTS));
+        }
     }
 }

--- a/api/src/test/java/io/airlift/api/validation/ObjectFieldServiceType.java
+++ b/api/src/test/java/io/airlift/api/validation/ObjectFieldServiceType.java
@@ -1,0 +1,41 @@
+package io.airlift.api.validation;
+
+import com.google.common.collect.ImmutableSet;
+import io.airlift.api.ApiServiceTrait;
+import io.airlift.api.ApiServiceType;
+
+import java.util.Set;
+
+public class ObjectFieldServiceType
+        implements ApiServiceType
+{
+    @Override
+    public String id()
+    {
+        return "public";
+    }
+
+    @Override
+    public int version()
+    {
+        return 1;
+    }
+
+    @Override
+    public String title()
+    {
+        return "test";
+    }
+
+    @Override
+    public String description()
+    {
+        return "test";
+    }
+
+    @Override
+    public Set<ApiServiceTrait> traits()
+    {
+        return ImmutableSet.of(ApiServiceTrait.ALLOW_OBJECT_ELEMENTS);
+    }
+}

--- a/api/src/test/java/io/airlift/api/validation/ResourceWithObjectField.java
+++ b/api/src/test/java/io/airlift/api/validation/ResourceWithObjectField.java
@@ -1,0 +1,13 @@
+package io.airlift.api.validation;
+
+import io.airlift.api.ApiDescription;
+import io.airlift.api.ApiResource;
+
+import java.util.List;
+import java.util.Map;
+
+@ApiResource(name = "objectField", description = "Resource with Object container fields")
+public record ResourceWithObjectField(
+        @ApiDescription("A name") String name,
+        @ApiDescription("Free-form list") List<Object> payloads,
+        @ApiDescription("Free-form map") Map<String, Object> attributes) {}

--- a/api/src/test/java/io/airlift/api/validation/ServiceWithObjectField.java
+++ b/api/src/test/java/io/airlift/api/validation/ServiceWithObjectField.java
@@ -1,0 +1,11 @@
+package io.airlift.api.validation;
+
+import io.airlift.api.ApiCreate;
+import io.airlift.api.ApiService;
+
+@ApiService(name = "objectFieldService", type = ObjectFieldServiceType.class, description = "Service with an Object field")
+public class ServiceWithObjectField
+{
+    @ApiCreate(description = "create something with an Object field")
+    public void create(ResourceWithObjectField ignore) {}
+}

--- a/api/src/test/java/io/airlift/api/validation/ServiceWithObjectFieldNoTrait.java
+++ b/api/src/test/java/io/airlift/api/validation/ServiceWithObjectFieldNoTrait.java
@@ -1,0 +1,12 @@
+package io.airlift.api.validation;
+
+import io.airlift.api.ApiCreate;
+import io.airlift.api.ApiService;
+import io.airlift.api.ServiceType;
+
+@ApiService(name = "objectFieldServiceNoTrait", type = ServiceType.class, description = "Service with an Object field but no trait")
+public class ServiceWithObjectFieldNoTrait
+{
+    @ApiCreate(description = "create something with an Object field", quotas = "yep")
+    public void create(ResourceWithObjectField ignore) {}
+}

--- a/api/src/test/java/io/airlift/api/validation/TestConforming.java
+++ b/api/src/test/java/io/airlift/api/validation/TestConforming.java
@@ -149,6 +149,23 @@ public class TestConforming
     }
 
     @Test
+    public void testAllowedObjectContainers()
+    {
+        // service whose type carries ALLOW_OBJECT_ELEMENTS may declare List<Object> / Map<String, Object> fields
+        ModelApi modelApi = ApiBuilder.apiBuilder().add(ServiceWithObjectField.class).build();
+        Module module = ApiModule.builder().addApi(modelApi).build();
+        Guice.createInjector(module, new JsonModule());
+    }
+
+    @Test
+    public void testObjectContainerWithoutTrait()
+    {
+        // service whose type lacks ALLOW_OBJECT_ELEMENTS must reject List<Object> / Map<String, Object>
+        ModelServices services = ApiBuilder.apiBuilder().add(ServiceWithObjectFieldNoTrait.class).build().modelServices();
+        assertThat(services.errors()).anyMatch(s -> s.contains("ALLOW_OBJECT_ELEMENTS"));
+    }
+
+    @Test
     public void testBadLookup()
     {
         ModelApi modelApi = ApiBuilder.apiBuilder().add(ServiceWithBadLookup.class).build();


### PR DESCRIPTION
Add a `ApiServiceTrait.ALLOW_OBJECT_ELEMENTS` trait so record components of type `List<Object>` or `Map<String, Object>` are accepted by the API builder and exposed as free-form `type: object` elements in the generated OpenAPI schema. `Object` fields remain rejected as before.

# Airlift contribution check list

 - [ ] Git commit messages follow https://cbea.ms/git-commit/.
 - [ ] All automated tests are passing.
 - [ ] Pull request was categorized using one of the existing labels.
