### PR TITLE
Use resolved enum wire values in API Builder

### DIFF
--- a/api-maven-plugin/src/main/java/io/airlift/api/maven/GenerateOpenApiMojo.java
+++ b/api-maven-plugin/src/main/java/io/airlift/api/maven/GenerateOpenApiMojo.java
@@ -15,6 +15,7 @@ package io.airlift.api.maven;
 
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.google.common.collect.ImmutableList;
+import io.airlift.api.ApiBuilderConfig;
 import io.airlift.api.ApiServiceType;
 import io.airlift.api.builders.ApiBuilder;
 import io.airlift.api.model.ModelApi;
@@ -228,7 +229,8 @@ public class GenerateOpenApiMojo
     private String generateOpenApi(List<Class<?>> serviceClassList, ApiServiceType serviceType)
             throws MojoExecutionException
     {
-        ApiBuilder apiBuilder = apiBuilder();
+        ApiBuilderConfig config = ApiBuilderConfig.jackson();
+        ApiBuilder apiBuilder = apiBuilder(config);
         for (Class<?> serviceClass : serviceClassList) {
             apiBuilder.add(serviceClass);
         }
@@ -244,7 +246,7 @@ public class GenerateOpenApiMojo
         Optional<SecurityScheme> security = parseSecurityScheme();
         OpenApiMetadata metadata = new OpenApiMetadata(security, ImmutableList.of(), basePath, Duration.ofMinutes(5));
 
-        OpenApiProvider openApiProvider = OpenApiProvider.create(modelApi.modelServices(), metadata);
+        OpenApiProvider openApiProvider = OpenApiProvider.create(modelApi.modelServices(), metadata, config);
         ModelServiceType modelServiceType = ModelServiceType.map(serviceType);
         OpenAPI openAPI = openApiProvider.build(modelServiceType, _ -> true);
 

--- a/api/src/main/java/io/airlift/api/ApiBuilderConfig.java
+++ b/api/src/main/java/io/airlift/api/ApiBuilderConfig.java
@@ -1,0 +1,30 @@
+package io.airlift.api;
+
+import io.airlift.api.internals.JacksonEnumValueResolver;
+
+import static java.util.Objects.requireNonNull;
+
+public final class ApiBuilderConfig
+{
+    private final ApiEnumValueResolver enumValueResolver;
+
+    private ApiBuilderConfig(ApiEnumValueResolver enumValueResolver)
+    {
+        this.enumValueResolver = requireNonNull(enumValueResolver, "enumValueResolver is null");
+    }
+
+    public static ApiBuilderConfig jackson()
+    {
+        return new ApiBuilderConfig(new JacksonEnumValueResolver());
+    }
+
+    public static ApiBuilderConfig of(ApiEnumValueResolver enumValueResolver)
+    {
+        return new ApiBuilderConfig(enumValueResolver);
+    }
+
+    public ApiEnumValueResolver enumValueResolver()
+    {
+        return enumValueResolver;
+    }
+}

--- a/api/src/main/java/io/airlift/api/ApiEnumNamingFormat.java
+++ b/api/src/main/java/io/airlift/api/ApiEnumNamingFormat.java
@@ -1,0 +1,42 @@
+package io.airlift.api;
+
+import java.util.regex.Pattern;
+
+import static java.util.Objects.requireNonNull;
+
+public enum ApiEnumNamingFormat
+{
+    PASCAL_CASE("PascalCase", "^[A-Z][a-zA-Z0-9]*$"),
+    UPPER_SNAKE_CASE("UPPER_SNAKE_CASE", "^[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)*$");
+
+    private final String value;
+    private final Pattern pattern;
+
+    ApiEnumNamingFormat(String value, String pattern)
+    {
+        this.value = requireNonNull(value, "value is null");
+        this.pattern = Pattern.compile(pattern);
+    }
+
+    public static ApiEnumNamingFormat fromString(String value)
+    {
+        requireNonNull(value, "value is null");
+        for (ApiEnumNamingFormat format : values()) {
+            if (format.value.equals(value)) {
+                return format;
+            }
+        }
+        throw new IllegalArgumentException("Unknown enum naming format: " + value);
+    }
+
+    public boolean isValid(String value)
+    {
+        return pattern.matcher(requireNonNull(value, "value is null")).matches();
+    }
+
+    @Override
+    public String toString()
+    {
+        return value;
+    }
+}

--- a/api/src/main/java/io/airlift/api/ApiEnumValueResolver.java
+++ b/api/src/main/java/io/airlift/api/ApiEnumValueResolver.java
@@ -1,0 +1,10 @@
+package io.airlift.api;
+
+import java.util.List;
+
+public interface ApiEnumValueResolver
+{
+    List<String> values(Class<?> enumClass);
+
+    String value(Enum<?> value);
+}

--- a/api/src/main/java/io/airlift/api/ApiServiceType.java
+++ b/api/src/main/java/io/airlift/api/ApiServiceType.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableSet;
 
 import java.util.Set;
 
+import static io.airlift.api.ApiEnumNamingFormat.PASCAL_CASE;
 import static io.airlift.api.ApiServiceTrait.DESCRIPTIONS_REQUIRED;
 import static io.airlift.api.ApiServiceTrait.QUOTAS_REQUIRED;
 import static io.airlift.api.ApiServiceTrait.REQUIRES_RESOURCE_IDS;
@@ -22,5 +23,10 @@ public interface ApiServiceType
     default Set<ApiServiceTrait> traits()
     {
         return ImmutableSet.of(USES_VERSIONED_RESOURCES, REQUIRES_RESOURCE_IDS, QUOTAS_REQUIRED, DESCRIPTIONS_REQUIRED);
+    }
+
+    default ApiEnumNamingFormat enumNamingFormat()
+    {
+        return PASCAL_CASE;
     }
 }

--- a/api/src/main/java/io/airlift/api/binding/ApiModule.java
+++ b/api/src/main/java/io/airlift/api/binding/ApiModule.java
@@ -2,6 +2,7 @@ package io.airlift.api.binding;
 
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
@@ -13,6 +14,8 @@ import com.google.inject.TypeLiteral;
 import com.google.inject.binder.AnnotatedBindingBuilder;
 import com.google.inject.binder.LinkedBindingBuilder;
 import com.google.inject.multibindings.MapBinder;
+import io.airlift.api.ApiBuilderConfig;
+import io.airlift.api.ApiEnumValueResolver;
 import io.airlift.api.ApiId;
 import io.airlift.api.ApiIdLookup;
 import io.airlift.api.ApiIdSupportsLookup;
@@ -68,6 +71,7 @@ public class ApiModule
     private final Optional<ApiCompatibilityTester> compatibilityTester;
     private final boolean withApiLogging;
     private final ApiMode apiMode;
+    private final ApiEnumValueResolver enumValueResolver;
 
     private ApiModule(
             ModelApi modelApi,
@@ -79,7 +83,8 @@ public class ApiModule
             OpenApiExtensionFilter extensionFilter,
             Optional<ApiCompatibilityTester> compatibilityTester,
             boolean withApiLogging,
-            ApiMode apiMode)
+            ApiMode apiMode,
+            ApiEnumValueResolver enumValueResolver)
     {
         this.modelApi = requireNonNull(modelApi, "api is null");
         this.requestFilters = ImmutableSet.copyOf(requestFilters);
@@ -91,6 +96,7 @@ public class ApiModule
         this.compatibilityTester = requireNonNull(compatibilityTester, "compatibilityTester is null");
         this.withApiLogging = withApiLogging;
         this.apiMode = requireNonNull(apiMode, "apiMode is null");
+        this.enumValueResolver = requireNonNull(enumValueResolver, "enumValueResolver is null");
     }
 
     public static Builder builder()
@@ -101,6 +107,7 @@ public class ApiModule
     public static final class Builder
     {
         private final ImmutableSet.Builder<ModelApi> modelApis = ImmutableSet.builder();
+        private final ImmutableList.Builder<Consumer<ApiBuilder>> apiConsumers = ImmutableList.builder();
         private final ImmutableSet.Builder<RequestFilter> requestFilters = ImmutableSet.builder();
         private final ImmutableSet.Builder<ResponseFilter> responseFilters = ImmutableSet.builder();
         private final ImmutableMap.Builder<Class<? extends ApiId<?, ?>>, Consumer<LinkedBindingBuilder<ApiIdLookup<? extends ApiId<?, ?>>>>> idLookupBindings = ImmutableMap.builder();
@@ -110,6 +117,7 @@ public class ApiModule
         private Optional<ApiCompatibilityTester> compatibilityTester = Optional.empty();
         private boolean withApiLogging;
         private ApiMode apiMode = ApiMode.DEBUG;
+        private ApiEnumValueResolver enumValueResolver = ApiBuilderConfig.jackson().enumValueResolver();
 
         private Builder() {}
 
@@ -139,10 +147,13 @@ public class ApiModule
 
         public Builder addApi(Consumer<ApiBuilder> consumer)
         {
-            ApiBuilder apiBuilder = ApiBuilder.apiBuilder();
-            consumer.accept(apiBuilder);
+            apiConsumers.add(requireNonNull(consumer, "consumer is null"));
+            return this;
+        }
 
-            modelApis.add(apiBuilder.build());
+        public Builder withApiBuilderConfig(ApiBuilderConfig config)
+        {
+            this.enumValueResolver = requireNonNull(config, "config is null").enumValueResolver();
             return this;
         }
 
@@ -223,12 +234,23 @@ public class ApiModule
                     localExtensionFilter,
                     compatibilityTester,
                     withApiLogging,
-                    apiMode);
+                    apiMode,
+                    enumValueResolver);
         }
 
         private ModelApi mergeApis()
         {
-            return modelApis.build()
+            ImmutableSet.Builder<ModelApi> apis = ImmutableSet.builder();
+            apis.addAll(modelApis.build());
+            apiConsumers.build().stream()
+                    .map(consumer -> {
+                        ApiBuilder apiBuilder = ApiBuilder.apiBuilder(enumValueResolver);
+                        consumer.accept(apiBuilder);
+                        return apiBuilder.build();
+                    })
+                    .forEach(apis::add);
+
+            return apis.build()
                     .stream()
                     .reduce(ModelApi::mergeWith)
                     .orElseGet(() -> new ModelApi(new ModelServices(ImmutableSet.of(), ImmutableSet.of(), ImmutableSet.of(), ImmutableSet.of()), ImmutableSet.of(), ImmutableSet.of(), ImmutableSet.of()));
@@ -273,7 +295,7 @@ public class ApiModule
         modelApi.modelServices().services().forEach(jaxrsResourceBuilder::bindService);
         jaxrsResourceBuilder.bindFeatures();
 
-        openApiMetadata.ifPresent(openApi -> binder.install(new OpenApiModule(modelApi.modelServices(), openApi, openApiFilterBinding, extensionFilter)));
+        openApiMetadata.ifPresent(openApi -> binder.install(new OpenApiModule(modelApi.modelServices(), openApi, openApiFilterBinding, extensionFilter, enumValueResolver)));
 
         modelApi.modelServices().deprecations().forEach(modelDeprecation -> deprecationBinder.addBinding(modelDeprecation.method()).toInstance(modelDeprecation));
 

--- a/api/src/main/java/io/airlift/api/builders/ApiBuilder.java
+++ b/api/src/main/java/io/airlift/api/builders/ApiBuilder.java
@@ -1,6 +1,8 @@
 package io.airlift.api.builders;
 
 import com.google.common.collect.ImmutableSet;
+import io.airlift.api.ApiBuilderConfig;
+import io.airlift.api.ApiEnumValueResolver;
 import io.airlift.api.model.ModelApi;
 import io.airlift.api.model.ModelServices;
 import io.airlift.api.validation.ValidationContext;
@@ -22,16 +24,28 @@ public class ApiBuilder
 {
     private final ValidationContext validationContext;
     private final ServicesBuilder servicesBuilder;
+    private final ApiEnumValueResolver enumValueResolver;
 
-    private ApiBuilder(ValidationContext validationContext, ServicesBuilder servicesBuilder)
+    private ApiBuilder(ValidationContext validationContext, ServicesBuilder servicesBuilder, ApiEnumValueResolver enumValueResolver)
     {
         this.validationContext = requireNonNull(validationContext, "validationContext is null");
         this.servicesBuilder = requireNonNull(servicesBuilder, "servicesBuilder is null");
+        this.enumValueResolver = requireNonNull(enumValueResolver, "enumValueResolver is null");
     }
 
     public static ApiBuilder apiBuilder()
     {
-        return new ApiBuilder(new ValidationContext(), ServicesBuilder.servicesBuilder());
+        return apiBuilder(ApiBuilderConfig.jackson());
+    }
+
+    public static ApiBuilder apiBuilder(ApiBuilderConfig config)
+    {
+        return apiBuilder(requireNonNull(config, "config is null").enumValueResolver());
+    }
+
+    public static ApiBuilder apiBuilder(ApiEnumValueResolver enumValueResolver)
+    {
+        return new ApiBuilder(new ValidationContext(), ServicesBuilder.servicesBuilder(enumValueResolver), enumValueResolver);
     }
 
     public ApiBuilder add(Class<?> serviceClass)
@@ -65,15 +79,15 @@ public class ApiBuilder
 
             modelService.methods().forEach(modelMethod -> {
                 validateMethod(context, modelMethod, modelService.service().type().serviceTraits());
-                validateResult(context, modelService.service(), modelMethod);
+                validateResult(context, modelService.service(), modelMethod, enumValueResolver);
 
-                modelMethod.responses().forEach(modelResponse -> validateResource(context, modelService.service(), modelResponse.resource()));
+                modelMethod.responses().forEach(modelResponse -> validateResource(context, modelService.service(), modelResponse.resource(), enumValueResolver));
 
                 modelMethod.parameters().stream()
                         .flatMap(parameter -> parameter.components().stream())
-                        .forEach(component -> validateParameter(context, modelService.service(), modelMethod, component.name(), component));
+                        .forEach(component -> validateParameter(context, modelService.service(), modelMethod, component.name(), component, enumValueResolver));
 
-                modelMethod.requestBody().ifPresent(requestBody -> validateRequestBody(context, modelService.service(), modelMethod, requestBody));
+                modelMethod.requestBody().ifPresent(requestBody -> validateRequestBody(context, modelService.service(), modelMethod, requestBody, enumValueResolver));
             });
         });
 

--- a/api/src/main/java/io/airlift/api/builders/MethodBuilder.java
+++ b/api/src/main/java/io/airlift/api/builders/MethodBuilder.java
@@ -130,11 +130,6 @@ public class MethodBuilder
         this.responses = requireNonNull(responses, "responses is null");    // do not copy
     }
 
-    public static MethodBuilder methodBuilder(Method method)
-    {
-        return new MethodBuilder(method, new LinkedHashMap<>(), ResourceBuilder::resourceBuilder, new LinkedHashMap<>());
-    }
-
     public static MethodBuilder methodBuilder(Method method, Function<Type, ResourceBuilder> resourceBuilderSupplier)
     {
         return new MethodBuilder(method, new LinkedHashMap<>(), resourceBuilderSupplier, new LinkedHashMap<>());

--- a/api/src/main/java/io/airlift/api/builders/ResourceBuilder.java
+++ b/api/src/main/java/io/airlift/api/builders/ResourceBuilder.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.reflect.TypeToken;
 import io.airlift.api.ApiDescription;
+import io.airlift.api.ApiEnumValueResolver;
 import io.airlift.api.ApiId;
 import io.airlift.api.ApiMultiPart;
 import io.airlift.api.ApiMultiPart.ApiMultiPartFormWithResource;
@@ -94,27 +95,29 @@ public class ResourceBuilder
     private final Type resource;
     private final Map<Type, ModelResource> builtResources;
     private final RecursionChecker recursionChecker;
+    private final ApiEnumValueResolver enumValueResolver;
 
-    private ResourceBuilder(Type resource, Map<Type, ModelResource> builtResources, RecursionChecker recursionChecker)
+    private ResourceBuilder(Type resource, Map<Type, ModelResource> builtResources, RecursionChecker recursionChecker, ApiEnumValueResolver enumValueResolver)
     {
         this.resource = requireNonNull(resource, "resource is null");
         this.builtResources = requireNonNull(builtResources, "validatedResources is null"); // do not copy
         this.recursionChecker = requireNonNull(recursionChecker, "recursionChecker is null");
+        this.enumValueResolver = requireNonNull(enumValueResolver, "enumValueResolver is null");
     }
 
-    public static ResourceBuilder resourceBuilder(Type resource)
+    public static ResourceBuilder resourceBuilder(Type resource, ApiEnumValueResolver enumValueResolver)
     {
-        return new ResourceBuilder(resource, new LinkedHashMap<>(), new RecursionChecker());
+        return new ResourceBuilder(resource, new LinkedHashMap<>(), new RecursionChecker(), enumValueResolver);
     }
 
     public static ResourceBuilder resourceBuilder(Type resource, ResourceBuilder from)
     {
-        return new ResourceBuilder(resource, from.builtResources, from.recursionChecker);
+        return new ResourceBuilder(resource, from.builtResources, from.recursionChecker, from.enumValueResolver);
     }
 
     public ResourceBuilder toBuilder(Type resource)
     {
-        return new ResourceBuilder(resource, builtResources, recursionChecker);
+        return new ResourceBuilder(resource, builtResources, recursionChecker, enumValueResolver);
     }
 
     public ModelResource build()
@@ -362,9 +365,19 @@ public class ResourceBuilder
                 .filter(Field::isEnumConstant)
                 .flatMap(field -> {
                     ApiDescription descriptionAnnotation = field.getAnnotation(ApiDescription.class);
-                    return Optional.ofNullable(descriptionAnnotation).map(description -> Map.entry(field.getName(), description.value())).stream();
+                    return Optional.ofNullable(descriptionAnnotation).map(description -> Map.entry(enumValue(field), description.value())).stream();
                 })
                 .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    private String enumValue(Field field)
+    {
+        try {
+            return enumValueResolver.value((Enum<?>) field.get(null));
+        }
+        catch (IllegalAccessException | IllegalArgumentException e) {
+            throw new ValidatorException("Could not read enum constant: %s".formatted(field.getName()), e);
+        }
     }
 
     private Class<?> unboxIfNeeded(Class<?> clazz)

--- a/api/src/main/java/io/airlift/api/builders/ServiceBuilder.java
+++ b/api/src/main/java/io/airlift/api/builders/ServiceBuilder.java
@@ -30,11 +30,6 @@ public class ServiceBuilder
         this.methodBuilder = requireNonNull(methodBuilder, "methodBuilder is null");
     }
 
-    public static ServiceBuilder serviceBuilder(Class<?> serviceClass)
-    {
-        return new ServiceBuilder(serviceClass, new LinkedHashMap<>(), MethodBuilder::methodBuilder);
-    }
-
     public static ServiceBuilder serviceBuilder(Class<?> serviceClass, Function<Method, MethodBuilder> methodSupplier)
     {
         return new ServiceBuilder(serviceClass, new LinkedHashMap<>(), methodSupplier);

--- a/api/src/main/java/io/airlift/api/builders/ServiceMetadataBuilder.java
+++ b/api/src/main/java/io/airlift/api/builders/ServiceMetadataBuilder.java
@@ -42,15 +42,10 @@ public class ServiceMetadataBuilder
 
         return new ModelServiceMetadata(
                 apiService.name(),
-                map(apiServiceType),
+                ModelServiceType.map(apiServiceType),
                 apiService.description(),
                 Arrays.stream(apiService.documentationLinks())
                         .map(URI::create)
                         .collect(toImmutableList()));
-    }
-
-    private static ModelServiceType map(ApiServiceType apiServiceType)
-    {
-        return new ModelServiceType(apiServiceType.id(), apiServiceType.version(), apiServiceType.title(), apiServiceType.description(), apiServiceType.traits());
     }
 }

--- a/api/src/main/java/io/airlift/api/builders/ServicesBuilder.java
+++ b/api/src/main/java/io/airlift/api/builders/ServicesBuilder.java
@@ -1,6 +1,7 @@
 package io.airlift.api.builders;
 
 import com.google.common.collect.ImmutableSet;
+import io.airlift.api.ApiEnumValueResolver;
 import io.airlift.api.model.ModelDeprecation;
 import io.airlift.api.model.ModelResponse;
 import io.airlift.api.model.ModelService;
@@ -31,10 +32,12 @@ public class ServicesBuilder
         services = ImmutableSet.builder();
     }
 
-    public static ServicesBuilder servicesBuilder()
+    public static ServicesBuilder servicesBuilder(ApiEnumValueResolver enumValueResolver)
     {
-        Function<Type, ResourceBuilder> resourceBuilder = createThunk(ResourceBuilder::resourceBuilder, ((type, builder) -> builder.toBuilder(type)));
-        Function<Method, MethodBuilder> methodBuilder = createThunk(method -> methodBuilder(method, resourceBuilder), ((method, builder) -> builder.toBuilder(method)));
+        requireNonNull(enumValueResolver, "enumValueResolver is null");
+
+        Function<Type, ResourceBuilder> configuredResourceBuilder = createThunk(type -> ResourceBuilder.resourceBuilder(type, enumValueResolver), ((type, builder) -> builder.toBuilder(type)));
+        Function<Method, MethodBuilder> methodBuilder = createThunk(method -> methodBuilder(method, configuredResourceBuilder), ((method, builder) -> builder.toBuilder(method)));
         Function<Class<?>, ServiceBuilder> serviceBuilder = createThunk(clazz -> ServiceBuilder.serviceBuilder(clazz, methodBuilder), (serviceClass, builder) -> builder.toBuilder(serviceClass));
 
         return new ServicesBuilder(serviceBuilder);

--- a/api/src/main/java/io/airlift/api/internals/JacksonEnumValueResolver.java
+++ b/api/src/main/java/io/airlift/api/internals/JacksonEnumValueResolver.java
@@ -1,0 +1,121 @@
+package io.airlift.api.internals;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.collect.ImmutableList;
+import io.airlift.api.ApiEnumValueResolver;
+import io.airlift.api.validation.ValidatorException;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static java.util.Objects.requireNonNull;
+
+public final class JacksonEnumValueResolver
+        implements ApiEnumValueResolver
+{
+    public JacksonEnumValueResolver() {}
+
+    @Override
+    public List<String> values(Class<?> enumClass)
+    {
+        validateEnumClass(enumClass);
+
+        ImmutableList.Builder<String> values = ImmutableList.builder();
+        Set<String> seenValues = new HashSet<>();
+        for (Object constant : enumClass.getEnumConstants()) {
+            String value = value((Enum<?>) constant);
+            if (!seenValues.add(value)) {
+                throw new ValidatorException("Duplicate enum wire value \"%s\" for enum %s".formatted(value, enumClass.getName()));
+            }
+            values.add(value);
+        }
+        return values.build();
+    }
+
+    @Override
+    public String value(Enum<?> value)
+    {
+        requireNonNull(value, "value is null");
+        Optional<Method> jsonValueMethod = jsonValueMethod(value.getDeclaringClass());
+        if (jsonValueMethod.isEmpty()) {
+            return value.toString();
+        }
+
+        Method method = jsonValueMethod.orElseThrow();
+        if (method.getName().equals("toString")) {
+            return value.toString();
+        }
+
+        Object resolvedValue;
+        try {
+            if (!method.canAccess(value)) {
+                throw new ValidatorException("@JsonValue method %s is not accessible on enum %s".formatted(method.getName(), value.getDeclaringClass().getName()));
+            }
+            resolvedValue = method.invoke(value);
+        }
+        catch (IllegalAccessException e) {
+            throw new ValidatorException("@JsonValue method %s is not accessible on enum %s".formatted(method.getName(), value.getDeclaringClass().getName()), e);
+        }
+        catch (InvocationTargetException e) {
+            throw new ValidatorException("@JsonValue method %s threw an exception for enum %s".formatted(method.getName(), value.getDeclaringClass().getName()), e);
+        }
+
+        if (resolvedValue == null) {
+            throw new ValidatorException("@JsonValue method %s on enum %s returned null".formatted(method.getName(), value.getDeclaringClass().getName()));
+        }
+        if (!(resolvedValue instanceof String stringValue)) {
+            throw new ValidatorException("@JsonValue method %s on enum %s must return a String".formatted(method.getName(), value.getDeclaringClass().getName()));
+        }
+        return stringValue;
+    }
+
+    private static Optional<Method> jsonValueMethod(Class<?> enumClass)
+    {
+        validateEnumClass(enumClass);
+
+        Method[] methods = Stream.of(enumClass.getDeclaredMethods())
+                .filter(method -> Optional.ofNullable(method.getAnnotation(JsonValue.class))
+                        .map(JsonValue::value)
+                        .orElse(false))
+                .toArray(Method[]::new);
+
+        if (methods.length > 1) {
+            throw new ValidatorException("Multiple @JsonValue methods found on enum %s".formatted(enumClass.getName()));
+        }
+        if (methods.length == 0) {
+            return Optional.empty();
+        }
+
+        Method method = methods[0];
+        if (method.getParameterCount() != 0) {
+            throw new ValidatorException("@JsonValue method %s on enum %s must not have parameters".formatted(method.getName(), enumClass.getName()));
+        }
+        if (Modifier.isStatic(method.getModifiers())) {
+            throw new ValidatorException("@JsonValue method %s is not an instance method on enum %s".formatted(method.getName(), enumClass.getName()));
+        }
+        return Optional.of(method);
+    }
+
+    private static void validateEnumClass(Class<?> enumClass)
+    {
+        requireNonNull(enumClass, "enumClass is null");
+        if (!enumClass.isEnum()) {
+            throw new ValidatorException("%s is not an enum".formatted(enumClass.getName()));
+        }
+        long jsonValueFields = Stream.of(enumClass.getDeclaredFields())
+                .filter(field -> Optional.ofNullable(field.getAnnotation(JsonValue.class))
+                        .map(JsonValue::value)
+                        .orElse(false))
+                .count();
+        if (jsonValueFields > 0) {
+            // Jackson supports field-based @JsonValue, but API Builder only resolves method-based enum values for now.
+            throw new ValidatorException("@JsonValue fields are not supported on enum %s".formatted(enumClass.getName()));
+        }
+    }
+}

--- a/api/src/main/java/io/airlift/api/model/ModelServiceType.java
+++ b/api/src/main/java/io/airlift/api/model/ModelServiceType.java
@@ -1,6 +1,7 @@
 package io.airlift.api.model;
 
 import com.google.common.collect.ImmutableSet;
+import io.airlift.api.ApiEnumNamingFormat;
 import io.airlift.api.ApiServiceTrait;
 import io.airlift.api.ApiServiceType;
 
@@ -8,19 +9,20 @@ import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
 
-public record ModelServiceType(String id, int version, String title, String description, Set<ApiServiceTrait> serviceTraits)
+public record ModelServiceType(String id, int version, String title, String description, Set<ApiServiceTrait> serviceTraits, ApiEnumNamingFormat enumNamingFormat)
 {
     public ModelServiceType
     {
         requireNonNull(id, "id is null");
         requireNonNull(title, "title is null");
         requireNonNull(description, "description is null");
+        requireNonNull(enumNamingFormat, "enumNamingFormat is null");
 
         serviceTraits = ImmutableSet.copyOf(serviceTraits);
     }
 
     public static ModelServiceType map(ApiServiceType apiServiceType)
     {
-        return new ModelServiceType(apiServiceType.id(), apiServiceType.version(), apiServiceType.title(), apiServiceType.description(), apiServiceType.traits());
+        return new ModelServiceType(apiServiceType.id(), apiServiceType.version(), apiServiceType.title(), apiServiceType.description(), apiServiceType.traits(), apiServiceType.enumNamingFormat());
     }
 }

--- a/api/src/main/java/io/airlift/api/openapi/OpenApiBuilder.java
+++ b/api/src/main/java/io/airlift/api/openapi/OpenApiBuilder.java
@@ -2,6 +2,7 @@ package io.airlift.api.openapi;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Streams;
+import io.airlift.api.ApiEnumValueResolver;
 import io.airlift.api.ApiIdSupportsLookup;
 import io.airlift.api.ApiTrait;
 import io.airlift.api.model.ModelDeprecation;
@@ -98,9 +99,10 @@ class OpenApiBuilder
             Collection<ModelDeprecation> deprecations,
             OpenApiMetadata metadata,
             Predicate<Method> methodFilter,
-            OpenApiExtensionFilter extensionFilter)
+            OpenApiExtensionFilter extensionFilter,
+            ApiEnumValueResolver enumValueResolver)
     {
-        return new OpenApiBuilder(serviceType, deprecations, metadata, methodFilter, extensionFilter);
+        return new OpenApiBuilder(serviceType, deprecations, metadata, methodFilter, extensionFilter, enumValueResolver);
     }
 
     enum JsonUriMode
@@ -422,13 +424,13 @@ class OpenApiBuilder
         });
     }
 
-    private OpenApiBuilder(ModelServiceType serviceType, Collection<ModelDeprecation> deprecations, OpenApiMetadata metadata, Predicate<Method> methodFilter, OpenApiExtensionFilter extensionFilter)
+    private OpenApiBuilder(ModelServiceType serviceType, Collection<ModelDeprecation> deprecations, OpenApiMetadata metadata, Predicate<Method> methodFilter, OpenApiExtensionFilter extensionFilter, ApiEnumValueResolver enumValueResolver)
     {
         this.serviceType = requireNonNull(serviceType, "serviceType is null");
         this.deprecations = deprecations.stream().collect(toImmutableMap(ModelDeprecation::method, identity()));
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.methodFilter = requireNonNull(methodFilter, "methodFilter is null");
-        this.schemaBuilder = new SchemaBuilder(serviceType.serviceTraits().contains(ENUMS_AS_STRINGS));
+        this.schemaBuilder = new SchemaBuilder(serviceType.serviceTraits().contains(ENUMS_AS_STRINGS), enumValueResolver);
         this.extensionFilter = requireNonNull(extensionFilter, "extensionFilter is null");
     }
 }

--- a/api/src/main/java/io/airlift/api/openapi/OpenApiModule.java
+++ b/api/src/main/java/io/airlift/api/openapi/OpenApiModule.java
@@ -5,6 +5,7 @@ import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.TypeLiteral;
 import com.google.inject.binder.AnnotatedBindingBuilder;
+import io.airlift.api.ApiEnumValueResolver;
 import io.airlift.api.model.ModelService;
 import io.airlift.api.model.ModelServiceType;
 import io.airlift.api.model.ModelServices;
@@ -30,13 +31,15 @@ public class OpenApiModule
     private final OpenApiMetadata metadata;
     private final Consumer<AnnotatedBindingBuilder<OpenApiFilter>> openApiFilterProviderBinding;
     private final OpenApiExtensionFilter extensionFilter;
+    private final ApiEnumValueResolver enumValueResolver;
 
-    public OpenApiModule(ModelServices modelServices, OpenApiMetadata metadata, Consumer<AnnotatedBindingBuilder<OpenApiFilter>> openApiFilterProviderBinding, OpenApiExtensionFilter extensionFilter)
+    public OpenApiModule(ModelServices modelServices, OpenApiMetadata metadata, Consumer<AnnotatedBindingBuilder<OpenApiFilter>> openApiFilterProviderBinding, OpenApiExtensionFilter extensionFilter, ApiEnumValueResolver enumValueResolver)
     {
         this.modelServices = requireNonNull(modelServices, "modelServices is null");
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.openApiFilterProviderBinding = requireNonNull(openApiFilterProviderBinding, "openApiFilterProviderBinding is null");
         this.extensionFilter = requireNonNull(extensionFilter, "extensionFilter is null");
+        this.enumValueResolver = requireNonNull(enumValueResolver, "enumValueResolver is null");
     }
 
     @Override
@@ -47,7 +50,7 @@ public class OpenApiModule
         binder.bind(new TypeLiteral<Collection<ModelServiceType>>() {}).toInstance(servicesByType.keySet());
 
         newOptionalBinder(binder, OpenApiProvider.class).setBinding().toInstance((serviceType, methodFilter) -> {
-            OpenApiBuilder builder = OpenApiBuilder.builder(serviceType, modelServices.deprecations(), metadata, methodFilter, extensionFilter);
+            OpenApiBuilder builder = OpenApiBuilder.builder(serviceType, modelServices.deprecations(), metadata, methodFilter, extensionFilter, enumValueResolver);
             servicesByType.getOrDefault(serviceType, ImmutableList.of()).forEach(builder::addService);
             return builder.build();
         });

--- a/api/src/main/java/io/airlift/api/openapi/OpenApiProvider.java
+++ b/api/src/main/java/io/airlift/api/openapi/OpenApiProvider.java
@@ -1,6 +1,8 @@
 package io.airlift.api.openapi;
 
 import com.google.common.collect.ImmutableList;
+import io.airlift.api.ApiBuilderConfig;
+import io.airlift.api.ApiEnumValueResolver;
 import io.airlift.api.model.ModelService;
 import io.airlift.api.model.ModelServiceType;
 import io.airlift.api.model.ModelServices;
@@ -12,22 +14,21 @@ import java.util.Map;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import static java.util.Objects.requireNonNull;
+
 public interface OpenApiProvider
 {
     OpenAPI build(ModelServiceType serviceType, Predicate<Method> methodFilter);
 
-    static OpenApiProvider create(ModelServices modelServices, OpenApiMetadata metadata)
+    static OpenApiProvider create(ModelServices modelServices, OpenApiMetadata metadata, ApiBuilderConfig config)
     {
-        return create(modelServices, metadata, (_, _, operation) -> operation);
-    }
+        ApiEnumValueResolver enumValueResolver = requireNonNull(config, "config is null").enumValueResolver();
 
-    static OpenApiProvider create(ModelServices modelServices, OpenApiMetadata metadata, OpenApiExtensionFilter extensionFilter)
-    {
         Map<ModelServiceType, List<ModelService>> servicesByType = modelServices.services().stream()
                 .collect(Collectors.groupingBy(modelService -> modelService.service().type()));
 
         return (serviceType, methodFilter) -> {
-            OpenApiBuilder builder = OpenApiBuilder.builder(serviceType, modelServices.deprecations(), metadata, methodFilter, extensionFilter);
+            OpenApiBuilder builder = OpenApiBuilder.builder(serviceType, modelServices.deprecations(), metadata, methodFilter, (_, _, operation) -> operation, enumValueResolver);
             servicesByType.getOrDefault(serviceType, ImmutableList.of()).forEach(builder::addService);
             return builder.build();
         };

--- a/api/src/main/java/io/airlift/api/openapi/SchemaBuilder.java
+++ b/api/src/main/java/io/airlift/api/openapi/SchemaBuilder.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.reflect.TypeToken;
+import io.airlift.api.ApiEnumValueResolver;
 import io.airlift.api.ApiId;
 import io.airlift.api.ApiResourceVersion;
 import io.airlift.api.model.ModelPolyResource;
@@ -34,7 +35,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Stream;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.airlift.api.ApiOpenApiTrait.USE_ONE_OF_DISCRIMINATORS;
@@ -53,21 +53,23 @@ class SchemaBuilder
 {
     private final Map<SchemaKey, Schema<?>> schemas;
     private final boolean enumsAsStrings;
+    private final ApiEnumValueResolver enumValueResolver;
     private final String schemaTag;
     private final Map<Type, ModelResource> typeToResourceCache;
     private final Map<String, Schema<?>> ofSchemas;
 
-    SchemaBuilder(boolean enumsAsStrings)
+    SchemaBuilder(boolean enumsAsStrings, ApiEnumValueResolver enumValueResolver)
     {
-        this(TAG_MODEL_DEFINITIONS, new LinkedHashMap<>(), enumsAsStrings, new LinkedHashMap<>(), new LinkedHashMap<>());
+        this(TAG_MODEL_DEFINITIONS, new LinkedHashMap<>(), enumsAsStrings, enumValueResolver, new LinkedHashMap<>(), new LinkedHashMap<>());
     }
 
-    private SchemaBuilder(String schemaTag, Map<SchemaKey, Schema<?>> schemas, boolean enumsAsStrings, Map<Type, ModelResource> typeToResourceCache, Map<String, Schema<?>> ofSchemas)
+    private SchemaBuilder(String schemaTag, Map<SchemaKey, Schema<?>> schemas, boolean enumsAsStrings, ApiEnumValueResolver enumValueResolver, Map<Type, ModelResource> typeToResourceCache, Map<String, Schema<?>> ofSchemas)
     {
         this.schemaTag = requireNonNull(schemaTag, "schemaTag is null");
         // don't copy
         this.schemas = requireNonNull(schemas, "schemas is null");
         this.enumsAsStrings = enumsAsStrings;
+        this.enumValueResolver = requireNonNull(enumValueResolver, "enumValueResolver is null");
         this.typeToResourceCache = requireNonNull(typeToResourceCache, "typeToResourceCache is null");  // don't copy
         this.ofSchemas = requireNonNull(ofSchemas, "ofSchemas is null");  // don't copy
     }
@@ -75,7 +77,7 @@ class SchemaBuilder
     @SuppressWarnings("SameParameterValue")
     SchemaBuilder withSchemaTag(String schemaTag)
     {
-        return new SchemaBuilder(schemaTag, schemas, enumsAsStrings, typeToResourceCache, ofSchemas);
+        return new SchemaBuilder(schemaTag, schemas, enumsAsStrings, enumValueResolver, typeToResourceCache, ofSchemas);
     }
 
     private record SchemaKey(Optional<String> parent, Type containerType, ModelResourceType resourceType, BuildSchemaMode mode)
@@ -227,7 +229,7 @@ class SchemaBuilder
     {
         StringSchema stringSchema = new StringSchema();
         if (!enumsAsStrings) {
-            Stream.of(clazz.getEnumConstants()).forEach(o -> stringSchema.addEnumItem(o.toString()));
+            enumValueResolver.values(clazz).forEach(stringSchema::addEnumItem);
         }
         return stringSchema;
     }

--- a/api/src/main/java/io/airlift/api/validation/ResourceValidator.java
+++ b/api/src/main/java/io/airlift/api/validation/ResourceValidator.java
@@ -2,6 +2,7 @@ package io.airlift.api.validation;
 
 import com.google.common.reflect.TypeToken;
 import io.airlift.api.ApiDescription;
+import io.airlift.api.ApiEnumValueResolver;
 import io.airlift.api.ApiId;
 import io.airlift.api.ApiMultiPart.ApiMultiPartForm;
 import io.airlift.api.ApiPagination;
@@ -51,42 +52,41 @@ import static io.airlift.api.validation.ResourceValidationState.Option.ALLOW_BOX
 import static io.airlift.api.validation.ResourceValidationState.Option.ALLOW_POLY_RESOURCES;
 import static io.airlift.api.validation.ResourceValidationState.Option.IS_RESULT_RESOURCE;
 import static io.airlift.api.validation.ResourceValidationState.Option.PARENT_IS_READ_ONLY;
-import static io.airlift.api.validation.ValidationContext.NameType.ENUM;
 import static io.airlift.api.validation.ValidationContext.NameType.STANDARD;
 import static io.airlift.api.validation.ValidationContext.isForcedReadOnly;
 
 public interface ResourceValidator
 {
-    static void validateResource(ValidationContext context, ModelServiceMetadata service, ModelResource modelResource)
+    static void validateResource(ValidationContext context, ModelServiceMetadata service, ModelResource modelResource, ApiEnumValueResolver enumValueResolver)
     {
         context.inContext("Resource %s".formatted(modelResource.type().getTypeName()),
-                subContext -> internalValidate(subContext, service, Optional.empty(), modelResource, ResourceValidationState.create()));
+                subContext -> internalValidate(subContext, service, Optional.empty(), modelResource, ResourceValidationState.create(), enumValueResolver));
     }
 
-    static void validateRequestBody(ValidationContext context, ModelServiceMetadata service, ModelMethod modelMethod, ModelResource modelResource)
+    static void validateRequestBody(ValidationContext context, ModelServiceMetadata service, ModelMethod modelMethod, ModelResource modelResource, ApiEnumValueResolver enumValueResolver)
     {
         context.inContext("Method: %s, request body %s".formatted(modelMethod.method(), modelResource.type().getTypeName()),
                 subContext -> {
                     if (modelResource.modifiers().contains(PATCH)) {
                         validatePatch(modelMethod.method(), modelResource);
                     }
-                    internalValidate(subContext, service, Optional.empty(), modelResource, ResourceValidationState.create());
+                    internalValidate(subContext, service, Optional.empty(), modelResource, ResourceValidationState.create(), enumValueResolver);
                 });
     }
 
-    static void validateParameter(ValidationContext context, ModelServiceMetadata service, ModelMethod modelMethod, String name, ModelResource modelResource)
+    static void validateParameter(ValidationContext context, ModelServiceMetadata service, ModelMethod modelMethod, String name, ModelResource modelResource, ApiEnumValueResolver enumValueResolver)
     {
         context.inContext("Method: %s, parameter %s, resource: %s".formatted(modelMethod.method(), name, modelResource.type().getTypeName()),
-                subContext -> internalValidate(subContext, service, Optional.of(name), modelResource, ResourceValidationState.create().withOptions(ALLOW_BASIC_RESOURCES)));
+                subContext -> internalValidate(subContext, service, Optional.of(name), modelResource, ResourceValidationState.create().withOptions(ALLOW_BASIC_RESOURCES), enumValueResolver));
     }
 
-    static void validateResult(ValidationContext context, ModelServiceMetadata service, ModelMethod modelMethod)
+    static void validateResult(ValidationContext context, ModelServiceMetadata service, ModelMethod modelMethod, ApiEnumValueResolver enumValueResolver)
     {
         context.inContext("Resource %s".formatted(modelMethod.returnType().type().getTypeName()),
-                subContext -> internalValidate(subContext, service, Optional.empty(), modelMethod.returnType(), ResourceValidationState.create().withOptions(IS_RESULT_RESOURCE)));
+                subContext -> internalValidate(subContext, service, Optional.empty(), modelMethod.returnType(), ResourceValidationState.create().withOptions(IS_RESULT_RESOURCE), enumValueResolver));
     }
 
-    private static void internalValidate(ValidationContext context, ModelServiceMetadata service, Optional<String> componentName, ModelResource modelResource, ResourceValidationState state)
+    private static void internalValidate(ValidationContext context, ModelServiceMetadata service, Optional<String> componentName, ModelResource modelResource, ResourceValidationState state, ApiEnumValueResolver enumValueResolver)
     {
         if (context.resourceHasBeenValidated(modelResource.type())) {
             return;
@@ -121,7 +121,7 @@ public interface ResourceValidator
                 }
 
                 if (isApiResource(modelResource.type())) {
-                    validateDeclaredResource(context, service, modelResource, state);
+                    validateDeclaredResource(context, service, modelResource, state, enumValueResolver);
                 }
             }
 
@@ -150,11 +150,11 @@ public interface ResourceValidator
                 }
 
                 if (isApiResource(modelResource.type())) {
-                    validateDeclaredResource(context, service, modelResource, state);
+                    validateDeclaredResource(context, service, modelResource, state, enumValueResolver);
                 }
             }
 
-            case RESOURCE -> validateDeclaredResource(context, service, modelResource, state);
+            case RESOURCE -> validateDeclaredResource(context, service, modelResource, state, enumValueResolver);
         }
     }
 
@@ -172,7 +172,7 @@ public interface ResourceValidator
                 isApiJsonType(clazz);
     }
 
-    private static void validateDeclaredResource(ValidationContext context, ModelServiceMetadata service, ModelResource modelResource, ResourceValidationState state)
+    private static void validateDeclaredResource(ValidationContext context, ModelServiceMetadata service, ModelResource modelResource, ResourceValidationState state, ApiEnumValueResolver enumValueResolver)
     {
         if (!modelResource.modifiers().contains(VOID)) {
             context.validateName(modelResource.name(), STANDARD);
@@ -192,7 +192,7 @@ public interface ResourceValidator
             }
         }
 
-        modelResource.polyResource().ifPresent(polyResource -> validatePolyResource(context, service, modelResource, polyResource, state));
+        modelResource.polyResource().ifPresent(polyResource -> validatePolyResource(context, service, modelResource, polyResource, state, enumValueResolver));
 
         modelResource.components().forEach(component -> {
             boolean hasDescription = !component.description().isBlank();
@@ -206,14 +206,14 @@ public interface ResourceValidator
                 throw new ValidatorException("%s component %s is missing %s annotation.".formatted(modelResource.type(), component.name(), ApiDescription.class.getSimpleName()));
             }
 
-            validateRecordComponentNaming(context, modelResource, component);
+            validateRecordComponentNaming(context, service, modelResource, component, enumValueResolver);
 
             ResourceValidationState nextState = state.withOptions(ALLOW_BASIC_RESOURCES, ALLOW_POLY_RESOURCES);
             if (component.modifiers().contains(READ_ONLY)) {
                 nextState = nextState.withOptions(PARENT_IS_READ_ONLY);
             }
 
-            internalValidate(context, service, Optional.of(component.name()), component, nextState);
+            internalValidate(context, service, Optional.of(component.name()), component, nextState, enumValueResolver);
 
             boolean isForcedReadOnly = isForcedReadOnly(component.type());
             boolean hasReadOnly = component.modifiers().contains(READ_ONLY);
@@ -269,7 +269,7 @@ TODO why this?
         return false;
     }
 
-    private static void validateRecordComponentNaming(ValidationContext context, ModelResource modelResource, ModelResource component)
+    private static void validateRecordComponentNaming(ValidationContext context, ModelServiceMetadata service, ModelResource modelResource, ModelResource component, ApiEnumValueResolver enumValueResolver)
     {
         boolean isCollection = component.resourceType() == LIST;
         boolean isOptional = component.modifiers().contains(OPTIONAL);
@@ -280,7 +280,7 @@ TODO why this?
 
         if (rawType.isEnum()) {
             context.inContext("For enumeration: " + rawType.getSimpleName(), subContext ->
-                    Stream.of(rawType.getEnumConstants()).forEach(e -> subContext.validateName(e.toString(), ENUM)));
+                    enumValueResolver.values(rawType).forEach(value -> subContext.validateEnumName(value, service.type().enumNamingFormat())));
         }
 
         if (ApiResourceVersion.class.isAssignableFrom(rawType)) {
@@ -315,7 +315,7 @@ TODO why this?
         }
     }
 
-    private static void validatePolyResource(ValidationContext context, ModelServiceMetadata service, ModelResource modelResource, ModelPolyResource polyResource, ResourceValidationState state)
+    private static void validatePolyResource(ValidationContext context, ModelServiceMetadata service, ModelResource modelResource, ModelPolyResource polyResource, ResourceValidationState state, ApiEnumValueResolver enumValueResolver)
     {
         if (modelResource.type() instanceof Class<?> clazz) {
             context.registerPolyResource(clazz);
@@ -331,7 +331,7 @@ TODO why this?
                                 throw new ValidatorException("%s is a sub-resource of %s and has a component that is the same as the %s key: %s".formatted(subResource.type(), ApiPolyResource.class.getSimpleName(), ApiPolyResource.class.getSimpleName(), polyResource.key()));
                             }
                             if (component.resourceType() != BASIC) {
-                                internalValidate(context, service, Optional.of(component.name()), component, state);
+                                internalValidate(context, service, Optional.of(component.name()), component, state, enumValueResolver);
                             }
                         }));
     }

--- a/api/src/main/java/io/airlift/api/validation/ValidationContext.java
+++ b/api/src/main/java/io/airlift/api/validation/ValidationContext.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import com.google.common.reflect.TypeToken;
 import io.airlift.api.ApiEnumId;
+import io.airlift.api.ApiEnumNamingFormat;
 import io.airlift.api.ApiId;
 import io.airlift.api.ApiPolyResource;
 import io.airlift.api.ApiResource;
@@ -59,7 +60,6 @@ public class ValidationContext
         - $: Asserts the end of the string.
      */
     private static final Pattern STANDARD_NAMING = Pattern.compile("^[a-z][a-zA-Z0-9]*$");
-    private static final Pattern ENUM_NAMING = Pattern.compile("^[A-Z][a-zA-Z0-9]*$");   // same as STANDARD_NAMING but first letter must be uppercase
     private static final Pattern ID_NAMING = Pattern.compile("^[a-z0-9][a-zA-Z0-9]*$");  // same as STANDARD_NAMING but first letter may be a number
 
     private static final Set<Type> forcedReadOnly = ImmutableSet.of(ApiResourceVersion.class);
@@ -154,7 +154,9 @@ public class ValidationContext
     public enum NameType
     {
         STANDARD(STANDARD_NAMING),
-        ENUM(ENUM_NAMING),
+        // Preserved for external source compatibility; new enum validation should use validateEnumName.
+        @Deprecated
+        ENUM(null),
         ID(ID_NAMING);
 
         private final Pattern pattern;
@@ -167,8 +169,20 @@ public class ValidationContext
 
     public void validateName(String name, NameType nameType)
     {
+        if (nameType == NameType.ENUM) {
+            validateEnumName(name, ApiEnumNamingFormat.PASCAL_CASE);
+            return;
+        }
+
         if ((name == null) || !nameType.pattern.matcher(name).matches()) {
             throw new ValidatorException("\"%s\" is not a valid name".formatted(name));
+        }
+    }
+
+    public void validateEnumName(String name, ApiEnumNamingFormat enumNamingFormat)
+    {
+        if ((name == null) || !enumNamingFormat.isValid(name)) {
+            throw new ValidatorException("\"%s\" is not a valid enum name for format %s".formatted(name, enumNamingFormat));
         }
     }
 

--- a/api/src/main/java/io/airlift/api/validation/ValidatorException.java
+++ b/api/src/main/java/io/airlift/api/validation/ValidatorException.java
@@ -19,9 +19,20 @@ public class ValidatorException
         this(ImmutableList.of(message));
     }
 
+    public ValidatorException(String message, Throwable cause)
+    {
+        this(ImmutableList.of(message), cause);
+    }
+
     public ValidatorException(List<String> messages)
     {
         super(messages.toString());
+        this.messages = ImmutableList.copyOf(messages);
+    }
+
+    public ValidatorException(List<String> messages, Throwable cause)
+    {
+        super(messages.toString(), cause);
         this.messages = ImmutableList.copyOf(messages);
     }
 

--- a/api/src/test/java/io/airlift/api/TestApiEnumNamingFormat.java
+++ b/api/src/test/java/io/airlift/api/TestApiEnumNamingFormat.java
@@ -1,0 +1,64 @@
+package io.airlift.api;
+
+import org.junit.jupiter.api.Test;
+
+import static io.airlift.api.ApiEnumNamingFormat.PASCAL_CASE;
+import static io.airlift.api.ApiEnumNamingFormat.UPPER_SNAKE_CASE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestApiEnumNamingFormat
+{
+    @Test
+    public void testStringValue()
+    {
+        assertThat(PASCAL_CASE).hasToString("PascalCase");
+        assertThat(UPPER_SNAKE_CASE).hasToString("UPPER_SNAKE_CASE");
+    }
+
+    @Test
+    public void testFromString()
+    {
+        assertThat(ApiEnumNamingFormat.fromString("PascalCase")).isEqualTo(PASCAL_CASE);
+        assertThat(ApiEnumNamingFormat.fromString("UPPER_SNAKE_CASE")).isEqualTo(UPPER_SNAKE_CASE);
+
+        assertThatThrownBy(() -> ApiEnumNamingFormat.fromString("PASCAL_CASE"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Unknown enum naming format: PASCAL_CASE");
+    }
+
+    @Test
+    public void testPascalCaseValidation()
+    {
+        assertThat(PASCAL_CASE.isValid("OrderStatus")).isTrue();
+        assertThat(PASCAL_CASE.isValid("A")).isTrue();
+        assertThat(PASCAL_CASE.isValid("Status1")).isTrue();
+
+        assertThat(PASCAL_CASE.isValid("orderStatus")).isFalse();
+        assertThat(PASCAL_CASE.isValid("_Order")).isFalse();
+        assertThat(PASCAL_CASE.isValid("123")).isFalse();
+        assertThat(PASCAL_CASE.isValid("")).isFalse();
+    }
+
+    @Test
+    public void testUpperSnakeCaseValidation()
+    {
+        assertThat(UPPER_SNAKE_CASE.isValid("ORDER_STATUS")).isTrue();
+        assertThat(UPPER_SNAKE_CASE.isValid("A_B")).isTrue();
+        assertThat(UPPER_SNAKE_CASE.isValid("STATUS_1")).isTrue();
+
+        assertThat(UPPER_SNAKE_CASE.isValid("Order_Status")).isFalse();
+        assertThat(UPPER_SNAKE_CASE.isValid("_ORDER")).isFalse();
+        assertThat(UPPER_SNAKE_CASE.isValid("ORDER_")).isFalse();
+        assertThat(UPPER_SNAKE_CASE.isValid("ORDER__STATUS")).isFalse();
+        assertThat(UPPER_SNAKE_CASE.isValid("")).isFalse();
+    }
+
+    @Test
+    public void testValidationRejectsNull()
+    {
+        assertThatThrownBy(() -> PASCAL_CASE.isValid(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("value is null");
+    }
+}

--- a/api/src/test/java/io/airlift/api/internals/TestJacksonEnumValueResolver.java
+++ b/api/src/test/java/io/airlift/api/internals/TestJacksonEnumValueResolver.java
@@ -1,0 +1,33 @@
+package io.airlift.api.internals;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.airlift.api.ApiBuilderConfig;
+import io.airlift.api.validation.ValidatorException;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationTargetException;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestJacksonEnumValueResolver
+{
+    @Test
+    public void testJsonValueInvocationExceptionPreservesCause()
+    {
+        assertThatThrownBy(() -> ApiBuilderConfig.jackson().enumValueResolver().value(ThrowingJsonValueEnum.Small))
+                .isInstanceOf(ValidatorException.class)
+                .hasMessage("[@JsonValue method value threw an exception for enum io.airlift.api.internals.TestJacksonEnumValueResolver$ThrowingJsonValueEnum]")
+                .hasCauseInstanceOf(InvocationTargetException.class);
+    }
+
+    private enum ThrowingJsonValueEnum
+    {
+        Small;
+
+        @JsonValue
+        public String value()
+        {
+            throw new IllegalStateException("no value");
+        }
+    }
+}

--- a/api/src/test/java/io/airlift/api/openapi/TestApiJsonSchemas.java
+++ b/api/src/test/java/io/airlift/api/openapi/TestApiJsonSchemas.java
@@ -1,6 +1,7 @@
 package io.airlift.api.openapi;
 
 import com.google.common.reflect.TypeToken;
+import io.airlift.api.ApiBuilderConfig;
 import io.airlift.api.ApiJsonList;
 import io.airlift.api.ApiJsonNode;
 import io.airlift.api.ApiJsonObject;
@@ -16,6 +17,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestApiJsonSchemas
 {
+    private static final ApiBuilderConfig CONFIG = ApiBuilderConfig.jackson();
+
     @Test
     public void testJsonNodeIsUnconstrained()
     {
@@ -46,9 +49,9 @@ public class TestApiJsonSchemas
     @Test
     public void testMapWithJsonNodeAllowsArbitraryJsonValues()
     {
-        ModelResource modelResource = resourceBuilder(new TypeToken<Map<String, ApiJsonNode>>() {}.getType()).build();
+        ModelResource modelResource = resourceBuilder(new TypeToken<Map<String, ApiJsonNode>>() {}.getType(), CONFIG.enumValueResolver()).build();
 
-        Schema<?> schema = new SchemaBuilder(false).buildSchema(modelResource, STANDARD);
+        Schema<?> schema = new SchemaBuilder(false, CONFIG.enumValueResolver()).buildSchema(modelResource, STANDARD);
 
         assertThat(schema.getType()).isEqualTo("object");
         assertThat(schema.getAdditionalProperties()).isInstanceOfSatisfying(Schema.class, additionalProperties -> {
@@ -59,6 +62,6 @@ public class TestApiJsonSchemas
 
     private static Schema<?> buildSchema(Class<?> clazz)
     {
-        return new SchemaBuilder(false).buildSchema(resourceBuilder(clazz).build(), STANDARD);
+        return new SchemaBuilder(false, CONFIG.enumValueResolver()).buildSchema(resourceBuilder(clazz, CONFIG.enumValueResolver()).build(), STANDARD);
     }
 }

--- a/api/src/test/java/io/airlift/api/validation/TestConforming.java
+++ b/api/src/test/java/io/airlift/api/validation/TestConforming.java
@@ -1,6 +1,7 @@
 package io.airlift.api.validation;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -13,7 +14,11 @@ import com.google.common.collect.ImmutableSet;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Module;
+import io.airlift.api.ApiBuilderConfig;
+import io.airlift.api.ApiCreate;
 import io.airlift.api.ApiDescription;
+import io.airlift.api.ApiEnumNamingFormat;
+import io.airlift.api.ApiEnumValueResolver;
 import io.airlift.api.ApiFilter;
 import io.airlift.api.ApiGet;
 import io.airlift.api.ApiJsonNode;
@@ -24,27 +29,37 @@ import io.airlift.api.ApiPolyResource;
 import io.airlift.api.ApiResource;
 import io.airlift.api.ApiService;
 import io.airlift.api.ApiServiceTrait;
+import io.airlift.api.ApiServiceType;
 import io.airlift.api.ApiStringId;
 import io.airlift.api.ServiceType;
 import io.airlift.api.binding.ApiModule;
 import io.airlift.api.binding.PolyResourceModule;
 import io.airlift.api.builders.ApiBuilder;
+import io.airlift.api.builders.ResourceBuilder;
 import io.airlift.api.model.ModelApi;
 import io.airlift.api.model.ModelResource;
 import io.airlift.api.model.ModelResourceType;
 import io.airlift.api.model.ModelServiceMetadata;
 import io.airlift.api.model.ModelServiceType;
 import io.airlift.api.model.ModelServices;
+import io.airlift.api.openapi.OpenApiMetadata;
+import io.airlift.api.openapi.OpenApiProvider;
+import io.airlift.api.openapi.models.OpenAPI;
+import io.airlift.api.openapi.models.Schema;
 import io.airlift.api.responses.ApiBadRequest;
 import io.airlift.json.JsonModule;
 import jakarta.ws.rs.WebApplicationException;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Type;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
-import static io.airlift.api.builders.ResourceBuilder.resourceBuilder;
+import static io.airlift.api.ApiEnumNamingFormat.PASCAL_CASE;
 import static io.airlift.api.internals.Mappers.buildHeaderName;
 import static io.airlift.api.model.ModelResourceModifier.OPTIONAL;
 import static io.airlift.api.model.ModelResourceModifier.RECURSIVE_REFERENCE;
@@ -56,7 +71,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestConforming
 {
-    private static final ModelServiceMetadata METADATA = new ModelServiceMetadata("dummy", new ModelServiceType("dummy", 1, "dummy", "dummy", ImmutableSet.copyOf(ApiServiceTrait.values())), "dummy", ImmutableList.of());
+    private static final ApiBuilderConfig CONFIG = ApiBuilderConfig.jackson();
+    private static final ModelServiceMetadata METADATA = new ModelServiceMetadata("dummy", new ModelServiceType("dummy", 1, "dummy", "dummy", ImmutableSet.copyOf(ApiServiceTrait.values()), PASCAL_CASE), "dummy", ImmutableList.of());
 
     @Test
     public void testDuplicateMethods()
@@ -77,6 +93,18 @@ public class TestConforming
     {
         ModelServices services = ApiBuilder.apiBuilder().add(ServiceWithBadVersion.class).build().modelServices();
         assertThat(services.errors()).anyMatch(s -> s.contains("ApiResourceVersion fields must be named"));
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testDeprecatedEnumNameTypeValidation()
+    {
+        ValidationContext validationContext = new ValidationContext();
+        validationContext.validateName("OrderStatus", ValidationContext.NameType.ENUM);
+
+        assertThatThrownBy(() -> validationContext.validateName("orderStatus", ValidationContext.NameType.ENUM))
+                .isInstanceOf(ValidatorException.class)
+                .hasMessageContaining("\"orderStatus\" is not a valid enum name for format PascalCase");
     }
 
     @Test
@@ -150,7 +178,7 @@ public class TestConforming
     {
         ValidationContext validationContext = new ValidationContext();
         ModelResource modelResource = resourceBuilder(BoxedOptionals.class).build();
-        validateResource(validationContext, METADATA, modelResource);
+        validateResource(validationContext, METADATA, modelResource, CONFIG.enumValueResolver());
 
         assertThat(validationContext.errors()).isEmpty();
         assertThat(modelResource.components().get(0).type()).isEqualTo(boolean.class);
@@ -183,6 +211,84 @@ public class TestConforming
         assertIdComponent(allTypes, "listOfUuidIds", ResourceWithAllTypes.SimpleUuidId.class, LIST, false);
         assertIdComponent(allTypes, "maybeUuidIds", ResourceWithAllTypes.SimpleUuidId.class, LIST, true);
         assertIdComponent(allTypes, "maybeUuidId", ResourceWithAllTypes.SimpleUuidId.class, BASIC, true);
+    }
+
+    @Test
+    public void testEnumNamingFormatValidation()
+    {
+        assertThat(ApiBuilder.apiBuilder().add(PascalCaseEnumService.class).build().modelServices().errors()).isEmpty();
+
+        assertThat(ApiBuilder.apiBuilder().add(UpperSnakeCaseEnumService.class).build().modelServices().errors()).isEmpty();
+
+        assertThat(ApiBuilder.apiBuilder().add(DefaultUpperSnakeCaseEnumService.class).build().modelServices().errors())
+                .anyMatch(error -> error.contains("SMALL_VALUE") && error.contains("PascalCase"));
+
+        assertThat(ApiBuilder.apiBuilder().add(InvalidEnumService.class).build().modelServices().errors())
+                .anyMatch(error -> error.contains("small") && error.contains("PascalCase"));
+    }
+
+    @Test
+    public void testJsonValueEnumValidation()
+    {
+        assertThat(ApiBuilder.apiBuilder().add(JsonValueToStringEnumService.class).build().modelServices().errors()).isEmpty();
+
+        assertThat(ApiBuilder.apiBuilder().add(CustomJsonValueEnumService.class).build().modelServices().errors()).isEmpty();
+
+        assertThat(ApiBuilder.apiBuilder().add(NonStringJsonValueEnumService.class).build().modelServices().errors())
+                .anyMatch(error -> error.contains("must return a String"));
+
+        assertThat(ApiBuilder.apiBuilder().add(NullJsonValueEnumService.class).build().modelServices().errors())
+                .anyMatch(error -> error.contains("returned null"));
+
+        assertThat(ApiBuilder.apiBuilder().add(DuplicateJsonValueEnumService.class).build().modelServices().errors())
+                .anyMatch(error -> error.contains("Duplicate enum wire value"));
+
+        assertThat(ApiBuilder.apiBuilder().add(MultipleJsonValueEnumService.class).build().modelServices().errors())
+                .anyMatch(error -> error.contains("Multiple @JsonValue methods"));
+
+        assertThat(ApiBuilder.apiBuilder().add(StaticJsonValueEnumService.class).build().modelServices().errors())
+                .anyMatch(error -> error.contains("is not an instance method"));
+    }
+
+    @Test
+    public void testOpenApiEnumValuesUseResolvedWireValues()
+    {
+        assertThat(openApiEnumValues(PascalCaseEnumService.class, "PascalCaseEnumResource", "value"))
+                .containsExactly("Small", "Large");
+
+        assertThat(openApiEnumValues(UpperSnakeCaseEnumService.class, "UpperSnakeCaseEnumResource", "value"))
+                .containsExactly("SMALL_VALUE", "LARGE_VALUE");
+
+        assertThat(openApiEnumValues(CustomJsonValueEnumService.class, "CustomJsonValueEnumResource", "value"))
+                .containsExactly("SmallWireValue", "LargeWireValue");
+        assertThat(openApiProperty(CustomJsonValueEnumService.class, "CustomJsonValueEnumResource", "value").getDescription())
+                .contains("\"SmallWireValue\"")
+                .contains("\"LargeWireValue\"");
+    }
+
+    @Test
+    public void testConfiguredEnumValueResolver()
+    {
+        ApiBuilderConfig config = ApiBuilderConfig.of(new ConfiguredEnumValueResolver());
+
+        ModelApi modelApi = ApiBuilder.apiBuilder(config).add(PascalCaseEnumService.class).build();
+        assertThat(modelApi.modelServices().errors()).isEmpty();
+
+        assertThat(openApiEnumValues(PascalCaseEnumService.class, "PascalCaseEnumResource", "value", config))
+                .containsExactly("ConfiguredSmall", "ConfiguredLarge");
+    }
+
+    @Test
+    public void testApiModuleAppliesConfiguredEnumValueResolverAtBuild()
+    {
+        ApiBuilderConfig config = ApiBuilderConfig.of(new ConfiguredEnumValueResolver());
+
+        Module module = ApiModule.builder()
+                .addApi(api -> api.add(DefaultUpperSnakeCaseEnumService.class))
+                .withApiBuilderConfig(config)
+                .build();
+
+        Guice.createInjector(module, new JsonModule());
     }
 
     @Test
@@ -239,7 +345,7 @@ public class TestConforming
     public void testJsonNodeIdFieldDisallowed()
     {
         ValidationContext validationContext = new ValidationContext();
-        validateResource(validationContext, METADATA, resourceBuilder(ResourceWithJsonNodeIdField.class).build());
+        validateResource(validationContext, METADATA, resourceBuilder(ResourceWithJsonNodeIdField.class).build(), CONFIG.enumValueResolver());
         assertThat(validationContext.errors()).anyMatch(error -> error.contains("ApiJson types cannot be used as API ID fields"));
     }
 
@@ -403,7 +509,7 @@ public class TestConforming
         ValidationContext validationContext = new ValidationContext();
 
         ModelResource modelResource = resourceBuilder(PolyResourceWithReusedKey.class).build();
-        validateResource(validationContext, METADATA, modelResource);
+        validateResource(validationContext, METADATA, modelResource, CONFIG.enumValueResolver());
 
         assertThat(validationContext.errors())
                 .anyMatch(s -> s.contains("ItsNotOk is a sub-resource of ApiPolyResource and has a component that is the same as the ApiPolyResource key: dontReuse"));
@@ -443,7 +549,7 @@ public class TestConforming
         ValidationContext validationContext = new ValidationContext();
         ModelResource modelResource = resourceBuilder(RecursiveModel.class).build();
 
-        validateResource(validationContext, METADATA, modelResource);
+        validateResource(validationContext, METADATA, modelResource, CONFIG.enumValueResolver());
 
         modelResource.components().forEach(component -> {
             if (component.type().equals(RecursiveModel.class)) {
@@ -457,19 +563,19 @@ public class TestConforming
         });
 
         ValidationContext validationContext2 = new ValidationContext();
-        validationContext2.inContext("", _ -> validateResource(validationContext2, METADATA, resourceBuilder(BadRecursiveModel1.class).build()));
+        validationContext2.inContext("", _ -> validateResource(validationContext2, METADATA, resourceBuilder(BadRecursiveModel1.class).build(), CONFIG.enumValueResolver()));
         assertThat(validationContext2.errors()).isNotEmpty().allMatch(s -> s.startsWith("Recursive resources are only allowed in collections"));
 
         ValidationContext validationContext3 = new ValidationContext();
-        validationContext3.inContext("", _ -> validateResource(validationContext3, METADATA, resourceBuilder(BadRecursiveModel2.class).build()));
+        validationContext3.inContext("", _ -> validateResource(validationContext3, METADATA, resourceBuilder(BadRecursiveModel2.class).build(), CONFIG.enumValueResolver()));
         assertThat(validationContext3.errors()).isNotEmpty().allMatch(s -> s.startsWith("Recursive resources are only allowed in collections"));
 
         ValidationContext validationContext4 = new ValidationContext();
-        validationContext4.inContext("", _ -> validateResource(validationContext4, METADATA, resourceBuilder(BadRecursiveModel3.class).build()));
+        validationContext4.inContext("", _ -> validateResource(validationContext4, METADATA, resourceBuilder(BadRecursiveModel3.class).build(), CONFIG.enumValueResolver()));
         assertThat(validationContext4.errors()).isNotEmpty().allMatch(s -> s.startsWith("Recursive resources are only allowed in collections"));
 
         ValidationContext validationContext5 = new ValidationContext();
-        validationContext5.inContext("", _ -> validateResource(validationContext5, METADATA, resourceBuilder(BadRecursiveModel4.class).build()));
+        validationContext5.inContext("", _ -> validateResource(validationContext5, METADATA, resourceBuilder(BadRecursiveModel4.class).build(), CONFIG.enumValueResolver()));
         assertThat(validationContext5.errors()).isNotEmpty().allMatch(s -> s.startsWith("Maps in resources must be Map<String, String>"));
     }
 
@@ -500,6 +606,334 @@ public class TestConforming
         }
         else {
             assertThat(component.modifiers()).doesNotContain(OPTIONAL);
+        }
+    }
+
+    private static List<String> openApiEnumValues(Class<?> serviceClass, String schemaName, String propertyName)
+    {
+        return openApiProperty(serviceClass, schemaName, propertyName).getEnum().stream()
+                .map(String.class::cast)
+                .toList();
+    }
+
+    private static List<String> openApiEnumValues(Class<?> serviceClass, String schemaName, String propertyName, ApiBuilderConfig config)
+    {
+        return openApiProperty(serviceClass, schemaName, propertyName, config).getEnum().stream()
+                .map(String.class::cast)
+                .toList();
+    }
+
+    private static Schema<?> openApiProperty(Class<?> serviceClass, String schemaName, String propertyName)
+    {
+        return openApiProperty(serviceClass, schemaName, propertyName, CONFIG);
+    }
+
+    private static Schema<?> openApiProperty(Class<?> serviceClass, String schemaName, String propertyName, ApiBuilderConfig config)
+    {
+        ModelApi modelApi = ApiBuilder.apiBuilder(config).add(serviceClass).build();
+        assertThat(modelApi.modelServices().errors()).isEmpty();
+
+        ModelServiceType serviceType = modelApi.modelServices().services().iterator().next().service().type();
+        OpenAPI openAPI = OpenApiProvider.create(modelApi.modelServices(), new OpenApiMetadata(Optional.empty(), ImmutableList.of()), config).build(serviceType, _ -> true);
+        Map<String, Schema> schemas = openAPI.getComponents().getSchemas();
+        Schema<?> schema = schemas.get(schemaName);
+        assertThat(schema).withFailMessage("Schema not found: %s. Found: %s", schemaName, schemas.keySet()).isNotNull();
+        Schema<?> property = schema.getProperties().get(propertyName);
+        assertThat(property).isNotNull();
+        return property;
+    }
+
+    private static ResourceBuilder resourceBuilder(Type resource)
+    {
+        return ResourceBuilder.resourceBuilder(resource, CONFIG.enumValueResolver());
+    }
+
+    private static class ConfiguredEnumValueResolver
+            implements ApiEnumValueResolver
+    {
+        @Override
+        public List<String> values(Class<?> enumClass)
+        {
+            ImmutableList.Builder<String> values = ImmutableList.builder();
+            for (Object constant : enumClass.getEnumConstants()) {
+                values.add(value((Enum<?>) constant));
+            }
+            return values.build();
+        }
+
+        @Override
+        public String value(Enum<?> value)
+        {
+            StringBuilder builder = new StringBuilder("Configured");
+            for (String part : value.name().split("_")) {
+                builder.append(part.charAt(0))
+                        .append(part.substring(1).toLowerCase(Locale.US));
+            }
+            return builder.toString();
+        }
+    }
+
+    public static class EnumServiceType
+            implements ApiServiceType
+    {
+        @Override
+        public String id()
+        {
+            return "enum";
+        }
+
+        @Override
+        public int version()
+        {
+            return 1;
+        }
+
+        @Override
+        public String title()
+        {
+            return "enum";
+        }
+
+        @Override
+        public String description()
+        {
+            return "enum";
+        }
+
+        @Override
+        public Set<ApiServiceTrait> traits()
+        {
+            return ImmutableSet.of();
+        }
+    }
+
+    public static class UpperSnakeCaseEnumServiceType
+            extends EnumServiceType
+    {
+        @Override
+        public ApiEnumNamingFormat enumNamingFormat()
+        {
+            return ApiEnumNamingFormat.UPPER_SNAKE_CASE;
+        }
+    }
+
+    @ApiService(type = EnumServiceType.class, name = "enum", description = "enum")
+    public static class PascalCaseEnumService
+    {
+        @ApiCreate(description = "create")
+        public void create(PascalCaseEnumResource resource) {}
+    }
+
+    @ApiResource(name = "pascalCaseEnumResource", description = "enum")
+    public record PascalCaseEnumResource(PascalCaseEnum value) {}
+
+    public enum PascalCaseEnum
+    {
+        Small,
+        Large,
+    }
+
+    @ApiService(type = UpperSnakeCaseEnumServiceType.class, name = "enum", description = "enum")
+    public static class UpperSnakeCaseEnumService
+    {
+        @ApiCreate(description = "create")
+        public void create(UpperSnakeCaseEnumResource resource) {}
+    }
+
+    @ApiResource(name = "upperSnakeCaseEnumResource", description = "enum")
+    public record UpperSnakeCaseEnumResource(UpperSnakeCaseEnum value) {}
+
+    public enum UpperSnakeCaseEnum
+    {
+        SMALL_VALUE,
+        LARGE_VALUE,
+    }
+
+    @ApiService(type = EnumServiceType.class, name = "enum", description = "enum")
+    public static class DefaultUpperSnakeCaseEnumService
+    {
+        @ApiCreate(description = "create")
+        public void create(UpperSnakeCaseEnumResource resource) {}
+    }
+
+    @ApiService(type = EnumServiceType.class, name = "enum", description = "enum")
+    public static class InvalidEnumService
+    {
+        @ApiCreate(description = "create")
+        public void create(InvalidEnumResource resource) {}
+    }
+
+    @ApiResource(name = "invalidEnumResource", description = "enum")
+    public record InvalidEnumResource(InvalidEnum value) {}
+
+    public enum InvalidEnum
+    {
+        small
+    }
+
+    @ApiService(type = EnumServiceType.class, name = "enum", description = "enum")
+    public static class JsonValueToStringEnumService
+    {
+        @ApiCreate(description = "create")
+        public void create(JsonValueToStringEnumResource resource) {}
+    }
+
+    @ApiResource(name = "jsonValueToStringEnumResource", description = "enum")
+    public record JsonValueToStringEnumResource(JsonValueToStringEnum value) {}
+
+    public enum JsonValueToStringEnum
+    {
+        Small;
+
+        @JsonValue
+        @Override
+        public String toString()
+        {
+            return "Small";
+        }
+    }
+
+    @ApiService(type = EnumServiceType.class, name = "enum", description = "enum")
+    public static class CustomJsonValueEnumService
+    {
+        @ApiCreate(description = "create")
+        public void create(CustomJsonValueEnumResource resource) {}
+    }
+
+    @ApiResource(name = "customJsonValueEnumResource", description = "enum")
+    public record CustomJsonValueEnumResource(CustomJsonValueEnum value) {}
+
+    public enum CustomJsonValueEnum
+    {
+        @ApiDescription("small value")
+        Small("SmallWireValue"),
+        @ApiDescription("large value")
+        Large("LargeWireValue");
+
+        private final String value;
+
+        CustomJsonValueEnum(String value)
+        {
+            this.value = value;
+        }
+
+        @JsonValue
+        public String value()
+        {
+            return value;
+        }
+    }
+
+    @ApiService(type = EnumServiceType.class, name = "enum", description = "enum")
+    public static class NonStringJsonValueEnumService
+    {
+        @ApiCreate(description = "create")
+        public void create(NonStringJsonValueEnumResource resource) {}
+    }
+
+    @ApiResource(name = "nonStringJsonValueEnumResource", description = "enum")
+    public record NonStringJsonValueEnumResource(NonStringJsonValueEnum value) {}
+
+    public enum NonStringJsonValueEnum
+    {
+        Small;
+
+        @JsonValue
+        public int value()
+        {
+            return 1;
+        }
+    }
+
+    @ApiService(type = EnumServiceType.class, name = "enum", description = "enum")
+    public static class NullJsonValueEnumService
+    {
+        @ApiCreate(description = "create")
+        public void create(NullJsonValueEnumResource resource) {}
+    }
+
+    @ApiResource(name = "nullJsonValueEnumResource", description = "enum")
+    public record NullJsonValueEnumResource(NullJsonValueEnum value) {}
+
+    public enum NullJsonValueEnum
+    {
+        Small;
+
+        @JsonValue
+        public String value()
+        {
+            return null;
+        }
+    }
+
+    @ApiService(type = EnumServiceType.class, name = "enum", description = "enum")
+    public static class DuplicateJsonValueEnumService
+    {
+        @ApiCreate(description = "create")
+        public void create(DuplicateJsonValueEnumResource resource) {}
+    }
+
+    @ApiResource(name = "duplicateJsonValueEnumResource", description = "enum")
+    public record DuplicateJsonValueEnumResource(DuplicateJsonValueEnum value) {}
+
+    public enum DuplicateJsonValueEnum
+    {
+        Small,
+        Large;
+
+        @JsonValue
+        public String value()
+        {
+            return "Duplicate";
+        }
+    }
+
+    @ApiService(type = EnumServiceType.class, name = "enum", description = "enum")
+    public static class MultipleJsonValueEnumService
+    {
+        @ApiCreate(description = "create")
+        public void create(MultipleJsonValueEnumResource resource) {}
+    }
+
+    @ApiResource(name = "multipleJsonValueEnumResource", description = "enum")
+    public record MultipleJsonValueEnumResource(MultipleJsonValueEnum value) {}
+
+    public enum MultipleJsonValueEnum
+    {
+        Small;
+
+        @JsonValue
+        @Override
+        public String toString()
+        {
+            return "Small";
+        }
+
+        @JsonValue
+        public String value()
+        {
+            return "Small";
+        }
+    }
+
+    @ApiService(type = EnumServiceType.class, name = "enum", description = "enum")
+    public static class StaticJsonValueEnumService
+    {
+        @ApiCreate(description = "create")
+        public void create(StaticJsonValueEnumResource resource) {}
+    }
+
+    @ApiResource(name = "staticJsonValueEnumResource", description = "enum")
+    public record StaticJsonValueEnumResource(StaticJsonValueEnum value) {}
+
+    public enum StaticJsonValueEnum
+    {
+        Small;
+
+        @JsonValue
+        public static String value()
+        {
+            return "Small";
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add configurable API enum naming formats with PascalCase as the default and UPPER_SNAKE_CASE opt-in per service type.
- Resolve enum wire values through a Jackson-aware resolver for validation, OpenAPI schemas, and enum descriptions.
- Cover PascalCase, UPPER_SNAKE_CASE, and @JsonValue enum behavior in API Builder tests.
