### PR TITLE
Remove type:object from OpenAPI schema for untyped Object fields

### DIFF
--- a/api/src/main/java/io/airlift/api/openapi/SchemaBuilder.java
+++ b/api/src/main/java/io/airlift/api/openapi/SchemaBuilder.java
@@ -157,7 +157,7 @@ class SchemaBuilder
                 case PAGINATED_RESULT -> buildPaginatedSchema(modelResource);
                 case JSON -> buildApiJsonSchema(modelResource);
                 default -> modelResource.modifiers().contains(IS_ANY_OBJECT)
-                        ? new Schema<>().type("object").description(adjustedDescription(modelResource))
+                        ? new Schema<>().description(adjustedDescription(modelResource))
                         : buildBasicOrResourceSchema(modelResource, mode);
             };
         }

--- a/api/src/test/java/io/airlift/api/servertests/openapi/TestOpenApiObjectField.java
+++ b/api/src/test/java/io/airlift/api/servertests/openapi/TestOpenApiObjectField.java
@@ -1,0 +1,44 @@
+package io.airlift.api.servertests.openapi;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.Resources;
+import io.airlift.api.builders.ApiBuilder;
+import io.airlift.api.model.ModelApi;
+import io.airlift.api.model.ModelServiceType;
+import io.airlift.api.model.ModelServices;
+import io.airlift.api.openapi.OpenApiMetadata;
+import io.airlift.api.openapi.OpenApiProvider;
+import io.airlift.api.openapi.models.OpenAPI;
+import io.airlift.api.validation.ServiceWithObjectField;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static io.airlift.api.servertests.openapi.TestOpenApi.validateOpenApiJson;
+import static io.airlift.json.JsonCodec.jsonCodec;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestOpenApiObjectField
+{
+    @Test
+    public void testOpenApiObjectFieldSchema()
+            throws Exception
+    {
+        ModelApi modelApi = ApiBuilder.apiBuilder().add(ServiceWithObjectField.class).build();
+        ModelServices modelServices = modelApi.modelServices();
+        ModelServiceType serviceType = modelServices.services().stream()
+                .map(service -> service.service().type())
+                .findFirst()
+                .orElseThrow();
+
+        OpenApiProvider provider = OpenApiProvider.create(modelServices, new OpenApiMetadata(Optional.empty(), ImmutableList.of()));
+        OpenAPI openAPI = provider.build(serviceType, _ -> true);
+        String actual = jsonCodec(OpenAPI.class).toJson(openAPI);
+
+        validateOpenApiJson(actual);
+
+        String expected = Resources.toString(Resources.getResource("openapi/object-field.json"), UTF_8);
+        assertThat(actual.strip()).isEqualTo(expected.strip());
+    }
+}

--- a/api/src/test/resources/openapi/object-field.json
+++ b/api/src/test/resources/openapi/object-field.json
@@ -1,0 +1,172 @@
+{
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "test",
+    "version" : "v1"
+  },
+  "tags" : [ {
+    "name" : "ObjectFieldService Service",
+    "description" : "Service with an Object field"
+  }, {
+    "name" : "About",
+    "description" : "test\n\n<a href=\"/public/openapi/v1/json\" style=\"text-decoration: none !important\" download=\"openApi.json\">⬇️ Download OpenAPI specification</a>\n"
+  }, {
+    "name" : "Model Definitions",
+    "description" : ""
+  }, {
+    "name" : "Responses",
+    "description" : ""
+  } ],
+  "paths" : {
+    "/public/api/v1/objectField" : {
+      "post" : {
+        "tags" : [ "ObjectFieldService Service" ],
+        "description" : "create something with an Object field",
+        "operationId" : "createObjectField",
+        "parameters" : [ ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/ObjectField"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "204" : {
+            "description" : "Success"
+          },
+          "400" : {
+            "description" : "ApiBadRequest",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BadRequest"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "ApiUnauthorized",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Unauthorized"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "ApiForbidden",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Forbidden"
+                }
+              }
+            }
+          },
+          "409" : {
+            "description" : "ApiAlreadyExists",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Exists"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "BadRequest" : {
+        "properties" : {
+          "message" : {
+            "type" : "string",
+            "description" : "Description of the error"
+          },
+          "fields" : {
+            "type" : "array",
+            "description" : "Any fields/values that are invalid or incorrect",
+            "items" : {
+              "type" : "string",
+              "description" : "Any fields/values that are invalid or incorrect"
+            }
+          }
+        },
+        "description" : "Invalid request",
+        "x-tags" : [ "Responses" ]
+      },
+      "Exists" : {
+        "properties" : {
+          "message" : {
+            "type" : "string",
+            "description" : ""
+          }
+        },
+        "description" : "Already exists",
+        "x-tags" : [ "Responses" ]
+      },
+      "Forbidden" : {
+        "properties" : {
+          "message" : {
+            "type" : "string",
+            "description" : ""
+          }
+        },
+        "description" : "Authorization failed",
+        "x-tags" : [ "Responses" ]
+      },
+      "ObjectField" : {
+        "required" : [ "attributes", "name", "payloads" ],
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "description" : "A name"
+          },
+          "payloads" : {
+            "type" : "array",
+            "description" : "Free-form list",
+            "items" : {
+              "description" : "Free-form list"
+            }
+          },
+          "attributes" : {
+            "type" : "object",
+            "description" : "Free-form map",
+            "additionalProperties" : {
+              "description" : "Free-form map"
+            }
+          }
+        },
+        "description" : "Resource with Object container fields",
+        "x-tags" : [ "Model Definitions" ]
+      },
+      "Unauthorized" : {
+        "properties" : {
+          "message" : {
+            "type" : "string",
+            "description" : ""
+          }
+        },
+        "description" : "Authorization failed",
+        "x-tags" : [ "Responses" ]
+      }
+    }
+  },
+  "x-tagGroups" : [ {
+    "name" : "Help",
+    "tags" : [ "About" ]
+  }, {
+    "name" : "Services",
+    "tags" : [ "ObjectFieldService Service" ]
+  }, {
+    "name" : "Models",
+    "tags" : [ "Model Definitions", "Responses" ]
+  } ]
+}


### PR DESCRIPTION
Extraction from https://github.com/airlift/airlift/pull/1946 
It's more like a followup to https://github.com/airlift/airlift/pull/1935 so it make sense to have this as separate PR/change

Also added test for verify the change.

# Airlift contribution check list

 - [ ] Git commit messages follow https://cbea.ms/git-commit/.
 - [ ] All automated tests are passing.
 - [ ] Pull request was categorized using one of the existing labels.
