### PR TITLE
Emit enum array in OpenAPI schema for parameters with allowedValues

### DIFF
--- a/api/src/main/java/io/airlift/api/openapi/OpenApiBuilder.java
+++ b/api/src/main/java/io/airlift/api/openapi/OpenApiBuilder.java
@@ -50,6 +50,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -432,11 +433,14 @@ class OpenApiBuilder
             Parameter parameter = (optionalParameter.location() == ModelOptionalParameter.Location.QUERY) ? new QueryParameter() : new HeaderParameter();
             Optional<Schema<?>> schema;
             if (externalParameter.externalType().isArray()) {
-                schema = schemaBuilder.buildBasicSchema(externalParameter.externalType().getComponentType()).map(s -> new ArraySchema().items(s));
+                schema = schemaBuilder.buildBasicSchema(externalParameter.externalType().getComponentType())
+                        .map(withEnumValues(optionalParameter.limitedValues()))
+                        .map(new ArraySchema()::items);
                 parameter.setExplode(true);
             }
             else {
-                schema = schemaBuilder.buildBasicSchema(externalParameter.externalType());
+                schema = schemaBuilder.buildBasicSchema(externalParameter.externalType())
+                        .map(withEnumValues(optionalParameter.limitedValues()));
             }
             if (schema.isEmpty()) {
                 throw new RuntimeException("Unsupported external type: " + externalParameter.externalType());
@@ -444,6 +448,16 @@ class OpenApiBuilder
             parameter.name(externalParameter.name()).description(externalParameter.description()).schema(schema.orElseThrow()).required(false);
             return parameter;
         });
+    }
+
+    private static Function<Schema<?>, Schema<?>> withEnumValues(Set<String> limitedValues)
+    {
+        return schema -> {
+            if (!limitedValues.isEmpty() && schema instanceof StringSchema stringSchema) {
+                limitedValues.forEach(stringSchema::addEnumItem);
+            }
+            return schema;
+        };
     }
 
     private Optional<Map.Entry<String, SecurityScheme>> buildSecurity()

--- a/api/src/test/resources/openapi/widget.json
+++ b/api/src/test/resources/openapi/widget.json
@@ -123,7 +123,8 @@
           "description" : "Sort/ordering in standard SQL ORDER BY format. Allowed values: id, name, size",
           "required" : false,
           "schema" : {
-            "type" : "string"
+            "type" : "string",
+            "enum" : [ "id", "name", "size" ]
           }
         }, {
           "in" : "query",


### PR DESCRIPTION
When a resource method declares `@ApiParameter(allowedValues = {"A", "B", "C"})`, the generated OpenAPI spec currently only appends "Allowed values: A, B, C" to the description string. The schema itself is just {"type": "string"} with no constraint.

This change adds a proper "enum": ["A", "B", "C"] array to the parameter's schema object,

# Airlift contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [x] All automated tests are passing.
 - [x] Pull request was categorized using one of the existing labels.
