### PR TITLE
Cache forward-decay weight calculation

### DIFF
--- a/stats/src/main/java/io/airlift/stats/DecayCounter.java
+++ b/stats/src/main/java/io/airlift/stats/DecayCounter.java
@@ -31,6 +31,12 @@ public final class DecayCounter
     private long landmarkInSeconds;
     private double count;
 
+    // The forward-decay weight is constant for a given (second, landmark) pair, so cache it and
+    // recompute the Math.exp only when the second rolls over or the landmark moves. add() is called
+    // on essentially every counted event, so this removes a Math.exp from the hot path.
+    private long cachedWeightSeconds = Long.MIN_VALUE;
+    private double cachedWeight;
+
     public DecayCounter(double alpha)
     {
         this(alpha, Ticker.systemTicker());
@@ -61,7 +67,19 @@ public final class DecayCounter
         if (nowInSeconds - landmarkInSeconds >= RESCALE_THRESHOLD_SECONDS) {
             rescaleToNewLandmark(nowInSeconds);
         }
-        count += value * weight(alpha, nowInSeconds, landmarkInSeconds);
+        count += value * currentWeight(nowInSeconds);
+    }
+
+    private double currentWeight(long nowInSeconds)
+    {
+        if (nowInSeconds != cachedWeightSeconds) {
+            // forward-decay multiplier exp(alpha * (now - landmark)): 1 at the landmark, growing >= 1
+            // as the clock advances so newer adds weigh more; the read path (getCount) divides it back out.
+            // Constant within a second, so the Math.exp runs only on this cache miss, not on every add.
+            cachedWeight = weight(alpha, nowInSeconds, landmarkInSeconds);
+            cachedWeightSeconds = nowInSeconds;
+        }
+        return cachedWeight;
     }
 
     public synchronized void merge(DecayCounter decayCounter)
@@ -88,13 +106,21 @@ public final class DecayCounter
     {
         // rescale the count based on a new landmark to avoid numerical overflow issues
         count = count / weight(alpha, newLandMarkInSeconds, landmarkInSeconds);
-        landmarkInSeconds = newLandMarkInSeconds;
+        setLandmarkInSeconds(newLandMarkInSeconds);
+    }
+
+    private void setLandmarkInSeconds(long landmarkInSeconds)
+    {
+        this.landmarkInSeconds = landmarkInSeconds;
+        // at the landmark the age (now - landmark) is 0, so the weight is exp(0) == 1; seed the cache with it directly
+        cachedWeightSeconds = landmarkInSeconds;
+        cachedWeight = 1.0;
     }
 
     @Managed
     public synchronized void reset()
     {
-        landmarkInSeconds = getTickInSeconds();
+        setLandmarkInSeconds(getTickInSeconds());
         count = 0;
     }
 
@@ -105,7 +131,7 @@ public final class DecayCounter
     public synchronized void resetTo(DecayCounter counter)
     {
         synchronized (counter) {
-            landmarkInSeconds = counter.landmarkInSeconds;
+            setLandmarkInSeconds(counter.landmarkInSeconds);
             count = counter.count;
         }
     }

--- a/stats/src/main/java/io/airlift/stats/DecayTDigest.java
+++ b/stats/src/main/java/io/airlift/stats/DecayTDigest.java
@@ -38,6 +38,11 @@ public class DecayTDigest
     private final double alpha;
     private long landmarkInSeconds;
 
+    // The forward-decay weight is constant for a given (second, landmark) pair, so cache it and
+    // recompute the Math.exp only when the second rolls over or the landmark moves.
+    private long cachedWeightSeconds = Long.MIN_VALUE;
+    private double cachedWeight;
+
     public DecayTDigest(double compression, double alpha)
     {
         this(new TDigest(compression), alpha, alpha == 0.0 ? noOpTicker() : Ticker.systemTicker());
@@ -103,13 +108,28 @@ public class DecayTDigest
 
     public void add(double value, double weight)
     {
-        rescaleIfNeeded();
-
         if (alpha > 0.0) {
-            weight *= weight(alpha, nowInSeconds(), landmarkInSeconds) * SCALE_FACTOR;
+            // read the tick once: it drives both the rescale check and the decay weight
+            long nowInSeconds = nowInSeconds();
+            if (nowInSeconds - landmarkInSeconds >= RESCALE_THRESHOLD_SECONDS) {
+                rescale(nowInSeconds);
+            }
+            weight *= currentWeight(nowInSeconds) * SCALE_FACTOR;
         }
 
         digest.add(value, weight);
+    }
+
+    private double currentWeight(long nowInSeconds)
+    {
+        if (nowInSeconds != cachedWeightSeconds) {
+            // forward-decay multiplier exp(alpha * (now - landmark)): 1 at the landmark, growing >= 1
+            // as the clock advances so newer adds weigh more; the read path (getCount) divides it back out.
+            // Constant within a second, so the Math.exp runs only on this cache miss, not on every add.
+            cachedWeight = weight(alpha, nowInSeconds, landmarkInSeconds);
+            cachedWeightSeconds = nowInSeconds;
+        }
+        return cachedWeight;
     }
 
     private void rescaleIfNeeded()
@@ -168,6 +188,9 @@ public class DecayTDigest
         digest.max = max;
 
         landmarkInSeconds = newLandmarkInSeconds;
+        // at the landmark the age (now - landmark) is 0, so the weight is exp(0) == 1; seed the cache with it directly
+        cachedWeightSeconds = newLandmarkInSeconds;
+        cachedWeight = 1.0;
     }
 
     private long nowInSeconds()

--- a/stats/src/main/java/io/airlift/stats/QuantileDigest.java
+++ b/stats/src/main/java/io/airlift/stats/QuantileDigest.java
@@ -68,6 +68,12 @@ public class QuantileDigest
     private final double alpha;
     private long landmarkInSeconds;
 
+    // The forward-decay weight is constant for a given (second, landmark) pair, so cache it and
+    // recompute the Math.exp only when the second rolls over or the landmark moves. add() is on the
+    // hot ingestion path, so this removes a Math.exp from every weighted insert.
+    private long cachedWeightSeconds = Long.MIN_VALUE;
+    private double cachedWeight;
+
     private double weightedCount;
     private long max = Long.MIN_VALUE;
     private long min = Long.MAX_VALUE;
@@ -263,7 +269,7 @@ public class QuantileDigest
                 needsCompression = true; // rescale affects weights globally, so force compression
             }
 
-            weight *= weight(alpha, nowInSeconds, landmarkInSeconds);
+            weight *= currentWeight(nowInSeconds);
         }
 
         max = Math.max(max, value);
@@ -639,6 +645,18 @@ public class QuantileDigest
         }
     }
 
+    private double currentWeight(long nowInSeconds)
+    {
+        if (nowInSeconds != cachedWeightSeconds) {
+            // forward-decay multiplier exp(alpha * (now - landmark)): 1 at the landmark, growing >= 1
+            // as the clock advances so newer adds weigh more; the read path normalizes it back out.
+            // Constant within a second, so the Math.exp runs only on this cache miss, not on every add.
+            cachedWeight = weight(alpha, nowInSeconds, landmarkInSeconds);
+            cachedWeightSeconds = nowInSeconds;
+        }
+        return cachedWeight;
+    }
+
     private void rescale(long newLandmarkInSeconds)
     {
         // rescale the weights based on a new landmark to avoid numerical overflow issues
@@ -648,6 +666,9 @@ public class QuantileDigest
             counts[i] /= factor;
         }
         landmarkInSeconds = newLandmarkInSeconds;
+        // at the landmark the age (now - landmark) is 0, so the weight is exp(0) == 1; seed the cache with it directly
+        cachedWeightSeconds = newLandmarkInSeconds;
+        cachedWeight = 1.0;
     }
 
     private int calculateCompressionFactor()


### PR DESCRIPTION
This avoids recalculating weight (using expensive Math.exp) on every add.

<!-- Thank you for submitting pull request to Airlift -->

# Airlift contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [x] All automated tests are passing.
 - [x] Pull request was categorized using one of the existing labels.
