### PR TITLE
Support JsonValue resource schemas

### DIFF
--- a/api/src/main/java/io/airlift/api/builders/MethodBuilder.java
+++ b/api/src/main/java/io/airlift/api/builders/MethodBuilder.java
@@ -1,6 +1,5 @@
 package io.airlift.api.builders;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.api.ApiCreate;
@@ -31,7 +30,6 @@ import io.airlift.api.model.ModelMethod;
 import io.airlift.api.model.ModelOptionalParameter;
 import io.airlift.api.model.ModelOptionalParameter.ExternalParameter;
 import io.airlift.api.model.ModelResource;
-import io.airlift.api.model.ModelResourceModifier;
 import io.airlift.api.model.ModelResourceType;
 import io.airlift.api.model.ModelResponse;
 import io.airlift.api.model.ModelSupportsIdLookup;
@@ -237,9 +235,7 @@ public class MethodBuilder
 
             return modelMethod.map(model -> {
                 if (isPatch) {
-                    ModelResource modifiedModelResource = requestBodyResource.withModifier(ModelResourceModifier.PATCH);
-                    ModelMethod modifiedModelMethod = model.withRequestBody(modifiedModelResource);
-                    return addPatchHelpToDescription(modifiedModelMethod);
+                    return addPatchHelpToDescription(model.withRequestBody(requestBodyResource.asPatchRequestBody()));
                 }
                 return model.withRequestBody(requestBodyResource);
             });
@@ -329,18 +325,10 @@ public class MethodBuilder
                         throw new ValidatorException("ApiJson types cannot be used as API path parameters");
                     }
 
-                    ModelResource modelResource = resourceBuilder.apply(resourceType).build();
-
-                    if (apiParameter.allowedValues().length > 0) {
-                        modelResource = modelResource.withLimitedValues(ImmutableSet.copyOf(apiParameter.allowedValues()));
-                    }
-
-                    ApiIdSupportsLookup supportsIdLookup = parameter.getType().getAnnotation(ApiIdSupportsLookup.class);
-                    if (supportsIdLookup != null) {
-                        modelResource = modelResource.withSupportsIdLookup(new ModelSupportsIdLookup((Class<? extends ApiId<?, ?>>) parameter.getType(), supportsIdLookup.value()));
-                    }
-
-                    parameters.add(modelResource);
+                    Optional<ModelSupportsIdLookup> supportsIdLookup = Optional.ofNullable(parameter.getType().getAnnotation(ApiIdSupportsLookup.class))
+                            .map(annotation -> new ModelSupportsIdLookup((Class<? extends ApiId<?, ?>>) parameter.getType(), annotation.value()));
+                    parameters.add(resourceBuilder.apply(resourceType).build()
+                            .asIdPathParameter(ImmutableSet.copyOf(apiParameter.allowedValues()), supportsIdLookup));
                 }
                 else if (!ApiResponseHeaders.class.isAssignableFrom(parameter.getType())) {
                     buildOptionalParameter(parameter, apiParameter).ifPresent(optionalParameters::add);
@@ -428,8 +416,9 @@ public class MethodBuilder
 
         if (resource == void.class) {
             if (allowVoidResult) {
-                return new ModelResource(resource, "", "", ImmutableList.of(), ModelResourceType.RESOURCE)
-                        .withModifier(VOID);
+                return ModelResource.builder(resource, "", "", ModelResourceType.RESOURCE)
+                        .withModifier(VOID)
+                        .build();
             }
             else {
                 throw new ValidatorException("Method cannot have void result");
@@ -444,7 +433,7 @@ public class MethodBuilder
         ModelResource validatedResource = resourceBuilder.apply(resource).build();
 
         if (isPaginated) {
-            return validatedResource.asResourceType(ModelResourceType.PAGINATED_RESULT).withContainerType(method.getGenericReturnType());
+            return validatedResource.asPaginatedResult(method.getGenericReturnType());
         }
 
         if (validatedResource.modifiers().contains(IS_STREAMING_RESPONSE) && !allowStreamingResult) {

--- a/api/src/main/java/io/airlift/api/builders/ResourceBuilder.java
+++ b/api/src/main/java/io/airlift/api/builders/ResourceBuilder.java
@@ -1,5 +1,6 @@
 package io.airlift.api.builders;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.reflect.TypeToken;
@@ -302,6 +303,7 @@ public class ResourceBuilder
 
         List<ModelResource> components = new ArrayList<>();
         Collection<ModelResourceModifier> modifiers = new HashSet<>();
+        Optional<ModelResource> jsonValueResource = Optional.empty();
         if (clazz.getAnnotation(ApiReadOnly.class) != null) {
             modifiers.add(TOP_LEVEL_READ_ONLY);
         }
@@ -342,7 +344,16 @@ public class ResourceBuilder
                 if (isUnwrapped) {
                     componentBuilder.withModifier(IS_UNWRAPPED);
                 }
-                components.add(componentBuilder.build());
+                ModelResource component = componentBuilder.build();
+
+                components.add(component);
+
+                if (isJsonValue(recordComponent, clazz)) {
+                    if (jsonValueResource.isPresent()) {
+                        throw new ValidatorException("%s has more than one @%s record component".formatted(clazz, JsonValue.class.getSimpleName()));
+                    }
+                    jsonValueResource = Optional.of(component);
+                }
             }
         }
         finally {
@@ -350,12 +361,34 @@ public class ResourceBuilder
             recursionChecker.popRecursionAllowed();
         }
 
-        return ModelResource.builder(clazz, name, description, RESOURCE)
+        ModelResource.Builder modelResourceBuilder = ModelResource.builder(clazz, name, description, RESOURCE)
                 .withOpenApiName(openApiName)
                 .withComponents(components)
                 .withModifiers(modifiers)
-                .withQuotas(quotas)
-                .build();
+                .withQuotas(quotas);
+        if (jsonValueResource.isPresent()) {
+            modelResourceBuilder.withJsonValueResource(jsonValueResource.orElseThrow());
+        }
+        return modelResourceBuilder.build();
+    }
+
+    private boolean isJsonValue(RecordComponent recordComponent, Class<?> clazz)
+    {
+        if (isActiveJsonValue(recordComponent.getAccessor().getAnnotation(JsonValue.class))) {
+            return true;
+        }
+
+        try {
+            return isActiveJsonValue(clazz.getDeclaredField(recordComponent.getName()).getAnnotation(JsonValue.class));
+        }
+        catch (NoSuchFieldException e) {
+            throw new ValidatorException("Could not find field for record component %s in %s".formatted(recordComponent.getName(), clazz));
+        }
+    }
+
+    private boolean isActiveJsonValue(JsonValue jsonValue)
+    {
+        return (jsonValue != null) && jsonValue.value();
     }
 
     private ModelResource buildPolyResource(Optional<String> componentName, ApiPolyResource apiPolyResource, Class<?> clazz)

--- a/api/src/main/java/io/airlift/api/builders/ResourceBuilder.java
+++ b/api/src/main/java/io/airlift/api/builders/ResourceBuilder.java
@@ -1,6 +1,5 @@
 package io.airlift.api.builders;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.reflect.TypeToken;
@@ -151,25 +150,28 @@ public class ResourceBuilder
         TypeToken<?> typeToken = TypeToken.of(typeResolver.resolveType(resource));
 
         if (typeToken.isSubtypeOf(Optional.class)) {
-            return internalBuildAndAdd(componentName, extractGenericParameter(typeToken.getType(), 0))
+            return ModelResource.builder(internalBuildAndAdd(componentName, extractGenericParameter(typeToken.getType(), 0)))
                     .withModifier(OPTIONAL)
-                    .withContainerType(resource);
+                    .withContainerType(resource)
+                    .build();
         }
 
         if (typeToken.isSubtypeOf(Collection.class)) {
             Type targetType = extractGenericParameter(typeToken.getType(), 0);
 
             if (Object.class.equals(targetType)) {
-                return anyObjectLeafResource()
-                        .asResourceType(ModelResourceType.LIST)
-                        .withContainerType(resource);
+                return anyObjectLeafResourceBuilder()
+                        .withResourceType(ModelResourceType.LIST)
+                        .withContainerType(resource)
+                        .build();
             }
 
             recursionChecker.pushRecursionAllowed(true);
             try {
-                return internalBuildAndAdd(componentName, targetType)
-                        .asResourceType(ModelResourceType.LIST)
-                        .withContainerType(resource);
+                return ModelResource.builder(internalBuildAndAdd(componentName, targetType))
+                        .withResourceType(ModelResourceType.LIST)
+                        .withContainerType(resource)
+                        .build();
             }
             finally {
                 recursionChecker.popRecursionAllowed();
@@ -180,63 +182,64 @@ public class ResourceBuilder
             Type keyType = extractGenericParameter(typeToken.getType(), 0);
             Type valueType = extractGenericParameter(typeToken.getType(), 1);
             if (keyType.equals(String.class) && (valueType.equals(String.class) || isApiJsonType(valueType))) {
-                return internalBuildAndAdd(componentName, valueType)
-                        .asResourceType(ModelResourceType.MAP)
-                        .withContainerType(resource);
+                return ModelResource.builder(internalBuildAndAdd(componentName, valueType))
+                        .withResourceType(ModelResourceType.MAP)
+                        .withContainerType(resource)
+                        .build();
             }
             if (keyType.equals(String.class) && valueType.equals(Object.class)) {
-                return anyObjectLeafResource()
-                        .asResourceType(ModelResourceType.MAP)
-                        .withContainerType(resource);
+                return anyObjectLeafResourceBuilder()
+                        .withResourceType(ModelResourceType.MAP)
+                        .withContainerType(resource)
+                        .build();
             }
-            return new ModelResource(String.class, String.class.getSimpleName(), "n/a", ImmutableList.of(), ModelResourceType.MAP).withContainerType(resource);
+            return ModelResource.builder(String.class, String.class.getSimpleName(), "n/a", ModelResourceType.MAP)
+                    .withContainerType(resource)
+                    .build();
         }
 
         if ((typeToken.getType() instanceof Class<?> clazz) && isBasic(clazz, true)) {
             Class<?> unboxed = unboxIfNeeded(clazz);
-            ModelResource modelResource = new ModelResource(unboxed, unboxed.getSimpleName(), "n/a", ImmutableList.of(), ModelResourceType.BASIC);
+            ModelResource.Builder modelResourceBuilder = ModelResource.builder(unboxed, unboxed.getSimpleName(), "n/a", ModelResourceType.BASIC);
             if (unboxed.isEnum()) {
                 Map<String, String> descriptions = enumDescriptions(unboxed);
                 if (!descriptions.isEmpty()) {
-                    modelResource = modelResource.withEnumDescriptions(descriptions);
+                    modelResourceBuilder.withEnumDescriptions(descriptions);
                 }
             }
-            return modelResource;
+            return modelResourceBuilder.build();
         }
 
         if (isApiJsonType(typeToken.getType())) {
-            return new ModelResource(
-                    typeToken.getRawType(),
-                    apiJsonResourceName(typeToken.getType()),
-                    apiJsonResourceDescription(typeToken.getType()),
-                    ImmutableList.of(),
-                    ModelResourceType.JSON);
+            return ModelResource.builder(typeToken.getRawType(), apiJsonResourceName(typeToken.getType()), apiJsonResourceDescription(typeToken.getType()), ModelResourceType.JSON)
+                    .build();
         }
 
         if (typeToken.isSubtypeOf(ApiStreamResponse.class)) {
-            ModelResource streamResource = internalBuildAndAdd(componentName, extractGenericParameter(typeToken.getType(), 0))
+            ModelResource.Builder streamResourceBuilder = ModelResource.builder(internalBuildAndAdd(componentName, extractGenericParameter(typeToken.getType(), 0)))
                     .withContainerType(typeToken.getType())
                     .withModifier(IS_STREAMING_RESPONSE)
                     .withModifier(HAS_RESOURCE_ID)
                     .withModifier(READ_ONLY)
                     .withModifier(HAS_VERSION);
             if (typeToken.isSubtypeOf(ApiServerSentEventStreamResponse.class)) {
-                streamResource = streamResource.withStreamingEventResource(internalBuildAndAdd(componentName, extractGenericParameter(typeToken.getType(), 1)));
+                streamResourceBuilder.withStreamingEventResource(internalBuildAndAdd(componentName, extractGenericParameter(typeToken.getType(), 1)));
             }
-            return streamResource;
+            return streamResourceBuilder.build();
         }
 
         if (typeToken.isSubtypeOf(ApiMultiPart.class)) {
             Type multiPartResourceType = extractGenericParameter(typeToken.getType(), 0);
 
-            ModelResource modelResource = internalBuildAndAdd(componentName, multiPartResourceType);
+            ModelResource.Builder modelResourceBuilder = ModelResource.builder(internalBuildAndAdd(componentName, multiPartResourceType));
             if (typeToken.isSubtypeOf(ApiMultiPartFormWithResource.class)) {
-                modelResource = modelResource.withModifier(MULTIPART_RESOURCE_IS_FIRST_ITEM);
+                modelResourceBuilder.withModifier(MULTIPART_RESOURCE_IS_FIRST_ITEM);
             }
 
-            return modelResource
+            return modelResourceBuilder
                     .withModifier(IS_MULTIPART_FORM)
-                    .withContainerType(resource);
+                    .withContainerType(resource)
+                    .build();
         }
 
         if ((typeToken.getType() instanceof Class<?> clazz) && clazz.isRecord()) {
@@ -290,7 +293,11 @@ public class ResourceBuilder
             if (!recursionChecker.recursionAllowed()) {
                 throw new ValidatorException("Recursive resources are only allowed in collections");
             }
-            return new ModelResource(type, name, openApiName, description, ImmutableList.of(), RESOURCE, ImmutableSet.of(RECURSIVE_REFERENCE), quotas);
+            return ModelResource.builder(type, name, description, RESOURCE)
+                    .withOpenApiName(openApiName)
+                    .withModifiers(ImmutableSet.of(RECURSIVE_REFERENCE))
+                    .withQuotas(quotas)
+                    .build();
         }
 
         List<ModelResource> components = new ArrayList<>();
@@ -324,18 +331,18 @@ public class ResourceBuilder
                 ModelResource componentModelResource = internalBuildAndAdd(Optional.of(recordComponent.getName()), recordComponent.getGenericType());
                 // the component resource name will not be accurate as it gets set to this record's component name, so set the openApiName appropriately
                 String componentOpenApiName = componentModelResource.openApiName().orElseGet(componentModelResource::name);
-                ModelResource component = componentModelResource.withNameAndDescription(recordComponent.getName(), Optional.of(componentOpenApiName), appliedDescription);
+                ModelResource.Builder componentBuilder = ModelResource.builder(componentModelResource)
+                        .withNameAndDescription(recordComponent.getName(), Optional.of(componentOpenApiName), appliedDescription);
 
                 boolean isForcedReadOnly = isForcedReadOnly(recordComponent.getType());
                 boolean hasReadOnly = (recordComponent.getAnnotation(ApiReadOnly.class) != null);
                 if (hasReadOnly || isForcedReadOnly) {
-                    component = component.withModifier(READ_ONLY);
+                    componentBuilder.withModifier(READ_ONLY);
                 }
                 if (isUnwrapped) {
-                    component = component.withModifier(IS_UNWRAPPED);
+                    componentBuilder.withModifier(IS_UNWRAPPED);
                 }
-
-                components.add(component);
+                components.add(componentBuilder.build());
             }
         }
         finally {
@@ -343,7 +350,12 @@ public class ResourceBuilder
             recursionChecker.popRecursionAllowed();
         }
 
-        return new ModelResource(clazz, name, openApiName, description, components, RESOURCE, modifiers, quotas);
+        return ModelResource.builder(clazz, name, description, RESOURCE)
+                .withOpenApiName(openApiName)
+                .withComponents(components)
+                .withModifiers(modifiers)
+                .withQuotas(quotas)
+                .build();
     }
 
     private ModelResource buildPolyResource(Optional<String> componentName, ApiPolyResource apiPolyResource, Class<?> clazz)
@@ -352,8 +364,11 @@ public class ResourceBuilder
                 .map(subResourceClass -> internalBuildAndAdd(componentName, subResourceClass))
                 .collect(toImmutableList());
 
-        return new ModelResource(clazz, apiPolyResource.name(), openApiName(apiPolyResource.openApiAlternateName()), apiPolyResource.description(), ImmutableList.of(), RESOURCE, ImmutableSet.of(), ImmutableSet.copyOf(apiPolyResource.quotas()))
-                .withPolyResource(new ModelPolyResource(apiPolyResource.key(), subResources, ImmutableSet.copyOf(apiPolyResource.openApiTraits())));
+        return ModelResource.builder(clazz, apiPolyResource.name(), apiPolyResource.description(), RESOURCE)
+                .withOpenApiName(openApiName(apiPolyResource.openApiAlternateName()))
+                .withQuotas(ImmutableSet.copyOf(apiPolyResource.quotas()))
+                .withPolyResource(new ModelPolyResource(apiPolyResource.key(), subResources, ImmutableSet.copyOf(apiPolyResource.openApiTraits())))
+                .build();
     }
 
     private ModelResource throwInvalid(Type type, Optional<String> name)
@@ -390,8 +405,9 @@ public class ResourceBuilder
         return supportedBoxedResourceTypes.getOrDefault(clazz, clazz);
     }
 
-    private static ModelResource anyObjectLeafResource()
+    private static ModelResource.Builder anyObjectLeafResourceBuilder()
     {
-        return new ModelResource(Object.class, Object.class.getSimpleName(), "n/a", ImmutableList.of(), ModelResourceType.BASIC).withModifier(IS_ANY_OBJECT);
+        return ModelResource.builder(Object.class, Object.class.getSimpleName(), "n/a", ModelResourceType.BASIC)
+                .withModifier(IS_ANY_OBJECT);
     }
 }

--- a/api/src/main/java/io/airlift/api/model/ModelResource.java
+++ b/api/src/main/java/io/airlift/api/model/ModelResource.java
@@ -8,12 +8,12 @@ import com.google.common.collect.ImmutableSet;
 import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.api.model.ModelResourceModifier.IS_UNWRAPPED;
 import static java.util.Objects.requireNonNull;
 
@@ -31,7 +31,8 @@ public record ModelResource(
         Optional<ModelSupportsIdLookup> supportsIdLookup,
         Optional<ModelPolyResource> polyResource,
         Optional<ModelResource> streamingEventResource,
-        Optional<Map<String, String>> enumDescriptions)
+        Optional<Map<String, String>> enumDescriptions,
+        Optional<ModelResource> jsonValueResource)
 {
     public ModelResource
     {
@@ -43,6 +44,8 @@ public record ModelResource(
         requireNonNull(containerType, "containerType is null");
         requireNonNull(polyResource, "polyResource is null");
         requireNonNull(streamingEventResource, "streamingEventResource is null");
+        requireNonNull(enumDescriptions, "enumDescriptions is null");
+        requireNonNull(jsonValueResource, "jsonValueResource is null");
 
         components = ImmutableList.copyOf(components);
         modifiers = ImmutableSet.copyOf(modifiers);
@@ -99,15 +102,23 @@ public record ModelResource(
     @VisibleForTesting
     public ModelResource asResourceWithoutUnwrappedComponents()
     {
-        List<ModelResource> components = components().stream()
-                .map(component -> builder(component)
-                        .withModifierRemoved(IS_UNWRAPPED)
-                        .build())
-                .collect(toImmutableList());
+        ImmutableList.Builder<ModelResource> components = ImmutableList.builder();
+        IdentityHashMap<ModelResource, ModelResource> updatedComponents = new IdentityHashMap<>();
 
-        return builder(this)
-                .withComponents(components)
-                .build();
+        for (ModelResource component : components()) {
+            ModelResource updatedComponent = builder(component)
+                    .withModifierRemoved(IS_UNWRAPPED)
+                    .build();
+            components.add(updatedComponent);
+            updatedComponents.put(component, updatedComponent);
+        }
+
+        Optional<ModelResource> updatedJsonValueResource = jsonValueResource()
+                .map(updatedComponents::get);
+        Builder builder = builder(this)
+                .withComponents(components.build());
+        updatedJsonValueResource.ifPresent(builder::withJsonValueResource);
+        return builder.build();
     }
 
     private static Set<ModelResourceModifier> modifiersWith(Collection<ModelResourceModifier> modifiers, ModelResourceModifier modifier)
@@ -140,6 +151,7 @@ public record ModelResource(
         private Optional<ModelPolyResource> polyResource;
         private Optional<ModelResource> streamingEventResource;
         private Optional<Map<String, String>> enumDescriptions;
+        private Optional<ModelResource> jsonValueResource;
 
         private Builder(Type type, String name, String description, ModelResourceType resourceType)
         {
@@ -153,6 +165,7 @@ public record ModelResource(
                     ImmutableSet.of(),
                     ImmutableSet.of(),
                     ImmutableSet.of(),
+                    Optional.empty(),
                     Optional.empty(),
                     Optional.empty(),
                     Optional.empty(),
@@ -174,7 +187,8 @@ public record ModelResource(
                     resource.supportsIdLookup(),
                     resource.polyResource(),
                     resource.streamingEventResource(),
-                    resource.enumDescriptions());
+                    resource.enumDescriptions(),
+                    resource.jsonValueResource());
         }
 
         private Builder(
@@ -191,7 +205,8 @@ public record ModelResource(
                 Optional<ModelSupportsIdLookup> supportsIdLookup,
                 Optional<ModelPolyResource> polyResource,
                 Optional<ModelResource> streamingEventResource,
-                Optional<Map<String, String>> enumDescriptions)
+                Optional<Map<String, String>> enumDescriptions,
+                Optional<ModelResource> jsonValueResource)
         {
             this.type = requireNonNull(type, "type is null");
             this.name = requireNonNull(name, "name is null");
@@ -207,6 +222,7 @@ public record ModelResource(
             this.polyResource = requireNonNull(polyResource, "polyResource is null");
             this.streamingEventResource = requireNonNull(streamingEventResource, "streamingEventResource is null");
             this.enumDescriptions = requireNonNull(enumDescriptions, "enumDescriptions is null").map(ImmutableMap::copyOf);
+            this.jsonValueResource = requireNonNull(jsonValueResource, "jsonValueResource is null");
         }
 
         public Builder withNameAndDescription(String name, Optional<String> openApiName, String description)
@@ -295,6 +311,12 @@ public record ModelResource(
             return this;
         }
 
+        public Builder withJsonValueResource(ModelResource jsonValueResource)
+        {
+            this.jsonValueResource = Optional.of(requireNonNull(jsonValueResource, "jsonValueResource is null"));
+            return this;
+        }
+
         public ModelResource build()
         {
             return new ModelResource(
@@ -311,7 +333,8 @@ public record ModelResource(
                     supportsIdLookup,
                     polyResource,
                     streamingEventResource,
-                    enumDescriptions);
+                    enumDescriptions,
+                    jsonValueResource);
         }
     }
 }

--- a/api/src/main/java/io/airlift/api/model/ModelResource.java
+++ b/api/src/main/java/io/airlift/api/model/ModelResource.java
@@ -1,5 +1,6 @@
 package io.airlift.api.model;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -12,6 +13,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.api.model.ModelResourceModifier.IS_UNWRAPPED;
 import static java.util.Objects.requireNonNull;
 
 public record ModelResource(
@@ -48,90 +51,267 @@ public record ModelResource(
         enumDescriptions = enumDescriptions.map(ImmutableMap::copyOf);
     }
 
-    public ModelResource(Type type, String name, String description, List<ModelResource> components, ModelResourceType resourceType)
+    public static Builder builder(Type type, String name, String description, ModelResourceType resourceType)
     {
-        this(type, name, Optional.empty(), description, components, resourceType, type, ImmutableSet.of(), ImmutableSet.of(), ImmutableSet.of(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+        return new Builder(type, name, description, resourceType);
     }
 
-    public ModelResource(Type type, String name, Optional<String> openApiName, String description, List<ModelResource> components, ModelResourceType resourceType, Collection<ModelResourceModifier> modifiers, Set<String> quotas)
+    public static Builder builder(ModelResource resource)
     {
-        this(type, name, openApiName, description, components, resourceType, type, modifiers, quotas, ImmutableSet.of(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+        return new Builder(resource);
     }
 
-    public ModelResource(
-            Type type,
-            String name,
-            Optional<String> openApiName,
-            String description,
-            List<ModelResource> components,
-            ModelResourceType resourceType,
-            Type containerType,
-            Collection<ModelResourceModifier> modifiers,
-            Set<String> quotas,
-            Set<String> limitedValues,
-            Optional<ModelSupportsIdLookup> supportsIdLookup,
-            Optional<ModelPolyResource> polyResource,
-            Optional<Map<String, String>> enumDescriptions)
+    public ModelResource asContainedResourceType(ModelResourceType resourceType)
     {
-        this(type, name, openApiName, description, components, resourceType, containerType, modifiers, quotas, limitedValues, supportsIdLookup, polyResource, Optional.empty(), enumDescriptions);
+        if ((resourceType != ModelResourceType.RESOURCE) && (resourceType != ModelResourceType.LIST)) {
+            throw new IllegalArgumentException("Unsupported contained resource type: " + resourceType);
+        }
+
+        return builder(this)
+                .withResourceType(resourceType)
+                .withContainerType(type)
+                .build();
     }
 
-    public ModelResource withNameAndDescription(String name, Optional<String> openApiName, String description)
+    public ModelResource asPatchRequestBody()
     {
-        return new ModelResource(type, name, openApiName, description, components, resourceType, containerType, modifiers, quotas, limitedValues, supportsIdLookup, polyResource, streamingEventResource, enumDescriptions);
+        return builder(this)
+                .withModifier(ModelResourceModifier.PATCH)
+                .build();
     }
 
-    public ModelResource asResourceType(ModelResourceType resourceType)
+    public ModelResource asIdPathParameter(Set<String> limitedValues, Optional<ModelSupportsIdLookup> supportsIdLookup)
     {
-        return new ModelResource(type, name, openApiName, description, components, resourceType, containerType, modifiers, quotas, limitedValues, supportsIdLookup, polyResource, streamingEventResource, enumDescriptions);
+        Builder builder = builder(this)
+                .withLimitedValues(limitedValues);
+        requireNonNull(supportsIdLookup, "supportsIdLookup is null").ifPresent(builder::withSupportsIdLookup);
+        return builder.build();
     }
 
-    public ModelResource withModifier(ModelResourceModifier modifier)
+    public ModelResource asPaginatedResult(Type containerType)
+    {
+        return builder(this)
+                .withResourceType(ModelResourceType.PAGINATED_RESULT)
+                .withContainerType(containerType)
+                .build();
+    }
+
+    @VisibleForTesting
+    public ModelResource asResourceWithoutUnwrappedComponents()
+    {
+        List<ModelResource> components = components().stream()
+                .map(component -> builder(component)
+                        .withModifierRemoved(IS_UNWRAPPED)
+                        .build())
+                .collect(toImmutableList());
+
+        return builder(this)
+                .withComponents(components)
+                .build();
+    }
+
+    private static Set<ModelResourceModifier> modifiersWith(Collection<ModelResourceModifier> modifiers, ModelResourceModifier modifier)
     {
         Set<ModelResourceModifier> newModifiers = new HashSet<>(modifiers);
-        newModifiers.add(modifier);
-        return new ModelResource(type, name, openApiName, description, components, resourceType, containerType, newModifiers, quotas, limitedValues, supportsIdLookup, polyResource, streamingEventResource, enumDescriptions);
+        newModifiers.add(requireNonNull(modifier, "modifier is null"));
+        return ImmutableSet.copyOf(newModifiers);
     }
 
-    public ModelResource withModifierRemoved(ModelResourceModifier modifier)
+    private static Set<ModelResourceModifier> modifiersWithout(Collection<ModelResourceModifier> modifiers, ModelResourceModifier modifier)
     {
         Set<ModelResourceModifier> newModifiers = new HashSet<>(modifiers);
-        newModifiers.remove(modifier);
-        return new ModelResource(type, name, openApiName, description, components, resourceType, containerType, newModifiers, quotas, limitedValues, supportsIdLookup, polyResource, streamingEventResource, enumDescriptions);
+        newModifiers.remove(requireNonNull(modifier, "modifier is null"));
+        return ImmutableSet.copyOf(newModifiers);
     }
 
-    public ModelResource withContainerType(Type containerType)
+    public static class Builder
     {
-        return new ModelResource(type, name, openApiName, description, components, resourceType, containerType, modifiers, quotas, limitedValues, supportsIdLookup, polyResource, streamingEventResource, enumDescriptions);
-    }
+        private Type type;
+        private String name;
+        private Optional<String> openApiName;
+        private String description;
+        private List<ModelResource> components;
+        private ModelResourceType resourceType;
+        private Type containerType;
+        private Collection<ModelResourceModifier> modifiers;
+        private Set<String> quotas;
+        private Set<String> limitedValues;
+        private Optional<ModelSupportsIdLookup> supportsIdLookup;
+        private Optional<ModelPolyResource> polyResource;
+        private Optional<ModelResource> streamingEventResource;
+        private Optional<Map<String, String>> enumDescriptions;
 
-    public ModelResource withLimitedValues(Set<String> limitedValues)
-    {
-        return new ModelResource(type, name, openApiName, description, components, resourceType, containerType, modifiers, quotas, limitedValues, supportsIdLookup, polyResource, streamingEventResource, enumDescriptions);
-    }
+        private Builder(Type type, String name, String description, ModelResourceType resourceType)
+        {
+            this(type,
+                    name,
+                    Optional.empty(),
+                    description,
+                    ImmutableList.of(),
+                    resourceType,
+                    type,
+                    ImmutableSet.of(),
+                    ImmutableSet.of(),
+                    ImmutableSet.of(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty());
+        }
 
-    public ModelResource withSupportsIdLookup(ModelSupportsIdLookup supportsIdLookup)
-    {
-        return new ModelResource(type, name, openApiName, description, components, resourceType, containerType, modifiers, quotas, limitedValues, Optional.of(supportsIdLookup), polyResource, streamingEventResource, enumDescriptions);
-    }
+        private Builder(ModelResource resource)
+        {
+            this(requireNonNull(resource, "resource is null").type(),
+                    resource.name(),
+                    resource.openApiName(),
+                    resource.description(),
+                    resource.components(),
+                    resource.resourceType(),
+                    resource.containerType(),
+                    resource.modifiers(),
+                    resource.quotas(),
+                    resource.limitedValues(),
+                    resource.supportsIdLookup(),
+                    resource.polyResource(),
+                    resource.streamingEventResource(),
+                    resource.enumDescriptions());
+        }
 
-    public ModelResource withPolyResource(ModelPolyResource polyResource)
-    {
-        return new ModelResource(type, name, openApiName, description, components, resourceType, containerType, modifiers, quotas, limitedValues, supportsIdLookup, Optional.of(polyResource), streamingEventResource, enumDescriptions);
-    }
+        private Builder(
+                Type type,
+                String name,
+                Optional<String> openApiName,
+                String description,
+                List<ModelResource> components,
+                ModelResourceType resourceType,
+                Type containerType,
+                Collection<ModelResourceModifier> modifiers,
+                Set<String> quotas,
+                Set<String> limitedValues,
+                Optional<ModelSupportsIdLookup> supportsIdLookup,
+                Optional<ModelPolyResource> polyResource,
+                Optional<ModelResource> streamingEventResource,
+                Optional<Map<String, String>> enumDescriptions)
+        {
+            this.type = requireNonNull(type, "type is null");
+            this.name = requireNonNull(name, "name is null");
+            this.openApiName = requireNonNull(openApiName, "openApiName is null");
+            this.description = requireNonNull(description, "description is null");
+            this.components = ImmutableList.copyOf(components);
+            this.resourceType = requireNonNull(resourceType, "resourceType is null");
+            this.containerType = requireNonNull(containerType, "containerType is null");
+            this.modifiers = ImmutableSet.copyOf(modifiers);
+            this.quotas = ImmutableSet.copyOf(quotas);
+            this.limitedValues = ImmutableSet.copyOf(limitedValues);
+            this.supportsIdLookup = requireNonNull(supportsIdLookup, "supportsIdLookup is null");
+            this.polyResource = requireNonNull(polyResource, "polyResource is null");
+            this.streamingEventResource = requireNonNull(streamingEventResource, "streamingEventResource is null");
+            this.enumDescriptions = requireNonNull(enumDescriptions, "enumDescriptions is null").map(ImmutableMap::copyOf);
+        }
 
-    public ModelResource withStreamingEventResource(ModelResource streamingEventResource)
-    {
-        return new ModelResource(type, name, openApiName, description, components, resourceType, containerType, modifiers, quotas, limitedValues, supportsIdLookup, polyResource, Optional.of(streamingEventResource), enumDescriptions);
-    }
+        public Builder withNameAndDescription(String name, Optional<String> openApiName, String description)
+        {
+            this.name = requireNonNull(name, "name is null");
+            this.openApiName = requireNonNull(openApiName, "openApiName is null");
+            this.description = requireNonNull(description, "description is null");
+            return this;
+        }
 
-    public ModelResource withEnumDescriptions(Map<String, String> enumDescriptions)
-    {
-        return new ModelResource(type, name, openApiName, description, components, resourceType, containerType, modifiers, quotas, limitedValues, supportsIdLookup, polyResource, streamingEventResource, Optional.of(enumDescriptions));
-    }
+        public Builder withOpenApiName(Optional<String> openApiName)
+        {
+            this.openApiName = requireNonNull(openApiName, "openApiName is null");
+            return this;
+        }
 
-    public ModelResource withComponents(List<ModelResource> components)
-    {
-        return new ModelResource(type, name, openApiName, description, components, resourceType, containerType, modifiers, quotas, limitedValues, supportsIdLookup, polyResource, streamingEventResource, enumDescriptions);
+        public Builder withComponents(List<ModelResource> components)
+        {
+            this.components = ImmutableList.copyOf(components);
+            return this;
+        }
+
+        public Builder withResourceType(ModelResourceType resourceType)
+        {
+            this.resourceType = requireNonNull(resourceType, "resourceType is null");
+            return this;
+        }
+
+        public Builder withContainerType(Type containerType)
+        {
+            this.containerType = requireNonNull(containerType, "containerType is null");
+            return this;
+        }
+
+        public Builder withModifiers(Collection<ModelResourceModifier> modifiers)
+        {
+            this.modifiers = ImmutableSet.copyOf(modifiers);
+            return this;
+        }
+
+        public Builder withModifier(ModelResourceModifier modifier)
+        {
+            this.modifiers = modifiersWith(modifiers, modifier);
+            return this;
+        }
+
+        public Builder withModifierRemoved(ModelResourceModifier modifier)
+        {
+            this.modifiers = modifiersWithout(modifiers, modifier);
+            return this;
+        }
+
+        public Builder withQuotas(Set<String> quotas)
+        {
+            this.quotas = ImmutableSet.copyOf(quotas);
+            return this;
+        }
+
+        public Builder withLimitedValues(Set<String> limitedValues)
+        {
+            this.limitedValues = ImmutableSet.copyOf(limitedValues);
+            return this;
+        }
+
+        public Builder withSupportsIdLookup(ModelSupportsIdLookup supportsIdLookup)
+        {
+            this.supportsIdLookup = Optional.of(requireNonNull(supportsIdLookup, "supportsIdLookup is null"));
+            return this;
+        }
+
+        public Builder withPolyResource(ModelPolyResource polyResource)
+        {
+            this.polyResource = Optional.of(requireNonNull(polyResource, "polyResource is null"));
+            return this;
+        }
+
+        public Builder withStreamingEventResource(ModelResource streamingEventResource)
+        {
+            this.streamingEventResource = Optional.of(requireNonNull(streamingEventResource, "streamingEventResource is null"));
+            return this;
+        }
+
+        public Builder withEnumDescriptions(Map<String, String> enumDescriptions)
+        {
+            this.enumDescriptions = Optional.of(ImmutableMap.copyOf(enumDescriptions));
+            return this;
+        }
+
+        public ModelResource build()
+        {
+            return new ModelResource(
+                    type,
+                    name,
+                    openApiName,
+                    description,
+                    components,
+                    resourceType,
+                    containerType,
+                    modifiers,
+                    quotas,
+                    limitedValues,
+                    supportsIdLookup,
+                    polyResource,
+                    streamingEventResource,
+                    enumDescriptions);
+        }
     }
 }

--- a/api/src/main/java/io/airlift/api/openapi/SchemaBuilder.java
+++ b/api/src/main/java/io/airlift/api/openapi/SchemaBuilder.java
@@ -317,8 +317,39 @@ class SchemaBuilder
         // prime the cache early to handle recursive references to themselves - Issue 1689
         typeToResourceCache.putIfAbsent(modelResource.type(), modelResource);
 
+        if (modelResource.jsonValueResource().isPresent()) {
+            return buildJsonValueResourceSchema(modelResource, modelResource.jsonValueResource().orElseThrow(), mode);
+        }
+
         Schema<?> schema = newNamedSchema(schemaName(modelResource, mode, Optional.empty())).description(adjustedDescription(modelResource));
         return buildResourceSchema(schema, modelResource, mode);
+    }
+
+    private Schema<?> buildJsonValueResourceSchema(ModelResource modelResource, ModelResource jsonValueResource, BuildSchemaMode mode)
+    {
+        Schema<?> valueSchema = buildSchema(jsonValueResource, mode);
+        Schema<?> schema = asNamedJsonValueSchema(valueSchema, schemaName(modelResource, mode, Optional.empty()), adjustedDescription(modelResource));
+
+        if (mode.isOf()) {
+            ofSchemas.put(schema.getName(), schema);
+            return schema;
+        }
+
+        schemas.put(new SchemaKey(Optional.empty(), modelResource.containerType(), modelResource.resourceType(), mode), schema);
+        return asRef(schema);
+    }
+
+    private Schema<?> asNamedJsonValueSchema(Schema<?> valueSchema, String name, String description)
+    {
+        if (valueSchema.get$ref() != null) {
+            return newNamedSchema(name)
+                    .description(description)
+                    .addAllOfItem(valueSchema);
+        }
+        return valueSchema
+                .name(name)
+                .tags(ImmutableList.of(schemaTag))
+                .description(description);
     }
 
     private Schema<?> buildResourceSchema(Schema<?> schema, ModelResource modelResource, BuildSchemaMode mode)

--- a/api/src/main/java/io/airlift/api/openapi/SchemaBuilder.java
+++ b/api/src/main/java/io/airlift/api/openapi/SchemaBuilder.java
@@ -157,10 +157,10 @@ class SchemaBuilder
             schema = switch (modelResource.resourceType()) {
                 case LIST -> modelResource.modifiers().contains(IS_ANY_OBJECT)
                         ? buildAnyObjectContainerSchema(modelResource)
-                        : asList(modelResource, buildSchema(asResource(removeContainer(modelResource)), mode));
+                        : asList(modelResource, buildSchema(modelResource.asContainedResourceType(ModelResourceType.RESOURCE), mode));
                 case MAP -> modelResource.modifiers().contains(IS_ANY_OBJECT)
                         ? buildAnyObjectContainerSchema(modelResource)
-                        : new MapSchema().description(adjustedDescription(modelResource)).additionalProperties(buildSchema(asResource(removeContainer(modelResource)), mode));
+                        : new MapSchema().description(adjustedDescription(modelResource)).additionalProperties(buildSchema(modelResource.asContainedResourceType(ModelResourceType.RESOURCE), mode));
                 case PAGINATED_RESULT -> buildPaginatedSchema(modelResource);
                 case JSON -> buildApiJsonSchema(modelResource);
                 default -> modelResource.modifiers().contains(IS_ANY_OBJECT)
@@ -262,26 +262,11 @@ class SchemaBuilder
         return modelResource.openApiName().orElseGet(modelResource::name);
     }
 
-    private ModelResource removeContainer(ModelResource modelResource)
-    {
-        return modelResource.withContainerType(modelResource.type());
-    }
-
-    private ModelResource asList(ModelResource modelResource)
-    {
-        return modelResource.asResourceType(ModelResourceType.LIST);
-    }
-
-    private ModelResource asResource(ModelResource modelResource)
-    {
-        // for these purposes resource and basic are interchangeable
-        return modelResource.asResourceType(ModelResourceType.RESOURCE);
-    }
-
     private Schema<?> buildPaginatedSchema(ModelResource modelResource)
     {
-        Schema<?> modelSchema = buildSchema(asList(removeContainer(modelResource)), BuildSchemaMode.STANDARD);
-        Schema<?> schema = newNamedSchema(schemaName(removeContainer(modelResource), BuildSchemaMode.STANDARD, Optional.of("Paginated")));
+        ModelResource resultResource = modelResource.asContainedResourceType(ModelResourceType.LIST);
+        Schema<?> modelSchema = buildSchema(resultResource, BuildSchemaMode.STANDARD);
+        Schema<?> schema = newNamedSchema(schemaName(resultResource, BuildSchemaMode.STANDARD, Optional.of("Paginated")));
         schema.addProperty("nextPageToken", new StringSchema().description("The next page token to use or \"\" if there are no more pages."));
         schema.addProperty("result", modelSchema.description("A page of results."));
         schemas.put(new SchemaKey(Optional.empty(), modelResource.containerType(), modelResource.resourceType(), BuildSchemaMode.STANDARD), schema);

--- a/api/src/main/java/io/airlift/api/openapi/SchemaBuilder.java
+++ b/api/src/main/java/io/airlift/api/openapi/SchemaBuilder.java
@@ -374,7 +374,12 @@ class SchemaBuilder
     private void buildComponentSchema(BuildSchemaMode mode, Schema<?> schema, ModelResource component)
     {
         if (component.modifiers().contains(IS_UNWRAPPED)) {
-            buildResourceSchema(schema, component, ofMode(mode));
+            if ((component.resourceType() == ModelResourceType.LIST) && component.jsonValueResource().isPresent()) {
+                buildUnwrappedJsonValueListComponentSchema(mode, schema, component);
+            }
+            else {
+                buildResourceSchema(schema, component, ofMode(mode));
+            }
         }
         else {
             Schema<?> componentSchema = buildSchema(component, mode);
@@ -382,6 +387,16 @@ class SchemaBuilder
             if (!mode.isPartialPatch() && !component.modifiers().contains(ModelResourceModifier.OPTIONAL)) {
                 schema.addRequiredItem(component.name());
             }
+        }
+    }
+
+    private void buildUnwrappedJsonValueListComponentSchema(BuildSchemaMode mode, Schema<?> schema, ModelResource component)
+    {
+        ModelResource jsonValueResource = component.jsonValueResource().orElseThrow();
+        Schema<?> componentSchema = asList(jsonValueResource, buildSchema(jsonValueResource, mode));
+        schema.addProperty(jsonValueResource.name(), componentSchema);
+        if (!mode.isPartialPatch() && !component.modifiers().contains(ModelResourceModifier.OPTIONAL)) {
+            schema.addRequiredItem(jsonValueResource.name());
         }
     }
 

--- a/api/src/main/java/io/airlift/api/validation/ResourceValidator.java
+++ b/api/src/main/java/io/airlift/api/validation/ResourceValidator.java
@@ -184,7 +184,7 @@ public interface ResourceValidator
         }
         modelResource.streamingEventResource().ifPresent(streamingEventResource ->
                 context.inContext("Streaming event resource %s".formatted(streamingEventResource.type().getTypeName()),
-                        subContext -> internalValidate(subContext, service, Optional.empty(), streamingEventResource, ResourceValidationState.create().withOptions(IS_RESULT_RESOURCE))));
+                        subContext -> internalValidate(subContext, service, Optional.empty(), streamingEventResource, ResourceValidationState.create().withOptions(IS_RESULT_RESOURCE), enumValueResolver)));
 
         if (modelResource.modifiers().contains(IS_MULTIPART_FORM)) {
             if (state.contains(IS_RESULT_RESOURCE)) {
@@ -196,6 +196,24 @@ public interface ResourceValidator
         }
 
         modelResource.polyResource().ifPresent(polyResource -> validatePolyResource(context, service, modelResource, polyResource, state, enumValueResolver));
+
+        modelResource.jsonValueResource().ifPresent(jsonValueResource -> {
+            modelResource.components().forEach(component -> {
+                if (component.modifiers().contains(IS_UNWRAPPED)) {
+                    throw new ValidatorException("@JsonValue resources cannot have @%s components. At: %s".formatted(ApiUnwrapped.class.getSimpleName(), modelResource.type()));
+                }
+            });
+
+            ResourceValidationState nextState = state.withOptions(ALLOW_BASIC_RESOURCES, ALLOW_POLY_RESOURCES);
+            if (jsonValueResource.modifiers().contains(READ_ONLY)) {
+                nextState = nextState.withOptions(PARENT_IS_READ_ONLY);
+            }
+            internalValidate(context, service, Optional.of(jsonValueResource.name()), jsonValueResource, nextState, enumValueResolver);
+        });
+
+        if (modelResource.jsonValueResource().isPresent()) {
+            return;
+        }
 
         modelResource.components().forEach(component -> {
             boolean hasDescription = !component.description().isBlank();

--- a/api/src/test/java/io/airlift/api/compatibility/CompatibilityTesterTests.java
+++ b/api/src/test/java/io/airlift/api/compatibility/CompatibilityTesterTests.java
@@ -22,7 +22,6 @@ import java.util.Set;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.io.MoreFiles.deleteRecursively;
-import static io.airlift.api.model.ModelResourceModifier.IS_UNWRAPPED;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class CompatibilityTesterTests
@@ -84,7 +83,6 @@ public class CompatibilityTesterTests
 
     private ModelResource removeUnwrapped(ModelResource modelResource)
     {
-        List<ModelResource> components = modelResource.components().stream().map(resource -> resource.withModifierRemoved(IS_UNWRAPPED)).collect(toImmutableList());
-        return modelResource.withComponents(components);
+        return modelResource.asResourceWithoutUnwrappedComponents();
     }
 }

--- a/api/src/test/java/io/airlift/api/openapi/TestObjectElementOpenApi.java
+++ b/api/src/test/java/io/airlift/api/openapi/TestObjectElementOpenApi.java
@@ -1,6 +1,7 @@
 package io.airlift.api.openapi;
 
 import com.google.common.collect.ImmutableList;
+import io.airlift.api.ApiBuilderConfig;
 import io.airlift.api.model.ModelApi;
 import io.airlift.api.model.ModelServiceType;
 import io.airlift.api.openapi.models.OpenAPI;
@@ -9,10 +10,12 @@ import io.airlift.api.validation.ServiceWithObjectField;
 import io.airlift.json.JsonCodec;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
 
 import static io.airlift.api.builders.ApiBuilder.apiBuilder;
+import static io.airlift.api.openapi.OpenApiMetadata.OpenApiVersion.OPENAPI_3_0_1;
 import static io.airlift.api.servertests.openapi.TestOpenApi.validateOpenApiJson;
 import static io.airlift.json.JsonCodec.jsonCodec;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -28,7 +31,7 @@ public class TestObjectElementOpenApi
         assertThat(modelApi.modelServices().errors()).isEmpty();
 
         ModelServiceType serviceType = modelApi.modelServices().services().iterator().next().service().type();
-        OpenAPI openAPI = OpenApiProvider.create(modelApi.modelServices(), new OpenApiMetadata(Optional.empty(), ImmutableList.of()))
+        OpenAPI openAPI = OpenApiProvider.create(modelApi.modelServices(), new OpenApiMetadata(Optional.empty(), ImmutableList.of(), "/", Duration.ofMinutes(5), OPENAPI_3_0_1), ApiBuilderConfig.jackson())
                 .build(serviceType, _ -> true);
 
         validateOpenApiJson(OPEN_API_CODEC.toJson(openAPI));

--- a/api/src/test/java/io/airlift/api/servertests/openapi/TestJsonValueOpenApi.java
+++ b/api/src/test/java/io/airlift/api/servertests/openapi/TestJsonValueOpenApi.java
@@ -5,6 +5,7 @@ import com.google.inject.Guice;
 import io.airlift.api.ApiBuilderConfig;
 import io.airlift.api.ApiCreate;
 import io.airlift.api.ApiCustom;
+import io.airlift.api.ApiDescription;
 import io.airlift.api.ApiGet;
 import io.airlift.api.ApiPolyResource;
 import io.airlift.api.ApiReadOnly;
@@ -85,6 +86,33 @@ public class TestJsonValueOpenApi
         Schema<?> schema = schema(openAPI, "KqlQueryResponse");
         assertThat(schema.getType()).isEqualTo("array");
         assertThat(schema.getItems().get$ref()).isEqualTo("#/components/schemas/SimpleValue");
+    }
+
+    @Test
+    public void testUnwrappedJsonValueObjectListSchema()
+    {
+        OpenAPI openAPI = buildOpenApi(JsonValueService.class);
+
+        Schema<?> objectField = schema(openAPI, "JsonValueObjectField");
+        assertThat(objectField).isNotNull();
+
+        Schema<?> payloads = objectField.getProperties().get("payloads");
+        assertThat(payloads.getType()).isEqualTo("array");
+        assertThat(payloads.getDescription()).isEqualTo("Free-form payloads");
+        Schema<?> payload = payloads.getItems();
+        assertThat(payload.getType()).isEqualTo("array");
+        assertUnconstrainedSchema(payload.getItems());
+        assertThat(objectField.getRequired()).contains("payloads");
+    }
+
+    @Test
+    public void testUnwrappedJsonValueOptionalValueIsRequiredWhenOuterListIsRequired()
+    {
+        OpenAPI openAPI = buildOpenApi(JsonValueService.class);
+
+        Schema<?> objectField = schema(openAPI, "JsonValueOptionalField");
+        assertThat(objectField).isNotNull();
+        assertThat(objectField.getRequired()).contains("payloads");
     }
 
     @Test
@@ -224,6 +252,18 @@ public class TestJsonValueOpenApi
         return openAPI.getComponents().getSchemas().get(name);
     }
 
+    private static void assertUnconstrainedSchema(Schema<?> schema)
+    {
+        assertThat(schema.getType()).isNull();
+        assertThat(schema.get$ref()).isNull();
+        assertThat(schema.getProperties()).isNull();
+        assertThat(schema.getItems()).isNull();
+        assertThat(schema.getAdditionalProperties()).isNull();
+        assertThat(schema.getAllOf()).isNull();
+        assertThat(schema.getOneOf()).isNull();
+        assertThat(schema.getDescription()).isNull();
+    }
+
     private static Schema<?> successResponseSchema(OpenAPI openAPI, String path)
     {
         return openAPI.getPaths()
@@ -279,6 +319,18 @@ public class TestJsonValueOpenApi
 
         @ApiGet(description = "Get inactive JsonValue")
         public InactiveJsonValue inactiveJsonValue()
+        {
+            return null;
+        }
+
+        @ApiGet(description = "Get unwrapped JsonValue Object list")
+        public JsonValueObjectField objectField()
+        {
+            return null;
+        }
+
+        @ApiGet(description = "Get unwrapped optional JsonValue")
+        public JsonValueOptionalField optionalField()
         {
             return null;
         }
@@ -369,6 +421,18 @@ public class TestJsonValueOpenApi
 
     @ApiResource(name = "readOnlyJsonValue", description = "Read-only JsonValue resource")
     public record ReadOnlyJsonValue(@ApiReadOnly @JsonValue List<Boolean> values) {}
+
+    @ApiResource(name = "jsonValueObjectField", description = "Resource with an unwrapped JsonValue Object list")
+    public record JsonValueObjectField(@ApiUnwrapped List<JsonValueObjectList> data) {}
+
+    @ApiResource(name = "jsonValueObjectList", description = "JsonValue Object list resource")
+    public record JsonValueObjectList(@ApiDescription("Free-form payloads") @JsonValue List<Object> payloads) {}
+
+    @ApiResource(name = "jsonValueOptionalField", description = "Resource with an unwrapped optional JsonValue list")
+    public record JsonValueOptionalField(@ApiUnwrapped List<JsonValueOptionalValue> data) {}
+
+    @ApiResource(name = "jsonValueOptionalValue", description = "JsonValue optional resource")
+    public record JsonValueOptionalValue(@ApiDescription("Optional payloads") @JsonValue Optional<String> payloads) {}
 
     @ApiResource(name = "simpleValue", description = "Simple value resource")
     public record SimpleValue(String name) {}

--- a/api/src/test/java/io/airlift/api/servertests/openapi/TestJsonValueOpenApi.java
+++ b/api/src/test/java/io/airlift/api/servertests/openapi/TestJsonValueOpenApi.java
@@ -1,0 +1,390 @@
+package io.airlift.api.servertests.openapi;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.inject.Guice;
+import io.airlift.api.ApiBuilderConfig;
+import io.airlift.api.ApiCreate;
+import io.airlift.api.ApiCustom;
+import io.airlift.api.ApiGet;
+import io.airlift.api.ApiPolyResource;
+import io.airlift.api.ApiReadOnly;
+import io.airlift.api.ApiResource;
+import io.airlift.api.ApiService;
+import io.airlift.api.ApiType;
+import io.airlift.api.ApiUnwrapped;
+import io.airlift.api.ServiceType;
+import io.airlift.api.binding.ApiModule;
+import io.airlift.api.builders.ApiBuilder;
+import io.airlift.api.model.ModelApi;
+import io.airlift.api.model.ModelResource;
+import io.airlift.api.model.ModelResourceType;
+import io.airlift.api.model.ModelServiceType;
+import io.airlift.api.openapi.OpenApiMetadata;
+import io.airlift.api.openapi.OpenApiProvider;
+import io.airlift.api.openapi.models.OpenAPI;
+import io.airlift.api.openapi.models.Schema;
+import io.airlift.api.validation.ObjectFieldServiceType;
+import io.airlift.json.JsonModule;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static io.airlift.api.model.ModelResourceModifier.IS_UNWRAPPED;
+import static io.airlift.api.openapi.OpenApiMetadata.OpenApiVersion.OPENAPI_3_0_1;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestJsonValueOpenApi
+{
+    private static final OpenApiMetadata OPEN_API_METADATA = new OpenApiMetadata(Optional.empty(), List.of(), "/", Duration.ofMinutes(5), OPENAPI_3_0_1);
+
+    @Test
+    public void testStringJsonValueResourceSchema()
+    {
+        OpenAPI openAPI = buildOpenApi(JsonValueService.class);
+
+        Schema<?> schema = schema(openAPI, "StringValue");
+        assertThat(schema.getType()).isEqualTo("string");
+        assertThat(schema.getDescription()).isEqualTo("String value resource");
+        assertThat(schema.getProperties()).isNull();
+    }
+
+    @Test
+    public void testListJsonValueResourceSchema()
+    {
+        OpenAPI openAPI = buildOpenApi(JsonValueService.class);
+
+        Schema<?> schema = schema(openAPI, "SimpleListValue");
+        assertThat(schema.getType()).isEqualTo("array");
+        assertThat(schema.getDescription()).isEqualTo("Simple list value resource");
+        assertThat(schema.getItems().get$ref()).isEqualTo("#/components/schemas/SimpleValue");
+    }
+
+    @Test
+    public void testPolyListJsonValueResourceSchema()
+    {
+        OpenAPI openAPI = buildOpenApi(JsonValueService.class);
+
+        Schema<?> schema = schema(openAPI, "PolyListValue");
+        assertThat(schema.getType()).isEqualTo("array");
+        assertThat(schema.getItems().get$ref()).isEqualTo("#/components/schemas/JsonValuePoly");
+    }
+
+    @Test
+    public void testResourceIdentityIsPreservedForPathsAndResponses()
+    {
+        OpenAPI openAPI = buildOpenApi(JsonValueService.class);
+
+        assertThat(openAPI.getPaths().getPaths()).containsKey("/public/api/v1/kqlQueryResponse:query");
+        assertThat(openAPI.getPaths().get("/public/api/v1/kqlQueryResponse:query").getGet().getOperationId()).isEqualTo("queryKqlQueryResponse");
+        assertThat(successResponseSchema(openAPI, "/public/api/v1/kqlQueryResponse:query").get$ref()).isEqualTo("#/components/schemas/KqlQueryResponse");
+
+        Schema<?> schema = schema(openAPI, "KqlQueryResponse");
+        assertThat(schema.getType()).isEqualTo("array");
+        assertThat(schema.getItems().get$ref()).isEqualTo("#/components/schemas/SimpleValue");
+    }
+
+    @Test
+    public void testOpenApiAlternateNameIsPreserved()
+    {
+        OpenAPI openAPI = buildOpenApi(JsonValueService.class);
+
+        assertThat(openAPI.getPaths().getPaths()).containsKey("/public/api/v1/alternateStringValue");
+        assertThat(successResponseSchema(openAPI, "/public/api/v1/alternateStringValue").get$ref()).isEqualTo("#/components/schemas/AlternateWireValue");
+
+        Schema<?> schema = schema(openAPI, "AlternateWireValue");
+        assertThat(schema.getType()).isEqualTo("string");
+        assertThat(schema.getDescription()).isEqualTo("Alternate string value resource");
+    }
+
+    @Test
+    public void testNormalRecordResourceIsUnchanged()
+    {
+        OpenAPI openAPI = buildOpenApi(JsonValueService.class);
+
+        Schema<?> schema = schema(openAPI, "NormalValue");
+        assertThat(schema.getProperties()).containsOnlyKeys("value");
+        assertThat(schema.getRequired()).containsExactly("value");
+    }
+
+    @Test
+    public void testInactiveJsonValueResourceIsStructural()
+    {
+        OpenAPI openAPI = buildOpenApi(JsonValueService.class);
+
+        Schema<?> schema = schema(openAPI, "InactiveJsonValue");
+        assertThat(schema.getProperties()).containsOnlyKeys("value");
+        assertThat(schema.getRequired()).containsExactly("value");
+    }
+
+    @Test
+    public void testMultipleJsonValueComponentsFailValidation()
+    {
+        assertThat(errors(MultipleJsonValueService.class))
+                .anyMatch(error -> error.contains("more than one @JsonValue record component"));
+    }
+
+    @Test
+    public void testJsonValueWithUnwrappedComponentFailsValidation()
+    {
+        assertThat(errors(JsonValueWithUnwrappedService.class))
+                .anyMatch(error -> error.contains("@JsonValue resources cannot have @ApiUnwrapped components"));
+    }
+
+    @Test
+    public void testUnsupportedJsonValueTypeFailsValidation()
+    {
+        assertThat(errors(UnsupportedJsonValueService.class))
+                .anyMatch(error -> error.contains("class java.lang.Object value") && error.contains("not a valid resource type"));
+    }
+
+    @Test
+    public void testReadOnlyJsonValueListValidation()
+    {
+        assertThat(errors(ReadOnlyJsonValueService.class)).isEmpty();
+    }
+
+    @Test
+    public void testJsonValueResourceRemainsMatchedToComponentWhenRemovingUnwrappedComponents()
+    {
+        ModelResource resource = modelApi(JsonValueService.class).modelServices().services().stream()
+                .flatMap(service -> service.methods().stream())
+                .filter(method -> method.returnType().type().equals(StringValue.class))
+                .findFirst()
+                .orElseThrow()
+                .returnType();
+
+        ModelResource updatedResource = resource.asResourceWithoutUnwrappedComponents();
+
+        assertThat(updatedResource.jsonValueResource()).isPresent();
+        assertThat(updatedResource.jsonValueResource().orElseThrow()).isSameAs(updatedResource.components().getFirst());
+    }
+
+    @Test
+    public void testJsonValueResourceUsesIdentityWhenRemovingUnwrappedComponents()
+    {
+        ModelResource first = ModelResource.builder(String.class, "value", "description", ModelResourceType.BASIC)
+                .withModifier(IS_UNWRAPPED)
+                .build();
+        ModelResource second = ModelResource.builder(String.class, "value", "description", ModelResourceType.BASIC)
+                .withModifier(IS_UNWRAPPED)
+                .build();
+        assertThat(first).isEqualTo(second);
+
+        ModelResource resource = ModelResource.builder(StringValue.class, "resource", "description", ModelResourceType.RESOURCE)
+                .withComponents(List.of(first, second))
+                .withJsonValueResource(second)
+                .build();
+
+        ModelResource updatedResource = resource.asResourceWithoutUnwrappedComponents();
+
+        assertThat(updatedResource.jsonValueResource()).isPresent();
+        assertThat(updatedResource.jsonValueResource().orElseThrow()).isSameAs(updatedResource.components().get(1));
+        assertThat(updatedResource.jsonValueResource().orElseThrow()).isNotSameAs(updatedResource.components().getFirst());
+    }
+
+    @Test
+    public void testSerializationValidation()
+    {
+        ModelApi modelApi = modelApi(SerializationJsonValueService.class);
+
+        Guice.createInjector(ApiModule.builder().addApi(modelApi).build(), new JsonModule());
+    }
+
+    private static OpenAPI buildOpenApi(Class<?> serviceClass)
+    {
+        ModelApi modelApi = modelApi(serviceClass);
+        ModelServiceType modelServiceType = modelApi.modelServices().services().stream()
+                .findFirst()
+                .orElseThrow()
+                .service()
+                .type();
+        return OpenApiProvider.create(modelApi.modelServices(), OPEN_API_METADATA, ApiBuilderConfig.jackson())
+                .build(modelServiceType, _ -> true);
+    }
+
+    private static ModelApi modelApi(Class<?> serviceClass)
+    {
+        ModelApi modelApi = ApiBuilder.apiBuilder().add(serviceClass).build();
+        assertThat(modelApi.modelServices().errors()).isEmpty();
+        return modelApi;
+    }
+
+    private static Set<String> errors(Class<?> serviceClass)
+    {
+        ModelApi modelApi = ApiBuilder.apiBuilder().add(serviceClass).build();
+        return modelApi.modelServices().errors();
+    }
+
+    private static Schema<?> schema(OpenAPI openAPI, String name)
+    {
+        return openAPI.getComponents().getSchemas().get(name);
+    }
+
+    private static Schema<?> successResponseSchema(OpenAPI openAPI, String path)
+    {
+        return openAPI.getPaths()
+                .get(path)
+                .getGet()
+                .getResponses()
+                .getResponse()
+                .get("200")
+                .getContent()
+                .getMediaTypes()
+                .get(APPLICATION_JSON)
+                .getSchema();
+    }
+
+    @ApiService(type = ObjectFieldServiceType.class, name = "json value", description = "Json value service")
+    public static class JsonValueService
+    {
+        @ApiGet(description = "Get string value")
+        public StringValue stringValue()
+        {
+            return null;
+        }
+
+        @ApiGet(description = "Get simple list value")
+        public SimpleListValue simpleListValue()
+        {
+            return null;
+        }
+
+        @ApiGet(description = "Get poly list value")
+        public PolyListValue polyListValue()
+        {
+            return null;
+        }
+
+        @ApiCustom(verb = "query", type = ApiType.GET, description = "Query values")
+        public KqlQueryResponse query()
+        {
+            return null;
+        }
+
+        @ApiGet(description = "Get normal value")
+        public NormalValue normalValue()
+        {
+            return null;
+        }
+
+        @ApiGet(description = "Get alternate string value")
+        public AlternateStringValue alternateStringValue()
+        {
+            return null;
+        }
+
+        @ApiGet(description = "Get inactive JsonValue")
+        public InactiveJsonValue inactiveJsonValue()
+        {
+            return null;
+        }
+    }
+
+    @ApiService(type = ServiceType.class, name = "multiple json value", description = "Multiple JsonValue service")
+    public static class MultipleJsonValueService
+    {
+        @ApiGet(description = "Get multiple")
+        public MultipleJsonValue multiple()
+        {
+            return null;
+        }
+    }
+
+    @ApiService(type = ServiceType.class, name = "json value unwrapped", description = "JsonValue unwrapped service")
+    public static class JsonValueWithUnwrappedService
+    {
+        @ApiGet(description = "Get unwrapped")
+        public JsonValueWithUnwrapped unwrapped()
+        {
+            return null;
+        }
+    }
+
+    @ApiService(type = ServiceType.class, name = "unsupported json value", description = "Unsupported JsonValue service")
+    public static class UnsupportedJsonValueService
+    {
+        @ApiGet(description = "Get unsupported")
+        public UnsupportedJsonValue unsupported()
+        {
+            return null;
+        }
+    }
+
+    @ApiService(type = ServiceType.class, name = "serialization json value", description = "Serialization JsonValue service")
+    public static class SerializationJsonValueService
+    {
+        @ApiGet(description = "Get string value")
+        public StringValue stringValue()
+        {
+            return null;
+        }
+
+        @ApiGet(description = "Get simple list value")
+        public SimpleListValue simpleListValue()
+        {
+            return null;
+        }
+    }
+
+    @ApiService(type = ServiceType.class, name = "read only json value", description = "Read-only JsonValue service")
+    public static class ReadOnlyJsonValueService
+    {
+        @ApiCreate(description = "Create read-only JsonValue", quotas = "test")
+        public void create(ReadOnlyJsonValue readOnlyJsonValue) {}
+    }
+
+    @ApiResource(name = "stringValue", description = "String value resource")
+    public record StringValue(@JsonValue String value) {}
+
+    @ApiResource(name = "simpleListValue", description = "Simple list value resource")
+    public record SimpleListValue(@JsonValue List<SimpleValue> values) {}
+
+    @ApiResource(name = "polyListValue", description = "Poly list value resource")
+    public record PolyListValue(@JsonValue List<JsonValuePoly> values) {}
+
+    @ApiResource(name = "kqlQueryResponse", description = "KQL query response")
+    public record KqlQueryResponse(@JsonValue List<SimpleValue> values) {}
+
+    @ApiResource(name = "normalValue", description = "Normal value resource")
+    public record NormalValue(String value) {}
+
+    @ApiResource(name = "alternateStringValue", openApiAlternateName = "alternateWireValue", description = "Alternate string value resource")
+    public record AlternateStringValue(@JsonValue String value) {}
+
+    @ApiResource(name = "inactiveJsonValue", description = "Inactive JsonValue resource")
+    public record InactiveJsonValue(@JsonValue(false) String value) {}
+
+    @ApiResource(name = "multipleJsonValue", description = "Multiple JsonValue resource")
+    public record MultipleJsonValue(@JsonValue String first, @JsonValue int second) {}
+
+    @ApiResource(name = "jsonValueWithUnwrapped", description = "JsonValue with unwrapped resource")
+    public record JsonValueWithUnwrapped(@JsonValue String value, @ApiUnwrapped UnwrappedValue unwrapped) {}
+
+    @ApiResource(name = "unsupportedJsonValue", description = "Unsupported JsonValue resource")
+    public record UnsupportedJsonValue(@JsonValue Object value) {}
+
+    @ApiResource(name = "readOnlyJsonValue", description = "Read-only JsonValue resource")
+    public record ReadOnlyJsonValue(@ApiReadOnly @JsonValue List<Boolean> values) {}
+
+    @ApiResource(name = "simpleValue", description = "Simple value resource")
+    public record SimpleValue(String name) {}
+
+    @ApiResource(name = "unwrappedValue", description = "Unwrapped value resource")
+    public record UnwrappedValue(String unwrapped) {}
+
+    @ApiPolyResource(name = "jsonValuePoly", description = "JsonValue poly resource", key = "type")
+    public sealed interface JsonValuePoly
+            permits PolyOne, PolyTwo {}
+
+    @ApiResource(name = "polyOne", description = "Poly one resource")
+    public record PolyOne(String one)
+            implements JsonValuePoly {}
+
+    @ApiResource(name = "polyTwo", description = "Poly two resource")
+    public record PolyTwo(String two)
+            implements JsonValuePoly {}
+}

--- a/api/src/test/java/io/airlift/api/servertests/openapi/TestOpenApiObjectField.java
+++ b/api/src/test/java/io/airlift/api/servertests/openapi/TestOpenApiObjectField.java
@@ -2,6 +2,7 @@ package io.airlift.api.servertests.openapi;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Resources;
+import io.airlift.api.ApiBuilderConfig;
 import io.airlift.api.builders.ApiBuilder;
 import io.airlift.api.model.ModelApi;
 import io.airlift.api.model.ModelServiceType;
@@ -12,8 +13,10 @@ import io.airlift.api.openapi.models.OpenAPI;
 import io.airlift.api.validation.ServiceWithObjectField;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.util.Optional;
 
+import static io.airlift.api.openapi.OpenApiMetadata.OpenApiVersion.OPENAPI_3_0_1;
 import static io.airlift.api.servertests.openapi.TestOpenApi.validateOpenApiJson;
 import static io.airlift.json.JsonCodec.jsonCodec;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -32,7 +35,7 @@ public class TestOpenApiObjectField
                 .findFirst()
                 .orElseThrow();
 
-        OpenApiProvider provider = OpenApiProvider.create(modelServices, new OpenApiMetadata(Optional.empty(), ImmutableList.of()));
+        OpenApiProvider provider = OpenApiProvider.create(modelServices, new OpenApiMetadata(Optional.empty(), ImmutableList.of(), "/", Duration.ofMinutes(5), OPENAPI_3_0_1), ApiBuilderConfig.jackson());
         OpenAPI openAPI = provider.build(serviceType, _ -> true);
         String actual = jsonCodec(OpenAPI.class).toJson(openAPI);
 

--- a/api/src/test/java/io/airlift/api/servertests/streaming/TestStreaming.java
+++ b/api/src/test/java/io/airlift/api/servertests/streaming/TestStreaming.java
@@ -1,6 +1,7 @@
 package io.airlift.api.servertests.streaming;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.airlift.api.ApiBuilderConfig;
 import io.airlift.api.builders.ApiBuilder;
 import io.airlift.api.model.ModelService;
 import io.airlift.api.model.ModelServices;
@@ -97,7 +98,7 @@ public class TestStreaming
         ModelServices modelServices = ApiBuilder.apiBuilder().add(StreamingService.class).build().modelServices();
         assertThat(modelServices.errors()).isEmpty();
         ModelService service = modelServices.services().iterator().next();
-        OpenApiProvider provider = OpenApiProvider.create(modelServices, new OpenApiMetadata(Optional.empty(), List.of(), "/", Duration.ofMinutes(5), OPENAPI_3_2_0));
+        OpenApiProvider provider = OpenApiProvider.create(modelServices, new OpenApiMetadata(Optional.empty(), List.of(), "/", Duration.ofMinutes(5), OPENAPI_3_2_0), ApiBuilderConfig.jackson());
         JsonNode openApi = jsonMapper.readTree(jsonMapper.writeValueAsString(provider.build(service.service().type(), _ -> true)));
 
         assertThat(openApi.at("/openapi").asText()).isEqualTo("3.2.0");

--- a/api/src/test/java/io/airlift/api/validation/TestConforming.java
+++ b/api/src/test/java/io/airlift/api/validation/TestConforming.java
@@ -52,6 +52,7 @@ import jakarta.ws.rs.WebApplicationException;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Type;
+import java.time.Duration;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -65,6 +66,7 @@ import static io.airlift.api.model.ModelResourceModifier.OPTIONAL;
 import static io.airlift.api.model.ModelResourceModifier.RECURSIVE_REFERENCE;
 import static io.airlift.api.model.ModelResourceType.BASIC;
 import static io.airlift.api.model.ModelResourceType.LIST;
+import static io.airlift.api.openapi.OpenApiMetadata.OpenApiVersion.OPENAPI_3_0_1;
 import static io.airlift.api.validation.ResourceValidator.validateResource;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -641,7 +643,7 @@ public class TestConforming
         assertThat(modelApi.modelServices().errors()).isEmpty();
 
         ModelServiceType serviceType = modelApi.modelServices().services().iterator().next().service().type();
-        OpenAPI openAPI = OpenApiProvider.create(modelApi.modelServices(), new OpenApiMetadata(Optional.empty(), ImmutableList.of()), config).build(serviceType, _ -> true);
+        OpenAPI openAPI = OpenApiProvider.create(modelApi.modelServices(), new OpenApiMetadata(Optional.empty(), ImmutableList.of(), "/", Duration.ofMinutes(5), OPENAPI_3_0_1), config).build(serviceType, _ -> true);
         Map<String, Schema> schemas = openAPI.getComponents().getSchemas();
         Schema<?> schema = schemas.get(schemaName);
         assertThat(schema).withFailMessage("Schema not found: %s. Found: %s", schemaName, schemas.keySet()).isNotNull();


### PR DESCRIPTION
## Summary
- model record resources with active Jackson `@JsonValue` as their delegated wire shape in OpenAPI
- preserve API Builder resource identity, paths, operation IDs, descriptions, tags, and alternate schema names
- add validation for ambiguous or unsupported `@JsonValue` resource declarations
- preserve the outer array layer for `@ApiUnwrapped List<T>` when `T` is a `@JsonValue` resource

## Stacking
This PR is currently stacked on #1955 and should be reviewed/merged after #1955.