### PR TITLE
Improve decay counter performance

### DIFF
--- a/stats/src/main/java/io/airlift/stats/CounterStat.java
+++ b/stats/src/main/java/io/airlift/stats/CounterStat.java
@@ -43,9 +43,11 @@ public final class CounterStat
 
     public void update(long count)
     {
-        oneMinute.add(count);
-        fiveMinute.add(count);
-        fifteenMinute.add(count);
+        // all three counters use the system ticker, so the tick can be read once and shared
+        long nowInSeconds = oneMinute.getTickInSeconds();
+        oneMinute.add(count, nowInSeconds);
+        fiveMinute.add(count, nowInSeconds);
+        fifteenMinute.add(count, nowInSeconds);
         this.count.add(count);
     }
 

--- a/stats/src/main/java/io/airlift/stats/DecayCounter.java
+++ b/stats/src/main/java/io/airlift/stats/DecayCounter.java
@@ -5,6 +5,8 @@ import com.google.errorprone.annotations.ThreadSafe;
 import org.weakref.jmx.Managed;
 
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.DoubleAdder;
+import java.util.concurrent.locks.StampedLock;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -28,8 +30,16 @@ public final class DecayCounter
     private final double alpha;
     private final Ticker ticker;
 
+    // Adds run under the read lock and accumulate into the adder concurrently. Operations
+    // that rescale or replace the accumulated count (rescale, merge, reset) require the
+    // write lock: DoubleAdder.sumThenReset() loses concurrent updates, so adds must be
+    // excluded while it runs.
+    private final StampedLock lock = new StampedLock();
+    private final DoubleAdder count = new DoubleAdder();
+    // written only under the write lock, read under the read lock
     private long landmarkInSeconds;
-    private double count;
+    // benign race: concurrent writers store the same value for the same (now, landmark)
+    private volatile CachedWeight cachedWeight;
 
     public DecayCounter(double alpha)
     {
@@ -41,91 +51,174 @@ public final class DecayCounter
         this(0, alpha, ticker, TimeUnit.NANOSECONDS.toSeconds(ticker.read()));
     }
 
-    private DecayCounter(double count, double alpha, Ticker ticker, long landmarkInSeconds)
+    private DecayCounter(double initialCount, double alpha, Ticker ticker, long landmarkInSeconds)
     {
-        this.count = count;
+        this.count.add(initialCount);
         this.alpha = alpha;
         this.ticker = ticker;
         this.landmarkInSeconds = landmarkInSeconds;
+        this.cachedWeight = new CachedWeight(landmarkInSeconds, landmarkInSeconds, 1.0);
     }
 
     public DecayCounter duplicate()
     {
-        return new DecayCounter(count, alpha, ticker, landmarkInSeconds);
-    }
-
-    public synchronized void add(long value)
-    {
-        long nowInSeconds = getTickInSeconds();
-
-        if (nowInSeconds - landmarkInSeconds >= RESCALE_THRESHOLD_SECONDS) {
-            rescaleToNewLandmark(nowInSeconds);
+        long stamp = lock.readLock();
+        try {
+            return new DecayCounter(count.sum(), alpha, ticker, landmarkInSeconds);
         }
-        count += value * weight(alpha, nowInSeconds, landmarkInSeconds);
+        finally {
+            lock.unlockRead(stamp);
+        }
     }
 
-    public synchronized void merge(DecayCounter decayCounter)
+    public void add(long value)
+    {
+        add(value, getTickInSeconds());
+    }
+
+    void add(long value, long nowInSeconds)
+    {
+        long stamp = lock.readLock();
+        try {
+            if (nowInSeconds - landmarkInSeconds >= RESCALE_THRESHOLD_SECONDS) {
+                long writeStamp = lock.tryConvertToWriteLock(stamp);
+                if (writeStamp == 0) {
+                    lock.unlockRead(stamp);
+                    writeStamp = lock.writeLock();
+                }
+                stamp = writeStamp;
+                // recheck: another thread may have rescaled while we waited for the write lock
+                if (nowInSeconds - landmarkInSeconds >= RESCALE_THRESHOLD_SECONDS) {
+                    rescaleToNewLandmark(nowInSeconds);
+                }
+            }
+            count.add(value * weightAt(nowInSeconds));
+        }
+        finally {
+            lock.unlock(stamp);
+        }
+    }
+
+    public void merge(DecayCounter decayCounter)
     {
         requireNonNull(decayCounter, "decayCounter is null");
         checkArgument(decayCounter.alpha == alpha, "Expected decayCounter to have alpha %s, but was %s", alpha, decayCounter.alpha);
 
-        synchronized (decayCounter) {
+        double otherCount;
+        long otherLandmarkInSeconds;
+        long otherStamp = decayCounter.lock.readLock();
+        try {
+            otherCount = decayCounter.count.sum();
+            otherLandmarkInSeconds = decayCounter.landmarkInSeconds;
+        }
+        finally {
+            decayCounter.lock.unlockRead(otherStamp);
+        }
+
+        long stamp = lock.writeLock();
+        try {
             // if the landmark this counter is behind the other counter
-            if (landmarkInSeconds < decayCounter.landmarkInSeconds) {
+            if (landmarkInSeconds < otherLandmarkInSeconds) {
                 // rescale this counter to the other counter, and add
-                rescaleToNewLandmark(decayCounter.landmarkInSeconds);
-                count += decayCounter.count;
+                rescaleToNewLandmark(otherLandmarkInSeconds);
+                count.add(otherCount);
             }
             else {
                 // rescale the other counter and add
-                double otherRescaledCount = decayCounter.count / weight(alpha, landmarkInSeconds, decayCounter.landmarkInSeconds);
-                count += otherRescaledCount;
+                count.add(otherCount / weight(alpha, landmarkInSeconds, otherLandmarkInSeconds));
             }
+        }
+        finally {
+            lock.unlockWrite(stamp);
         }
     }
 
     private void rescaleToNewLandmark(long newLandMarkInSeconds)
     {
         // rescale the count based on a new landmark to avoid numerical overflow issues
-        count = count / weight(alpha, newLandMarkInSeconds, landmarkInSeconds);
+        double oldCount = count.sumThenReset();
+        count.add(oldCount / weight(alpha, newLandMarkInSeconds, landmarkInSeconds));
         landmarkInSeconds = newLandMarkInSeconds;
     }
 
     @Managed
-    public synchronized void reset()
+    public void reset()
     {
-        landmarkInSeconds = getTickInSeconds();
-        count = 0;
+        long nowInSeconds = getTickInSeconds();
+        long stamp = lock.writeLock();
+        try {
+            landmarkInSeconds = nowInSeconds;
+            count.reset();
+        }
+        finally {
+            lock.unlockWrite(stamp);
+        }
     }
 
     /**
      * This is a hack to work around limitations in Jmxutils.
      */
     @Deprecated
-    public synchronized void resetTo(DecayCounter counter)
+    public void resetTo(DecayCounter counter)
     {
-        synchronized (counter) {
-            landmarkInSeconds = counter.landmarkInSeconds;
-            count = counter.count;
+        double otherCount;
+        long otherLandmarkInSeconds;
+        long otherStamp = counter.lock.readLock();
+        try {
+            otherCount = counter.count.sum();
+            otherLandmarkInSeconds = counter.landmarkInSeconds;
+        }
+        finally {
+            counter.lock.unlockRead(otherStamp);
+        }
+
+        long stamp = lock.writeLock();
+        try {
+            landmarkInSeconds = otherLandmarkInSeconds;
+            count.reset();
+            count.add(otherCount);
+        }
+        finally {
+            lock.unlockWrite(stamp);
         }
     }
 
     @Managed
-    public synchronized double getCount()
+    public double getCount()
     {
         long nowInSeconds = getTickInSeconds();
-        return count / weight(alpha, nowInSeconds, landmarkInSeconds);
+        long stamp = lock.readLock();
+        try {
+            return count.sum() / weightAt(nowInSeconds);
+        }
+        finally {
+            lock.unlockRead(stamp);
+        }
     }
 
     @Managed
-    public synchronized double getRate()
+    public double getRate()
     {
         // The total time covered by this counter is equivalent to the integral of the weight function from 0 to Infinity,
         // which equals 1/alpha. The count per unit time is, therefore, count / (1/alpha)
         return getCount() * alpha;
     }
 
-    private long getTickInSeconds()
+    // The weight depends only on second-granularity timestamps, so within a given second
+    // every add recomputes the same value. Caching it keeps Math.exp off the hot path.
+    private double weightAt(long nowInSeconds)
+    {
+        long landmark = landmarkInSeconds;
+        CachedWeight cached = cachedWeight;
+        if (cached.nowInSeconds == nowInSeconds && cached.landmarkInSeconds == landmark) {
+            return cached.weight;
+        }
+        double computedWeight = weight(alpha, nowInSeconds, landmark);
+        cachedWeight = new CachedWeight(nowInSeconds, landmark, computedWeight);
+        return computedWeight;
+    }
+
+    long getTickInSeconds()
     {
         return TimeUnit.NANOSECONDS.toSeconds(ticker.read());
     }
@@ -152,4 +245,6 @@ public final class DecayCounter
     }
 
     public record DecayCounterSnapshot(double count, double rate) {}
+
+    private record CachedWeight(long nowInSeconds, long landmarkInSeconds, double weight) {}
 }

--- a/stats/src/test/java/io/airlift/stats/TestDecayCounter.java
+++ b/stats/src/test/java/io/airlift/stats/TestDecayCounter.java
@@ -3,6 +3,9 @@ package io.airlift.stats;
 import io.airlift.testing.TestingTicker;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,6 +36,38 @@ public class TestDecayCounter
 
         double expected = 2 + 1 / Math.E;
         assertThat(Math.abs(counter.getCount() - expected)).isLessThan(1e-9);
+    }
+
+    @Test
+    public void testConcurrentAdds()
+            throws Exception
+    {
+        int threads = 8;
+        int addsPerThread = 100_000;
+
+        // with no decay the weight is always 1, so the count must be the exact sum of all adds
+        DecayCounter counter = new DecayCounter(ExponentialDecay.all());
+
+        CyclicBarrier barrier = new CyclicBarrier(threads);
+        List<Thread> workers = new ArrayList<>();
+        for (int i = 0; i < threads; i++) {
+            workers.add(Thread.ofPlatform().start(() -> {
+                try {
+                    barrier.await();
+                }
+                catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+                for (int j = 0; j < addsPerThread; j++) {
+                    counter.add(1);
+                }
+            }));
+        }
+        for (Thread worker : workers) {
+            worker.join();
+        }
+
+        assertThat(counter.getCount()).isEqualTo((double) threads * addsPerThread);
     }
 
     @Test


### PR DESCRIPTION
By avoiding 3 monitor acquisitions, 3 nanoTime() and 3 Math.exp calls.

synchronized monitor → StampedLock: add() now takes the read lock, so concurrent adders no longer serialize against each other. The write lock is only needed for the rare operations that replace the accumulated count - rescale (once per 50 seconds), merge, reset, resetTo.

<!-- Thank you for submitting pull request to Airlift -->

# Airlift contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [x] All automated tests are passing.
 - [x] Pull request was categorized using one of the existing labels.
