### PR TITLE
Add API request cancellation

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -36,3 +36,4 @@ See [Introduction](docs/starting.md) for details on how API Builder enhances JAX
 | [Quotas](docs/quotas.md)                            | Managing resource quotas                                                                                 |
 | [Streaming](docs/streaming.md)                      | Streaming responses                                                                                      |
 | [Multi-part Uploads](docs/multipart.md)             | Multi-part uploads                                                                                       |
+| [Request Cancellation](docs/cancellation.md)        | Cleaning up work when an API request is cancelled                                                        |

--- a/api/docs/cancellation.md
+++ b/api/docs/cancellation.md
@@ -1,0 +1,36 @@
+[◀︎ Airlift](../../README.md) • [◀︎ API Builder](../README.md)
+
+# API Builder: Request Cancellation
+
+API methods can inject `@Context ApiCancellation` to register cleanup work that should run if
+the request cannot complete normally, such as when the client disconnects, the request fails, or
+the request times out.
+
+```java
+@ApiGet(description = "Get a report")
+public Report getReport(@ApiParameter ReportId reportId, @Context ApiCancellation cancellation)
+{
+    cancellation.onCancel(cleanupExecutor, () -> report.cancel());
+    return reportRunner.run(reportId);
+}
+```
+
+Cancellation requires both API and HTTP server setup:
+
+```java
+ApiModule.builder()
+        .addApi(ReportService.class)
+        .withCancellableRequestExecutor(cancellableRequestExecutor)
+        .build();
+
+httpServerBinder(binder).withFeature(REQUEST_CANCELLATION);
+```
+
+The cancellable request executor runs API method bodies that declare `@Context ApiCancellation`,
+so request work can be interrupted independently from the main HTTP request thread. Cancellation
+listeners run on the executor supplied to `ApiCancellation.onCancel(...)`.
+
+Size the cancellable request executor for the number of API requests using this feature that the
+service must run concurrently. If the executor is saturated, requests whose API methods declare
+`@Context ApiCancellation` wait for a thread from that pool, so the service backs up there instead
+of on the main HTTP request thread.

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -138,6 +138,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
@@ -180,6 +185,12 @@
                     <artifactId>aopalliance-repackaged</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/api/src/main/java/io/airlift/api/ApiCancellation.java
+++ b/api/src/main/java/io/airlift/api/ApiCancellation.java
@@ -1,0 +1,26 @@
+package io.airlift.api;
+
+import java.util.concurrent.Executor;
+
+/**
+ * Request-scoped cancellation token for APIs that need to clean up work when the request cannot complete normally.
+ */
+public interface ApiCancellation
+{
+    boolean isCancelled();
+
+    /**
+     * Registers a listener to run once on the supplied executor when the request is cancelled.
+     */
+    ListenerRegistration onCancel(Executor executor, Runnable listener);
+
+    interface ListenerRegistration
+            extends AutoCloseable
+    {
+        /**
+         * Removes the listener if cancellation has not already started.
+         */
+        @Override
+        void close();
+    }
+}

--- a/api/src/main/java/io/airlift/api/binding/ApiCancellableRequestExecutorProvider.java
+++ b/api/src/main/java/io/airlift/api/binding/ApiCancellableRequestExecutorProvider.java
@@ -1,0 +1,30 @@
+package io.airlift.api.binding;
+
+import io.opentelemetry.context.Context;
+import org.glassfish.jersey.server.ManagedAsyncExecutor;
+import org.glassfish.jersey.spi.ExecutorServiceProvider;
+
+import java.util.concurrent.ExecutorService;
+
+import static java.util.Objects.requireNonNull;
+
+@ManagedAsyncExecutor
+class ApiCancellableRequestExecutorProvider
+        implements ExecutorServiceProvider
+{
+    private final ExecutorService executor;
+
+    ApiCancellableRequestExecutorProvider(ExecutorService executor)
+    {
+        this.executor = Context.taskWrapping(requireNonNull(executor, "executor is null"));
+    }
+
+    @Override
+    public ExecutorService getExecutorService()
+    {
+        return executor;
+    }
+
+    @Override
+    public void dispose(ExecutorService executorService) {}
+}

--- a/api/src/main/java/io/airlift/api/binding/ApiCancellationRequestFilter.java
+++ b/api/src/main/java/io/airlift/api/binding/ApiCancellationRequestFilter.java
@@ -1,0 +1,25 @@
+package io.airlift.api.binding;
+
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+
+import java.util.concurrent.CompletableFuture;
+
+import static io.airlift.api.binding.ApiCancellationValueParamProvider.REQUEST_CANCELLATION_ATTRIBUTE;
+
+class ApiCancellationRequestFilter
+        implements ContainerRequestFilter
+{
+    @Override
+    public void filter(ContainerRequestContext requestContext)
+    {
+        // Jersey servlet requests expose servlet attributes as request context properties.
+        Object value = requestContext.getProperty(REQUEST_CANCELLATION_ATTRIBUTE);
+        if (value == null) {
+            return;
+        }
+        if (!(value instanceof CompletableFuture<?>)) {
+            throw new IllegalStateException("Expected CompletableFuture in request attribute: " + REQUEST_CANCELLATION_ATTRIBUTE);
+        }
+    }
+}

--- a/api/src/main/java/io/airlift/api/binding/ApiCancellationValueParamProvider.java
+++ b/api/src/main/java/io/airlift/api/binding/ApiCancellationValueParamProvider.java
@@ -1,0 +1,46 @@
+package io.airlift.api.binding;
+
+import io.airlift.api.ApiCancellation;
+import org.glassfish.jersey.model.Parameter.Source;
+import org.glassfish.jersey.server.ContainerRequest;
+import org.glassfish.jersey.server.model.Parameter;
+import org.glassfish.jersey.server.spi.internal.ValueParamProvider;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+/**
+ * Injects @Context ApiCancellation from the request cancellation attribute.
+ */
+class ApiCancellationValueParamProvider
+        implements ValueParamProvider
+{
+    static final String REQUEST_CANCELLATION_ATTRIBUTE = "io.airlift.request-cancellation";
+
+    @Override
+    public Function<ContainerRequest, ?> getValueProvider(Parameter parameter)
+    {
+        if ((parameter.getSource() == Source.CONTEXT) && ApiCancellation.class.equals(parameter.getRawType())) {
+            return ApiCancellationValueParamProvider::getOrCreate;
+        }
+        return null;
+    }
+
+    @Override
+    public PriorityType getPriority()
+    {
+        return Priority.HIGH;
+    }
+
+    private static ApiCancellation getOrCreate(ContainerRequest request)
+    {
+        Object value = request.getProperty(REQUEST_CANCELLATION_ATTRIBUTE);
+        if (value == null) {
+            return RequestApiCancellation.empty();
+        }
+        if (!(value instanceof CompletableFuture<?> cancellation)) {
+            throw new IllegalStateException("Expected CompletableFuture in request attribute: " + REQUEST_CANCELLATION_ATTRIBUTE);
+        }
+        return new RequestApiCancellation(cancellation);
+    }
+}

--- a/api/src/main/java/io/airlift/api/binding/ApiModule.java
+++ b/api/src/main/java/io/airlift/api/binding/ApiModule.java
@@ -14,6 +14,7 @@ import com.google.inject.TypeLiteral;
 import com.google.inject.binder.LinkedBindingBuilder;
 import com.google.inject.multibindings.MapBinder;
 import io.airlift.api.ApiBuilderConfig;
+import io.airlift.api.ApiCancellation;
 import io.airlift.api.ApiEnumValueResolver;
 import io.airlift.api.ApiId;
 import io.airlift.api.ApiIdLookup;
@@ -47,6 +48,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -58,6 +60,7 @@ import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.api.binding.ApiBindingKeys.annotatedKey;
 import static io.airlift.api.binding.ApiMapBinders.newMapBinder;
 import static io.airlift.api.binding.JaxrsResourceBuilder.jaxrsResourceBuilder;
+import static io.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
 import static java.util.Objects.requireNonNull;
 
 public class ApiModule
@@ -75,6 +78,7 @@ public class ApiModule
     private final boolean withApiLogging;
     private final ApiMode apiMode;
     private final ApiEnumValueResolver enumValueResolver;
+    private final Optional<ExecutorService> cancellableRequestExecutor;
 
     private ApiModule(
             ModelApi modelApi,
@@ -88,7 +92,8 @@ public class ApiModule
             Optional<ApiCompatibilityTester> compatibilityTester,
             boolean withApiLogging,
             ApiMode apiMode,
-            ApiEnumValueResolver enumValueResolver)
+            ApiEnumValueResolver enumValueResolver,
+            Optional<ExecutorService> cancellableRequestExecutor)
     {
         this.modelApi = requireNonNull(modelApi, "api is null");
         this.bindingAnnotation = requireNonNull(bindingAnnotation, "bindingAnnotation is null");
@@ -102,6 +107,7 @@ public class ApiModule
         this.withApiLogging = withApiLogging;
         this.apiMode = requireNonNull(apiMode, "apiMode is null");
         this.enumValueResolver = requireNonNull(enumValueResolver, "enumValueResolver is null");
+        this.cancellableRequestExecutor = requireNonNull(cancellableRequestExecutor, "cancellableRequestExecutor is null");
     }
 
     public static Builder builder()
@@ -124,6 +130,7 @@ public class ApiModule
         private boolean withApiLogging;
         private ApiMode apiMode = ApiMode.DEBUG;
         private ApiEnumValueResolver enumValueResolver = ApiBuilderConfig.jackson().enumValueResolver();
+        private Optional<ExecutorService> cancellableRequestExecutor = Optional.empty();
 
         private Builder() {}
 
@@ -219,6 +226,14 @@ public class ApiModule
             return this;
         }
 
+        public Builder withCancellableRequestExecutor(ExecutorService executor)
+        {
+            checkArgument(this.cancellableRequestExecutor.isEmpty(), "cancellable request executor is already set");
+
+            this.cancellableRequestExecutor = Optional.of(requireNonNull(executor, "executor is null"));
+            return this;
+        }
+
         public Builder forProduction()
         {
             this.apiMode = ApiMode.PRODUCTION;
@@ -250,7 +265,8 @@ public class ApiModule
                     compatibilityTester,
                     withApiLogging,
                     apiMode,
-                    enumValueResolver);
+                    enumValueResolver,
+                    cancellableRequestExecutor);
         }
 
         private ModelApi mergeApis()
@@ -275,6 +291,16 @@ public class ApiModule
     @Override
     public void configure(Binder binder)
     {
+        boolean hasCancellableMethods = hasCancellableMethods();
+        if (hasCancellableMethods && cancellableRequestExecutor.isEmpty()) {
+            binder.addError(
+                    "API methods with @Context %s require a cancellable request executor. Call %s.%s().%s(...).",
+                    ApiCancellation.class.getSimpleName(),
+                    ApiModule.class.getSimpleName(),
+                    "builder",
+                    "withCancellableRequestExecutor");
+        }
+
         bindApi(binder);
 
         newOptionalBinder(binder, annotatedKey(ApiQuotaController.class, bindingAnnotation)).setBinding().toInstance(new ApiQuotaControllerProxy());
@@ -307,6 +333,8 @@ public class ApiModule
         binder.bind(annotatedKey(new TypeLiteral<Set<ModelServiceType>>() {}, bindingAnnotation)).toInstance(servicesByType.keySet());
 
         JaxrsResourceBuilder jaxrsResourceBuilder = jaxrsResourceBuilder(binder, withApiLogging, bindingAnnotation);
+        cancellableRequestExecutor.ifPresent(executor -> jaxrsBinder(binder, bindingAnnotation).bindInstance(new ApiCancellableRequestExecutorProvider(executor)));
+
         MapBinder<Method, ModelDeprecation> deprecationBinder = newMapBinder(
                 binder,
                 new TypeLiteral<>() {},
@@ -323,6 +351,13 @@ public class ApiModule
         modelApi.modelServices().deprecations().forEach(modelDeprecation -> deprecationBinder.addBinding(modelDeprecation.method()).toInstance(modelDeprecation));
 
         bindContainerFilters(binder);
+    }
+
+    private boolean hasCancellableMethods()
+    {
+        return modelApi.modelServices().services().stream()
+                .flatMap(service -> service.methods().stream())
+                .anyMatch(JaxrsResourceBuilder::isCancellable);
     }
 
     private void bindContainerFilters(Binder binder)

--- a/api/src/main/java/io/airlift/api/binding/JaxrsResourceBuilder.java
+++ b/api/src/main/java/io/airlift/api/binding/JaxrsResourceBuilder.java
@@ -8,6 +8,7 @@ import com.google.inject.Provider;
 import com.google.inject.Scopes;
 import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.MapBinder;
+import io.airlift.api.ApiCancellation;
 import io.airlift.api.ApiId;
 import io.airlift.api.ApiIdLookup;
 import io.airlift.api.ApiService;
@@ -32,6 +33,7 @@ import org.glassfish.jersey.server.model.ResourceMethod;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -98,7 +100,9 @@ class JaxrsResourceBuilder
         newOptionalBinder(binder, annotatedKey(OpenApiMetadata.class, bindingAnnotation));
 
         bindAnnotated(PatchFieldsBuilder.class);
+        jaxrsBinder.bind(ApiCancellationRequestFilter.class);
         jaxrsBinder.bind(SpecialApiTypeValueParamProvider.class, specialApiTypeValueParamProvider());
+        jaxrsBinder.bind(ApiCancellationValueParamProvider.class);
         jaxrsBinder.bind(PaginationValueParamProvider.class);
         jaxrsBinder.bind(JaxrsBindingBridge.class, jaxrsBindingBridgeProvider());
         jaxrsBinder.bind(JaxrsMapper.class, jaxrsMapperProvider());
@@ -153,7 +157,20 @@ class JaxrsResourceBuilder
                 methodBuilder.consumes(isMultiPartForm ? MULTIPART_FORM_DATA_TYPE : APPLICATION_JSON_TYPE).produces(getResponseType(method.returnType()));
             }
         }
+        if (isCancellable(method)) {
+            methodBuilder.managedAsync();
+        }
         methodBuilder.handledBy(service.serviceClass(), method.method());
+    }
+
+    static boolean isCancellable(ModelMethod method)
+    {
+        for (Parameter parameter : method.method().getParameters()) {
+            if (parameter.isAnnotationPresent(jakarta.ws.rs.core.Context.class) && ApiCancellation.class.equals(parameter.getType())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private List<MediaType> getResponseType(ModelResource returnType)

--- a/api/src/main/java/io/airlift/api/binding/RequestApiCancellation.java
+++ b/api/src/main/java/io/airlift/api/binding/RequestApiCancellation.java
@@ -1,0 +1,71 @@
+package io.airlift.api.binding;
+
+import io.airlift.api.ApiCancellation;
+import io.airlift.log.Logger;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+import static java.util.Objects.requireNonNull;
+
+class RequestApiCancellation
+        implements ApiCancellation
+{
+    private static final Logger log = Logger.get(RequestApiCancellation.class);
+    private static final ListenerRegistration NOOP_REGISTRATION = () -> {};
+
+    private final CompletableFuture<?> cancellation;
+
+    RequestApiCancellation(CompletableFuture<?> cancellation)
+    {
+        this.cancellation = requireNonNull(cancellation, "cancellation is null");
+    }
+
+    static ApiCancellation empty()
+    {
+        return new RequestApiCancellation(CompletableFuture.completedFuture(null));
+    }
+
+    @Override
+    public boolean isCancelled()
+    {
+        return cancellation.isCancelled();
+    }
+
+    @Override
+    public ListenerRegistration onCancel(Executor executor, Runnable listener)
+    {
+        requireNonNull(executor, "executor is null");
+        requireNonNull(listener, "listener is null");
+
+        if (cancellation.isDone() && !cancellation.isCancelled()) {
+            return NOOP_REGISTRATION;
+        }
+
+        CompletableFuture<?> registration = cancellation.whenComplete((_, _) -> {
+            if (!cancellation.isCancelled()) {
+                return;
+            }
+
+            try {
+                executor.execute(() -> {
+                    try {
+                        listener.run();
+                    }
+                    catch (Throwable e) {
+                        log.warn(e, "API cancellation listener failed");
+                    }
+                });
+            }
+            catch (RuntimeException e) {
+                log.warn(e, "API cancellation listener executor rejected listener");
+            }
+        });
+
+        return () -> {
+            if (!cancellation.isDone()) {
+                registration.cancel(false);
+            }
+        };
+    }
+}

--- a/api/src/test/java/io/airlift/api/binding/TestApiCancellationTriggerFilter.java
+++ b/api/src/test/java/io/airlift/api/binding/TestApiCancellationTriggerFilter.java
@@ -1,0 +1,32 @@
+package io.airlift.api.binding;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+
+import static io.airlift.api.binding.ApiCancellationValueParamProvider.REQUEST_CANCELLATION_ATTRIBUTE;
+
+public class TestApiCancellationTriggerFilter
+        implements Filter
+{
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException
+    {
+        chain.doFilter(request, response);
+
+        if (request instanceof HttpServletRequest httpRequest && httpRequest.getRequestURI().endsWith("/cancel")) {
+            Object cancellation = request.getAttribute(REQUEST_CANCELLATION_ATTRIBUTE);
+            if (!(cancellation instanceof CompletableFuture<?> requestCancellation)) {
+                throw new ServletException("Expected request cancellation future");
+            }
+            requestCancellation.cancel(false);
+        }
+    }
+}

--- a/api/src/test/java/io/airlift/api/binding/TestRequestApiCancellation.java
+++ b/api/src/test/java/io/airlift/api/binding/TestRequestApiCancellation.java
@@ -1,0 +1,138 @@
+package io.airlift.api.binding;
+
+import io.airlift.api.ApiCancellation;
+import io.airlift.http.server.RequestCancellationServletFilter;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+public class TestRequestApiCancellation
+{
+    @Test
+    public void testRequestCancellationAttributeMatchesHttpServer()
+    {
+        assertThat(ApiCancellationValueParamProvider.REQUEST_CANCELLATION_ATTRIBUTE)
+                .isEqualTo(RequestCancellationServletFilter.REQUEST_CANCELLATION_ATTRIBUTE);
+    }
+
+    @Test
+    public void testCancellationRunsListenersOnce()
+    {
+        CompletableFuture<Void> cancellationFuture = new CompletableFuture<>();
+        RequestApiCancellation cancellation = new RequestApiCancellation(cancellationFuture);
+        AtomicInteger listenerCalls = new AtomicInteger();
+
+        cancellation.onCancel(Runnable::run, listenerCalls::incrementAndGet);
+
+        cancellationFuture.cancel(false);
+        cancellationFuture.cancel(false);
+
+        assertThat(cancellation.isCancelled()).isTrue();
+        assertThat(listenerCalls).hasValue(1);
+    }
+
+    @Test
+    public void testClosedRegistrationDoesNotRun()
+    {
+        CompletableFuture<Void> cancellationFuture = new CompletableFuture<>();
+        RequestApiCancellation cancellation = new RequestApiCancellation(cancellationFuture);
+        AtomicInteger listenerCalls = new AtomicInteger();
+
+        ApiCancellation.ListenerRegistration registration = cancellation.onCancel(Runnable::run, listenerCalls::incrementAndGet);
+        registration.close();
+
+        cancellationFuture.cancel(false);
+
+        assertThat(cancellation.isCancelled()).isTrue();
+        assertThat(listenerCalls).hasValue(0);
+    }
+
+    @Test
+    public void testLateRegistrationRunsImmediatelyAfterCancellation()
+    {
+        CompletableFuture<Void> cancellationFuture = new CompletableFuture<>();
+        RequestApiCancellation cancellation = new RequestApiCancellation(cancellationFuture);
+        AtomicInteger listenerCalls = new AtomicInteger();
+
+        cancellationFuture.cancel(false);
+        cancellation.onCancel(Runnable::run, listenerCalls::incrementAndGet);
+
+        assertThat(listenerCalls).hasValue(1);
+    }
+
+    @Test
+    public void testCompletionClearsListenersWithoutCancellation()
+    {
+        CompletableFuture<Void> cancellationFuture = new CompletableFuture<>();
+        RequestApiCancellation cancellation = new RequestApiCancellation(cancellationFuture);
+        AtomicInteger listenerCalls = new AtomicInteger();
+
+        cancellation.onCancel(Runnable::run, listenerCalls::incrementAndGet);
+        cancellationFuture.complete(null);
+        cancellationFuture.cancel(false);
+
+        assertThat(cancellation.isCancelled()).isFalse();
+        assertThat(listenerCalls).hasValue(0);
+    }
+
+    @Test
+    public void testCancellationUsesRegisteredExecutor()
+    {
+        CompletableFuture<Void> cancellationFuture = new CompletableFuture<>();
+        RequestApiCancellation cancellation = new RequestApiCancellation(cancellationFuture);
+        AtomicReference<Runnable> submittedTask = new AtomicReference<>();
+        AtomicInteger listenerCalls = new AtomicInteger();
+        Executor executor = submittedTask::set;
+
+        cancellation.onCancel(executor, listenerCalls::incrementAndGet);
+        cancellationFuture.cancel(false);
+
+        assertThat(listenerCalls).hasValue(0);
+        assertThat(submittedTask).hasValueSatisfying(Runnable::run);
+        assertThat(listenerCalls).hasValue(1);
+    }
+
+    @Test
+    public void testCloseAfterCancellationStartedDoesNotPreventListener()
+    {
+        CompletableFuture<Void> cancellationFuture = new CompletableFuture<>();
+        RequestApiCancellation cancellation = new RequestApiCancellation(cancellationFuture);
+        AtomicReference<Runnable> submittedTask = new AtomicReference<>();
+        AtomicInteger listenerCalls = new AtomicInteger();
+        Executor executor = submittedTask::set;
+
+        ApiCancellation.ListenerRegistration registration = cancellation.onCancel(executor, listenerCalls::incrementAndGet);
+        cancellationFuture.cancel(false);
+        registration.close();
+
+        assertThat(listenerCalls).hasValue(0);
+        assertThat(submittedTask).hasValueSatisfying(Runnable::run);
+        assertThat(listenerCalls).hasValue(1);
+    }
+
+    @Test
+    public void testRejectedExecutorDoesNotEscapeFromCancellation()
+    {
+        CompletableFuture<Void> cancellationFuture = new CompletableFuture<>();
+        RequestApiCancellation cancellation = new RequestApiCancellation(cancellationFuture);
+        AtomicInteger listenerCalls = new AtomicInteger();
+        Executor rejectingExecutor = _ -> {
+            throw new RejectedExecutionException("rejected");
+        };
+
+        cancellation.onCancel(rejectingExecutor, listenerCalls::incrementAndGet);
+
+        assertThatNoException().isThrownBy(() -> cancellationFuture.cancel(false));
+        assertThat(listenerCalls).hasValue(0);
+
+        assertThatNoException().isThrownBy(() -> cancellation.onCancel(rejectingExecutor, listenerCalls::incrementAndGet));
+        assertThat(listenerCalls).hasValue(0);
+    }
+}

--- a/api/src/test/java/io/airlift/api/servertests/ServerTestBase.java
+++ b/api/src/test/java/io/airlift/api/servertests/ServerTestBase.java
@@ -61,7 +61,17 @@ public class ServerTestBase
         this(Optional.of(serviceClass), builderConsumer);
     }
 
+    protected ServerTestBase(Class<?> serviceClass, Consumer<ApiModule.Builder> builderConsumer, Module... additionalModules)
+    {
+        this(Optional.of(serviceClass), builderConsumer, ImmutableList.copyOf(additionalModules));
+    }
+
     private ServerTestBase(Optional<Class<?>> maybeServiceClass, Consumer<ApiModule.Builder> builderConsumer)
+    {
+        this(maybeServiceClass, builderConsumer, ImmutableList.of());
+    }
+
+    private ServerTestBase(Optional<Class<?>> maybeServiceClass, Consumer<ApiModule.Builder> builderConsumer, Iterable<Module> additionalModules)
     {
         ImmutableList.Builder<Module> modules = ImmutableList.<Module>builder()
                 .add(new NodeModule())
@@ -75,6 +85,7 @@ public class ServerTestBase
         builderConsumer.accept(builder);
         Module apiModule = builder.build();
         modules.add(apiModule);
+        modules.addAll(additionalModules);
 
         ImmutableMap.Builder<String, String> serverProperties = ImmutableMap.<String, String>builder()
                 .put("node.environment", "testing");

--- a/api/src/test/java/io/airlift/api/servertests/standard/TestApiCancellation.java
+++ b/api/src/test/java/io/airlift/api/servertests/standard/TestApiCancellation.java
@@ -1,0 +1,118 @@
+package io.airlift.api.servertests.standard;
+
+import com.google.inject.multibindings.Multibinder;
+import io.airlift.api.ApiCancellation;
+import io.airlift.api.ApiGet;
+import io.airlift.api.ApiParameter;
+import io.airlift.api.ApiResourceVersion;
+import io.airlift.api.ApiService;
+import io.airlift.api.ServiceType;
+import io.airlift.api.binding.TestApiCancellationTriggerFilter;
+import io.airlift.api.servertests.ServerTestBase;
+import io.airlift.http.client.Request;
+import io.airlift.json.JsonCodec;
+import jakarta.servlet.Filter;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.UriBuilder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.airlift.http.client.JsonResponseHandler.createJsonResponseHandler;
+import static io.airlift.http.client.Request.Builder.prepareGet;
+import static io.airlift.http.server.HttpServerBinder.httpServerBinder;
+import static io.airlift.http.server.ServerFeature.REQUEST_CANCELLATION;
+import static io.airlift.json.JsonCodec.jsonCodec;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestApiCancellation
+        extends ServerTestBase
+{
+    private static final String CANCELLABLE_REQUEST_THREAD_NAME = "api-cancellable-request-test";
+    private static final String CANCELLATION_LISTENER_THREAD_NAME = "api-cancellation-listener-test";
+    private static final ExecutorService CANCELLABLE_REQUEST_EXECUTOR = Executors.newSingleThreadExecutor(daemonThreadFactory(CANCELLABLE_REQUEST_THREAD_NAME));
+    private static final ExecutorService CANCELLATION_LISTENER_EXECUTOR = Executors.newSingleThreadExecutor(daemonThreadFactory(CANCELLATION_LISTENER_THREAD_NAME));
+    private static final JsonCodec<Thing> THING_JSON_CODEC = jsonCodec(Thing.class);
+    private static final AtomicReference<CompletableFuture<String>> cancellationListenerThread = new AtomicReference<>();
+
+    public TestApiCancellation()
+    {
+        super(CancellableService.class,
+                builder -> builder.withCancellableRequestExecutor(CANCELLABLE_REQUEST_EXECUTOR),
+                binder -> {
+                    Multibinder.newSetBinder(binder, Filter.class).addBinding().to(TestApiCancellationTriggerFilter.class);
+                    httpServerBinder(binder).withFeature(REQUEST_CANCELLATION);
+                });
+    }
+
+    @AfterAll
+    public void shutdownExecutors()
+    {
+        CANCELLABLE_REQUEST_EXECUTOR.shutdownNow();
+        CANCELLATION_LISTENER_EXECUTOR.shutdownNow();
+    }
+
+    @Test
+    public void testCancellableApiRunsOnCancellableRequestExecutor()
+    {
+        URI uri = UriBuilder.fromUri(baseUri).path("public/api/v1/thing/12345").build();
+        Request request = prepareGet().setUri(uri).build();
+
+        Thing thing = httpClient.execute(request, createJsonResponseHandler(THING_JSON_CODEC));
+
+        assertThat(thing.name()).isEqualTo(CANCELLABLE_REQUEST_THREAD_NAME);
+        assertThat(thing.qty()).isEqualTo(0);
+    }
+
+    @Test
+    public void testCancellationListenerRunsWhenServletCancelsRequest()
+            throws Exception
+    {
+        CompletableFuture<String> listenerThread = new CompletableFuture<>();
+        cancellationListenerThread.set(listenerThread);
+        try {
+            URI uri = UriBuilder.fromUri(baseUri).path("public/api/v1/thing/cancel").build();
+            Request request = prepareGet().setUri(uri).build();
+
+            Thing thing = httpClient.execute(request, createJsonResponseHandler(THING_JSON_CODEC));
+
+            assertThat(thing.name()).isEqualTo(CANCELLABLE_REQUEST_THREAD_NAME);
+            assertThat(listenerThread.get(5, TimeUnit.SECONDS)).isEqualTo(CANCELLATION_LISTENER_THREAD_NAME);
+        }
+        finally {
+            cancellationListenerThread.set(null);
+        }
+    }
+
+    @SuppressWarnings("unused")
+    @ApiService(type = ServiceType.class, name = "cancellable", description = "Cancellable API test")
+    public static class CancellableService
+    {
+        @ApiGet(description = "Get cancellable thing")
+        public Thing getThing(@ApiParameter ThingId thingId, @Context ApiCancellation cancellation)
+        {
+            if (thingId.toString().equals("cancel")) {
+                CompletableFuture<String> listenerThread = cancellationListenerThread.get();
+                cancellation.onCancel(CANCELLATION_LISTENER_EXECUTOR, () -> listenerThread.complete(Thread.currentThread().getName()));
+            }
+            return new Thing(new ApiResourceVersion(1), thingId, Thread.currentThread().getName(), cancellation.isCancelled() ? 1 : 0, Optional.empty());
+        }
+    }
+
+    private static ThreadFactory daemonThreadFactory(String name)
+    {
+        return runnable -> {
+            Thread thread = new Thread(runnable, name);
+            thread.setDaemon(true);
+            return thread;
+        };
+    }
+}

--- a/http-server/src/main/java/io/airlift/http/server/HttpServer.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServer.java
@@ -88,6 +88,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.http.server.ServerFeature.CASE_SENSITIVE_HEADER_CACHE;
 import static io.airlift.http.server.ServerFeature.LEGACY_URI_COMPLIANCE;
+import static io.airlift.http.server.ServerFeature.REQUEST_CANCELLATION;
 import static io.airlift.http.server.ServerFeature.VIRTUAL_THREADS;
 import static java.lang.Math.max;
 import static java.lang.Math.toIntExact;
@@ -296,7 +297,14 @@ public class HttpServer
          */
         StatisticsHandler statsHandler = new StatisticsHandler();
 
-        ServletContextHandler servletContext = createServletContext(servlet, resources, filters, Set.of("http", "https"), showStackTrace, serverFeatures.contains(LEGACY_URI_COMPLIANCE));
+        ServletContextHandler servletContext = createServletContext(
+                servlet,
+                resources,
+                filters,
+                Set.of("http", "https"),
+                showStackTrace,
+                serverFeatures.contains(LEGACY_URI_COMPLIANCE),
+                serverFeatures.contains(REQUEST_CANCELLATION));
 
         if (enableCompression) {
             CompressionHandler compressionHandler = new CompressionHandler();
@@ -413,7 +421,8 @@ public class HttpServer
             Set<Filter> filters,
             Set<String> connectorNames,
             boolean showStackTrace,
-            boolean enableLegacyUriCompliance)
+            boolean enableLegacyUriCompliance,
+            boolean requestCancellationEnabled)
     {
         ServletContextHandler context = new ServletContextHandler(ServletContextHandler.NO_SESSIONS);
         ErrorHandler handler = new ErrorHandler();
@@ -425,6 +434,11 @@ public class HttpServer
             // allow encoded slashes to occur in URI paths
             context.getServletHandler().setDecodeAmbiguousURIs(true);
         }
+        if (requestCancellationEnabled) {
+            // -- low-level server filters
+            context.addFilter(new FilterHolder(new RequestCancellationServletFilter()), "/*", null);
+        }
+
         // -- user provided filters
         for (Filter filter : filters) {
             context.addFilter(new FilterHolder(filter), "/*", null);

--- a/http-server/src/main/java/io/airlift/http/server/RequestCancellationServletFilter.java
+++ b/http-server/src/main/java/io/airlift/http/server/RequestCancellationServletFilter.java
@@ -1,0 +1,206 @@
+package io.airlift.http.server;
+
+import jakarta.servlet.AsyncEvent;
+import jakarta.servlet.AsyncListener;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import org.eclipse.jetty.ee11.servlet.ServletContextRequest;
+import org.eclipse.jetty.io.Connection;
+import org.eclipse.jetty.server.Request;
+
+import java.io.IOException;
+import java.lang.ref.WeakReference;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+public final class RequestCancellationServletFilter
+        implements Filter
+{
+    public static final String REQUEST_CANCELLATION_ATTRIBUTE = "io.airlift.request-cancellation";
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException
+    {
+        CompletableFuture<Void> cancellation = new CompletableFuture<>();
+        CancellationCleanup cleanup = new CancellationCleanup(cancellation);
+        request.setAttribute(REQUEST_CANCELLATION_ATTRIBUTE, cancellation);
+        boolean cleanupRegistered = getJettyRequest(request)
+                .map(jettyRequest -> {
+                    registerJettyListeners(jettyRequest, cancellation, cleanup);
+                    return true;
+                })
+                .orElse(false);
+
+        try {
+            chain.doFilter(request, response);
+        }
+        finally {
+            if (request.isAsyncStarted()) {
+                try {
+                    request.getAsyncContext().addListener(new CancellationAsyncListener(cancellation, cleanup));
+                }
+                catch (IllegalStateException ignored) {
+                    cleanup.run();
+                }
+            }
+            else if (!cleanupRegistered) {
+                cleanup.run();
+            }
+        }
+    }
+
+    private static void registerJettyListeners(Request request, CompletableFuture<Void> cancellation, CancellationCleanup cleanup)
+    {
+        registerJettyListeners(new JettyRequestLifecycle(request), cancellation, cleanup);
+    }
+
+    static void registerJettyListeners(RequestLifecycle request, CompletableFuture<Void> cancellation, CancellationCleanup cleanup)
+    {
+        request.addFailureListener(_ -> cancellation.cancel(false));
+        Connection connection = request.getConnection();
+        if (connection != null) {
+            // Connections can outlive individual requests, so this listener is weak and is removed on request completion.
+            WeakCancellationListener listener = new WeakCancellationListener(cancellation);
+            connection.addEventListener(listener);
+            cleanup.setConnectionListener(new ConnectionListenerRegistration(connection, listener));
+        }
+        request.addCompletionListener(_ -> cleanup.run());
+    }
+
+    private static Optional<Request> getJettyRequest(ServletRequest request)
+    {
+        try {
+            return Optional.of(ServletContextRequest.getServletContextRequest(request));
+        }
+        catch (IllegalStateException ignored) {
+            return Optional.empty();
+        }
+    }
+
+    static class CancellationCleanup
+            implements Runnable
+    {
+        private final CompletableFuture<Void> cancellation;
+        private final AtomicBoolean done = new AtomicBoolean();
+        private volatile Optional<ConnectionListenerRegistration> connectionListener = Optional.empty();
+
+        CancellationCleanup(CompletableFuture<Void> cancellation)
+        {
+            this.cancellation = cancellation;
+        }
+
+        private void setConnectionListener(ConnectionListenerRegistration connectionListener)
+        {
+            this.connectionListener = Optional.of(connectionListener);
+            if (done.get()) {
+                connectionListener.close();
+            }
+        }
+
+        @Override
+        public void run()
+        {
+            if (!done.compareAndSet(false, true)) {
+                return;
+            }
+
+            cancellation.complete(null);
+            connectionListener.ifPresent(ConnectionListenerRegistration::close);
+        }
+    }
+
+    private record ConnectionListenerRegistration(Connection connection, Connection.Listener listener)
+            implements AutoCloseable
+    {
+        @Override
+        public void close()
+        {
+            connection.removeEventListener(listener);
+        }
+    }
+
+    interface RequestLifecycle
+    {
+        void addFailureListener(Consumer<Throwable> listener);
+
+        Connection getConnection();
+
+        void addCompletionListener(Consumer<Throwable> listener);
+    }
+
+    private record JettyRequestLifecycle(Request request)
+            implements RequestLifecycle
+    {
+        @Override
+        public void addFailureListener(Consumer<Throwable> listener)
+        {
+            request.addFailureListener(listener);
+        }
+
+        @Override
+        public Connection getConnection()
+        {
+            return request.getConnectionMetaData().getConnection();
+        }
+
+        @Override
+        public void addCompletionListener(Consumer<Throwable> listener)
+        {
+            Request.addCompletionListener(request, listener);
+        }
+    }
+
+    record WeakCancellationListener(WeakReference<CompletableFuture<Void>> cancellation)
+            implements Connection.Listener
+    {
+        WeakCancellationListener(CompletableFuture<Void> cancellation)
+        {
+            this(new WeakReference<>(cancellation));
+        }
+
+        @Override
+        public void onClosed(Connection connection)
+        {
+            CompletableFuture<Void> cancellation = this.cancellation.get();
+            if (cancellation != null) {
+                cancellation.cancel(false);
+            }
+        }
+    }
+
+    record CancellationAsyncListener(CompletableFuture<Void> cancellation, CancellationCleanup cleanup)
+            implements AsyncListener
+    {
+        @Override
+        public void onComplete(AsyncEvent event)
+        {
+            cleanup.run();
+        }
+
+        @Override
+        public void onTimeout(AsyncEvent event)
+        {
+            cancellation.cancel(false);
+            cleanup.run();
+        }
+
+        @Override
+        public void onError(AsyncEvent event)
+        {
+            cancellation.cancel(false);
+            cleanup.run();
+        }
+
+        @Override
+        public void onStartAsync(AsyncEvent event)
+        {
+            event.getAsyncContext().addListener(this);
+        }
+    }
+}

--- a/http-server/src/main/java/io/airlift/http/server/ServerFeature.java
+++ b/http-server/src/main/java/io/airlift/http/server/ServerFeature.java
@@ -8,7 +8,8 @@ public enum ServerFeature
 {
     VIRTUAL_THREADS,
     LEGACY_URI_COMPLIANCE,
-    CASE_SENSITIVE_HEADER_CACHE;
+    CASE_SENSITIVE_HEADER_CACHE,
+    REQUEST_CANCELLATION;
 
     public static Set<ServerFeature> defaults()
     {
@@ -25,6 +26,7 @@ public enum ServerFeature
         private boolean virtualThreads;
         private boolean legacyUriCompliance;
         private boolean caseSensitiveHeaderCache;
+        private boolean requestCancellation;
 
         private Builder() {}
 
@@ -46,6 +48,12 @@ public enum ServerFeature
             return this;
         }
 
+        public Builder withRequestCancellation(boolean requestCancellation)
+        {
+            this.requestCancellation = requestCancellation;
+            return this;
+        }
+
         public Set<ServerFeature> build()
         {
             ImmutableSet.Builder<ServerFeature> features = ImmutableSet.builder();
@@ -57,6 +65,9 @@ public enum ServerFeature
             }
             if (caseSensitiveHeaderCache) {
                 features.add(CASE_SENSITIVE_HEADER_CACHE);
+            }
+            if (requestCancellation) {
+                features.add(REQUEST_CANCELLATION);
             }
             return features.build();
         }

--- a/http-server/src/test/java/io/airlift/http/server/TestHttpServerModule.java
+++ b/http-server/src/test/java/io/airlift/http/server/TestHttpServerModule.java
@@ -34,6 +34,8 @@ import io.airlift.node.testing.TestingNodeModule;
 import io.airlift.tracing.TracingModule;
 import jakarta.servlet.Filter;
 import jakarta.servlet.Servlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -51,6 +53,7 @@ import java.lang.annotation.Target;
 import java.lang.management.ManagementFactory;
 import java.net.URI;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
@@ -63,7 +66,9 @@ import static io.airlift.http.client.Request.Builder.prepareGet;
 import static io.airlift.http.client.StatusResponseHandler.createStatusResponseHandler;
 import static io.airlift.http.client.StringResponseHandler.createStringResponseHandler;
 import static io.airlift.http.server.HttpServerBinder.httpServerBinder;
+import static io.airlift.http.server.RequestCancellationServletFilter.REQUEST_CANCELLATION_ATTRIBUTE;
 import static io.airlift.http.server.ServerFeature.LEGACY_URI_COMPLIANCE;
+import static io.airlift.http.server.ServerFeature.REQUEST_CANCELLATION;
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.PARAMETER;
@@ -163,6 +168,20 @@ public class TestHttpServerModule
     }
 
     @Test
+    public void testRequestCancellationFilterIsDisabledByDefault()
+            throws Exception
+    {
+        assertRequestCancellationAttribute(false);
+    }
+
+    @Test
+    public void testRequestCancellationFilterIsEnabledByFeature()
+            throws Exception
+    {
+        assertRequestCancellationAttribute(true);
+    }
+
+    @Test
     public void testHttpServerUri()
             throws Exception
     {
@@ -195,6 +214,44 @@ public class TestHttpServerModule
             assertThat(httpServerInfo.getHttpsUri()).isNull();
         }
         catch (Exception e) {
+            server.stop();
+        }
+    }
+
+    private void assertRequestCancellationAttribute(boolean enabled)
+            throws Exception
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("http-server.http.port", "0")
+                .put("http-server.log.path", new File(tempDir, "http-request.log").getAbsolutePath())
+                .build();
+
+        Bootstrap app = new Bootstrap(
+                new HttpServerModule(),
+                new TestingNodeModule(),
+                new TracingModule("airlift.http-server", "1.0"),
+                binder -> {
+                    binder.bind(Servlet.class).to(RequestCancellationAttributeServlet.class);
+                    if (enabled) {
+                        httpServerBinder(binder).withFeature(REQUEST_CANCELLATION);
+                    }
+                });
+
+        Injector injector = app
+                .setRequiredConfigurationProperties(properties)
+                .doNotInitializeLogging()
+                .initialize();
+
+        HttpServer server = injector.getInstance(HttpServer.class);
+        server.start();
+        try (HttpClient client = new JettyHttpClient()) {
+            URI httpUri = injector.getInstance(HttpServerInfo.class).getHttpUri();
+            StringResponse response = client.execute(prepareGet().setUri(httpUri).build(), createStringResponseHandler());
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK.code());
+            assertThat(response.getBody()).isEqualTo(Boolean.toString(enabled));
+        }
+        finally {
             server.stop();
         }
     }
@@ -304,4 +361,17 @@ public class TestHttpServerModule
     @Target({FIELD, PARAMETER, METHOD})
     @BindingAnnotation
     public @interface Internal {}
+
+    public static class RequestCancellationAttributeServlet
+            extends HttpServlet
+    {
+        @Override
+        protected void doGet(HttpServletRequest request, HttpServletResponse response)
+                throws IOException
+        {
+            Object cancellation = request.getAttribute(REQUEST_CANCELLATION_ATTRIBUTE);
+            response.setStatus(HttpServletResponse.SC_OK);
+            response.getWriter().write(Boolean.toString(cancellation instanceof CompletableFuture<?>));
+        }
+    }
 }

--- a/http-server/src/test/java/io/airlift/http/server/TestRequestCancellationServletFilter.java
+++ b/http-server/src/test/java/io/airlift/http/server/TestRequestCancellationServletFilter.java
@@ -1,0 +1,315 @@
+package io.airlift.http.server;
+
+import jakarta.servlet.ServletRequest;
+import org.eclipse.jetty.io.Connection;
+import org.eclipse.jetty.io.EndPoint;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EventListener;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static io.airlift.http.server.RequestCancellationServletFilter.REQUEST_CANCELLATION_ATTRIBUTE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestRequestCancellationServletFilter
+{
+    @Test
+    public void testRequestCancellationIsStoredBeforeFilterChainRuns()
+            throws Exception
+    {
+        ServletRequest request = testingServletRequest();
+        AtomicReference<Object> chainCancellation = new AtomicReference<>();
+
+        new RequestCancellationServletFilter().doFilter(
+                request,
+                null,
+                (servletRequest, _) -> chainCancellation.set(servletRequest.getAttribute(REQUEST_CANCELLATION_ATTRIBUTE)));
+
+        assertThat(chainCancellation.get()).isInstanceOf(CompletableFuture.class);
+    }
+
+    @Test
+    public void testJettyFailureListenerCancelsRequest()
+    {
+        CompletableFuture<Void> cancellation = new CompletableFuture<>();
+        TestingRequestLifecycle request = new TestingRequestLifecycle(new TestingConnection());
+
+        RequestCancellationServletFilter.registerJettyListeners(
+                request,
+                cancellation,
+                new RequestCancellationServletFilter.CancellationCleanup(cancellation));
+
+        request.failureListener.get().accept(new RuntimeException("request failed"));
+
+        assertThat(cancellation).isCancelled();
+    }
+
+    @Test
+    public void testConnectionCloseListenerCancelsRequest()
+    {
+        CompletableFuture<Void> cancellation = new CompletableFuture<>();
+        TestingConnection connection = new TestingConnection();
+
+        RequestCancellationServletFilter.registerJettyListeners(
+                new TestingRequestLifecycle(connection),
+                cancellation,
+                new RequestCancellationServletFilter.CancellationCleanup(cancellation));
+
+        connection.listeners.getFirst().onClosed(connection);
+
+        assertThat(cancellation).isCancelled();
+    }
+
+    @Test
+    public void testRequestCompletionRemovesConnectionListener()
+    {
+        CompletableFuture<Void> cancellation = new CompletableFuture<>();
+        TestingConnection connection = new TestingConnection();
+        TestingRequestLifecycle request = new TestingRequestLifecycle(connection);
+
+        RequestCancellationServletFilter.registerJettyListeners(
+                request,
+                cancellation,
+                new RequestCancellationServletFilter.CancellationCleanup(cancellation));
+
+        assertThat(connection.listeners).hasSize(1);
+        Connection.Listener connectionListener = connection.listeners.getFirst();
+
+        request.completionListener.get().accept(null);
+        connectionListener.onClosed(connection);
+        connection.close();
+
+        assertThat(connection.listeners).isEmpty();
+        assertThat(cancellation).isCompleted();
+        assertThat(cancellation).isNotCancelled();
+    }
+
+    @Test
+    public void testRequestCompletionWinsRaceWithConnectionClose()
+    {
+        CompletableFuture<Void> cancellation = new CompletableFuture<>();
+        TestingConnection connection = new TestingConnection();
+        TestingRequestLifecycle request = new TestingRequestLifecycle(connection);
+
+        RequestCancellationServletFilter.registerJettyListeners(
+                request,
+                cancellation,
+                new RequestCancellationServletFilter.CancellationCleanup(cancellation));
+
+        connection.closeDuringListenerRemoval = true;
+        request.completionListener.get().accept(null);
+
+        assertThat(connection.listeners).isEmpty();
+        assertThat(cancellation).isCompleted();
+        assertThat(cancellation).isNotCancelled();
+    }
+
+    @Test
+    public void testAsyncTimeoutCancelsRequest()
+    {
+        CompletableFuture<Void> cancellation = new CompletableFuture<>();
+
+        new RequestCancellationServletFilter.CancellationAsyncListener(
+                cancellation,
+                new RequestCancellationServletFilter.CancellationCleanup(cancellation))
+                .onTimeout(null);
+
+        assertThat(cancellation).isCancelled();
+    }
+
+    @Test
+    public void testAsyncErrorCancelsRequest()
+    {
+        CompletableFuture<Void> cancellation = new CompletableFuture<>();
+
+        new RequestCancellationServletFilter.CancellationAsyncListener(
+                cancellation,
+                new RequestCancellationServletFilter.CancellationCleanup(cancellation))
+                .onError(null);
+
+        assertThat(cancellation).isCancelled();
+    }
+
+    @Test
+    public void testConnectionCloseCancelsRequest()
+    {
+        CompletableFuture<Void> cancellation = new CompletableFuture<>();
+
+        new RequestCancellationServletFilter.WeakCancellationListener(cancellation)
+                .onClosed(null);
+
+        assertThat(cancellation).isCancelled();
+    }
+
+    private static ServletRequest testingServletRequest()
+    {
+        Map<String, Object> attributes = new HashMap<>();
+        return (ServletRequest) Proxy.newProxyInstance(
+                TestRequestCancellationServletFilter.class.getClassLoader(),
+                new Class<?>[] {ServletRequest.class},
+                (_, method, args) -> switch (method.getName()) {
+                    case "getAttribute" -> attributes.get((String) args[0]);
+                    case "getAttributeNames" -> Collections.enumeration(attributes.keySet());
+                    case "setAttribute" -> {
+                        attributes.put((String) args[0], args[1]);
+                        yield null;
+                    }
+                    case "removeAttribute" -> {
+                        attributes.remove((String) args[0]);
+                        yield null;
+                    }
+                    case "isAsyncStarted" -> false;
+                    case "getAsyncContext" -> throw new IllegalStateException("async is not started");
+                    case "toString" -> "testing servlet request";
+                    default -> defaultValue(method.getReturnType());
+                });
+    }
+
+    private static Object defaultValue(Class<?> returnType)
+    {
+        if (!returnType.isPrimitive()) {
+            return null;
+        }
+        if (returnType == boolean.class) {
+            return false;
+        }
+        if (returnType == int.class) {
+            return 0;
+        }
+        if (returnType == long.class) {
+            return 0L;
+        }
+        if (returnType == double.class) {
+            return 0.0;
+        }
+        if (returnType == float.class) {
+            return 0.0f;
+        }
+        if (returnType == byte.class) {
+            return (byte) 0;
+        }
+        if (returnType == short.class) {
+            return (short) 0;
+        }
+        if (returnType == char.class) {
+            return (char) 0;
+        }
+        throw new IllegalArgumentException("Unexpected primitive return type: " + returnType);
+    }
+
+    private static class TestingRequestLifecycle
+            implements RequestCancellationServletFilter.RequestLifecycle
+    {
+        private final Connection connection;
+        private final AtomicReference<Consumer<Throwable>> failureListener = new AtomicReference<>();
+        private final AtomicReference<Consumer<Throwable>> completionListener = new AtomicReference<>();
+
+        private TestingRequestLifecycle(Connection connection)
+        {
+            this.connection = connection;
+        }
+
+        @Override
+        public void addFailureListener(Consumer<Throwable> listener)
+        {
+            failureListener.set(listener);
+        }
+
+        @Override
+        public Connection getConnection()
+        {
+            return connection;
+        }
+
+        @Override
+        public void addCompletionListener(Consumer<Throwable> listener)
+        {
+            completionListener.set(listener);
+        }
+    }
+
+    private static class TestingConnection
+            implements Connection
+    {
+        private final List<Listener> listeners = new ArrayList<>();
+        private boolean closeDuringListenerRemoval;
+
+        @Override
+        public void addEventListener(EventListener listener)
+        {
+            listeners.add((Listener) listener);
+        }
+
+        @Override
+        public void removeEventListener(EventListener listener)
+        {
+            if (closeDuringListenerRemoval) {
+                ((Listener) listener).onClosed(this);
+            }
+            listeners.remove(listener);
+        }
+
+        @Override
+        public void onOpen() {}
+
+        @Override
+        public void onClose(Throwable cause) {}
+
+        @Override
+        public EndPoint getEndPoint()
+        {
+            return null;
+        }
+
+        @Override
+        public void close()
+        {
+            List.copyOf(listeners).forEach(listener -> listener.onClosed(this));
+        }
+
+        @Override
+        public boolean onIdleExpired(TimeoutException timeoutException)
+        {
+            return false;
+        }
+
+        @Override
+        public long getMessagesIn()
+        {
+            return 0;
+        }
+
+        @Override
+        public long getMessagesOut()
+        {
+            return 0;
+        }
+
+        @Override
+        public long getBytesIn()
+        {
+            return 0;
+        }
+
+        @Override
+        public long getBytesOut()
+        {
+            return 0;
+        }
+
+        @Override
+        public long getCreatedTimeStamp()
+        {
+            return 0;
+        }
+    }
+}


### PR DESCRIPTION
## Why
- Expensive API handlers need a framework-supported way to stop backend work when clients abandon requests.
- Leaving cancellation to each resource implementation would make callers responsible for preserving request context, tracing, executor handoff, and lifecycle details.
- API Builder should keep its typed request/response model without taking a direct dependency on Jetty internals.
- Long-lived keep-alive connections must not retain completed request cancellation state.

## Approach
- Add a request-scoped `ApiCancellation` interface injectable with `@Context`.
- Run API methods that use `ApiCancellation` on the configured cancellable request executor.
- Add an opt-in `REQUEST_CANCELLATION` HTTP server feature that installs the low-level Jetty cancellation filter.
- Have the HTTP server publish a generic request cancellation future, and have API Builder adapt that into `ApiCancellation`.
- Require cancellation listeners to provide their own executor for cleanup work.
- Document the API and HTTP server setup, including executor sizing expectations.

# Airlift contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [x] All automated tests are passing.
 - [x] Pull request was categorized using one of the existing labels.