### PR TITLE
Support external metric producers

### DIFF
--- a/opentelemetry/src/main/java/io/airlift/opentelemetry/OpenTelemetryModule.java
+++ b/opentelemetry/src/main/java/io/airlift/opentelemetry/OpenTelemetryModule.java
@@ -20,6 +20,7 @@ import io.opentelemetry.sdk.logs.SdkLoggerProvider;
 import io.opentelemetry.sdk.logs.SdkLoggerProviderBuilder;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder;
+import io.opentelemetry.sdk.metrics.export.MetricProducer;
 import io.opentelemetry.sdk.metrics.export.MetricReader;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
@@ -67,6 +68,7 @@ public class OpenTelemetryModule
     {
         newSetBinder(binder, SpanProcessor.class);
         newSetBinder(binder, MetricReader.class);
+        newSetBinder(binder, MetricProducer.class);
         newSetBinder(binder, LogRecordProcessor.class);
         configBinder(binder).bindConfig(OpenTelemetryConfig.class);
     }
@@ -76,12 +78,13 @@ public class OpenTelemetryModule
     public OpenTelemetry createOpenTelemetry(
             Set<SpanProcessor> spanProcessors,
             Set<MetricReader> metricReaders,
+            Set<MetricProducer> metricProducers,
             Set<LogRecordProcessor> logRecordProcessors,
             SdkTracerProvider tracerProvider,
             SdkMeterProvider meterProvider,
             SdkLoggerProvider loggerProvider)
     {
-        if (spanProcessors.isEmpty() && metricReaders.isEmpty() && logRecordProcessors.isEmpty()) {
+        if (spanProcessors.isEmpty() && metricReaders.isEmpty() && metricProducers.isEmpty() && logRecordProcessors.isEmpty()) {
             return OpenTelemetry.noop();
         }
 
@@ -141,11 +144,12 @@ public class OpenTelemetryModule
 
     @Provides
     @Singleton
-    public SdkMeterProvider createMeterProvider(Resource resource, Set<MetricReader> metricReaders)
+    public SdkMeterProvider createMeterProvider(Resource resource, Set<MetricReader> metricReaders, Set<MetricProducer> metricProducers)
     {
         SdkMeterProviderBuilder builder = SdkMeterProvider.builder()
                 .setResource(resource);
         metricReaders.forEach(builder::registerMetricReader);
+        metricProducers.forEach(builder::registerMetricProducer);
         return builder.build();
     }
 
@@ -161,9 +165,9 @@ public class OpenTelemetryModule
 
     @Provides
     @Singleton
-    public Meter createMeter(Set<MetricReader> metricReaders, SdkMeterProvider meterProvider)
+    public Meter createMeter(Set<MetricReader> metricReaders, Set<MetricProducer> metricProducers, SdkMeterProvider meterProvider)
     {
-        if (metricReaders.isEmpty()) {
+        if (metricReaders.isEmpty() && metricProducers.isEmpty()) {
             return MeterProvider.noop().get("noop");
         }
         return meterProvider.get(serviceName);

--- a/opentelemetry/src/test/java/io/airlift/opentelemetry/TestOpenTelemetryModule.java
+++ b/opentelemetry/src/test/java/io/airlift/opentelemetry/TestOpenTelemetryModule.java
@@ -14,10 +14,12 @@ import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.logs.export.SimpleLogRecordProcessor;
 import io.opentelemetry.sdk.metrics.data.LongPointData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.export.MetricProducer;
 import io.opentelemetry.sdk.metrics.export.MetricReader;
 import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
 import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricExporter;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.data.SpanData;
@@ -25,6 +27,9 @@ import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.semconv.DeploymentAttributes;
 import io.opentelemetry.semconv.ServiceAttributes;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.google.common.collect.MoreCollectors.onlyElement;
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
@@ -183,5 +188,31 @@ public class TestOpenTelemetryModule
                 entry(ServiceAttributes.SERVICE_NAME, "testService"),
                 entry(ServiceAttributes.SERVICE_VERSION, "testVersion"),
                 entry(DeploymentAttributes.DEPLOYMENT_ENVIRONMENT_NAME, environment));
+    }
+
+    @Test
+    void testCustomMetricProducer()
+    {
+        InMemoryMetricReader reader = InMemoryMetricReader.create();
+        AtomicBoolean produced = new AtomicBoolean();
+        MetricProducer producer = _ -> {
+            produced.set(true);
+            return List.of();
+        };
+
+        Injector injector = new Bootstrap(
+                new TestingNodeModule(),
+                new OpenTelemetryModule("testService", "testVersion"),
+                binder -> newSetBinder(binder, MetricReader.class).addBinding()
+                        .toInstance(reader),
+                binder -> newSetBinder(binder, MetricProducer.class).addBinding()
+                        .toInstance(producer))
+                .quiet()
+                .initialize();
+
+        injector.getInstance(Meter.class);
+        reader.collectAllMetrics();
+
+        assertThat(produced).isTrue();
     }
 }


### PR DESCRIPTION
## Why
- Applications can already bind custom span processors, metric readers, and log record processors into Airlift's OpenTelemetry module.
- MetricProducer is the corresponding OpenTelemetry SDK extension point for callback-style metric sources.
- Without a Guice binding for MetricProducer, applications that need producer-backed metrics must replace or duplicate Airlift's OpenTelemetry module wiring.

## Approach
- Add a MetricProducer multibinder to OpenTelemetryModule.
- Register bound producers with SdkMeterProvider alongside bound metric readers.
- Include metric producers in the module's metric no-op checks.

## Test plan
- mvnd airstyle:format -pl opentelemetry -Dairstyle.includes=io/airlift/opentelemetry/OpenTelemetryModule.java,io/airlift/opentelemetry/TestOpenTelemetryModule.java
- mvnd install -pl opentelemetry -am -DskipTests
- mvnd test -pl opentelemetry -Dtest=TestOpenTelemetryModule