### PR TITLE
Emit any JSON schema for object elements

### DIFF
--- a/api/src/main/java/io/airlift/api/internals/ApiJsonTypes.java
+++ b/api/src/main/java/io/airlift/api/internals/ApiJsonTypes.java
@@ -3,7 +3,6 @@ package io.airlift.api.internals;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.reflect.TypeToken;
 import io.airlift.api.ApiJson;
 import io.airlift.api.ApiJsonList;
 import io.airlift.api.ApiJsonNode;
@@ -11,7 +10,7 @@ import io.airlift.api.ApiJsonObject;
 
 import java.lang.reflect.Type;
 
-import static io.airlift.api.internals.Generics.typeResolver;
+import static io.airlift.api.internals.Generics.rawClass;
 
 public final class ApiJsonTypes
 {
@@ -71,10 +70,5 @@ public final class ApiJsonTypes
     private static IllegalArgumentException unsupportedType(Class<?> clazz)
     {
         return new IllegalArgumentException("Unsupported ApiJson type: " + clazz.getName());
-    }
-
-    private static Class<?> rawClass(Type type)
-    {
-        return TypeToken.of(typeResolver.resolveType(type)).getRawType();
     }
 }

--- a/api/src/main/java/io/airlift/api/internals/Generics.java
+++ b/api/src/main/java/io/airlift/api/internals/Generics.java
@@ -34,6 +34,11 @@ public interface Generics
         throw new ValidatorException("Expected %s to be parameterized type".formatted(type));
     }
 
+    static Class<?> rawClass(Type type)
+    {
+        return TypeToken.of(typeResolver.resolveType(type)).getRawType();
+    }
+
     static void validateMap(Type type)
     {
         TypeToken<?> typeToken = TypeToken.of(typeResolver.resolveType(type));

--- a/api/src/main/java/io/airlift/api/openapi/SchemaBuilder.java
+++ b/api/src/main/java/io/airlift/api/openapi/SchemaBuilder.java
@@ -40,6 +40,7 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.airlift.api.ApiOpenApiTrait.USE_ONE_OF_DISCRIMINATORS;
 import static io.airlift.api.internals.ApiJsonTypes.isApiJsonType;
 import static io.airlift.api.internals.ApiJsonTypes.jacksonJsonType;
+import static io.airlift.api.internals.Generics.extractGenericParameter;
 import static io.airlift.api.internals.Strings.capitalize;
 import static io.airlift.api.model.ModelResourceModifier.IS_ANY_OBJECT;
 import static io.airlift.api.model.ModelResourceModifier.IS_UNWRAPPED;
@@ -152,8 +153,12 @@ class SchemaBuilder
         Schema<?> schema = schemas.get(new SchemaKey(Optional.empty(), modelResource.containerType(), modelResource.resourceType(), mode));
         if (schema == null) {
             schema = switch (modelResource.resourceType()) {
-                case LIST -> asList(modelResource, buildSchema(asResource(removeContainer(modelResource)), mode));
-                case MAP -> new MapSchema().description(adjustedDescription(modelResource)).additionalProperties(buildSchema(asResource(removeContainer(modelResource)), mode));
+                case LIST -> modelResource.modifiers().contains(IS_ANY_OBJECT)
+                        ? buildAnyObjectContainerSchema(modelResource)
+                        : asList(modelResource, buildSchema(asResource(removeContainer(modelResource)), mode));
+                case MAP -> modelResource.modifiers().contains(IS_ANY_OBJECT)
+                        ? buildAnyObjectContainerSchema(modelResource)
+                        : new MapSchema().description(adjustedDescription(modelResource)).additionalProperties(buildSchema(asResource(removeContainer(modelResource)), mode));
                 case PAGINATED_RESULT -> buildPaginatedSchema(modelResource);
                 case JSON -> buildApiJsonSchema(modelResource);
                 default -> modelResource.modifiers().contains(IS_ANY_OBJECT)
@@ -171,6 +176,24 @@ class SchemaBuilder
     private Schema<?> asList(ModelResource modelResource, Schema<?> schema)
     {
         return new ArraySchema().description(adjustedDescription(modelResource)).items(schema);
+    }
+
+    private Schema<?> buildAnyObjectContainerSchema(ModelResource modelResource)
+    {
+        return buildAnyObjectContainerSchema(modelResource.containerType())
+                .description(adjustedDescription(modelResource));
+    }
+
+    private Schema<?> buildAnyObjectContainerSchema(Type type)
+    {
+        TypeToken<?> typeToken = TypeToken.of(type);
+        if (typeToken.isSubtypeOf(Collection.class)) {
+            return new ArraySchema().items(buildAnyObjectContainerSchema(extractGenericParameter(typeToken.getType(), 0)));
+        }
+        if (typeToken.isSubtypeOf(Map.class)) {
+            return new MapSchema().additionalProperties(buildAnyObjectContainerSchema(extractGenericParameter(typeToken.getType(), 1)));
+        }
+        return new Schema<>();
     }
 
     Optional<Schema<?>> buildBasicSchema(Class<?> clazz)

--- a/api/src/main/java/io/airlift/api/validation/ResourceSerializationValidator.java
+++ b/api/src/main/java/io/airlift/api/validation/ResourceSerializationValidator.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import java.util.UUID;
 
 import static io.airlift.api.internals.ApiJsonTypes.isApiJsonType;
+import static io.airlift.api.internals.Generics.rawClass;
 import static java.util.Objects.requireNonNull;
 
 public class ResourceSerializationValidator
@@ -183,28 +184,22 @@ public class ResourceSerializationValidator
             if (validationContext.isActiveValidatingResource(typeArgument)) {
                 return ImmutableList.of();
             }
-            return ImmutableList.of(getDefaultValue(validationContext, (Class<?>) typeArgument, typeArgument));
+            return ImmutableList.of(getDefaultValue(validationContext, rawClass(typeArgument), typeArgument));
         }
         if (Collection.class.isAssignableFrom(clazz) && (type instanceof ParameterizedType parameterizedType)) {
             Type typeArgument = parameterizedType.getActualTypeArguments()[0];
             if (validationContext.isActiveValidatingResource(typeArgument)) {
                 return ImmutableSet.of();
             }
-            return ImmutableSet.of(getDefaultValue(validationContext, (Class<?>) typeArgument, typeArgument));
+            return ImmutableSet.of(getDefaultValue(validationContext, rawClass(typeArgument), typeArgument));
         }
         if (Map.class.isAssignableFrom(clazz) && (type instanceof ParameterizedType parameterizedType)) {
             Type typeArgument = parameterizedType.getActualTypeArguments()[1];
-            return ImmutableMap.of("dummy", getDefaultValue(validationContext, (Class<?>) typeArgument, typeArgument));
+            return ImmutableMap.of("dummy", getDefaultValue(validationContext, rawClass(typeArgument), typeArgument));
         }
         if (Optional.class.isAssignableFrom(clazz) && (type instanceof ParameterizedType parameterizedType)) {
             Type typeArgument = parameterizedType.getActualTypeArguments()[0];
-            Class<?> classArgument;
-            if (typeArgument instanceof ParameterizedType parameterizedTypeArgument) {
-                classArgument = (Class<?>) parameterizedTypeArgument.getRawType();
-            }
-            else {
-                classArgument = (Class<?>) typeArgument;
-            }
+            Class<?> classArgument = rawClass(typeArgument);
             if (validationContext.isActiveValidatingResource(typeArgument)) {
                 return Optional.empty();
             }

--- a/api/src/test/java/io/airlift/api/openapi/TestObjectElementOpenApi.java
+++ b/api/src/test/java/io/airlift/api/openapi/TestObjectElementOpenApi.java
@@ -1,0 +1,67 @@
+package io.airlift.api.openapi;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.api.model.ModelApi;
+import io.airlift.api.model.ModelServiceType;
+import io.airlift.api.openapi.models.OpenAPI;
+import io.airlift.api.openapi.models.Schema;
+import io.airlift.api.validation.ServiceWithObjectField;
+import io.airlift.json.JsonCodec;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static io.airlift.api.builders.ApiBuilder.apiBuilder;
+import static io.airlift.api.servertests.openapi.TestOpenApi.validateOpenApiJson;
+import static io.airlift.json.JsonCodec.jsonCodec;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestObjectElementOpenApi
+{
+    private static final JsonCodec<OpenAPI> OPEN_API_CODEC = jsonCodec(OpenAPI.class);
+
+    @Test
+    public void testObjectElementSchemasAreUnconstrained()
+    {
+        ModelApi modelApi = apiBuilder().add(ServiceWithObjectField.class).build();
+        assertThat(modelApi.modelServices().errors()).isEmpty();
+
+        ModelServiceType serviceType = modelApi.modelServices().services().iterator().next().service().type();
+        OpenAPI openAPI = OpenApiProvider.create(modelApi.modelServices(), new OpenApiMetadata(Optional.empty(), ImmutableList.of()))
+                .build(serviceType, _ -> true);
+
+        validateOpenApiJson(OPEN_API_CODEC.toJson(openAPI));
+
+        Schema<?> objectField = openAPI.getComponents().getSchemas().get("ObjectField");
+        assertThat(objectField).isNotNull();
+        Map<String, Schema> properties = objectField.getProperties();
+
+        Schema<?> payloads = properties.get("payloads");
+        assertThat(payloads.getType()).isEqualTo("array");
+        assertUnconstrainedSchema(payloads.getItems());
+
+        Schema<?> rows = properties.get("rows");
+        assertThat(rows.getType()).isEqualTo("array");
+        Schema<?> row = rows.getItems();
+        assertThat(row.getType()).isEqualTo("array");
+        assertUnconstrainedSchema(row.getItems());
+
+        Schema<?> attributes = properties.get("attributes");
+        assertThat(attributes.getType()).isEqualTo("object");
+        assertThat(attributes.getAdditionalProperties()).isInstanceOf(Schema.class);
+        assertUnconstrainedSchema((Schema<?>) attributes.getAdditionalProperties());
+    }
+
+    private static void assertUnconstrainedSchema(Schema<?> schema)
+    {
+        assertThat(schema.getType()).isNull();
+        assertThat(schema.get$ref()).isNull();
+        assertThat(schema.getProperties()).isNull();
+        assertThat(schema.getItems()).isNull();
+        assertThat(schema.getAdditionalProperties()).isNull();
+        assertThat(schema.getAllOf()).isNull();
+        assertThat(schema.getOneOf()).isNull();
+        assertThat(schema.getDescription()).isNull();
+    }
+}

--- a/api/src/test/java/io/airlift/api/validation/ResourceWithObjectField.java
+++ b/api/src/test/java/io/airlift/api/validation/ResourceWithObjectField.java
@@ -10,4 +10,5 @@ import java.util.Map;
 public record ResourceWithObjectField(
         @ApiDescription("A name") String name,
         @ApiDescription("Free-form list") List<Object> payloads,
+        @ApiDescription("Free-form rows") List<List<Object>> rows,
         @ApiDescription("Free-form map") Map<String, Object> attributes) {}

--- a/api/src/test/java/io/airlift/api/validation/ResourceWithObjectListField.java
+++ b/api/src/test/java/io/airlift/api/validation/ResourceWithObjectListField.java
@@ -1,0 +1,10 @@
+package io.airlift.api.validation;
+
+import io.airlift.api.ApiDescription;
+import io.airlift.api.ApiResource;
+
+import java.util.List;
+
+@ApiResource(name = "objectListField", description = "Resource with Object list field")
+public record ResourceWithObjectListField(
+        @ApiDescription("Free-form list") List<Object> payloads) {}

--- a/api/src/test/java/io/airlift/api/validation/ResourceWithObjectMapField.java
+++ b/api/src/test/java/io/airlift/api/validation/ResourceWithObjectMapField.java
@@ -1,0 +1,10 @@
+package io.airlift.api.validation;
+
+import io.airlift.api.ApiDescription;
+import io.airlift.api.ApiResource;
+
+import java.util.Map;
+
+@ApiResource(name = "objectMapField", description = "Resource with Object map field")
+public record ResourceWithObjectMapField(
+        @ApiDescription("Free-form map") Map<String, Object> attributes) {}

--- a/api/src/test/java/io/airlift/api/validation/ServiceWithObjectListFieldNoTrait.java
+++ b/api/src/test/java/io/airlift/api/validation/ServiceWithObjectListFieldNoTrait.java
@@ -1,0 +1,12 @@
+package io.airlift.api.validation;
+
+import io.airlift.api.ApiCreate;
+import io.airlift.api.ApiService;
+import io.airlift.api.ServiceType;
+
+@ApiService(name = "objectListFieldServiceNoTrait", type = ServiceType.class, description = "Service with an Object list field but no trait")
+public class ServiceWithObjectListFieldNoTrait
+{
+    @ApiCreate(description = "create something with an Object list field", quotas = "yep")
+    public void create(ResourceWithObjectListField ignore) {}
+}

--- a/api/src/test/java/io/airlift/api/validation/ServiceWithObjectMapFieldNoTrait.java
+++ b/api/src/test/java/io/airlift/api/validation/ServiceWithObjectMapFieldNoTrait.java
@@ -1,0 +1,12 @@
+package io.airlift.api.validation;
+
+import io.airlift.api.ApiCreate;
+import io.airlift.api.ApiService;
+import io.airlift.api.ServiceType;
+
+@ApiService(name = "objectMapFieldServiceNoTrait", type = ServiceType.class, description = "Service with an Object map field but no trait")
+public class ServiceWithObjectMapFieldNoTrait
+{
+    @ApiCreate(description = "create something with an Object map field", quotas = "yep")
+    public void create(ResourceWithObjectMapField ignore) {}
+}

--- a/api/src/test/java/io/airlift/api/validation/TestConforming.java
+++ b/api/src/test/java/io/airlift/api/validation/TestConforming.java
@@ -207,18 +207,25 @@ public class TestConforming
     @Test
     public void testAllowedObjectContainers()
     {
-        // service whose type carries ALLOW_OBJECT_ELEMENTS may declare List<Object> / Map<String, Object> fields
+        // service whose type carries ALLOW_OBJECT_ELEMENTS may declare List<Object>, nested List<Object>, and Map<String, Object> fields
         ModelApi modelApi = ApiBuilder.apiBuilder().add(ServiceWithObjectField.class).build();
+        assertThat(modelApi.modelServices().errors()).isEmpty();
         Module module = ApiModule.builder().addApi(modelApi).build();
         Guice.createInjector(module, new JsonModule());
     }
 
     @Test
-    public void testObjectContainerWithoutTrait()
+    public void testObjectListWithoutTrait()
     {
-        // service whose type lacks ALLOW_OBJECT_ELEMENTS must reject List<Object> / Map<String, Object>
-        ModelServices services = ApiBuilder.apiBuilder().add(ServiceWithObjectFieldNoTrait.class).build().modelServices();
-        assertThat(services.errors()).anyMatch(s -> s.contains("ALLOW_OBJECT_ELEMENTS"));
+        ModelServices services = ApiBuilder.apiBuilder().add(ServiceWithObjectListFieldNoTrait.class).build().modelServices();
+        assertThat(services.errors()).anyMatch(s -> s.contains("java.util.List<java.lang.Object> requires service trait ALLOW_OBJECT_ELEMENTS"));
+    }
+
+    @Test
+    public void testObjectMapWithoutTrait()
+    {
+        ModelServices services = ApiBuilder.apiBuilder().add(ServiceWithObjectMapFieldNoTrait.class).build().modelServices();
+        assertThat(services.errors()).anyMatch(s -> s.contains("java.util.Map<java.lang.String, java.lang.Object> requires service trait ALLOW_OBJECT_ELEMENTS"));
     }
 
     @Test

--- a/api/src/test/resources/openapi/object-field.json
+++ b/api/src/test/resources/openapi/object-field.json
@@ -123,7 +123,7 @@
         "x-tags" : [ "Responses" ]
       },
       "ObjectField" : {
-        "required" : [ "attributes", "name", "payloads" ],
+        "required" : [ "attributes", "name", "payloads", "rows" ],
         "properties" : {
           "name" : {
             "type" : "string",
@@ -132,16 +132,20 @@
           "payloads" : {
             "type" : "array",
             "description" : "Free-form list",
+            "items" : { }
+          },
+          "rows" : {
+            "type" : "array",
+            "description" : "Free-form rows",
             "items" : {
-              "description" : "Free-form list"
+              "type" : "array",
+              "items" : { }
             }
           },
           "attributes" : {
             "type" : "object",
             "description" : "Free-form map",
-            "additionalProperties" : {
-              "description" : "Free-form map"
-            }
+            "additionalProperties" : { }
           }
         },
         "description" : "Resource with Object container fields",


### PR DESCRIPTION
Summary

- Emit unconstrained OpenAPI schemas for `ALLOW_OBJECT_ELEMENTS` Java `Object` leaves instead of object-only schemas.
- Preserve array and map container structure so `List<List<Object>>` and `Map<String, Object>` allow arbitrary JSON values.
- Add focused validation and OpenAPI assertions for accepted/rejected object-element containers.
