### PR TITLE
Add OTLP TLS private key password and PEM config support

### DIFF
--- a/opentelemetry/pom.xml
+++ b/opentelemetry/pom.xml
@@ -36,6 +36,11 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>security</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>units</artifactId>
         </dependency>
 

--- a/opentelemetry/src/main/java/io/airlift/opentelemetry/OpenTelemetryExporterConfig.java
+++ b/opentelemetry/src/main/java/io/airlift/opentelemetry/OpenTelemetryExporterConfig.java
@@ -27,8 +27,11 @@ public class OpenTelemetryExporterConfig
     private Optional<Integer> logMaxQueueSize = Optional.empty();
     private Optional<Duration> logScheduleDelay = Optional.empty();
     private Optional<Path> trustedCertificatesPath = Optional.empty();
+    private Optional<String> trustedCertificatesPem = Optional.empty();
     private Optional<Path> clientCertificatePath = Optional.empty();
+    private Optional<String> clientCertificatePem = Optional.empty();
     private Optional<Path> clientKeyPath = Optional.empty();
+    private Optional<String> clientKeyPem = Optional.empty();
     private Optional<String> clientKeyPassword = Optional.empty();
 
     @NotNull
@@ -174,6 +177,18 @@ public class OpenTelemetryExporterConfig
         return this;
     }
 
+    public Optional<String> getTrustedCertificatesPem()
+    {
+        return trustedCertificatesPem;
+    }
+
+    @Config("otel.exporter.tls.trusted-certificates-pem")
+    public OpenTelemetryExporterConfig setTrustedCertificatesPem(String trustedCertificatesPem)
+    {
+        this.trustedCertificatesPem = Optional.ofNullable(trustedCertificatesPem);
+        return this;
+    }
+
     public Optional<@FileExists Path> getClientCertificatePath()
     {
         return clientCertificatePath;
@@ -186,6 +201,18 @@ public class OpenTelemetryExporterConfig
         return this;
     }
 
+    public Optional<String> getClientCertificatePem()
+    {
+        return clientCertificatePem;
+    }
+
+    @Config("otel.exporter.tls.client-certificate-pem")
+    public OpenTelemetryExporterConfig setClientCertificatePem(String clientCertificatePem)
+    {
+        this.clientCertificatePem = Optional.ofNullable(clientCertificatePem);
+        return this;
+    }
+
     public Optional<@FileExists Path> getClientKeyPath()
     {
         return clientKeyPath;
@@ -195,6 +222,19 @@ public class OpenTelemetryExporterConfig
     public OpenTelemetryExporterConfig setClientKeyPath(Path clientKeyPath)
     {
         this.clientKeyPath = Optional.ofNullable(clientKeyPath);
+        return this;
+    }
+
+    public Optional<String> getClientKeyPem()
+    {
+        return clientKeyPem;
+    }
+
+    @Config("otel.exporter.tls.client-key-pem")
+    @ConfigSecuritySensitive
+    public OpenTelemetryExporterConfig setClientKeyPem(String clientKeyPem)
+    {
+        this.clientKeyPem = Optional.ofNullable(clientKeyPem);
         return this;
     }
 
@@ -211,15 +251,43 @@ public class OpenTelemetryExporterConfig
         return this;
     }
 
-    @AssertTrue(message = "client certificate and key paths must be set together")
+    @AssertTrue(message = "client certificate and key must be set together")
     public boolean isClientTlsValid()
     {
-        return clientCertificatePath.isPresent() == clientKeyPath.isPresent();
+        return hasClientCertificate() == hasClientKey();
     }
 
-    @AssertTrue(message = "client key password requires client key path")
+    @AssertTrue(message = "client key password requires client key")
     public boolean isClientKeyPasswordValid()
     {
-        return clientKeyPassword.isEmpty() || clientKeyPath.isPresent();
+        return clientKeyPassword.isEmpty() || hasClientKey();
+    }
+
+    @AssertTrue(message = "trusted certificates path and PEM cannot both be set")
+    public boolean isTrustedCertificatesSourceValid()
+    {
+        return trustedCertificatesPath.isEmpty() || trustedCertificatesPem.isEmpty();
+    }
+
+    @AssertTrue(message = "client certificate path and PEM cannot both be set")
+    public boolean isClientCertificateSourceValid()
+    {
+        return clientCertificatePath.isEmpty() || clientCertificatePem.isEmpty();
+    }
+
+    @AssertTrue(message = "client key path and PEM cannot both be set")
+    public boolean isClientKeySourceValid()
+    {
+        return clientKeyPath.isEmpty() || clientKeyPem.isEmpty();
+    }
+
+    private boolean hasClientCertificate()
+    {
+        return clientCertificatePath.isPresent() || clientCertificatePem.isPresent();
+    }
+
+    private boolean hasClientKey()
+    {
+        return clientKeyPath.isPresent() || clientKeyPem.isPresent();
     }
 }

--- a/opentelemetry/src/main/java/io/airlift/opentelemetry/OpenTelemetryExporterConfig.java
+++ b/opentelemetry/src/main/java/io/airlift/opentelemetry/OpenTelemetryExporterConfig.java
@@ -1,6 +1,7 @@
 package io.airlift.opentelemetry;
 
 import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigSecuritySensitive;
 import io.airlift.configuration.LegacyConfig;
 import io.airlift.configuration.validation.FileExists;
 import io.airlift.units.Duration;
@@ -28,6 +29,7 @@ public class OpenTelemetryExporterConfig
     private Optional<Path> trustedCertificatesPath = Optional.empty();
     private Optional<Path> clientCertificatePath = Optional.empty();
     private Optional<Path> clientKeyPath = Optional.empty();
+    private Optional<String> clientKeyPassword = Optional.empty();
 
     @NotNull
     @Pattern(regexp = "^(http|https)://.*$", message = "must start with http:// or https://")
@@ -196,9 +198,28 @@ public class OpenTelemetryExporterConfig
         return this;
     }
 
+    public Optional<String> getClientKeyPassword()
+    {
+        return clientKeyPassword;
+    }
+
+    @Config("otel.exporter.tls.client-key-password")
+    @ConfigSecuritySensitive
+    public OpenTelemetryExporterConfig setClientKeyPassword(String clientKeyPassword)
+    {
+        this.clientKeyPassword = Optional.ofNullable(clientKeyPassword);
+        return this;
+    }
+
     @AssertTrue(message = "client certificate and key paths must be set together")
     public boolean isClientTlsValid()
     {
         return clientCertificatePath.isPresent() == clientKeyPath.isPresent();
+    }
+
+    @AssertTrue(message = "client key password requires client key path")
+    public boolean isClientKeyPasswordValid()
+    {
+        return clientKeyPassword.isEmpty() || clientKeyPath.isPresent();
     }
 }

--- a/opentelemetry/src/main/java/io/airlift/opentelemetry/OpenTelemetryExporterModule.java
+++ b/opentelemetry/src/main/java/io/airlift/opentelemetry/OpenTelemetryExporterModule.java
@@ -3,6 +3,8 @@ package io.airlift.opentelemetry;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.multibindings.ProvidesIntoSet;
+import io.airlift.security.pem.PemReader;
+import io.airlift.security.pem.PemWriter;
 import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporter;
 import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporterBuilder;
 import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter;
@@ -32,9 +34,12 @@ import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
+import java.security.GeneralSecurityException;
+import java.util.Optional;
 import java.util.function.BiConsumer;
 
 import static io.airlift.configuration.ConfigBinder.configBinder;
+import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.nio.file.Files.readAllBytes;
 
 public class OpenTelemetryExporterModule
@@ -151,7 +156,7 @@ public class OpenTelemetryExporterModule
         if (config.getClientCertificatePath().isPresent() && config.getClientKeyPath().isPresent()) {
             clientTlsSetter.accept(
                     builder,
-                    readFile(config.getClientKeyPath().orElseThrow()),
+                    readPrivateKeyFile(config.getClientKeyPath().orElseThrow(), config.getClientKeyPassword()),
                     readFile(config.getClientCertificatePath().orElseThrow()));
         }
 
@@ -165,6 +170,24 @@ public class OpenTelemetryExporterModule
         }
         catch (IOException e) {
             throw new UncheckedIOException("Failed to read OpenTelemetry TLS file: " + path, e);
+        }
+    }
+
+    private static byte[] readPrivateKeyFile(Path path, Optional<String> password)
+    {
+        if (password.isEmpty()) {
+            return readFile(path);
+        }
+
+        try {
+            // OTLP does not accept encrypted PEM private keys, so decode and reencode the key.
+            return PemWriter.writePrivateKey(PemReader.loadPrivateKey(path.toFile(), password)).getBytes(US_ASCII);
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException("Failed to read OpenTelemetry client key file: " + path, e);
+        }
+        catch (GeneralSecurityException e) {
+            throw new IllegalArgumentException("Failed to read OpenTelemetry client key file: " + path, e);
         }
     }
 

--- a/opentelemetry/src/main/java/io/airlift/opentelemetry/OpenTelemetryExporterModule.java
+++ b/opentelemetry/src/main/java/io/airlift/opentelemetry/OpenTelemetryExporterModule.java
@@ -150,45 +150,63 @@ public class OpenTelemetryExporterModule
             ClientTlsSetter<T> clientTlsSetter)
     {
         config.getTrustedCertificatesPath()
-                .map(OpenTelemetryExporterModule::readFile)
+                .map(path -> readFile(path, "OpenTelemetry trusted certificates"))
+                .or(() -> config.getTrustedCertificatesPem().map(OpenTelemetryExporterModule::pemToBytes))
                 .ifPresent(trustedCertificates -> trustedCertificatesSetter.accept(builder, trustedCertificates));
 
-        if (config.getClientCertificatePath().isPresent() && config.getClientKeyPath().isPresent()) {
+        Optional<byte[]> clientKey = readPrivateKey(config.getClientKeyPath(), config.getClientKeyPem(), config.getClientKeyPassword());
+        Optional<byte[]> clientCertificate = config.getClientCertificatePath()
+                .map(path -> readFile(path, "OpenTelemetry client certificate"))
+                .or(() -> config.getClientCertificatePem().map(OpenTelemetryExporterModule::pemToBytes));
+        if (clientKey.isPresent() && clientCertificate.isPresent()) {
             clientTlsSetter.accept(
                     builder,
-                    readPrivateKeyFile(config.getClientKeyPath().orElseThrow(), config.getClientKeyPassword()),
-                    readFile(config.getClientCertificatePath().orElseThrow()));
+                    clientKey.orElseThrow(),
+                    clientCertificate.orElseThrow());
         }
 
         return builder;
     }
 
-    private static byte[] readFile(Path path)
+    private static byte[] readFile(Path path, String description)
     {
         try {
             return readAllBytes(path);
         }
         catch (IOException e) {
-            throw new UncheckedIOException("Failed to read OpenTelemetry TLS file: " + path, e);
+            throw new UncheckedIOException("Failed to read " + description + " file: " + path, e);
         }
     }
 
-    private static byte[] readPrivateKeyFile(Path path, Optional<String> password)
+    private static Optional<byte[]> readPrivateKey(Optional<Path> path, Optional<String> pem, Optional<String> password)
     {
+        if (path.isEmpty() && pem.isEmpty()) {
+            return Optional.empty();
+        }
+
         if (password.isEmpty()) {
-            return readFile(path);
+            return Optional.of(path.map(file -> readFile(file, "OpenTelemetry client key"))
+                    .orElseGet(() -> pemToBytes(pem.orElseThrow())));
         }
 
         try {
             // OTLP does not accept encrypted PEM private keys, so decode and reencode the key.
-            return PemWriter.writePrivateKey(PemReader.loadPrivateKey(path.toFile(), password)).getBytes(US_ASCII);
+            if (path.isPresent()) {
+                return Optional.of(PemWriter.writePrivateKey(PemReader.loadPrivateKey(path.orElseThrow().toFile(), password)).getBytes(US_ASCII));
+            }
+            return Optional.of(PemWriter.writePrivateKey(PemReader.loadPrivateKey(pem.orElseThrow(), password)).getBytes(US_ASCII));
         }
         catch (IOException e) {
-            throw new UncheckedIOException("Failed to read OpenTelemetry client key file: " + path, e);
+            throw new UncheckedIOException("Failed to read OpenTelemetry client key", e);
         }
         catch (GeneralSecurityException e) {
-            throw new IllegalArgumentException("Failed to read OpenTelemetry client key file: " + path, e);
+            throw new IllegalArgumentException("Failed to read OpenTelemetry client key", e);
         }
+    }
+
+    private static byte[] pemToBytes(String pem)
+    {
+        return pem.getBytes(US_ASCII);
     }
 
     @FunctionalInterface

--- a/opentelemetry/src/test/java/io/airlift/opentelemetry/TestOpenTelemetryExporterConfig.java
+++ b/opentelemetry/src/test/java/io/airlift/opentelemetry/TestOpenTelemetryExporterConfig.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
@@ -33,8 +34,11 @@ public class TestOpenTelemetryExporterConfig
                 .setLogMaxQueueSize(null)
                 .setLogScheduleDelay(null)
                 .setTrustedCertificatesPath(null)
+                .setTrustedCertificatesPem(null)
                 .setClientCertificatePath(null)
+                .setClientCertificatePem(null)
                 .setClientKeyPath(null)
+                .setClientKeyPem(null)
                 .setClientKeyPassword(null));
     }
 
@@ -72,7 +76,47 @@ public class TestOpenTelemetryExporterConfig
                 .setClientKeyPath(Path.of("./pom.xml"))
                 .setClientKeyPassword("key-password");
 
-        assertFullMapping(properties, expected);
+        assertFullMapping(
+                properties,
+                expected,
+                Set.of(
+                        "otel.exporter.tls.trusted-certificates-pem",
+                        "otel.exporter.tls.client-certificate-pem",
+                        "otel.exporter.tls.client-key-pem"));
+    }
+
+    @Test
+    public void testExplicitPemPropertyMappings()
+    {
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("otel.exporter.tls.trusted-certificates-pem", "trusted-certificates-pem")
+                .put("otel.exporter.tls.client-certificate-pem", "client-certificate-pem")
+                .put("otel.exporter.tls.client-key-pem", "client-key-pem")
+                .put("otel.exporter.tls.client-key-password", "key-password")
+                .buildOrThrow();
+
+        OpenTelemetryExporterConfig expected = new OpenTelemetryExporterConfig()
+                .setTrustedCertificatesPem("trusted-certificates-pem")
+                .setClientCertificatePem("client-certificate-pem")
+                .setClientKeyPem("client-key-pem")
+                .setClientKeyPassword("key-password");
+
+        assertFullMapping(
+                properties,
+                expected,
+                Set.of(
+                        "otel.exporter.endpoint",
+                        "otel.exporter.protocol",
+                        "otel.exporter.interval",
+                        "otel.exporter.span.max-export-batch-size",
+                        "otel.exporter.span.max-queue-size",
+                        "otel.exporter.span.schedule-delay",
+                        "otel.exporter.log.max-export-batch-size",
+                        "otel.exporter.log.max-queue-size",
+                        "otel.exporter.log.schedule-delay",
+                        "otel.exporter.tls.trusted-certificates-path",
+                        "otel.exporter.tls.client-certificate-path",
+                        "otel.exporter.tls.client-key-path"));
     }
 
     @Test
@@ -82,7 +126,18 @@ public class TestOpenTelemetryExporterConfig
                 new OpenTelemetryExporterConfig()
                         .setClientCertificatePath(Path.of("/certs/client.pem")),
                 "clientTlsValid",
-                "client certificate and key paths must be set together",
+                "client certificate and key must be set together",
+                AssertTrue.class);
+    }
+
+    @Test
+    public void testClientCertificatePemWithoutKeyFailsValidation()
+    {
+        assertFailsValidation(
+                new OpenTelemetryExporterConfig()
+                        .setClientCertificatePem("client-certificate-pem"),
+                "clientTlsValid",
+                "client certificate and key must be set together",
                 AssertTrue.class);
     }
 
@@ -93,7 +148,18 @@ public class TestOpenTelemetryExporterConfig
                 new OpenTelemetryExporterConfig()
                         .setClientKeyPath(Path.of("/certs/client.key")),
                 "clientTlsValid",
-                "client certificate and key paths must be set together",
+                "client certificate and key must be set together",
+                AssertTrue.class);
+    }
+
+    @Test
+    public void testClientKeyPemWithoutCertificateFailsValidation()
+    {
+        assertFailsValidation(
+                new OpenTelemetryExporterConfig()
+                        .setClientKeyPem("client-key-pem"),
+                "clientTlsValid",
+                "client certificate and key must be set together",
                 AssertTrue.class);
     }
 
@@ -104,7 +170,43 @@ public class TestOpenTelemetryExporterConfig
                 new OpenTelemetryExporterConfig()
                         .setClientKeyPassword("key-password"),
                 "clientKeyPasswordValid",
-                "client key password requires client key path",
+                "client key password requires client key",
+                AssertTrue.class);
+    }
+
+    @Test
+    public void testTrustedCertificatesPathAndPemFailsValidation()
+    {
+        assertFailsValidation(
+                new OpenTelemetryExporterConfig()
+                        .setTrustedCertificatesPath(Path.of("./pom.xml"))
+                        .setTrustedCertificatesPem("trusted-certificates-pem"),
+                "trustedCertificatesSourceValid",
+                "trusted certificates path and PEM cannot both be set",
+                AssertTrue.class);
+    }
+
+    @Test
+    public void testClientCertificatePathAndPemFailsValidation()
+    {
+        assertFailsValidation(
+                new OpenTelemetryExporterConfig()
+                        .setClientCertificatePath(Path.of("./pom.xml"))
+                        .setClientCertificatePem("client-certificate-pem"),
+                "clientCertificateSourceValid",
+                "client certificate path and PEM cannot both be set",
+                AssertTrue.class);
+    }
+
+    @Test
+    public void testClientKeyPathAndPemFailsValidation()
+    {
+        assertFailsValidation(
+                new OpenTelemetryExporterConfig()
+                        .setClientKeyPath(Path.of("./pom.xml"))
+                        .setClientKeyPem("client-key-pem"),
+                "clientKeySourceValid",
+                "client key path and PEM cannot both be set",
                 AssertTrue.class);
     }
 

--- a/opentelemetry/src/test/java/io/airlift/opentelemetry/TestOpenTelemetryExporterConfig.java
+++ b/opentelemetry/src/test/java/io/airlift/opentelemetry/TestOpenTelemetryExporterConfig.java
@@ -34,7 +34,8 @@ public class TestOpenTelemetryExporterConfig
                 .setLogScheduleDelay(null)
                 .setTrustedCertificatesPath(null)
                 .setClientCertificatePath(null)
-                .setClientKeyPath(null));
+                .setClientKeyPath(null)
+                .setClientKeyPassword(null));
     }
 
     @Test
@@ -53,6 +54,7 @@ public class TestOpenTelemetryExporterConfig
                 .put("otel.exporter.tls.trusted-certificates-path", "./pom.xml")
                 .put("otel.exporter.tls.client-certificate-path", "./pom.xml")
                 .put("otel.exporter.tls.client-key-path", "./pom.xml")
+                .put("otel.exporter.tls.client-key-password", "key-password")
                 .buildOrThrow();
 
         OpenTelemetryExporterConfig expected = new OpenTelemetryExporterConfig()
@@ -67,7 +69,8 @@ public class TestOpenTelemetryExporterConfig
                 .setLogScheduleDelay(new Duration(5, TimeUnit.SECONDS))
                 .setTrustedCertificatesPath(Path.of("./pom.xml"))
                 .setClientCertificatePath(Path.of("./pom.xml"))
-                .setClientKeyPath(Path.of("./pom.xml"));
+                .setClientKeyPath(Path.of("./pom.xml"))
+                .setClientKeyPassword("key-password");
 
         assertFullMapping(properties, expected);
     }
@@ -91,6 +94,17 @@ public class TestOpenTelemetryExporterConfig
                         .setClientKeyPath(Path.of("/certs/client.key")),
                 "clientTlsValid",
                 "client certificate and key paths must be set together",
+                AssertTrue.class);
+    }
+
+    @Test
+    public void testClientKeyPasswordWithoutKeyFailsValidation()
+    {
+        assertFailsValidation(
+                new OpenTelemetryExporterConfig()
+                        .setClientKeyPassword("key-password"),
+                "clientKeyPasswordValid",
+                "client key password requires client key path",
                 AssertTrue.class);
     }
 

--- a/opentelemetry/src/test/java/io/airlift/opentelemetry/TestOpenTelemetryExporterModule.java
+++ b/opentelemetry/src/test/java/io/airlift/opentelemetry/TestOpenTelemetryExporterModule.java
@@ -1,5 +1,7 @@
 package io.airlift.opentelemetry;
 
+import io.airlift.security.cert.CertificateBuilder;
+import io.airlift.security.pem.PemWriter;
 import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporter;
 import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter;
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
@@ -11,12 +13,33 @@ import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import org.junit.jupiter.api.Test;
 
+import javax.crypto.Cipher;
+import javax.crypto.EncryptedPrivateKeyInfo;
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.spec.PBEParameterSpec;
+import javax.security.auth.x500.X500Principal;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.cert.X509Certificate;
+import java.security.spec.ECGenParameterSpec;
+import java.time.LocalDate;
+import java.time.ZoneId;
+
 import static io.airlift.opentelemetry.OpenTelemetryExporterConfig.Protocol.GRPC;
 import static io.airlift.opentelemetry.OpenTelemetryExporterConfig.Protocol.HTTP_PROTOBUF;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static java.util.Base64.getMimeEncoder;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static javax.crypto.Cipher.ENCRYPT_MODE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 final class TestOpenTelemetryExporterModule
 {
+    private static final String KEY_PASSWORD = "key-password";
+
     @Test
     void testGrpcExporterIsCreated()
     {
@@ -24,14 +47,7 @@ final class TestOpenTelemetryExporterModule
                 .setProtocol(GRPC)
                 .setEndpoint("http://localhost:4317");
 
-        SpanExporter spanExporter = OpenTelemetryExporterModule.createSpanExporter(config);
-        assertThat(spanExporter).isInstanceOf(OtlpGrpcSpanExporter.class);
-
-        MetricExporter metricExporter = OpenTelemetryExporterModule.createMetricExporter(config);
-        assertThat(metricExporter).isInstanceOf(OtlpGrpcMetricExporter.class);
-
-        LogRecordExporter logRecordExporter = OpenTelemetryExporterModule.createLogRecordExporter(config);
-        assertThat(logRecordExporter).isInstanceOf(OtlpGrpcLogRecordExporter.class);
+        assertExportersCreated(config);
     }
 
     @Test
@@ -41,13 +57,129 @@ final class TestOpenTelemetryExporterModule
                 .setProtocol(HTTP_PROTOBUF)
                 .setEndpoint("http://localhost:4317");
 
-        SpanExporter spanExporter = OpenTelemetryExporterModule.createSpanExporter(config);
-        assertThat(spanExporter).isInstanceOf(OtlpHttpSpanExporter.class);
-
-        MetricExporter metricExporter = OpenTelemetryExporterModule.createMetricExporter(config);
-        assertThat(metricExporter).isInstanceOf(OtlpHttpMetricExporter.class);
-
-        LogRecordExporter logRecordExporter = OpenTelemetryExporterModule.createLogRecordExporter(config);
-        assertThat(logRecordExporter).isInstanceOf(OtlpHttpLogRecordExporter.class);
+        assertExportersCreated(config);
     }
+
+    @Test
+    void testPemTlsConfigIsLoaded()
+            throws Exception
+    {
+        TlsMaterials tlsMaterials = createTlsMaterials();
+
+        assertExportersCreated(new OpenTelemetryExporterConfig()
+                .setProtocol(GRPC)
+                .setEndpoint("https://localhost:4317")
+                .setTrustedCertificatesPem(tlsMaterials.certificatePem())
+                .setClientCertificatePem(tlsMaterials.certificatePem())
+                .setClientKeyPem(tlsMaterials.privateKeyPem()));
+
+        assertExportersCreated(new OpenTelemetryExporterConfig()
+                .setProtocol(HTTP_PROTOBUF)
+                .setEndpoint("https://localhost:4318")
+                .setTrustedCertificatesPem(tlsMaterials.certificatePem())
+                .setClientCertificatePem(tlsMaterials.certificatePem())
+                .setClientKeyPem(tlsMaterials.privateKeyPem()));
+    }
+
+    @Test
+    void testEncryptedPemClientKeyIsLoaded()
+            throws Exception
+    {
+        TlsMaterials tlsMaterials = createTlsMaterials();
+
+        assertExportersCreated(new OpenTelemetryExporterConfig()
+                .setProtocol(GRPC)
+                .setEndpoint("https://localhost:4317")
+                .setTrustedCertificatesPem(tlsMaterials.certificatePem())
+                .setClientCertificatePem(tlsMaterials.certificatePem())
+                .setClientKeyPem(tlsMaterials.encryptedPrivateKeyPem())
+                .setClientKeyPassword(KEY_PASSWORD));
+
+        assertExportersCreated(new OpenTelemetryExporterConfig()
+                .setProtocol(HTTP_PROTOBUF)
+                .setEndpoint("https://localhost:4318")
+                .setTrustedCertificatesPem(tlsMaterials.certificatePem())
+                .setClientCertificatePem(tlsMaterials.certificatePem())
+                .setClientKeyPem(tlsMaterials.encryptedPrivateKeyPem())
+                .setClientKeyPassword(KEY_PASSWORD));
+    }
+
+    private static void assertExportersCreated(OpenTelemetryExporterConfig config)
+    {
+        SpanExporter spanExporter = null;
+        MetricExporter metricExporter = null;
+        LogRecordExporter logRecordExporter = null;
+        try {
+            spanExporter = OpenTelemetryExporterModule.createSpanExporter(config);
+            metricExporter = OpenTelemetryExporterModule.createMetricExporter(config);
+            logRecordExporter = OpenTelemetryExporterModule.createLogRecordExporter(config);
+
+            if (config.getProtocol() == GRPC) {
+                assertThat(spanExporter).isInstanceOf(OtlpGrpcSpanExporter.class);
+                assertThat(metricExporter).isInstanceOf(OtlpGrpcMetricExporter.class);
+                assertThat(logRecordExporter).isInstanceOf(OtlpGrpcLogRecordExporter.class);
+                return;
+            }
+
+            assertThat(spanExporter).isInstanceOf(OtlpHttpSpanExporter.class);
+            assertThat(metricExporter).isInstanceOf(OtlpHttpMetricExporter.class);
+            assertThat(logRecordExporter).isInstanceOf(OtlpHttpLogRecordExporter.class);
+        }
+        finally {
+            if (spanExporter != null) {
+                spanExporter.shutdown().join(10, SECONDS);
+            }
+            if (metricExporter != null) {
+                metricExporter.shutdown().join(10, SECONDS);
+            }
+            if (logRecordExporter != null) {
+                logRecordExporter.shutdown().join(10, SECONDS);
+            }
+        }
+    }
+
+    private static TlsMaterials createTlsMaterials()
+            throws Exception
+    {
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("EC");
+        generator.initialize(new ECGenParameterSpec("secp256r1"));
+        KeyPair keyPair = generator.generateKeyPair();
+        LocalDate notBefore = LocalDate.now(ZoneId.systemDefault());
+
+        X509Certificate certificate = CertificateBuilder.certificateBuilder()
+                .setKeyPair(keyPair)
+                .setSerialNumber(12345)
+                .setIssuer(new X500Principal("CN=issuer,O=Airlift"))
+                .setNotBefore(notBefore)
+                .setNotAfter(notBefore.plusDays(1))
+                .setSubject(new X500Principal("CN=subject,O=Airlift"))
+                .buildSelfSigned();
+
+        return new TlsMaterials(
+                PemWriter.writeCertificate(certificate),
+                PemWriter.writePrivateKey(keyPair.getPrivate()),
+                writeEncryptedPrivateKey(keyPair));
+    }
+
+    private static String writeEncryptedPrivateKey(KeyPair keyPair)
+            throws Exception
+    {
+        SecretKeyFactory keyFactory = SecretKeyFactory.getInstance("PBEWithMD5AndDES");
+        SecretKey key = keyFactory.generateSecret(new PBEKeySpec(KEY_PASSWORD.toCharArray()));
+
+        Cipher cipher = Cipher.getInstance("PBEWithMD5AndDES");
+        cipher.init(ENCRYPT_MODE, key, new PBEParameterSpec("12345678".getBytes(US_ASCII), 1_000));
+
+        EncryptedPrivateKeyInfo encryptedPrivateKeyInfo = new EncryptedPrivateKeyInfo(cipher.getParameters(), cipher.doFinal(keyPair.getPrivate().getEncoded()));
+        return pem("ENCRYPTED PRIVATE KEY", encryptedPrivateKeyInfo.getEncoded());
+    }
+
+    private static String pem(String type, byte[] encoded)
+    {
+        return "-----BEGIN " + type + "-----\n" +
+                getMimeEncoder(64, new byte[] {'\n'}).encodeToString(encoded) + '\n' +
+                "-----END " + type + "-----\n";
+    }
+
+    private record TlsMaterials(String certificatePem, String privateKeyPem, String encryptedPrivateKeyPem) {}
 }


### PR DESCRIPTION
## Summary
- Add support for `otel.exporter.tls.client-key-password`
- Add direct PEM config options for trusted certificates, client certificate, and client key

# Airlift contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [x] All automated tests are passing.
 - [x] Pull request was categorized using one of the existing labels.
