### PR TITLE
Add typed server-sent event stream responses

### DIFF
--- a/api-maven-plugin/src/main/java/io/airlift/api/maven/GenerateOpenApiMojo.java
+++ b/api-maven-plugin/src/main/java/io/airlift/api/maven/GenerateOpenApiMojo.java
@@ -20,6 +20,7 @@ import io.airlift.api.builders.ApiBuilder;
 import io.airlift.api.model.ModelApi;
 import io.airlift.api.model.ModelServiceType;
 import io.airlift.api.openapi.OpenApiMetadata;
+import io.airlift.api.openapi.OpenApiMetadata.OpenApiVersion;
 import io.airlift.api.openapi.OpenApiMetadata.SecurityScheme;
 import io.airlift.api.openapi.OpenApiProvider;
 import io.airlift.api.openapi.models.OpenAPI;
@@ -76,6 +77,9 @@ public class GenerateOpenApiMojo
 
     @Parameter(property = "api.securityScheme")
     private String securityScheme;
+
+    @Parameter(property = "api.openApiVersion", defaultValue = "3.0.1")
+    private String openApiVersion;
 
     @Parameter(property = "api.prettyPrint", defaultValue = "true")
     private boolean prettyPrint;
@@ -242,7 +246,7 @@ public class GenerateOpenApiMojo
         }
 
         Optional<SecurityScheme> security = parseSecurityScheme();
-        OpenApiMetadata metadata = new OpenApiMetadata(security, ImmutableList.of(), basePath, Duration.ofMinutes(5));
+        OpenApiMetadata metadata = new OpenApiMetadata(security, ImmutableList.of(), basePath, Duration.ofMinutes(5), parseOpenApiVersion());
 
         OpenApiProvider openApiProvider = OpenApiProvider.create(modelApi.modelServices(), metadata);
         ModelServiceType modelServiceType = ModelServiceType.map(serviceType);
@@ -259,6 +263,24 @@ public class GenerateOpenApiMojo
         catch (IOException e) {
             throw new MojoExecutionException("Failed to serialize OpenAPI spec to JSON", e);
         }
+    }
+
+    private OpenApiVersion parseOpenApiVersion()
+            throws MojoExecutionException
+    {
+        if (openApiVersion == null || openApiVersion.isBlank()) {
+            return OpenApiVersion.OPENAPI_3_0_1;
+        }
+
+        String configuredOpenApiVersion = openApiVersion.trim();
+        for (OpenApiVersion version : OpenApiVersion.values()) {
+            if (version.value().equals(configuredOpenApiVersion) || version.name().equals(configuredOpenApiVersion)) {
+                return version;
+            }
+        }
+        throw new MojoExecutionException(
+                "Invalid OpenAPI version: %s. Valid values are: %s"
+                        .formatted(configuredOpenApiVersion, Arrays.stream(OpenApiVersion.values()).map(version -> version.value() + " or " + version.name()).toList()));
     }
 
     private Optional<SecurityScheme> parseSecurityScheme()

--- a/api-maven-plugin/src/test/java/io/airlift/api/maven/tests/OpenApiGenerationTest.java
+++ b/api-maven-plugin/src/test/java/io/airlift/api/maven/tests/OpenApiGenerationTest.java
@@ -278,6 +278,26 @@ class OpenApiGenerationTest
     }
 
     @MavenPluginTest
+    void testOpenApiVersionCanBeConfigured()
+            throws Exception
+    {
+        File basedir = resources.getBasedir("full-service");
+
+        maven.forProject(basedir)
+                .withCliOptions("-Dapi.openApiVersion=3.2.0")
+                .execute("clean", "compile", "process-classes")
+                .assertErrorFreeLog();
+
+        File openapiFile = new File(basedir, "target/openapi.json");
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode openapi = mapper.readTree(openapiFile);
+
+        assertThat(openapi.get("openapi").asText())
+                .describedAs("OpenAPI version should match the configured version")
+                .isEqualTo("3.2.0");
+    }
+
+    @MavenPluginTest
     void testInvalidSecuritySchemeFailsBuild()
             throws Exception
     {
@@ -292,6 +312,24 @@ class OpenApiGenerationTest
 
         assertThat(openapiFile)
                 .describedAs("OpenAPI spec should not be written when security scheme is invalid")
+                .doesNotExist();
+    }
+
+    @MavenPluginTest
+    void testInvalidOpenApiVersionFailsBuild()
+            throws Exception
+    {
+        File basedir = resources.getBasedir("full-service");
+        File openapiFile = new File(basedir, "target/openapi.json");
+
+        maven.forProject(basedir)
+                .withCliOptions("-Dapi.openApiVersion=3.1.0")
+                .execute("clean", "compile", "process-classes")
+                .assertLogText("Invalid OpenAPI version")
+                .assertNoLogText("BUILD SUCCESS");
+
+        assertThat(openapiFile)
+                .describedAs("OpenAPI spec should not be written when OpenAPI version is invalid")
                 .doesNotExist();
     }
 

--- a/api/docs/streaming.md
+++ b/api/docs/streaming.md
@@ -2,8 +2,9 @@
 
 # API Builder: Streaming Responses
 
-`@ApiGet` and `@ApiCreate` methods can stream responses by returning an `ApiTextStreamResponse`, `ApiByteStreamResponse`, or `ApiOutputStreamResponse` instance. The instance must be
-parameterized with a [resource](resources.md) that it represents. `@ApiCustom` methods can also stream responses when their `type` is `GET` or `CREATE`.
+`@ApiGet` and `@ApiCreate` methods can stream responses by returning an `ApiTextStreamResponse`, `ApiByteStreamResponse`, `ApiOutputStreamResponse`, or
+`ApiServerSentEventStreamResponse` instance. The instance must be parameterized with a [resource](resources.md) that it represents. `@ApiCustom` methods can
+also stream responses when their `type` is `GET` or `CREATE`.
 
 E.g.
 
@@ -40,4 +41,28 @@ public ApiByteStreamResponse<MyResource> myPostCustomStreamedResponse(MyCreateRe
 {
     return new ApiByteStreamResponse<>(myByteStream);
 }
+
+@ApiGet(...)
+public ApiServerSentEventStreamResponse<MyResource, MyEvent> myStreamedResponse(...)
+{
+    Consumer<OutputStream> consumer = outputStream -> {
+        // write server-sent event frames such as: data: <json>\n\n
+    };
+    return new ApiServerSentEventStreamResponse<>(consumer);
+}
+
+@ApiCreate(...)
+public ApiServerSentEventStreamResponse<MyResource, MyEvent> myPostStreamedResponse(MyCreateRequest request)
+{
+    Consumer<OutputStream> consumer = outputStream -> {
+        // write server-sent event frames such as: data: <json>\n\n
+    };
+    return new ApiServerSentEventStreamResponse<>(consumer);
+}
 ```
+
+`ApiTextStreamResponse` produces `text/plain`, while `ApiByteStreamResponse` and `ApiOutputStreamResponse` produce `application/octet-stream`.
+
+`ApiServerSentEventStreamResponse<RESOURCE, EVENT>` produces `text/event-stream`. `RESOURCE` keeps the API Builder resource and path semantics. `EVENT`
+describes the JSON payload the application writes in each SSE `data:` frame. API Builder sets the response content type and documents the event payload type,
+but the application still owns writing valid SSE frames.

--- a/api/src/main/java/io/airlift/api/ApiStreamResponse.java
+++ b/api/src/main/java/io/airlift/api/ApiStreamResponse.java
@@ -49,4 +49,14 @@ public sealed interface ApiStreamResponse
             requireNonNull(stream, "stream is null");
         }
     }
+
+    @SuppressWarnings("unused")
+    record ApiServerSentEventStreamResponse<RESOURCE, EVENT>(Consumer<OutputStream> stream)
+            implements ApiStreamResponse
+    {
+        public ApiServerSentEventStreamResponse
+        {
+            requireNonNull(stream, "stream is null");
+        }
+    }
 }

--- a/api/src/main/java/io/airlift/api/binding/ApiStreamResponseWriter.java
+++ b/api/src/main/java/io/airlift/api/binding/ApiStreamResponseWriter.java
@@ -3,6 +3,7 @@ package io.airlift.api.binding;
 import io.airlift.api.ApiStreamResponse;
 import io.airlift.api.ApiStreamResponse.ApiByteStreamResponse;
 import io.airlift.api.ApiStreamResponse.ApiOutputStreamResponse;
+import io.airlift.api.ApiStreamResponse.ApiServerSentEventStreamResponse;
 import io.airlift.api.ApiStreamResponse.ApiTextStreamResponse;
 import io.airlift.api.validation.ValidationContext;
 import jakarta.ws.rs.WebApplicationException;
@@ -50,6 +51,8 @@ public class ApiStreamResponseWriter
             case ApiByteStreamResponse<?> byteStreamResponse -> byteStreamResponse.stream().transferTo(entityStream);
 
             case ApiOutputStreamResponse<?> outputStreamResponse -> outputStreamResponse.stream().accept(entityStream);
+
+            case ApiServerSentEventStreamResponse<?, ?> eventStreamResponse -> eventStreamResponse.stream().accept(entityStream);
         }
     }
 }

--- a/api/src/main/java/io/airlift/api/builders/ResourceBuilder.java
+++ b/api/src/main/java/io/airlift/api/builders/ResourceBuilder.java
@@ -14,6 +14,7 @@ import io.airlift.api.ApiResource;
 import io.airlift.api.ApiResourceVersion;
 import io.airlift.api.ApiResponse;
 import io.airlift.api.ApiStreamResponse;
+import io.airlift.api.ApiStreamResponse.ApiServerSentEventStreamResponse;
 import io.airlift.api.ApiUnwrapped;
 import io.airlift.api.internals.Mappers;
 import io.airlift.api.model.ModelPolyResource;
@@ -210,12 +211,16 @@ public class ResourceBuilder
         }
 
         if (typeToken.isSubtypeOf(ApiStreamResponse.class)) {
-            return internalBuildAndAdd(componentName, extractGenericParameter(typeToken.getType(), 0))
+            ModelResource streamResource = internalBuildAndAdd(componentName, extractGenericParameter(typeToken.getType(), 0))
                     .withContainerType(typeToken.getType())
                     .withModifier(IS_STREAMING_RESPONSE)
                     .withModifier(HAS_RESOURCE_ID)
                     .withModifier(READ_ONLY)
                     .withModifier(HAS_VERSION);
+            if (typeToken.isSubtypeOf(ApiServerSentEventStreamResponse.class)) {
+                streamResource = streamResource.withStreamingEventResource(internalBuildAndAdd(componentName, extractGenericParameter(typeToken.getType(), 1)));
+            }
+            return streamResource;
         }
 
         if (typeToken.isSubtypeOf(ApiMultiPart.class)) {

--- a/api/src/main/java/io/airlift/api/model/ModelResource.java
+++ b/api/src/main/java/io/airlift/api/model/ModelResource.java
@@ -27,6 +27,7 @@ public record ModelResource(
         Set<String> limitedValues,
         Optional<ModelSupportsIdLookup> supportsIdLookup,
         Optional<ModelPolyResource> polyResource,
+        Optional<ModelResource> streamingEventResource,
         Optional<Map<String, String>> enumDescriptions)
 {
     public ModelResource
@@ -38,6 +39,7 @@ public record ModelResource(
         requireNonNull(resourceType, "resourceType is null");
         requireNonNull(containerType, "containerType is null");
         requireNonNull(polyResource, "polyResource is null");
+        requireNonNull(streamingEventResource, "streamingEventResource is null");
 
         components = ImmutableList.copyOf(components);
         modifiers = ImmutableSet.copyOf(modifiers);
@@ -48,65 +50,88 @@ public record ModelResource(
 
     public ModelResource(Type type, String name, String description, List<ModelResource> components, ModelResourceType resourceType)
     {
-        this(type, name, Optional.empty(), description, components, resourceType, type, ImmutableSet.of(), ImmutableSet.of(), ImmutableSet.of(), Optional.empty(), Optional.empty(), Optional.empty());
+        this(type, name, Optional.empty(), description, components, resourceType, type, ImmutableSet.of(), ImmutableSet.of(), ImmutableSet.of(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
     }
 
     public ModelResource(Type type, String name, Optional<String> openApiName, String description, List<ModelResource> components, ModelResourceType resourceType, Collection<ModelResourceModifier> modifiers, Set<String> quotas)
     {
-        this(type, name, openApiName, description, components, resourceType, type, modifiers, quotas, ImmutableSet.of(), Optional.empty(), Optional.empty(), Optional.empty());
+        this(type, name, openApiName, description, components, resourceType, type, modifiers, quotas, ImmutableSet.of(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+    }
+
+    public ModelResource(
+            Type type,
+            String name,
+            Optional<String> openApiName,
+            String description,
+            List<ModelResource> components,
+            ModelResourceType resourceType,
+            Type containerType,
+            Collection<ModelResourceModifier> modifiers,
+            Set<String> quotas,
+            Set<String> limitedValues,
+            Optional<ModelSupportsIdLookup> supportsIdLookup,
+            Optional<ModelPolyResource> polyResource,
+            Optional<Map<String, String>> enumDescriptions)
+    {
+        this(type, name, openApiName, description, components, resourceType, containerType, modifiers, quotas, limitedValues, supportsIdLookup, polyResource, Optional.empty(), enumDescriptions);
     }
 
     public ModelResource withNameAndDescription(String name, Optional<String> openApiName, String description)
     {
-        return new ModelResource(type, name, openApiName, description, components, resourceType, containerType, modifiers, quotas, limitedValues, supportsIdLookup, polyResource, enumDescriptions);
+        return new ModelResource(type, name, openApiName, description, components, resourceType, containerType, modifiers, quotas, limitedValues, supportsIdLookup, polyResource, streamingEventResource, enumDescriptions);
     }
 
     public ModelResource asResourceType(ModelResourceType resourceType)
     {
-        return new ModelResource(type, name, openApiName, description, components, resourceType, containerType, modifiers, quotas, limitedValues, supportsIdLookup, polyResource, enumDescriptions);
+        return new ModelResource(type, name, openApiName, description, components, resourceType, containerType, modifiers, quotas, limitedValues, supportsIdLookup, polyResource, streamingEventResource, enumDescriptions);
     }
 
     public ModelResource withModifier(ModelResourceModifier modifier)
     {
         Set<ModelResourceModifier> newModifiers = new HashSet<>(modifiers);
         newModifiers.add(modifier);
-        return new ModelResource(type, name, openApiName, description, components, resourceType, containerType, newModifiers, quotas, limitedValues, supportsIdLookup, polyResource, enumDescriptions);
+        return new ModelResource(type, name, openApiName, description, components, resourceType, containerType, newModifiers, quotas, limitedValues, supportsIdLookup, polyResource, streamingEventResource, enumDescriptions);
     }
 
     public ModelResource withModifierRemoved(ModelResourceModifier modifier)
     {
         Set<ModelResourceModifier> newModifiers = new HashSet<>(modifiers);
         newModifiers.remove(modifier);
-        return new ModelResource(type, name, openApiName, description, components, resourceType, containerType, newModifiers, quotas, limitedValues, supportsIdLookup, polyResource, enumDescriptions);
+        return new ModelResource(type, name, openApiName, description, components, resourceType, containerType, newModifiers, quotas, limitedValues, supportsIdLookup, polyResource, streamingEventResource, enumDescriptions);
     }
 
     public ModelResource withContainerType(Type containerType)
     {
-        return new ModelResource(type, name, openApiName, description, components, resourceType, containerType, modifiers, quotas, limitedValues, supportsIdLookup, polyResource, enumDescriptions);
+        return new ModelResource(type, name, openApiName, description, components, resourceType, containerType, modifiers, quotas, limitedValues, supportsIdLookup, polyResource, streamingEventResource, enumDescriptions);
     }
 
     public ModelResource withLimitedValues(Set<String> limitedValues)
     {
-        return new ModelResource(type, name, openApiName, description, components, resourceType, containerType, modifiers, quotas, limitedValues, supportsIdLookup, polyResource, enumDescriptions);
+        return new ModelResource(type, name, openApiName, description, components, resourceType, containerType, modifiers, quotas, limitedValues, supportsIdLookup, polyResource, streamingEventResource, enumDescriptions);
     }
 
     public ModelResource withSupportsIdLookup(ModelSupportsIdLookup supportsIdLookup)
     {
-        return new ModelResource(type, name, openApiName, description, components, resourceType, containerType, modifiers, quotas, limitedValues, Optional.of(supportsIdLookup), polyResource, enumDescriptions);
+        return new ModelResource(type, name, openApiName, description, components, resourceType, containerType, modifiers, quotas, limitedValues, Optional.of(supportsIdLookup), polyResource, streamingEventResource, enumDescriptions);
     }
 
     public ModelResource withPolyResource(ModelPolyResource polyResource)
     {
-        return new ModelResource(type, name, openApiName, description, components, resourceType, containerType, modifiers, quotas, limitedValues, supportsIdLookup, Optional.of(polyResource), enumDescriptions);
+        return new ModelResource(type, name, openApiName, description, components, resourceType, containerType, modifiers, quotas, limitedValues, supportsIdLookup, Optional.of(polyResource), streamingEventResource, enumDescriptions);
+    }
+
+    public ModelResource withStreamingEventResource(ModelResource streamingEventResource)
+    {
+        return new ModelResource(type, name, openApiName, description, components, resourceType, containerType, modifiers, quotas, limitedValues, supportsIdLookup, polyResource, Optional.of(streamingEventResource), enumDescriptions);
     }
 
     public ModelResource withEnumDescriptions(Map<String, String> enumDescriptions)
     {
-        return new ModelResource(type, name, openApiName, description, components, resourceType, containerType, modifiers, quotas, limitedValues, supportsIdLookup, polyResource, Optional.of(enumDescriptions));
+        return new ModelResource(type, name, openApiName, description, components, resourceType, containerType, modifiers, quotas, limitedValues, supportsIdLookup, polyResource, streamingEventResource, Optional.of(enumDescriptions));
     }
 
     public ModelResource withComponents(List<ModelResource> components)
     {
-        return new ModelResource(type, name, openApiName, description, components, resourceType, containerType, modifiers, quotas, limitedValues, supportsIdLookup, polyResource, enumDescriptions);
+        return new ModelResource(type, name, openApiName, description, components, resourceType, containerType, modifiers, quotas, limitedValues, supportsIdLookup, polyResource, streamingEventResource, enumDescriptions);
     }
 }

--- a/api/src/main/java/io/airlift/api/openapi/OpenApiBuilder.java
+++ b/api/src/main/java/io/airlift/api/openapi/OpenApiBuilder.java
@@ -131,6 +131,7 @@ class OpenApiBuilder
     OpenAPI build()
     {
         OpenAPI openAPI = new OpenAPI();
+        openAPI.openapi(metadata.openApiVersion().value());
 
         Info info = new Info()
                 .title(serviceType.title())
@@ -268,7 +269,7 @@ class OpenApiBuilder
         }
         else if (modelMethod.returnType().modifiers().contains(IS_STREAMING_RESPONSE)) {
             ValidationContext tempValidationContext = new ValidationContext();
-            MediaType item = new MediaType().schema(new StringSchema());
+            MediaType item = buildStreamingResponseMediaType(modelMethod.returnType());
             apiResponse.description("Success").setContent(new Content().addMediaType(tempValidationContext.streamingResponseMediaType(modelMethod.returnType()).toString(), item));
             apiResponses.addApiResponse(SUCCESS, apiResponse);
         }
@@ -296,6 +297,39 @@ class OpenApiBuilder
         operation.parameters(buildParameters(modelMethod));
 
         return extensionFilter.apply(modelService, modelMethod, operation);
+    }
+
+    private MediaType buildStreamingResponseMediaType(ModelResource returnType)
+    {
+        Optional<ModelResource> streamingEventResource = returnType.streamingEventResource();
+        if (streamingEventResource.isEmpty()) {
+            return new MediaType().schema(new StringSchema());
+        }
+
+        Schema<?> eventSchema = schemaBuilder.buildSchema(streamingEventResource.orElseThrow(), BuildSchemaMode.STANDARD);
+        return switch (metadata.openApiVersion()) {
+            case OPENAPI_3_0_1 -> buildOpenApi301StreamingResponseMediaType(eventSchema);
+            case OPENAPI_3_2_0 -> buildOpenApi320StreamingResponseMediaType(eventSchema);
+        };
+    }
+
+    private MediaType buildOpenApi301StreamingResponseMediaType(Schema<?> eventSchema)
+    {
+        return new MediaType()
+                .schema(new StringSchema())
+                .airliftEventSchema(eventSchema);
+    }
+
+    private static MediaType buildOpenApi320StreamingResponseMediaType(Schema<?> eventSchema)
+    {
+        Schema<?> dataSchema = new StringSchema()
+                .contentMediaType(APPLICATION_JSON)
+                .contentSchema(eventSchema);
+        Schema<?> itemSchema = new Schema<>()
+                .type("object")
+                .addProperty("data", dataSchema)
+                .addRequiredItem("data");
+        return new MediaType().itemSchema(itemSchema);
     }
 
     private String buildMethodName(ModelMethod modelMethod)

--- a/api/src/main/java/io/airlift/api/openapi/OpenApiMetadata.java
+++ b/api/src/main/java/io/airlift/api/openapi/OpenApiMetadata.java
@@ -8,18 +8,15 @@ import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
-public record OpenApiMetadata(Optional<SecurityScheme> security, List<ServiceDetail> serviceDetails, String basePath, Duration cacheDuration)
+public record OpenApiMetadata(Optional<SecurityScheme> security, List<ServiceDetail> serviceDetails, String basePath, Duration cacheDuration, OpenApiVersion openApiVersion)
 {
     public OpenApiMetadata
     {
         requireNonNull(security, "security is null");
         requireNonNull(basePath, "basePath is null");
+        requireNonNull(cacheDuration, "cacheDuration is null");
+        requireNonNull(openApiVersion, "openApiVersion is null");
         serviceDetails = ImmutableList.copyOf(serviceDetails);
-    }
-
-    public OpenApiMetadata(Optional<SecurityScheme> security, List<ServiceDetail> serviceDetails)
-    {
-        this(security, serviceDetails, "/", Duration.ofMinutes(5));
     }
 
     public enum SecurityScheme
@@ -27,6 +24,24 @@ public record OpenApiMetadata(Optional<SecurityScheme> security, List<ServiceDet
         BEARER_ACCESS_TOKEN,
         BEARER_JWT,
         BASIC,
+    }
+
+    public enum OpenApiVersion
+    {
+        OPENAPI_3_0_1("3.0.1"),
+        OPENAPI_3_2_0("3.2.0");
+
+        private final String value;
+
+        public String value()
+        {
+            return value;
+        }
+
+        OpenApiVersion(String value)
+        {
+            this.value = value;
+        }
     }
 
     public static final String SECTION_HELP = "Help";

--- a/api/src/main/java/io/airlift/api/openapi/models/MediaType.java
+++ b/api/src/main/java/io/airlift/api/openapi/models/MediaType.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class MediaType
 {
     private Schema schema;
+    private Schema itemSchema;
+    private Schema airliftEventSchema;
 
     @JsonProperty
     public Schema getSchema()
@@ -21,6 +23,40 @@ public class MediaType
     public MediaType schema(Schema schema)
     {
         this.schema = schema;
+        return this;
+    }
+
+    @JsonProperty
+    public Schema getItemSchema()
+    {
+        return itemSchema;
+    }
+
+    public void setItemSchema(Schema itemSchema)
+    {
+        this.itemSchema = itemSchema;
+    }
+
+    public MediaType itemSchema(Schema itemSchema)
+    {
+        this.itemSchema = itemSchema;
+        return this;
+    }
+
+    @JsonProperty("x-airlift-event-schema")
+    public Schema getAirliftEventSchema()
+    {
+        return airliftEventSchema;
+    }
+
+    public void setAirliftEventSchema(Schema airliftEventSchema)
+    {
+        this.airliftEventSchema = airliftEventSchema;
+    }
+
+    public MediaType airliftEventSchema(Schema airliftEventSchema)
+    {
+        this.airliftEventSchema = airliftEventSchema;
         return this;
     }
 }

--- a/api/src/main/java/io/airlift/api/openapi/models/Schema.java
+++ b/api/src/main/java/io/airlift/api/openapi/models/Schema.java
@@ -31,6 +31,8 @@ public class Schema<T>
     private List<Schema> oneOf;
     private Discriminator discriminator;
     private List<String> tags;
+    private String contentMediaType;
+    private Schema<?> contentSchema;
 
     public Schema() {}
 
@@ -388,5 +390,39 @@ public class Schema<T>
             this._enum = new ArrayList<>();
         }
         this._enum.add(_enumItem);
+    }
+
+    @JsonProperty
+    public String getContentMediaType()
+    {
+        return contentMediaType;
+    }
+
+    public void setContentMediaType(String contentMediaType)
+    {
+        this.contentMediaType = contentMediaType;
+    }
+
+    public Schema contentMediaType(String contentMediaType)
+    {
+        this.contentMediaType = contentMediaType;
+        return this;
+    }
+
+    @JsonProperty
+    public Schema<?> getContentSchema()
+    {
+        return contentSchema;
+    }
+
+    public void setContentSchema(Schema<?> contentSchema)
+    {
+        this.contentSchema = contentSchema;
+    }
+
+    public Schema contentSchema(Schema<?> contentSchema)
+    {
+        this.contentSchema = contentSchema;
+        return this;
     }
 }

--- a/api/src/main/java/io/airlift/api/validation/ResourceValidator.java
+++ b/api/src/main/java/io/airlift/api/validation/ResourceValidator.java
@@ -182,6 +182,9 @@ public interface ResourceValidator
         if (modelResource.modifiers().contains(IS_STREAMING_RESPONSE) && !state.contains(IS_RESULT_RESOURCE)) {
             throw new ValidatorException("%s cannot be a parameter".formatted(ApiStreamResponse.class.getSimpleName()));
         }
+        modelResource.streamingEventResource().ifPresent(streamingEventResource ->
+                context.inContext("Streaming event resource %s".formatted(streamingEventResource.type().getTypeName()),
+                        subContext -> internalValidate(subContext, service, Optional.empty(), streamingEventResource, ResourceValidationState.create().withOptions(IS_RESULT_RESOURCE))));
 
         if (modelResource.modifiers().contains(IS_MULTIPART_FORM)) {
             if (state.contains(IS_RESULT_RESOURCE)) {

--- a/api/src/main/java/io/airlift/api/validation/ValidationContext.java
+++ b/api/src/main/java/io/airlift/api/validation/ValidationContext.java
@@ -11,6 +11,7 @@ import io.airlift.api.ApiResource;
 import io.airlift.api.ApiResourceVersion;
 import io.airlift.api.ApiStreamResponse.ApiByteStreamResponse;
 import io.airlift.api.ApiStreamResponse.ApiOutputStreamResponse;
+import io.airlift.api.ApiStreamResponse.ApiServerSentEventStreamResponse;
 import io.airlift.api.ApiStreamResponse.ApiTextStreamResponse;
 import io.airlift.api.ApiStringId;
 import io.airlift.api.ApiUuidId;
@@ -63,6 +64,7 @@ public class ValidationContext
     private static final Pattern ID_NAMING = Pattern.compile("^[a-z0-9][a-zA-Z0-9]*$");  // same as STANDARD_NAMING but first letter may be a number
 
     private static final Set<Type> forcedReadOnly = ImmutableSet.of(ApiResourceVersion.class);
+    public static final MediaType TEXT_EVENT_STREAM_TYPE = MediaType.valueOf("text/event-stream");
 
     public ValidationContext()
     {
@@ -104,6 +106,9 @@ public class ValidationContext
     public MediaType streamingResponseMediaType(Type type)
     {
         TypeToken<?> typeToken = TypeToken.of(typeResolver.resolveType(type));
+        if (typeToken.isSubtypeOf(ApiServerSentEventStreamResponse.class)) {
+            return TEXT_EVENT_STREAM_TYPE;
+        }
         if (typeToken.isSubtypeOf(ApiByteStreamResponse.class) || typeToken.isSubtypeOf(ApiOutputStreamResponse.class)) {
             return APPLICATION_OCTET_STREAM_TYPE;
         }

--- a/api/src/test/java/io/airlift/api/servertests/integration/testingserver/TestingApiModule.java
+++ b/api/src/test/java/io/airlift/api/servertests/integration/testingserver/TestingApiModule.java
@@ -9,10 +9,12 @@ import io.airlift.api.openapi.OpenApiMetadata;
 import io.airlift.api.openapi.OpenApiMetadata.ServiceDetail;
 import io.airlift.api.servertests.integration.testingserver.external.PublicWidgetApi;
 
+import java.time.Duration;
 import java.util.Optional;
 
 import static io.airlift.api.compatability.ApiCompatibilityTester.basePathFromClass;
 import static io.airlift.api.compatability.ApiCompatibilityTester.newDefaultInstance;
+import static io.airlift.api.openapi.OpenApiMetadata.OpenApiVersion.OPENAPI_3_0_1;
 import static io.airlift.api.openapi.OpenApiMetadata.SECTION_HELP;
 import static io.airlift.api.openapi.OpenApiMetadata.SecurityScheme.BEARER_ACCESS_TOKEN;
 
@@ -31,7 +33,7 @@ public class TestingApiModule
                 ```
                 """);
 
-        OpenApiMetadata openApiMetadata = new OpenApiMetadata(Optional.of(BEARER_ACCESS_TOKEN), ImmutableList.of(serviceDetail));
+        OpenApiMetadata openApiMetadata = new OpenApiMetadata(Optional.of(BEARER_ACCESS_TOKEN), ImmutableList.of(serviceDetail), "/", Duration.ofMinutes(5), OPENAPI_3_0_1);
 
         Module apiModule = ApiModule.builder()
                 .addApi(apiBuilder -> apiBuilder.add(PublicWidgetApi.class))

--- a/api/src/test/java/io/airlift/api/servertests/openapi/TestOpenApi.java
+++ b/api/src/test/java/io/airlift/api/servertests/openapi/TestOpenApi.java
@@ -12,8 +12,10 @@ import jakarta.ws.rs.core.UriBuilder;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
+import java.time.Duration;
 import java.util.Optional;
 
+import static io.airlift.api.openapi.OpenApiMetadata.OpenApiVersion.OPENAPI_3_0_1;
 import static io.airlift.api.openapi.OpenApiMetadata.SecurityScheme.BEARER_ACCESS_TOKEN;
 import static io.airlift.http.client.Request.Builder.prepareGet;
 import static io.airlift.http.client.StringResponseHandler.createStringResponseHandler;
@@ -23,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestOpenApi
         extends ServerTestBase
 {
-    private static final OpenApiMetadata OPEN_API_METADATA = new OpenApiMetadata(Optional.of(BEARER_ACCESS_TOKEN), ImmutableList.of());
+    private static final OpenApiMetadata OPEN_API_METADATA = new OpenApiMetadata(Optional.of(BEARER_ACCESS_TOKEN), ImmutableList.of(), "/", Duration.ofMinutes(5), OPENAPI_3_0_1);
 
     public TestOpenApi()
     {

--- a/api/src/test/java/io/airlift/api/servertests/openapi/recursive/TestRecursive.java
+++ b/api/src/test/java/io/airlift/api/servertests/openapi/recursive/TestRecursive.java
@@ -17,9 +17,11 @@ import io.airlift.api.servertests.ServerTestBase;
 import io.airlift.json.JsonCodec;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Optional;
 
+import static io.airlift.api.openapi.OpenApiMetadata.OpenApiVersion.OPENAPI_3_0_1;
 import static io.airlift.api.servertests.openapi.TestOpenApi.validateOpenApiJson;
 import static io.airlift.json.JsonCodec.jsonCodec;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -38,7 +40,7 @@ public class TestRecursive
         super(builder -> builder
                 .addApi(apiBuilder -> apiBuilder.add(ComplexRecursiveService.class))
                 .addApi(apiBuilder -> apiBuilder.add(SimpleRecursiveService.class))
-                .withOpenApiMetadata(new OpenApiMetadata(Optional.empty(), ImmutableList.of())));
+                .withOpenApiMetadata(new OpenApiMetadata(Optional.empty(), ImmutableList.of(), "/", Duration.ofMinutes(5), OPENAPI_3_0_1)));
 
         openApiProvider = injector.getInstance(OpenApiProvider.class);
         modelServiceTypes = injector.getInstance(Key.get(new TypeLiteral<>() {}));

--- a/api/src/test/java/io/airlift/api/servertests/streaming/StreamingEvent.java
+++ b/api/src/test/java/io/airlift/api/servertests/streaming/StreamingEvent.java
@@ -1,0 +1,7 @@
+package io.airlift.api.servertests.streaming;
+
+import io.airlift.api.ApiDescription;
+import io.airlift.api.ApiResource;
+
+@ApiResource(name = "streamingEvent", description = "An event sent through a server-sent event stream")
+public record StreamingEvent(@ApiDescription("Event type") String type, @ApiDescription("Event message") String message) {}

--- a/api/src/test/java/io/airlift/api/servertests/streaming/StreamingService.java
+++ b/api/src/test/java/io/airlift/api/servertests/streaming/StreamingService.java
@@ -9,6 +9,7 @@ import io.airlift.api.ApiResponseHeaders;
 import io.airlift.api.ApiService;
 import io.airlift.api.ApiStreamResponse.ApiByteStreamResponse;
 import io.airlift.api.ApiStreamResponse.ApiOutputStreamResponse;
+import io.airlift.api.ApiStreamResponse.ApiServerSentEventStreamResponse;
 import io.airlift.api.ApiStreamResponse.ApiTextStreamResponse;
 import io.airlift.api.ServiceType;
 import io.airlift.api.responses.ApiException;
@@ -69,6 +70,33 @@ public class StreamingService
     {
         quotaController.recordQuotaUsage(request, "STREAMING");
         return new ApiTextStreamResponse<>("This is streaming post: " + streamingRequest.something());
+    }
+
+    @ApiCustom(type = GET, verb = "events", description = "server-sent events")
+    public ApiServerSentEventStreamResponse<StreamingResource, StreamingEvent> streamEvents()
+    {
+        return new ApiServerSentEventStreamResponse<>(outputStream -> {
+            try {
+                outputStream.write("data: {\"type\":\"message\",\"message\":\"hello\"}\n\n".getBytes(StandardCharsets.UTF_8));
+            }
+            catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    @ApiCustom(type = CREATE, verb = "postEvents", description = "server-sent events over post", quotas = "postEvents")
+    public ApiServerSentEventStreamResponse<StreamingResource, StreamingEvent> createEvents(@Context Request request)
+    {
+        quotaController.recordQuotaUsage(request, "postEvents");
+        return new ApiServerSentEventStreamResponse<>(outputStream -> {
+            try {
+                outputStream.write("data: {\"type\":\"message\",\"message\":\"posted\"}\n\n".getBytes(StandardCharsets.UTF_8));
+            }
+            catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
     }
 
     @ApiCustom(type = LIST, verb = "bad", description = "bad")

--- a/api/src/test/java/io/airlift/api/servertests/streaming/TestStreaming.java
+++ b/api/src/test/java/io/airlift/api/servertests/streaming/TestStreaming.java
@@ -1,5 +1,11 @@
 package io.airlift.api.servertests.streaming;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import io.airlift.api.builders.ApiBuilder;
+import io.airlift.api.model.ModelService;
+import io.airlift.api.model.ModelServices;
+import io.airlift.api.openapi.OpenApiMetadata;
+import io.airlift.api.openapi.OpenApiProvider;
 import io.airlift.api.servertests.ServerTestBase;
 import io.airlift.http.client.Request;
 import io.airlift.http.client.StatusResponseHandler.StatusResponse;
@@ -9,8 +15,12 @@ import jakarta.ws.rs.core.UriBuilder;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
+import java.time.Duration;
+import java.util.List;
 import java.util.Optional;
 
+import static io.airlift.api.openapi.OpenApiMetadata.OpenApiVersion.OPENAPI_3_0_1;
+import static io.airlift.api.openapi.OpenApiMetadata.OpenApiVersion.OPENAPI_3_2_0;
 import static io.airlift.http.client.HeaderNames.ACCEPT;
 import static io.airlift.http.client.HeaderNames.CONTENT_DISPOSITION;
 import static io.airlift.http.client.HeaderNames.CONTENT_TYPE;
@@ -20,6 +30,7 @@ import static io.airlift.http.client.Request.Builder.preparePost;
 import static io.airlift.http.client.StatusResponseHandler.createStatusResponseHandler;
 import static io.airlift.http.client.StringResponseHandler.createStringResponseHandler;
 import static io.airlift.json.JsonCodec.jsonCodec;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestStreaming
@@ -27,7 +38,7 @@ public class TestStreaming
 {
     public TestStreaming()
     {
-        super(StreamingService.class);
+        super(StreamingService.class, builder -> builder.withOpenApiMetadata(new OpenApiMetadata(Optional.empty(), List.of(), "/", Duration.ofMinutes(5), OPENAPI_3_0_1)));
     }
 
     @Test
@@ -45,6 +56,59 @@ public class TestStreaming
         assertThat(stringResponse.getHeader(CONTENT_TYPE)).hasValue(MediaType.APPLICATION_OCTET_STREAM);
         assertThat(stringResponse.getHeader(CONTENT_DISPOSITION)).hasValue("attachment; filename=\"foo.bar\"");
         assertThat(stringResponse.getBody()).isEqualTo("This is streaming output");
+
+        stringResponse = doRequest(Optional.of("events"));
+        assertThat(stringResponse.getHeader(CONTENT_TYPE)).hasValue("text/event-stream");
+        assertThat(stringResponse.getBody()).isEqualTo("data: {\"type\":\"message\",\"message\":\"hello\"}\n\n");
+    }
+
+    @Test
+    public void testPostStreaming()
+    {
+        URI uri = UriBuilder.fromUri(baseUri).path("public/api/v1/streamer:postEvents").build();
+        Request request = preparePost().setUri(uri).build();
+        StringResponse stringResponse = httpClient.execute(request, createStringResponseHandler());
+
+        assertThat(stringResponse.getHeader(CONTENT_TYPE)).hasValue("text/event-stream");
+        assertThat(stringResponse.getBody()).isEqualTo("data: {\"type\":\"message\",\"message\":\"posted\"}\n\n");
+    }
+
+    @Test
+    public void testDefaultOpenApiStreaming()
+            throws Exception
+    {
+        JsonNode openApi = getOpenApi();
+        assertThat(openApi.at("/openapi").asText()).isEqualTo("3.0.1");
+
+        JsonNode outputMediaType = openApi.at("/paths/~1public~1api~1v1~1streamer:output/get/responses/200/content/application~1octet-stream");
+        assertThat(outputMediaType.at("/schema/type").asText()).isEqualTo("string");
+        assertThat(outputMediaType.has("x-airlift-event-schema")).isFalse();
+
+        JsonNode eventMediaType = openApi.at("/paths/~1public~1api~1v1~1streamer:events/get/responses/200/content/text~1event-stream");
+        assertThat(eventMediaType.at("/schema/type").asText()).isEqualTo("string");
+        assertThat(eventMediaType.at("/x-airlift-event-schema/$ref").asText()).isEqualTo("#/components/schemas/StreamingEvent");
+        assertThat(openApi.at("/components/schemas/StreamingEvent").isMissingNode()).isFalse();
+    }
+
+    @Test
+    public void testOpenApi32Streaming()
+            throws Exception
+    {
+        ModelServices modelServices = ApiBuilder.apiBuilder().add(StreamingService.class).build().modelServices();
+        assertThat(modelServices.errors()).isEmpty();
+        ModelService service = modelServices.services().iterator().next();
+        OpenApiProvider provider = OpenApiProvider.create(modelServices, new OpenApiMetadata(Optional.empty(), List.of(), "/", Duration.ofMinutes(5), OPENAPI_3_2_0));
+        JsonNode openApi = jsonMapper.readTree(jsonMapper.writeValueAsString(provider.build(service.service().type(), _ -> true)));
+
+        assertThat(openApi.at("/openapi").asText()).isEqualTo("3.2.0");
+        JsonNode eventMediaType = openApi.at("/paths/~1public~1api~1v1~1streamer:events/get/responses/200/content/text~1event-stream");
+        assertThat(eventMediaType.has("schema")).isFalse();
+        assertThat(eventMediaType.at("/itemSchema/type").asText()).isEqualTo("object");
+        assertThat(eventMediaType.at("/itemSchema/required/0").asText()).isEqualTo("data");
+        assertThat(eventMediaType.at("/itemSchema/properties/data/type").asText()).isEqualTo("string");
+        assertThat(eventMediaType.at("/itemSchema/properties/data/contentMediaType").asText()).isEqualTo("application/json");
+        assertThat(eventMediaType.at("/itemSchema/properties/data/contentSchema/$ref").asText()).isEqualTo("#/components/schemas/StreamingEvent");
+        assertThat(eventMediaType.at("/itemSchema/properties/event").isMissingNode()).isTrue();
     }
 
     @Test
@@ -85,5 +149,16 @@ public class TestStreaming
         URI uri = verb.map(v -> URI.create(tempUri.toString() + ":" + v)).orElse(tempUri);
 
         return prepareGet().setUri(uri).build();
+    }
+
+    private JsonNode getOpenApi()
+            throws Exception
+    {
+        URI uri = UriBuilder.fromUri(baseUri).path("/public/openapi/v1/json").build();
+        Request request = prepareGet().setUri(uri).build();
+        StringResponse response = httpClient.execute(request, createStringResponseHandler());
+
+        assertThat(response.getStatusCode()).isEqualTo(200);
+        return jsonMapper.readTree(response.getBody().getBytes(UTF_8));
     }
 }


### PR DESCRIPTION
Summary

- Adds `ApiServerSentEventStreamResponse<RESOURCE, EVENT>` for app-owned SSE frame writing with `text/event-stream` runtime content type.
- Carries typed event payload metadata through validation and generated OpenAPI.
- Keeps default OpenAPI 3.0.1 stream output backward-compatible with `schema: string` plus `x-airlift-event-schema`, and adds opt-in 3.2 `itemSchema` output.
