### PR TITLE
Support qualified API JAX-RS bindings

### DIFF
--- a/api/src/main/java/io/airlift/api/binding/ApiModule.java
+++ b/api/src/main/java/io/airlift/api/binding/ApiModule.java
@@ -42,6 +42,7 @@ import io.airlift.api.validation.ValidatorException;
 import jakarta.ws.rs.container.ContainerRequestFilter;
 import jakarta.ws.rs.container.ContainerResponseFilter;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
@@ -72,6 +73,7 @@ public class ApiModule
     private final boolean withApiLogging;
     private final ApiMode apiMode;
     private final ApiEnumValueResolver enumValueResolver;
+    private final Optional<Class<? extends Annotation>> jaxrsQualifier;
 
     private ApiModule(
             ModelApi modelApi,
@@ -84,7 +86,8 @@ public class ApiModule
             Optional<ApiCompatibilityTester> compatibilityTester,
             boolean withApiLogging,
             ApiMode apiMode,
-            ApiEnumValueResolver enumValueResolver)
+            ApiEnumValueResolver enumValueResolver,
+            Optional<Class<? extends Annotation>> jaxrsQualifier)
     {
         this.modelApi = requireNonNull(modelApi, "api is null");
         this.requestFilters = ImmutableSet.copyOf(requestFilters);
@@ -97,6 +100,7 @@ public class ApiModule
         this.withApiLogging = withApiLogging;
         this.apiMode = requireNonNull(apiMode, "apiMode is null");
         this.enumValueResolver = requireNonNull(enumValueResolver, "enumValueResolver is null");
+        this.jaxrsQualifier = requireNonNull(jaxrsQualifier, "jaxrsQualifier is null");
     }
 
     public static Builder builder()
@@ -118,6 +122,7 @@ public class ApiModule
         private boolean withApiLogging;
         private ApiMode apiMode = ApiMode.DEBUG;
         private ApiEnumValueResolver enumValueResolver = ApiBuilderConfig.jackson().enumValueResolver();
+        private Optional<Class<? extends Annotation>> jaxrsQualifier = Optional.empty();
 
         private Builder() {}
 
@@ -213,6 +218,14 @@ public class ApiModule
             return this;
         }
 
+        public Builder withJaxrsQualifier(Class<? extends Annotation> jaxrsQualifier)
+        {
+            checkArgument(this.jaxrsQualifier.isEmpty(), "jaxrsQualifier is already set");
+
+            this.jaxrsQualifier = Optional.of(requireNonNull(jaxrsQualifier, "jaxrsQualifier is null"));
+            return this;
+        }
+
         public Builder forProduction()
         {
             this.apiMode = ApiMode.PRODUCTION;
@@ -235,7 +248,8 @@ public class ApiModule
                     compatibilityTester,
                     withApiLogging,
                     apiMode,
-                    enumValueResolver);
+                    enumValueResolver,
+                    jaxrsQualifier);
         }
 
         private ModelApi mergeApis()
@@ -287,7 +301,7 @@ public class ApiModule
         Map<ModelServiceType, List<ModelService>> servicesByType = modelApi.modelServices().services().stream().collect(Collectors.groupingBy(modelService -> modelService.service().type()));
         binder.bind(new TypeLiteral<Set<ModelServiceType>>() {}).toInstance(servicesByType.keySet());
 
-        JaxrsResourceBuilder jaxrsResourceBuilder = jaxrsResourceBuilder(binder, withApiLogging);
+        JaxrsResourceBuilder jaxrsResourceBuilder = jaxrsResourceBuilder(binder, withApiLogging, jaxrsQualifier);
         MapBinder<Method, ModelDeprecation> deprecationBinder = MapBinder.newMapBinder(binder, Method.class, ModelDeprecation.class);
 
         binder.bind(ModelServices.class).toInstance(modelApi.modelServices());
@@ -295,7 +309,9 @@ public class ApiModule
         modelApi.modelServices().services().forEach(jaxrsResourceBuilder::bindService);
         jaxrsResourceBuilder.bindFeatures();
 
-        openApiMetadata.ifPresent(openApi -> binder.install(new OpenApiModule(modelApi.modelServices(), openApi, openApiFilterBinding, extensionFilter, enumValueResolver)));
+        openApiMetadata.ifPresent(openApi -> binder.install(jaxrsQualifier
+                .<Module>map(qualifier -> new OpenApiModule(modelApi.modelServices(), openApi, openApiFilterBinding, extensionFilter, enumValueResolver, qualifier))
+                .orElseGet(() -> new OpenApiModule(modelApi.modelServices(), openApi, openApiFilterBinding, extensionFilter, enumValueResolver))));
 
         modelApi.modelServices().deprecations().forEach(modelDeprecation -> deprecationBinder.addBinding(modelDeprecation.method()).toInstance(modelDeprecation));
 

--- a/api/src/main/java/io/airlift/api/binding/JaxrsResourceBuilder.java
+++ b/api/src/main/java/io/airlift/api/binding/JaxrsResourceBuilder.java
@@ -20,7 +20,9 @@ import jakarta.ws.rs.core.MediaType;
 import org.glassfish.jersey.server.model.Resource;
 import org.glassfish.jersey.server.model.ResourceMethod;
 
+import java.lang.annotation.Annotation;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -46,14 +48,16 @@ class JaxrsResourceBuilder
     private final JaxrsBinder jaxrsBinder;
     private final MapBinder<ModelService, Object> servicesBinder;
 
-    static JaxrsResourceBuilder jaxrsResourceBuilder(Binder binder, boolean withApiLogging)
+    static JaxrsResourceBuilder jaxrsResourceBuilder(Binder binder, boolean withApiLogging, Optional<Class<? extends Annotation>> jaxrsQualifier)
     {
-        return new JaxrsResourceBuilder(binder, withApiLogging);
+        return new JaxrsResourceBuilder(binder, withApiLogging, jaxrsQualifier);
     }
 
-    private JaxrsResourceBuilder(Binder binder, boolean withApiLogging)
+    private JaxrsResourceBuilder(Binder binder, boolean withApiLogging, Optional<Class<? extends Annotation>> jaxrsQualifier)
     {
-        jaxrsBinder = jaxrsBinder(binder);
+        jaxrsBinder = requireNonNull(jaxrsQualifier, "jaxrsQualifier is null")
+                .map(qualifier -> jaxrsBinder(binder, qualifier))
+                .orElseGet(() -> jaxrsBinder(binder));
         this.binder = requireNonNull(binder, "binder is null");
 
         servicesBinder = MapBinder.newMapBinder(binder, new TypeLiteral<ModelService>() {}, new TypeLiteral<>() {}).permitDuplicates();

--- a/api/src/main/java/io/airlift/api/openapi/OpenApiModule.java
+++ b/api/src/main/java/io/airlift/api/openapi/OpenApiModule.java
@@ -12,9 +12,11 @@ import io.airlift.api.model.ModelServices;
 import io.airlift.jaxrs.JaxrsBinder;
 import org.glassfish.jersey.server.model.Resource;
 
+import java.lang.annotation.Annotation;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -32,14 +34,26 @@ public class OpenApiModule
     private final Consumer<AnnotatedBindingBuilder<OpenApiFilter>> openApiFilterProviderBinding;
     private final OpenApiExtensionFilter extensionFilter;
     private final ApiEnumValueResolver enumValueResolver;
+    private final Optional<Class<? extends Annotation>> jaxrsQualifier;
 
     public OpenApiModule(ModelServices modelServices, OpenApiMetadata metadata, Consumer<AnnotatedBindingBuilder<OpenApiFilter>> openApiFilterProviderBinding, OpenApiExtensionFilter extensionFilter, ApiEnumValueResolver enumValueResolver)
+    {
+        this(modelServices, metadata, openApiFilterProviderBinding, extensionFilter, enumValueResolver, Optional.empty());
+    }
+
+    public OpenApiModule(ModelServices modelServices, OpenApiMetadata metadata, Consumer<AnnotatedBindingBuilder<OpenApiFilter>> openApiFilterProviderBinding, OpenApiExtensionFilter extensionFilter, ApiEnumValueResolver enumValueResolver, Class<? extends Annotation> jaxrsQualifier)
+    {
+        this(modelServices, metadata, openApiFilterProviderBinding, extensionFilter, enumValueResolver, Optional.of(requireNonNull(jaxrsQualifier, "jaxrsQualifier is null")));
+    }
+
+    private OpenApiModule(ModelServices modelServices, OpenApiMetadata metadata, Consumer<AnnotatedBindingBuilder<OpenApiFilter>> openApiFilterProviderBinding, OpenApiExtensionFilter extensionFilter, ApiEnumValueResolver enumValueResolver, Optional<Class<? extends Annotation>> jaxrsQualifier)
     {
         this.modelServices = requireNonNull(modelServices, "modelServices is null");
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.openApiFilterProviderBinding = requireNonNull(openApiFilterProviderBinding, "openApiFilterProviderBinding is null");
         this.extensionFilter = requireNonNull(extensionFilter, "extensionFilter is null");
         this.enumValueResolver = requireNonNull(enumValueResolver, "enumValueResolver is null");
+        this.jaxrsQualifier = requireNonNull(jaxrsQualifier, "jaxrsQualifier is null");
     }
 
     @Override
@@ -59,7 +73,9 @@ public class OpenApiModule
 
         binder.bind(OpenApiMetadata.class).toInstance(metadata);
 
-        JaxrsBinder jaxrsBinder = jaxrsBinder(binder);
+        JaxrsBinder jaxrsBinder = jaxrsQualifier
+                .map(qualifier -> jaxrsBinder(binder, qualifier))
+                .orElseGet(() -> jaxrsBinder(binder));
         jaxrsBinder.bindInstance(buildOpenApiResource(metadata));
         jaxrsBinder.bind(OpenApiResource.class);
     }

--- a/api/src/test/java/io/airlift/api/validation/TestConforming.java
+++ b/api/src/test/java/io/airlift/api/validation/TestConforming.java
@@ -11,9 +11,12 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.inject.BindingAnnotation;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import com.google.inject.Key;
 import com.google.inject.Module;
+import com.google.inject.TypeLiteral;
 import io.airlift.api.ApiBuilderConfig;
 import io.airlift.api.ApiCreate;
 import io.airlift.api.ApiDescription;
@@ -44,13 +47,16 @@ import io.airlift.api.model.ModelServiceType;
 import io.airlift.api.model.ModelServices;
 import io.airlift.api.openapi.OpenApiMetadata;
 import io.airlift.api.openapi.OpenApiProvider;
+import io.airlift.api.openapi.OpenApiResource;
 import io.airlift.api.openapi.models.OpenAPI;
 import io.airlift.api.openapi.models.Schema;
 import io.airlift.api.responses.ApiBadRequest;
 import io.airlift.json.JsonModule;
 import jakarta.ws.rs.WebApplicationException;
+import org.glassfish.jersey.server.model.Resource;
 import org.junit.jupiter.api.Test;
 
+import java.lang.annotation.Retention;
 import java.lang.reflect.Type;
 import java.time.Duration;
 import java.util.List;
@@ -68,6 +74,7 @@ import static io.airlift.api.model.ModelResourceType.BASIC;
 import static io.airlift.api.model.ModelResourceType.LIST;
 import static io.airlift.api.openapi.OpenApiMetadata.OpenApiVersion.OPENAPI_3_0_1;
 import static io.airlift.api.validation.ResourceValidator.validateResource;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -291,6 +298,25 @@ public class TestConforming
                 .build();
 
         Guice.createInjector(module, new JsonModule());
+    }
+
+    @Test
+    public void testApiModuleBindsJaxrsResourcesWithConfiguredQualifier()
+    {
+        Module module = ApiModule.builder()
+                .addApi(api -> api.add(PascalCaseEnumService.class))
+                .withOpenApiMetadata(new OpenApiMetadata(Optional.empty(), ImmutableList.of(), "/", Duration.ofMinutes(5), OPENAPI_3_0_1))
+                .withJaxrsQualifier(ForTestJaxrs.class)
+                .build();
+
+        Injector injector = Guice.createInjector(module, new JsonModule());
+        Key<Set<Object>> defaultJaxrsResources = Key.get(new TypeLiteral<>() {});
+        Key<Set<Object>> qualifiedJaxrsResources = Key.get(new TypeLiteral<>() {}, ForTestJaxrs.class);
+
+        assertThat(injector.getExistingBinding(defaultJaxrsResources)).isNull();
+        assertThat(injector.getInstance(qualifiedJaxrsResources))
+                .anySatisfy(resource -> assertThat(resource).isInstanceOf(Resource.class))
+                .anySatisfy(resource -> assertThat(resource).isInstanceOf(OpenApiResource.class));
     }
 
     @Test
@@ -681,6 +707,10 @@ public class TestConforming
             return builder.toString();
         }
     }
+
+    @BindingAnnotation
+    @Retention(RUNTIME)
+    private @interface ForTestJaxrs {}
 
     public static class EnumServiceType
             implements ApiServiceType


### PR DESCRIPTION
## Why

`ApiModule` currently registers generated API Builder JAX-RS resources with the default `JaxrsBinder`. Applications that run multiple JAX-RS servers or enforce explicit server qualifiers need those generated API resources to target the same qualifier as the rest of the application, without bridge modules or validator exemptions for Airlift internals.

## Example

An application with a public HTTP server can already bind regular resources with `jaxrsBinder(binder, ForPublic.class)`. API Builder resources should be able to use the same server binding:

```java
install(ApiModule.builder()
        .addApi(api -> api.add(ChatApi.class))
        .withJaxrsQualifier(ForPublic.class)
        .build());
```

With this change, generated API resources and OpenAPI resources are registered only in the `ForPublic` JAX-RS resource set.