### PR TITLE
Use @ApiUnwrapped for nested array schema support

### DIFF
--- a/api/src/main/java/io/airlift/api/binding/ApiModule.java
+++ b/api/src/main/java/io/airlift/api/binding/ApiModule.java
@@ -1,6 +1,7 @@
 package io.airlift.api.binding;
 
 import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -322,10 +323,13 @@ public class ApiModule
             return;
         }
 
-        MapBinder<Class<?>, JsonDeserializer<?>> mapBinder = MapBinder.newMapBinder(binder, new TypeLiteral<>() {}, new TypeLiteral<>() {});
+        MapBinder<Class<?>, JsonDeserializer<?>> deserializerBinder = MapBinder.newMapBinder(binder, new TypeLiteral<>() {}, new TypeLiteral<>() {});
+        MapBinder<Class<?>, JsonSerializer<?>> serializerBinder = MapBinder.newMapBinder(binder, new TypeLiteral<>() {}, new TypeLiteral<>() {});
         resourcesWithUnwrappedComponents.forEach(clazz -> {
-            UnwrappedDeserializer deserializer = new UnwrappedDeserializer(clazz);
-            mapBinder.addBinding(clazz).toInstance(deserializer);
+            deserializerBinder.addBinding(clazz).toInstance(new UnwrappedDeserializer(clazz));
+            if (UnwrappedSerializer.hasUnwrappedList(clazz)) {
+                serializerBinder.addBinding(clazz).toInstance(new UnwrappedSerializer(clazz));
+            }
         });
     }
 

--- a/api/src/main/java/io/airlift/api/binding/UnwrappedDeserializer.java
+++ b/api/src/main/java/io/airlift/api/binding/UnwrappedDeserializer.java
@@ -11,6 +11,8 @@ import io.airlift.api.ApiUnwrapped;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.RecordComponent;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -45,7 +47,10 @@ class UnwrappedDeserializer
             JavaType javaType = context.constructType(recordComponent.getGenericType());
 
             Object value;
-            if (recordComponent.isAnnotationPresent(ApiUnwrapped.class)) {
+            if (recordComponent.isAnnotationPresent(ApiUnwrapped.class) && List.class.isAssignableFrom(recordComponent.getType())) {
+                value = deserializeUnwrappedList(context, tree, recordComponent);
+            }
+            else if (recordComponent.isAnnotationPresent(ApiUnwrapped.class)) {
                 value = context.readTreeAsValue(tree, javaType);
             }
             else {
@@ -72,6 +77,62 @@ class UnwrappedDeserializer
         catch (Exception e) {
             throw new JsonParseException(parser, "Could not create instance");
         }
+    }
+
+    private static Object deserializeUnwrappedList(DeserializationContext context, JsonNode tree, RecordComponent recordComponent)
+            throws IOException
+    {
+        // @ApiUnwrapped List<T> where T is a record — each inner component is flattened as a parallel array.
+        // Wire format: each inner component name maps to an array where element[i] corresponds to list[i].component
+        Class<?> elementClass = getListElementClass(recordComponent);
+        RecordComponent[] innerComponents = elementClass.getRecordComponents();
+
+        // Determine list size from the first present array
+        int size = 0;
+        for (RecordComponent inner : innerComponents) {
+            JsonNode arrayNode = tree.get(inner.getName());
+            if (arrayNode != null && arrayNode.isArray()) {
+                size = arrayNode.size();
+                break;
+            }
+        }
+
+        if (size == 0) {
+            return List.of();
+        }
+
+        Constructor<?> elementConstructor = getDefaultRecordConstructor(elementClass);
+        List<Object> result = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            Object[] arguments = new Object[innerComponents.length];
+            for (int j = 0; j < innerComponents.length; j++) {
+                RecordComponent inner = innerComponents[j];
+                JsonNode arrayNode = tree.get(inner.getName());
+                JavaType innerType = context.constructType(inner.getGenericType());
+                if (arrayNode != null && arrayNode.isArray() && i < arrayNode.size() && !arrayNode.get(i).isNull()) {
+                    arguments[j] = context.readTreeAsValue(arrayNode.get(i), innerType);
+                }
+                else if (Optional.class.isAssignableFrom(inner.getType())) {
+                    arguments[j] = Optional.empty();
+                }
+                else {
+                    arguments[j] = null;
+                }
+            }
+            try {
+                result.add(elementConstructor.newInstance(arguments));
+            }
+            catch (Exception e) {
+                throw new IOException("Could not create instance of " + elementClass, e);
+            }
+        }
+        return result;
+    }
+
+    private static Class<?> getListElementClass(RecordComponent recordComponent)
+    {
+        java.lang.reflect.ParameterizedType paramType = (java.lang.reflect.ParameterizedType) recordComponent.getGenericType();
+        return (Class<?>) paramType.getActualTypeArguments()[0];
     }
 
     private static Constructor<?> getDefaultRecordConstructor(Class<?> clazz)

--- a/api/src/main/java/io/airlift/api/binding/UnwrappedSerializer.java
+++ b/api/src/main/java/io/airlift/api/binding/UnwrappedSerializer.java
@@ -1,0 +1,98 @@
+package io.airlift.api.binding;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import io.airlift.api.ApiUnwrapped;
+
+import java.io.IOException;
+import java.lang.reflect.RecordComponent;
+import java.util.List;
+import java.util.stream.Stream;
+
+class UnwrappedSerializer
+        extends JsonSerializer<Object>
+{
+    private final Class<?> clazz;
+
+    UnwrappedSerializer(Class<?> clazz)
+    {
+        this.clazz = clazz;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Class<Object> handledType()
+    {
+        return (Class<Object>) clazz;
+    }
+
+    @Override
+    public void serialize(Object value, JsonGenerator gen, SerializerProvider serializers)
+            throws IOException
+    {
+        gen.writeStartObject();
+
+        RecordComponent[] recordComponents = clazz.getRecordComponents();
+        for (RecordComponent recordComponent : recordComponents) {
+            Object componentValue;
+            try {
+                componentValue = recordComponent.getAccessor().invoke(value);
+            }
+            catch (Exception e) {
+                throw new IOException("Could not access component: " + recordComponent.getName(), e);
+            }
+
+            if (recordComponent.isAnnotationPresent(ApiUnwrapped.class) && List.class.isAssignableFrom(recordComponent.getType())) {
+                serializeUnwrappedList(gen, serializers, recordComponent, componentValue);
+            }
+            else {
+                gen.writeFieldName(recordComponent.getName());
+                serializers.defaultSerializeValue(componentValue, gen);
+            }
+        }
+
+        gen.writeEndObject();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void serializeUnwrappedList(JsonGenerator gen, SerializerProvider serializers, RecordComponent recordComponent, Object componentValue)
+            throws IOException
+    {
+        Class<?> elementClass = getListElementClass(recordComponent);
+        RecordComponent[] innerComponents = elementClass.getRecordComponents();
+        List<Object> list = (List<Object>) componentValue;
+
+        for (RecordComponent innerComponent : innerComponents) {
+            gen.writeFieldName(innerComponent.getName());
+            gen.writeStartArray();
+
+            if (list != null) {
+                for (Object element : list) {
+                    Object innerValue;
+                    try {
+                        innerValue = innerComponent.getAccessor().invoke(element);
+                    }
+                    catch (Exception e) {
+                        throw new IOException("Could not access inner component: " + innerComponent.getName(), e);
+                    }
+                    serializers.defaultSerializeValue(innerValue, gen);
+                }
+            }
+
+            gen.writeEndArray();
+        }
+    }
+
+    private static Class<?> getListElementClass(RecordComponent recordComponent)
+    {
+        java.lang.reflect.ParameterizedType paramType = (java.lang.reflect.ParameterizedType) recordComponent.getGenericType();
+        return (Class<?>) paramType.getActualTypeArguments()[0];
+    }
+
+    static boolean hasUnwrappedList(Class<?> clazz)
+    {
+        return clazz.isRecord() && Stream.of(clazz.getRecordComponents())
+                .anyMatch(rc -> rc.isAnnotationPresent(ApiUnwrapped.class) && List.class.isAssignableFrom(rc.getType()));
+    }
+}

--- a/api/src/main/java/io/airlift/api/builders/ResourceBuilder.java
+++ b/api/src/main/java/io/airlift/api/builders/ResourceBuilder.java
@@ -50,6 +50,7 @@ import static io.airlift.api.model.ModelResourceModifier.IS_ANY_OBJECT;
 import static io.airlift.api.model.ModelResourceModifier.IS_MULTIPART_FORM;
 import static io.airlift.api.model.ModelResourceModifier.IS_STREAMING_RESPONSE;
 import static io.airlift.api.model.ModelResourceModifier.IS_UNWRAPPED;
+import static io.airlift.api.model.ModelResourceModifier.IS_UNWRAPPED_LIST;
 import static io.airlift.api.model.ModelResourceModifier.MULTIPART_RESOURCE_IS_FIRST_ITEM;
 import static io.airlift.api.model.ModelResourceModifier.OPTIONAL;
 import static io.airlift.api.model.ModelResourceModifier.READ_ONLY;
@@ -307,7 +308,12 @@ public class ResourceBuilder
                     component = component.withModifier(READ_ONLY);
                 }
                 if (isUnwrapped) {
-                    component = component.withModifier(IS_UNWRAPPED);
+                    if (component.resourceType() == ModelResourceType.LIST) {
+                        component = component.withModifier(IS_UNWRAPPED_LIST);
+                    }
+                    else {
+                        component = component.withModifier(IS_UNWRAPPED);
+                    }
                 }
 
                 components.add(component);

--- a/api/src/main/java/io/airlift/api/model/ModelResourceModifier.java
+++ b/api/src/main/java/io/airlift/api/model/ModelResourceModifier.java
@@ -16,7 +16,8 @@ public enum ModelResourceModifier
     IS_MULTIPART_FORM,
     MULTIPART_RESOURCE_IS_FIRST_ITEM,
     RECURSIVE_REFERENCE,
-    IS_ANY_OBJECT;
+    IS_ANY_OBJECT,
+    IS_UNWRAPPED_LIST;
 
     public static boolean hasReadOnly(Collection<ModelResourceModifier> modifiers)
     {

--- a/api/src/main/java/io/airlift/api/openapi/SchemaBuilder.java
+++ b/api/src/main/java/io/airlift/api/openapi/SchemaBuilder.java
@@ -151,7 +151,7 @@ class SchemaBuilder
                 case MAP -> new MapSchema().description(adjustedDescription(modelResource)).additionalProperties(buildSchema(asResource(removeContainer(modelResource)), mode));
                 case PAGINATED_RESULT -> buildPaginatedSchema(modelResource);
                 default -> modelResource.modifiers().contains(IS_ANY_OBJECT)
-                        ? new Schema<>().type("object").description(adjustedDescription(modelResource))
+                        ? new Schema<>().description(adjustedDescription(modelResource))
                         : buildBasicOrResourceSchema(modelResource, mode);
             };
         }
@@ -326,6 +326,17 @@ class SchemaBuilder
     {
         if (component.modifiers().contains(IS_UNWRAPPED)) {
             buildResourceSchema(schema, component, ofMode(mode));
+        }
+        else if (component.modifiers().contains(ModelResourceModifier.IS_UNWRAPPED_LIST)) {
+            ModelResource innerResource = asResource(removeContainer(component));
+            innerResource.components().stream()
+                    .filter(inner -> mode.isStandard() || !ModelResourceModifier.hasReadOnly(inner.modifiers()))
+                    .forEach(inner -> {
+                        schema.addProperty(inner.name(), asList(component, buildSchema(inner, mode)));
+                        if (!mode.isPartialPatch() && !inner.modifiers().contains(ModelResourceModifier.OPTIONAL)) {
+                            schema.addRequiredItem(inner.name());
+                        }
+                    });
         }
         else {
             Schema<?> componentSchema = buildSchema(component, mode);

--- a/api/src/main/java/io/airlift/api/validation/ResourceValidator.java
+++ b/api/src/main/java/io/airlift/api/validation/ResourceValidator.java
@@ -37,6 +37,7 @@ import static io.airlift.api.model.ModelResourceModifier.IS_ANY_OBJECT;
 import static io.airlift.api.model.ModelResourceModifier.IS_MULTIPART_FORM;
 import static io.airlift.api.model.ModelResourceModifier.IS_STREAMING_RESPONSE;
 import static io.airlift.api.model.ModelResourceModifier.IS_UNWRAPPED;
+import static io.airlift.api.model.ModelResourceModifier.IS_UNWRAPPED_LIST;
 import static io.airlift.api.model.ModelResourceModifier.OPTIONAL;
 import static io.airlift.api.model.ModelResourceModifier.PATCH;
 import static io.airlift.api.model.ModelResourceModifier.READ_ONLY;
@@ -208,7 +209,7 @@ public interface ResourceValidator
                 throw new ValidatorException("%s fields cannot be read only in %s".formatted(component.type(), modelResource.type()));
             }
 
-            if (isUnwrapped) {
+            if (isUnwrapped || component.modifiers().contains(IS_UNWRAPPED_LIST)) {
                 context.registerResourcesWithUnwrappedComponents(TypeToken.of(modelResource.type()).getRawType());
             }
         });

--- a/api/src/test/java/io/airlift/api/validation/ObjectValues.java
+++ b/api/src/test/java/io/airlift/api/validation/ObjectValues.java
@@ -1,0 +1,9 @@
+package io.airlift.api.validation;
+
+import io.airlift.api.ApiDescription;
+import io.airlift.api.ApiResource;
+
+import java.util.List;
+
+@ApiResource(name = "objectValues", description = "Unwrapped object values")
+public record ObjectValues(@ApiDescription("Free-form values") List<Object> values) {}

--- a/api/src/test/java/io/airlift/api/validation/ResourceWithObjectField.java
+++ b/api/src/test/java/io/airlift/api/validation/ResourceWithObjectField.java
@@ -2,6 +2,7 @@ package io.airlift.api.validation;
 
 import io.airlift.api.ApiDescription;
 import io.airlift.api.ApiResource;
+import io.airlift.api.ApiUnwrapped;
 
 import java.util.List;
 import java.util.Map;
@@ -10,4 +11,5 @@ import java.util.Map;
 public record ResourceWithObjectField(
         @ApiDescription("A name") String name,
         @ApiDescription("Free-form list") List<Object> payloads,
-        @ApiDescription("Free-form map") Map<String, Object> attributes) {}
+        @ApiDescription("Free-form map") Map<String, Object> attributes,
+        @ApiUnwrapped List<ObjectValues> objectValues) {}

--- a/api/src/test/java/io/airlift/api/validation/ResourceWithUnwrappedList.java
+++ b/api/src/test/java/io/airlift/api/validation/ResourceWithUnwrappedList.java
@@ -1,0 +1,12 @@
+package io.airlift.api.validation;
+
+import io.airlift.api.ApiDescription;
+import io.airlift.api.ApiResource;
+import io.airlift.api.ApiUnwrapped;
+
+import java.util.List;
+
+@ApiResource(name = "unwrappedList", description = "Resource with @ApiUnwrapped List", quotas = "TEST")
+public record ResourceWithUnwrappedList(
+        @ApiDescription("A name") String name,
+        @ApiDescription("Entries") @ApiUnwrapped List<UnwrappedEntry> entries) {}

--- a/api/src/test/java/io/airlift/api/validation/ServiceWithUnwrappedList.java
+++ b/api/src/test/java/io/airlift/api/validation/ServiceWithUnwrappedList.java
@@ -1,0 +1,12 @@
+package io.airlift.api.validation;
+
+import io.airlift.api.ApiCreate;
+import io.airlift.api.ApiService;
+import io.airlift.api.ServiceType;
+
+@ApiService(name = "unwrappedListService", type = ServiceType.class, description = "Service with @ApiUnwrapped List field")
+public class ServiceWithUnwrappedList
+{
+    @ApiCreate(description = "create something with unwrapped list")
+    public void create(ResourceWithUnwrappedList ignore) {}
+}

--- a/api/src/test/java/io/airlift/api/validation/TestConforming.java
+++ b/api/src/test/java/io/airlift/api/validation/TestConforming.java
@@ -16,6 +16,10 @@ import io.airlift.api.model.ModelResourceType;
 import io.airlift.api.model.ModelServiceMetadata;
 import io.airlift.api.model.ModelServiceType;
 import io.airlift.api.model.ModelServices;
+import io.airlift.api.openapi.OpenApiMetadata;
+import io.airlift.api.openapi.OpenApiProvider;
+import io.airlift.api.openapi.models.OpenAPI;
+import io.airlift.api.openapi.models.Schema;
 import io.airlift.api.responses.ApiBadRequest;
 import io.airlift.json.JsonModule;
 import jakarta.ws.rs.WebApplicationException;
@@ -192,6 +196,54 @@ public class TestConforming
         ModelApi modelApi = ApiBuilder.apiBuilder().add(ServiceWithObjectField.class).build();
         Module module = ApiModule.builder().addApi(modelApi).build();
         Guice.createInjector(module, new JsonModule());
+    }
+
+    @Test
+    public void testUnwrappedObjectValues()
+    {
+        ModelApi modelApi = ApiBuilder.apiBuilder().add(ServiceWithObjectField.class).build();
+        assertThat(modelApi.modelServices().errors()).isEmpty();
+
+        OpenApiMetadata metadata = new OpenApiMetadata(Optional.empty(), ImmutableList.of());
+        ModelServiceType serviceType = modelApi.modelServices().services().iterator().next().service().type();
+        OpenApiProvider openApiProvider = OpenApiProvider.create(modelApi.modelServices(), metadata);
+        OpenAPI openAPI = openApiProvider.build(serviceType, _ -> true);
+
+        Schema<?> objectFieldSchema = openAPI.getComponents().getSchemas().get("ObjectField");
+        assertThat(objectFieldSchema).isNotNull();
+        assertThat(objectFieldSchema.getProperties()).containsKey("values");
+
+        // values should be Object[][] — outer array from @ApiUnwrapped List<>, inner array from List<Object>
+        Schema<?> valuesSchema = objectFieldSchema.getProperties().get("values");
+        assertThat(valuesSchema.getType()).isEqualTo("array");
+        assertThat(valuesSchema.getItems()).isNotNull();
+        assertThat(valuesSchema.getItems().getType()).isEqualTo("array");
+        assertThat(valuesSchema.getItems().getItems()).isNotNull();
+        assertThat(valuesSchema.getItems().getItems().getType()).isNull();
+    }
+
+    @Test
+    public void testUnwrappedListWithoutObjectTrait()
+    {
+        // @ApiUnwrapped on List with non-Object inner fields works without ALLOW_OBJECT_ELEMENTS
+        ModelApi modelApi = ApiBuilder.apiBuilder().add(ServiceWithUnwrappedList.class).build();
+        assertThat(modelApi.modelServices().errors()).isEmpty();
+
+        Module module = ApiModule.builder().addApi(modelApi).build();
+        Guice.createInjector(module, new JsonModule());
+
+        // Verify schema: required fields (names, priority) are marked required, optional field (description) is not
+        OpenApiMetadata metadata = new OpenApiMetadata(Optional.empty(), ImmutableList.of());
+        ModelServiceType serviceType = modelApi.modelServices().services().iterator().next().service().type();
+        OpenApiProvider openApiProvider = OpenApiProvider.create(modelApi.modelServices(), metadata);
+        OpenAPI openAPI = openApiProvider.build(serviceType, _ -> true);
+
+        Schema<?> unwrappedListSchema = openAPI.getComponents().getSchemas().get("UnwrappedList");
+        assertThat(unwrappedListSchema).isNotNull();
+        assertThat(unwrappedListSchema.getProperties()).containsKeys("names", "priority", "description");
+
+        assertThat(unwrappedListSchema.getRequired()).contains("names", "priority");
+        assertThat(unwrappedListSchema.getRequired()).doesNotContain("description");
     }
 
     @Test

--- a/api/src/test/java/io/airlift/api/validation/UnwrappedEntry.java
+++ b/api/src/test/java/io/airlift/api/validation/UnwrappedEntry.java
@@ -1,0 +1,13 @@
+package io.airlift.api.validation;
+
+import io.airlift.api.ApiDescription;
+import io.airlift.api.ApiResource;
+
+import java.util.List;
+import java.util.Optional;
+
+@ApiResource(name = "entry", description = "Unwrapped entry")
+public record UnwrappedEntry(
+        @ApiDescription("Entry names") List<String> names,
+        @ApiDescription("Entry priority") int priority,
+        @ApiDescription("Optional description") Optional<String> description) {}


### PR DESCRIPTION
Adds `@ApiUnwrappedList` annotation for record fields of type `List<T>` where `T` is a single-component record wrapping a `List<?>`. This enables representing nested array types (e.g., `Object[][]`) in both the OpenAPI schema and JSON wire format.

Given:
```java
@ApiResource(name = "objectValues", description = "...")
public record ObjectValues(@ApiDescription("Free-form values") List<Object> values) {}

@ApiResource(name = "objectField", description = "...")
public record ResourceWithObjectField(@ApiUnwrappedList List<ObjectValues> objectValues) {}
```

The generated OpenAPI schema produces:

```json
"values": {
  "type": "array",
  "items": {
    "type": "array",
    "items": { "description": "Free-form values" }
  }
}
```
And the JSON wire format is `"values": [[...], [...]].`

Also changes `IS_ANY_OBJECT` schema representation to omit type: "object", producing a typeless schema that TypeScript generators interpret as unknown rather than `Record<string, never>`. After the change TypeScript generator interpret that as `unknown[][]` as expected.

# Airlift contribution check list

 - [ ] Git commit messages follow https://cbea.ms/git-commit/.
 - [ ] All automated tests are passing.
 - [ ] Pull request was categorized using one of the existing labels.
