### PR TITLE
Add YAML support

### DIFF
--- a/api/src/main/java/io/airlift/api/binding/PolyResourceModule.java
+++ b/api/src/main/java/io/airlift/api/binding/PolyResourceModule.java
@@ -3,15 +3,15 @@ package io.airlift.api.binding;
 import com.google.inject.Module;
 import io.airlift.api.ApiPolyResource;
 import io.airlift.api.ApiResource;
-import io.airlift.json.JsonSubType;
-import io.airlift.json.JsonSubType.SubTypeSubBuilder;
-import io.airlift.json.JsonSubTypeBinder;
+import io.airlift.json.JacksonSubType;
+import io.airlift.json.JacksonSubType.SubTypeSubBuilder;
+import io.airlift.json.JacksonSubTypeBinder;
 
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import static io.airlift.json.JsonSubTypeBinder.jsonSubTypeBinder;
+import static io.airlift.json.JacksonSubTypeBinder.jacksonSubTypeBinder;
 import static java.util.Objects.requireNonNull;
 
 public class PolyResourceModule
@@ -59,10 +59,10 @@ public class PolyResourceModule
             public Module build()
             {
                 return binder -> {
-                    JsonSubTypeBinder jsonSubTypeBinder = jsonSubTypeBinder(binder);
+                    JacksonSubTypeBinder jacksonSubTypeBinder = jacksonSubTypeBinder(binder);
 
                     metadatas.forEach(metadata -> {
-                        SubTypeSubBuilder subTypeSubBuilder = JsonSubType.builder().forBase(metadata.clazz(), metadata.key());
+                        SubTypeSubBuilder subTypeSubBuilder = JacksonSubType.builder().forBase(metadata.clazz(), metadata.key());
 
                         Stream.of(metadata.clazz.getPermittedSubclasses()).forEach(subClass -> {
                             ApiResource subApiResource = subClass.getAnnotation(ApiResource.class);
@@ -72,7 +72,7 @@ public class PolyResourceModule
                             subTypeSubBuilder.add(subClass, subApiResource.name());
                         });
 
-                        jsonSubTypeBinder.bindJsonSubType(subTypeSubBuilder.build());
+                        jacksonSubTypeBinder.bindJacksonSubType(subTypeSubBuilder.build());
                     });
                 };
             }

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -170,6 +170,12 @@
                 <artifactId>tracing</artifactId>
                 <version>${project.version}</version>
             </dependency>
+
+            <dependency>
+                <groupId>io.airlift</groupId>
+                <artifactId>yaml</artifactId>
+                <version>${project.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/http-client/pom.xml
+++ b/http-client/pom.xml
@@ -81,6 +81,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>yaml</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-api</artifactId>
         </dependency>

--- a/http-client/src/main/java/io/airlift/http/client/DefaultingYamlResponseHandler.java
+++ b/http-client/src/main/java/io/airlift/http/client/DefaultingYamlResponseHandler.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.http.client;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.primitives.Ints;
+import io.airlift.yaml.YamlCodec;
+
+import java.io.InputStream;
+import java.util.Set;
+
+import static io.airlift.http.client.ResponseHandlerUtils.isYamlContent;
+
+public class DefaultingYamlResponseHandler<T>
+        implements ResponseHandler<T, RuntimeException>
+{
+    public static <T> DefaultingYamlResponseHandler<T> createDefaultingYamlResponseHandler(YamlCodec<T> yamlCodec, T defaultValue)
+    {
+        return new DefaultingYamlResponseHandler<>(yamlCodec, defaultValue);
+    }
+
+    public static <T> DefaultingYamlResponseHandler<T> createDefaultingYamlResponseHandler(YamlCodec<T> yamlCodec, T defaultValue, int firstSuccessfulResponseCode, int... otherSuccessfulResponseCodes)
+    {
+        return new DefaultingYamlResponseHandler<>(yamlCodec, defaultValue, firstSuccessfulResponseCode, otherSuccessfulResponseCodes);
+    }
+
+    private final YamlCodec<T> yamlCodec;
+    private final T defaultValue;
+    private final Set<Integer> successfulResponseCodes;
+
+    private DefaultingYamlResponseHandler(YamlCodec<T> yamlCodec, T defaultValue)
+    {
+        this(yamlCodec, defaultValue, 200, 201, 202, 203, 204, 205, 206);
+    }
+
+    private DefaultingYamlResponseHandler(YamlCodec<T> yamlCodec, T defaultValue, int firstSuccessfulResponseCode, int... otherSuccessfulResponseCodes)
+    {
+        this.yamlCodec = yamlCodec;
+        this.defaultValue = defaultValue;
+        this.successfulResponseCodes = ImmutableSet.<Integer>builder().add(firstSuccessfulResponseCode).addAll(Ints.asList(otherSuccessfulResponseCodes)).build();
+    }
+
+    @Override
+    public T handleException(Request request, Exception exception)
+    {
+        return defaultValue;
+    }
+
+    @Override
+    public T handle(Request request, Response response)
+    {
+        if (!successfulResponseCodes.contains(response.getStatusCode())) {
+            return defaultValue;
+        }
+        if (!isYamlContent(response)) {
+            return defaultValue;
+        }
+        try (InputStream inputStream = response.getInputStream()) {
+            return yamlCodec.fromYaml(inputStream);
+        }
+        catch (Exception e) {
+            return defaultValue;
+        }
+    }
+}

--- a/http-client/src/main/java/io/airlift/http/client/FullYamlResponseHandler.java
+++ b/http-client/src/main/java/io/airlift/http/client/FullYamlResponseHandler.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.http.client;
+
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ListMultimap;
+import com.google.common.net.MediaType;
+import io.airlift.http.client.FullYamlResponseHandler.YamlResponse;
+import io.airlift.yaml.YamlCodec;
+import jakarta.annotation.Nullable;
+
+import java.nio.charset.Charset;
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static io.airlift.http.client.HeaderNames.CONTENT_TYPE;
+import static io.airlift.http.client.ResponseHandlerUtils.getResponseBytes;
+import static io.airlift.http.client.ResponseHandlerUtils.isYamlContent;
+import static io.airlift.http.client.ResponseHandlerUtils.propagate;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+
+public class FullYamlResponseHandler<T>
+        implements ResponseHandler<YamlResponse<T>, RuntimeException>
+{
+    public static <T> FullYamlResponseHandler<T> createFullYamlResponseHandler(YamlCodec<T> yamlCodec)
+    {
+        return new FullYamlResponseHandler<>(yamlCodec);
+    }
+
+    private final YamlCodec<T> yamlCodec;
+
+    private FullYamlResponseHandler(YamlCodec<T> yamlCodec)
+    {
+        this.yamlCodec = yamlCodec;
+    }
+
+    @Override
+    public YamlResponse<T> handleException(Request request, Exception exception)
+    {
+        throw propagate(request, exception);
+    }
+
+    @Override
+    public YamlResponse<T> handle(Request request, Response response)
+    {
+        byte[] bytes = getResponseBytes(request, response);
+        if (!isYamlContent(response)) {
+            return new YamlResponse<>(response.getStatusCode(), response.getHeaders(), bytes);
+        }
+        return new YamlResponse<>(response.getStatusCode(), response.getHeaders(), yamlCodec, bytes);
+    }
+
+    public static class YamlResponse<T>
+    {
+        private final int statusCode;
+        private final ListMultimap<HeaderName, String> headers;
+        private final boolean hasValue;
+        private final byte[] yamlBytes;
+        private final byte[] responseBytes;
+        private final T value;
+        private final IllegalArgumentException exception;
+
+        public YamlResponse(int statusCode, ListMultimap<HeaderName, String> headers, byte[] responseBytes)
+        {
+            this.statusCode = statusCode;
+            this.headers = ImmutableListMultimap.copyOf(headers);
+
+            this.hasValue = false;
+            this.yamlBytes = null;
+            this.responseBytes = requireNonNull(responseBytes, "responseBytes is null");
+            this.value = null;
+            this.exception = null;
+        }
+
+        @SuppressWarnings("ThrowableInstanceNeverThrown")
+        public YamlResponse(int statusCode, ListMultimap<HeaderName, String> headers, YamlCodec<T> yamlCodec, byte[] yamlBytes)
+        {
+            this.statusCode = statusCode;
+            this.headers = ImmutableListMultimap.copyOf(headers);
+
+            this.yamlBytes = requireNonNull(yamlBytes, "yamlBytes is null");
+            this.responseBytes = requireNonNull(yamlBytes, "responseBytes is null");
+
+            T value = null;
+            IllegalArgumentException exception = null;
+            try {
+                value = yamlCodec.fromYaml(yamlBytes);
+            }
+            catch (IllegalArgumentException e) {
+                exception = new IllegalArgumentException("Unable to create %s from YAML response:\n[%s]".formatted(yamlCodec.getType(), getYaml()), e);
+            }
+            this.hasValue = (exception == null);
+            this.value = value;
+            this.exception = exception;
+        }
+
+        public int getStatusCode()
+        {
+            return statusCode;
+        }
+
+        @Nullable
+        @Deprecated
+        public String getHeader(String name)
+        {
+            return getHeader(HeaderName.of(name)).orElse(null);
+        }
+
+        public Optional<String> getHeader(HeaderName name)
+        {
+            List<String> values = getHeaders().get(name);
+            return values.isEmpty() ? Optional.empty() : Optional.ofNullable(values.getFirst());
+        }
+
+        public List<String> getHeaders(HeaderName name)
+        {
+            return headers.get(name);
+        }
+
+        @Deprecated
+        public List<String> getHeaders(String name)
+        {
+            return getHeaders(HeaderName.of(name));
+        }
+
+        public ListMultimap<HeaderName, String> getHeaders()
+        {
+            return headers;
+        }
+
+        public boolean hasValue()
+        {
+            return hasValue;
+        }
+
+        public T getValue()
+        {
+            if (!hasValue) {
+                throw new IllegalStateException("Response does not contain a YAML value", exception);
+            }
+            return value;
+        }
+
+        public int getResponseSize()
+        {
+            return responseBytes.length;
+        }
+
+        public byte[] getResponseBytes()
+        {
+            return responseBytes.clone();
+        }
+
+        public String getResponseBody()
+        {
+            return new String(responseBytes, getCharset());
+        }
+
+        public byte[] getYamlBytes()
+        {
+            return (yamlBytes == null) ? null : yamlBytes.clone();
+        }
+
+        public String getYaml()
+        {
+            return (yamlBytes == null) ? null : new String(yamlBytes, UTF_8);
+        }
+
+        public IllegalArgumentException getException()
+        {
+            return exception;
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("statusCode", statusCode)
+                    .add("headers", headers)
+                    .add("hasValue", hasValue)
+                    .add("value", value)
+                    .toString();
+        }
+
+        private Charset getCharset()
+        {
+            try {
+                return getHeader(CONTENT_TYPE)
+                        .map(MediaType::parse)
+                        .map(MediaType::charset)
+                        .flatMap(optional -> optional.toJavaUtil())
+                        .orElse(UTF_8);
+            }
+            catch (RuntimeException e) {
+                return UTF_8;
+            }
+        }
+    }
+}

--- a/http-client/src/main/java/io/airlift/http/client/ResponseHandlerUtils.java
+++ b/http-client/src/main/java/io/airlift/http/client/ResponseHandlerUtils.java
@@ -50,6 +50,23 @@ public final class ResponseHandlerUtils
                 .orElse(false);
     }
 
+    public static boolean isYamlContent(Response response)
+    {
+        return response.getHeader(CONTENT_TYPE)
+                .map(MediaType::parse)
+                // Empty charset is considered UTF-8. Any explicit charset is accepted.
+                .map(ResponseHandlerUtils::isYamlMediaType)
+                .orElse(false);
+    }
+
+    private static boolean isYamlMediaType(MediaType type)
+    {
+        String major = type.type();
+        String sub = type.subtype();
+        return (major.equals("application") && (sub.equals("yaml") || sub.equals("x-yaml")))
+                || (major.equals("text") && (sub.equals("yaml") || sub.equals("x-yaml")));
+    }
+
     public static InputStream getResponseStream(Response response)
     {
         return switch (response.getContent()) {

--- a/http-client/src/main/java/io/airlift/http/client/StaticBodyGenerator.java
+++ b/http-client/src/main/java/io/airlift/http/client/StaticBodyGenerator.java
@@ -19,7 +19,7 @@ import java.nio.charset.Charset;
 
 public sealed class StaticBodyGenerator
         implements BodyGenerator
-        permits JsonBodyGenerator
+        permits JsonBodyGenerator, YamlBodyGenerator
 {
     public static StaticBodyGenerator createStaticBodyGenerator(String body, Charset charset)
     {

--- a/http-client/src/main/java/io/airlift/http/client/StreamingYamlResponseHandler.java
+++ b/http-client/src/main/java/io/airlift/http/client/StreamingYamlResponseHandler.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.http.client;
+
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.io.CountingInputStream;
+import io.airlift.yaml.YamlCodec;
+
+import java.io.InputStream;
+
+import static io.airlift.http.client.HeaderNames.CONTENT_TYPE;
+import static io.airlift.http.client.ResponseHandlerUtils.getResponseBytes;
+import static io.airlift.http.client.ResponseHandlerUtils.getResponseStream;
+import static io.airlift.http.client.ResponseHandlerUtils.isYamlContent;
+import static java.util.Objects.requireNonNull;
+
+public class StreamingYamlResponseHandler<T>
+        implements ResponseHandler<YamlResponse<T>, RuntimeException>
+{
+    private final YamlCodec<T> codec;
+
+    public StreamingYamlResponseHandler(YamlCodec<T> codec)
+    {
+        this.codec = requireNonNull(codec, "codec is null");
+    }
+
+    public static <T> StreamingYamlResponseHandler<T> streamingYamlResponseHandler(YamlCodec<T> yamlCodec)
+    {
+        return new StreamingYamlResponseHandler<>(yamlCodec);
+    }
+
+    @Override
+    public YamlResponse<T> handleException(Request request, Exception exception)
+            throws RuntimeException
+    {
+        return new YamlResponse.Exception<>(request, -1, ImmutableListMultimap.of(), exception);
+    }
+
+    @Override
+    public YamlResponse<T> handle(Request request, Response response)
+            throws RuntimeException
+    {
+        int statusCode = response.getStatusCode();
+
+        try {
+            if (response.getHeader(CONTENT_TYPE).isEmpty()) {
+                return new YamlResponse.NonYamlBytes<>(
+                        request,
+                        statusCode,
+                        response.getHeaders(),
+                        getResponseBytes(request, response),
+                        new UnexpectedResponseException("Content-Type is not set for response", request, response));
+            }
+
+            if (isYamlContent(response)) {
+                try (InputStream stream = getResponseStream(response); CountingInputStream countingInputStream = new CountingInputStream(stream)) {
+                    return new YamlResponse.YamlValue<>(request, statusCode, response.getHeaders(), codec.fromYaml(countingInputStream), countingInputStream.getCount());
+                }
+            }
+
+            return new YamlResponse.NonYamlBytes<>(
+                    request,
+                    statusCode,
+                    response.getHeaders(),
+                    getResponseBytes(request, response),
+                    new UnexpectedResponseException("Expected YAML response from server but got %s".formatted(response.getHeader(CONTENT_TYPE).orElseThrow()), request, response));
+        }
+        catch (Exception e) {
+            return new YamlResponse.Exception<>(request, statusCode, response.getHeaders(), e);
+        }
+    }
+}

--- a/http-client/src/main/java/io/airlift/http/client/YamlBodyGenerator.java
+++ b/http-client/src/main/java/io/airlift/http/client/YamlBodyGenerator.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.http.client;
+
+import io.airlift.yaml.YamlCodec;
+
+public final class YamlBodyGenerator<T>
+        extends StaticBodyGenerator
+{
+    public static <T> YamlBodyGenerator<T> yamlBodyGenerator(YamlCodec<T> yamlCodec, T instance)
+    {
+        return new YamlBodyGenerator<>(yamlCodec, instance);
+    }
+
+    private YamlBodyGenerator(YamlCodec<T> yamlCodec, T instance)
+    {
+        super(yamlCodec.toYamlBytes(instance));
+    }
+}

--- a/http-client/src/main/java/io/airlift/http/client/YamlResponse.java
+++ b/http-client/src/main/java/io/airlift/http/client/YamlResponse.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.http.client;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Multimap;
+import com.google.common.net.MediaType;
+
+import java.nio.charset.Charset;
+import java.util.List;
+import java.util.Optional;
+
+import static io.airlift.http.client.HeaderNames.CONTENT_TYPE;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+
+public sealed interface YamlResponse<T>
+{
+    T yamlValue();
+
+    Optional<Throwable> exception();
+
+    Request request();
+
+    Multimap<HeaderName, String> headers();
+
+    default List<String> getHeader(HeaderName name)
+    {
+        return ImmutableList.copyOf(headers().get(name));
+    }
+
+    int statusCode();
+
+    record YamlValue<T>(@Override Request request, @Override int statusCode, @Override Multimap<HeaderName, String> headers, @Override T yamlValue, long bytesRead)
+            implements YamlResponse<T>
+    {
+        public YamlValue
+        {
+            requireNonNull(request, "request is null");
+            requireNonNull(headers, "headers is null");
+            requireNonNull(yamlValue, "yamlValue is null");
+        }
+
+        @Override
+        public Optional<Throwable> exception()
+        {
+            return Optional.empty();
+        }
+    }
+
+    record Exception<T>(@Override Request request, @Override int statusCode, @Override Multimap<HeaderName, String> headers, Throwable throwable)
+            implements YamlResponse<T>
+    {
+        public Exception
+        {
+            requireNonNull(request, "request is null");
+            requireNonNull(throwable, "throwable is null");
+        }
+
+        @Override
+        public T yamlValue()
+        {
+            throw new IllegalStateException("Response does not contain a YAML value", throwable);
+        }
+
+        @Override
+        public Optional<Throwable> exception()
+        {
+            return Optional.of(throwable);
+        }
+    }
+
+    record NonYamlBytes<T>(@Override Request request, @Override int statusCode, @Override Multimap<HeaderName, String> headers, byte[] responseBytes, Throwable throwable)
+            implements YamlResponse<T>
+    {
+        public NonYamlBytes
+        {
+            requireNonNull(request, "request is null");
+            requireNonNull(headers, "headers is null");
+            requireNonNull(responseBytes, "responseBytes is null");
+            requireNonNull(throwable, "throwable is null");
+        }
+
+        @Override
+        public T yamlValue()
+        {
+            throw new IllegalStateException("Could not decode response to YAML", throwable);
+        }
+
+        @Override
+        public Optional<Throwable> exception()
+        {
+            return Optional.of(throwable);
+        }
+
+        public String stringValue()
+        {
+            return new String(responseBytes, charset());
+        }
+
+        public Charset charset()
+        {
+            List<String> values = getHeader(CONTENT_TYPE);
+            if (!values.isEmpty()) {
+                try {
+                    return MediaType.parse(values.getFirst()).charset().or(UTF_8);
+                }
+                catch (RuntimeException ignored) {
+                }
+            }
+            return UTF_8;
+        }
+    }
+}

--- a/http-client/src/main/java/io/airlift/http/client/YamlResponseHandler.java
+++ b/http-client/src/main/java/io/airlift/http/client/YamlResponseHandler.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.http.client;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.primitives.Ints;
+import io.airlift.yaml.YamlCodec;
+
+import java.util.Set;
+
+import static io.airlift.http.client.HeaderNames.CONTENT_TYPE;
+import static io.airlift.http.client.ResponseHandlerUtils.getResponseBytes;
+import static io.airlift.http.client.ResponseHandlerUtils.isYamlContent;
+import static io.airlift.http.client.ResponseHandlerUtils.propagate;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class YamlResponseHandler<T>
+        implements ResponseHandler<T, RuntimeException>
+{
+    public static <T> YamlResponseHandler<T> createYamlResponseHandler(YamlCodec<T> yamlCodec)
+    {
+        return new YamlResponseHandler<>(yamlCodec);
+    }
+
+    public static <T> YamlResponseHandler<T> createYamlResponseHandler(YamlCodec<T> yamlCodec, int firstSuccessfulResponseCode, int... otherSuccessfulResponseCodes)
+    {
+        return new YamlResponseHandler<>(yamlCodec, firstSuccessfulResponseCode, otherSuccessfulResponseCodes);
+    }
+
+    private final YamlCodec<T> yamlCodec;
+    private final Set<Integer> successfulResponseCodes;
+
+    private YamlResponseHandler(YamlCodec<T> yamlCodec)
+    {
+        this(yamlCodec, 200, 201, 202, 203, 204, 205, 206);
+    }
+
+    private YamlResponseHandler(YamlCodec<T> yamlCodec, int firstSuccessfulResponseCode, int... otherSuccessfulResponseCodes)
+    {
+        this.yamlCodec = yamlCodec;
+        this.successfulResponseCodes = ImmutableSet.<Integer>builder().add(firstSuccessfulResponseCode).addAll(Ints.asList(otherSuccessfulResponseCodes)).build();
+    }
+
+    @Override
+    public T handleException(Request request, Exception exception)
+    {
+        throw propagate(request, exception);
+    }
+
+    @Override
+    public T handle(Request request, Response response)
+    {
+        if (!successfulResponseCodes.contains(response.getStatusCode())) {
+            throw new UnexpectedResponseException(
+                    "Expected response code to be %s, but was %d".formatted(successfulResponseCodes, response.getStatusCode()),
+                    request,
+                    response);
+        }
+
+        if (!isYamlContent(response)) {
+            throw new UnexpectedResponseException("Expected YAML response from server but got %s".formatted(response.getHeader(CONTENT_TYPE).orElse(null)), request, response);
+        }
+
+        byte[] bytes = getResponseBytes(request, response);
+
+        try {
+            return yamlCodec.fromYaml(bytes);
+        }
+        catch (IllegalArgumentException e) {
+            String yaml = new String(bytes, UTF_8);
+            throw new IllegalArgumentException("Unable to create %s from YAML response: <%s>".formatted(yamlCodec.getType(), yaml), e);
+        }
+    }
+}

--- a/http-client/src/test/java/io/airlift/http/client/TestYamlResponseHandler.java
+++ b/http-client/src/test/java/io/airlift/http/client/TestYamlResponseHandler.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.http.client;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.net.MediaType;
+import io.airlift.http.client.testing.TestingResponse;
+import io.airlift.yaml.YamlCodec;
+import org.junit.jupiter.api.Test;
+
+import static com.google.common.net.MediaType.PLAIN_TEXT_UTF_8;
+import static io.airlift.http.client.HttpStatus.OK;
+import static io.airlift.http.client.YamlResponseHandler.createYamlResponseHandler;
+import static io.airlift.http.client.testing.TestingResponse.mockResponse;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestYamlResponseHandler
+{
+    private static final MediaType APPLICATION_YAML = MediaType.create("application", "yaml").withCharset(UTF_8);
+
+    private final YamlCodec<User> codec = YamlCodec.yamlCodec(User.class);
+    private final YamlResponseHandler<User> handler = createYamlResponseHandler(codec);
+
+    @Test
+    public void testValidYaml()
+    {
+        User user = new User("Joe", 25);
+        User response = handler.handle(null, mockResponse(OK, APPLICATION_YAML, codec.toYaml(user)));
+
+        assertThat(response.getName()).isEqualTo(user.getName());
+        assertThat(response.getAge()).isEqualTo(user.getAge());
+    }
+
+    @Test
+    public void testValidYamlWithXYamlContentType()
+    {
+        MediaType xYaml = MediaType.create("application", "x-yaml").withCharset(UTF_8);
+        User user = new User("Joe", 25);
+        User response = handler.handle(null, mockResponse(OK, xYaml, codec.toYaml(user)));
+
+        assertThat(response.getName()).isEqualTo(user.getName());
+    }
+
+    @Test
+    public void testInvalidYaml()
+    {
+        String yaml = "age: not_a_number\n";
+        assertThatThrownBy(() -> handler.handle(null, mockResponse(OK, APPLICATION_YAML, yaml)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unable to create");
+    }
+
+    @Test
+    public void testNonYamlResponse()
+    {
+        assertThatThrownBy(() -> handler.handle(null, mockResponse(OK, PLAIN_TEXT_UTF_8, "hello")))
+                .isInstanceOf(UnexpectedResponseException.class)
+                .hasMessageContaining("Expected YAML response from server but got text/plain");
+    }
+
+    @Test
+    public void testMissingContentType()
+    {
+        assertThatThrownBy(() -> handler.handle(null, new TestingResponse(OK, ImmutableListMultimap.of(), "hello".getBytes(UTF_8))))
+                .isInstanceOf(UnexpectedResponseException.class)
+                .hasMessageContaining("Expected YAML response from server but got null");
+    }
+
+    public static class User
+    {
+        private final String name;
+        private final int age;
+
+        @JsonCreator
+        public User(@JsonProperty("name") String name, @JsonProperty("age") int age)
+        {
+            this.name = name;
+            this.age = age;
+        }
+
+        @JsonProperty
+        public String getName()
+        {
+            return name;
+        }
+
+        @JsonProperty
+        public int getAge()
+        {
+            return age;
+        }
+    }
+}

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -25,6 +25,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
             <artifactId>jackson-jakarta-rs-base</artifactId>
         </dependency>
@@ -32,6 +37,11 @@
         <dependency>
             <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
             <artifactId>jackson-jakarta-rs-json-provider</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
+            <artifactId>jackson-jakarta-rs-yaml-provider</artifactId>
         </dependency>
 
         <dependency>
@@ -163,6 +173,12 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>yaml</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -68,7 +68,6 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>units</artifactId>
-            <optional>true</optional>
         </dependency>
 
         <dependency>

--- a/jaxrs/src/main/java/io/airlift/jaxrs/JaxRsJsonMapper.java
+++ b/jaxrs/src/main/java/io/airlift/jaxrs/JaxRsJsonMapper.java
@@ -26,12 +26,20 @@ import static com.fasterxml.jackson.jakarta.rs.cfg.JakartaRSFeature.ADD_NO_SNIFF
 public class JaxRsJsonMapper
         extends JacksonJsonProvider
 {
+    private JsonParsingConfig parsingConfig = JsonParsingConfig.unbounded();
+
     @Inject
     public JaxRsJsonMapper(JsonMapper jsonMapper)
     {
         super(jsonMapper);
         enable(ADD_NO_SNIFF_HEADER);
         enable(INCLUDE_SOURCE_IN_LOCATION);
+    }
+
+    @Inject(optional = true)
+    public void setParsingConfig(JsonParsingConfig parsingConfig)
+    {
+        this.parsingConfig = parsingConfig;
     }
 
     /**
@@ -44,10 +52,19 @@ public class JaxRsJsonMapper
     public Object readFrom(Class<Object> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, String> httpHeaders, InputStream entityStream)
             throws IOException
     {
+        InputStream stream = parsingConfig.maxPayloadSize()
+                .map(size -> (InputStream) new LimitInputStream(entityStream, size.toBytes()))
+                .orElse(entityStream);
         try {
-            return super.readFrom(type, genericType, annotations, mediaType, httpHeaders, entityStream);
+            return super.readFrom(type, genericType, annotations, mediaType, httpHeaders, stream);
         }
         catch (IOException e) {
+            // Jackson may wrap the underlying IOException.
+            for (Throwable cause = e; cause != null; cause = cause.getCause()) {
+                if (cause instanceof PayloadTooLargeException payloadTooLarge) {
+                    throw payloadTooLarge;
+                }
+            }
             // Re-throw real IO exceptions that are not due to bad JSON
             if (!(e instanceof JsonProcessingException) && !(e instanceof EOFException)) {
                 throw e;

--- a/jaxrs/src/main/java/io/airlift/jaxrs/JaxRsYamlMapper.java
+++ b/jaxrs/src/main/java/io/airlift/jaxrs/JaxRsYamlMapper.java
@@ -1,0 +1,90 @@
+package io.airlift.jaxrs;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import com.fasterxml.jackson.jakarta.rs.yaml.JacksonYAMLProvider;
+import com.google.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.Provider;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import static com.fasterxml.jackson.jakarta.rs.cfg.JakartaRSFeature.ADD_NO_SNIFF_HEADER;
+
+@Provider
+@Consumes({"application/yaml", "application/x-yaml", "text/yaml", "text/x-yaml"})
+// Server quality (qs) below the JSON provider's so JSON wins when a client sends "*/*"
+// (no Accept header) or otherwise expresses no preference between JSON and YAML.
+@Produces("application/yaml;qs=0.5")
+public class JaxRsYamlMapper
+        extends JacksonYAMLProvider
+{
+    public JaxRsYamlMapper()
+    {
+        super(new YAMLMapper());
+        enable(ADD_NO_SNIFF_HEADER);
+    }
+
+    @Inject(optional = true)
+    public void setYamlMapper(YAMLMapper yamlMapper)
+    {
+        setMapper(yamlMapper);
+    }
+
+    /**
+     * Throws YamlParsingException only when Jakarta-RS container calls to deserialize given YAML value.
+     * Distinguishes between:
+     * - JsonProcessingException due to Jakarta-RS deserialization
+     * - JsonProcessingException due to operation happening in resource body
+     */
+    @Override
+    public Object readFrom(Class<Object> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, String> httpHeaders, InputStream entityStream)
+            throws IOException
+    {
+        try {
+            return super.readFrom(type, genericType, annotations, mediaType, httpHeaders, entityStream);
+        }
+        catch (IOException e) {
+            if (!(e instanceof JsonProcessingException) && !(e instanceof EOFException)) {
+                throw e;
+            }
+            throw new YamlParsingException(e);
+        }
+    }
+
+    @Override
+    protected boolean hasMatchingMediaType(MediaType mediaType)
+    {
+        if (mediaType == null) {
+            return true;
+        }
+        String subtype = mediaType.getSubtype();
+        // JacksonYAMLProvider's default only matches "yaml" or "*+yaml"; we also accept "x-yaml"
+        // for compatibility with legacy clients.
+        return "yaml".equalsIgnoreCase(subtype)
+                || "x-yaml".equalsIgnoreCase(subtype)
+                || subtype.endsWith("+yaml");
+    }
+
+    @Override
+    protected boolean hasMatchingMediaTypeForWriting(MediaType mediaType)
+    {
+        // Only write YAML when the chosen response media type is explicitly YAML.
+        // Without this override, a resource method without an explicit @Produces would
+        // pick YAML over JSON whenever a wildcard Accept (or no Accept) reached the server.
+        if (mediaType == null) {
+            return false;
+        }
+        String subtype = mediaType.getSubtype();
+        return "yaml".equalsIgnoreCase(subtype)
+                || "x-yaml".equalsIgnoreCase(subtype)
+                || subtype.endsWith("+yaml");
+    }
+}

--- a/jaxrs/src/main/java/io/airlift/jaxrs/JaxRsYamlMapper.java
+++ b/jaxrs/src/main/java/io/airlift/jaxrs/JaxRsYamlMapper.java
@@ -26,6 +26,8 @@ import static com.fasterxml.jackson.jakarta.rs.cfg.JakartaRSFeature.ADD_NO_SNIFF
 public class JaxRsYamlMapper
         extends JacksonYAMLProvider
 {
+    private YamlParsingConfig parsingConfig = YamlParsingConfig.unbounded();
+
     public JaxRsYamlMapper()
     {
         super(new YAMLMapper());
@@ -38,6 +40,12 @@ public class JaxRsYamlMapper
         setMapper(yamlMapper);
     }
 
+    @Inject(optional = true)
+    public void setParsingConfig(YamlParsingConfig parsingConfig)
+    {
+        this.parsingConfig = parsingConfig;
+    }
+
     /**
      * Throws YamlParsingException only when Jakarta-RS container calls to deserialize given YAML value.
      * Distinguishes between:
@@ -48,10 +56,19 @@ public class JaxRsYamlMapper
     public Object readFrom(Class<Object> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, String> httpHeaders, InputStream entityStream)
             throws IOException
     {
+        InputStream stream = parsingConfig.maxPayloadSize()
+                .map(size -> (InputStream) new LimitInputStream(entityStream, size.toBytes()))
+                .orElse(entityStream);
         try {
-            return super.readFrom(type, genericType, annotations, mediaType, httpHeaders, entityStream);
+            return super.readFrom(type, genericType, annotations, mediaType, httpHeaders, stream);
         }
         catch (IOException e) {
+            // SnakeYAML wraps the underlying IOException
+            for (Throwable cause = e; cause != null; cause = cause.getCause()) {
+                if (cause instanceof PayloadTooLargeException payloadTooLarge) {
+                    throw payloadTooLarge;
+                }
+            }
             if (!(e instanceof JsonProcessingException) && !(e instanceof EOFException)) {
                 throw e;
             }

--- a/jaxrs/src/main/java/io/airlift/jaxrs/JaxrsBinder.java
+++ b/jaxrs/src/main/java/io/airlift/jaxrs/JaxrsBinder.java
@@ -4,7 +4,6 @@ import com.google.inject.Binder;
 import com.google.inject.Provider;
 import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.Multibinder;
-import io.airlift.jaxrs.JsonParsingFeature.MappingEnabled;
 
 import java.lang.annotation.Annotation;
 import java.util.Optional;
@@ -13,7 +12,6 @@ import static com.google.inject.Scopes.SINGLETON;
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.jaxrs.BinderUtils.qualifiedKey;
-import static io.airlift.jaxrs.JsonParsingFeature.MappingEnabled.DISABLED;
 import static java.util.Objects.requireNonNull;
 
 public class JaxrsBinder
@@ -85,7 +83,17 @@ public class JaxrsBinder
 
     public JaxrsBinder disableJsonExceptionMapper()
     {
-        newOptionalBinder(binder, qualifiedKey(qualifier, MappingEnabled.class)).setBinding().toInstance(DISABLED);
+        newOptionalBinder(binder, qualifiedKey(qualifier, JsonParsingFeature.MappingEnabled.class))
+                .setBinding()
+                .toInstance(JsonParsingFeature.MappingEnabled.DISABLED);
+        return this;
+    }
+
+    public JaxrsBinder disableYamlExceptionMapper()
+    {
+        newOptionalBinder(binder, qualifiedKey(qualifier, YamlParsingFeature.MappingEnabled.class))
+                .setBinding()
+                .toInstance(YamlParsingFeature.MappingEnabled.DISABLED);
         return this;
     }
 }

--- a/jaxrs/src/main/java/io/airlift/jaxrs/JaxrsBinder.java
+++ b/jaxrs/src/main/java/io/airlift/jaxrs/JaxrsBinder.java
@@ -4,6 +4,7 @@ import com.google.inject.Binder;
 import com.google.inject.Provider;
 import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.Multibinder;
+import io.airlift.units.DataSize;
 
 import java.lang.annotation.Annotation;
 import java.util.Optional;
@@ -94,6 +95,24 @@ public class JaxrsBinder
         newOptionalBinder(binder, qualifiedKey(qualifier, YamlParsingFeature.MappingEnabled.class))
                 .setBinding()
                 .toInstance(YamlParsingFeature.MappingEnabled.DISABLED);
+        return this;
+    }
+
+    public JaxrsBinder withJsonMaxPayloadSize(DataSize maxPayloadSize)
+    {
+        requireNonNull(maxPayloadSize, "maxPayloadSize is null");
+        newOptionalBinder(binder, qualifiedKey(qualifier, JsonParsingConfig.class))
+                .setBinding()
+                .toInstance(new JsonParsingConfig(Optional.of(maxPayloadSize)));
+        return this;
+    }
+
+    public JaxrsBinder withYamlMaxPayloadSize(DataSize maxPayloadSize)
+    {
+        requireNonNull(maxPayloadSize, "maxPayloadSize is null");
+        newOptionalBinder(binder, qualifiedKey(qualifier, YamlParsingConfig.class))
+                .setBinding()
+                .toInstance(new YamlParsingConfig(Optional.of(maxPayloadSize)));
         return this;
     }
 }

--- a/jaxrs/src/main/java/io/airlift/jaxrs/JaxrsModule.java
+++ b/jaxrs/src/main/java/io/airlift/jaxrs/JaxrsModule.java
@@ -69,6 +69,8 @@ public class JaxrsModule
                 .setDefault()
                 .toInstance(YamlParsingFeature.MappingEnabled.ENABLED);
 
+        jaxrsBinder.bind(PayloadTooLargeExceptionMapper.class);
+
         if (getProperty("tracing.enabled").map(Boolean::parseBoolean).orElse(false)) {
             jaxrsBinder.bind(TracingDynamicFeature.class);
         }

--- a/jaxrs/src/main/java/io/airlift/jaxrs/JaxrsModule.java
+++ b/jaxrs/src/main/java/io/airlift/jaxrs/JaxrsModule.java
@@ -17,7 +17,6 @@ package io.airlift.jaxrs;
 
 import com.google.inject.Binder;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
-import io.airlift.jaxrs.JsonParsingFeature.MappingEnabled;
 import io.airlift.jaxrs.tracing.TracingDynamicFeature;
 import jakarta.annotation.Nullable;
 import jakarta.servlet.Servlet;
@@ -30,7 +29,6 @@ import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.jaxrs.BinderUtils.qualifiedKey;
 import static io.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
-import static io.airlift.jaxrs.JsonParsingFeature.MappingEnabled.ENABLED;
 
 public class JaxrsModule
         extends AbstractConfigurationAwareModule
@@ -60,9 +58,16 @@ public class JaxrsModule
         jaxrsBinder.bind(JaxRsJsonMapper.class);
         jaxrsBinder.bind(JsonParsingFeature.class, new JsonParsingFeature.Provider(qualifier));
 
-        newOptionalBinder(binder, qualifiedKey(qualifier, MappingEnabled.class))
+        newOptionalBinder(binder, qualifiedKey(qualifier, JsonParsingFeature.MappingEnabled.class))
                 .setDefault()
-                .toInstance(ENABLED);
+                .toInstance(JsonParsingFeature.MappingEnabled.ENABLED);
+
+        jaxrsBinder.bind(JaxRsYamlMapper.class);
+        jaxrsBinder.bind(YamlParsingFeature.class, new YamlParsingFeature.Provider(qualifier));
+
+        newOptionalBinder(binder, qualifiedKey(qualifier, YamlParsingFeature.MappingEnabled.class))
+                .setDefault()
+                .toInstance(YamlParsingFeature.MappingEnabled.ENABLED);
 
         if (getProperty("tracing.enabled").map(Boolean::parseBoolean).orElse(false)) {
             jaxrsBinder.bind(TracingDynamicFeature.class);

--- a/jaxrs/src/main/java/io/airlift/jaxrs/JsonParsingConfig.java
+++ b/jaxrs/src/main/java/io/airlift/jaxrs/JsonParsingConfig.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.jaxrs;
+
+import io.airlift.units.DataSize;
+
+import java.util.Optional;
+
+public record JsonParsingConfig(Optional<DataSize> maxPayloadSize)
+{
+    public JsonParsingConfig
+    {
+        maxPayloadSize = maxPayloadSize == null ? Optional.empty() : maxPayloadSize;
+    }
+
+    public static JsonParsingConfig unbounded()
+    {
+        return new JsonParsingConfig(Optional.empty());
+    }
+}

--- a/jaxrs/src/main/java/io/airlift/jaxrs/LimitInputStream.java
+++ b/jaxrs/src/main/java/io/airlift/jaxrs/LimitInputStream.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.jaxrs;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static java.util.Objects.requireNonNull;
+
+class LimitInputStream
+        extends FilterInputStream
+{
+    private final long maxBytes;
+    private long bytesRead;
+
+    LimitInputStream(InputStream in, long maxBytes)
+    {
+        super(requireNonNull(in, "in is null"));
+        this.maxBytes = maxBytes;
+    }
+
+    @Override
+    public int read()
+            throws IOException
+    {
+        int b = super.read();
+        if (b != -1) {
+            advance(1);
+        }
+        return b;
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len)
+            throws IOException
+    {
+        int n = super.read(b, off, len);
+        if (n > 0) {
+            advance(n);
+        }
+        return n;
+    }
+
+    private void advance(long n)
+            throws PayloadTooLargeException
+    {
+        bytesRead += n;
+        if (bytesRead > maxBytes) {
+            throw new PayloadTooLargeException("Request payload exceeds maximum size of %d bytes".formatted(maxBytes));
+        }
+    }
+}

--- a/jaxrs/src/main/java/io/airlift/jaxrs/PayloadTooLargeException.java
+++ b/jaxrs/src/main/java/io/airlift/jaxrs/PayloadTooLargeException.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.jaxrs;
+
+import java.io.IOException;
+
+public class PayloadTooLargeException
+        extends IOException
+{
+    public PayloadTooLargeException(String message)
+    {
+        super(message);
+    }
+}

--- a/jaxrs/src/main/java/io/airlift/jaxrs/PayloadTooLargeExceptionMapper.java
+++ b/jaxrs/src/main/java/io/airlift/jaxrs/PayloadTooLargeExceptionMapper.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.jaxrs;
+
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
+
+@Provider
+public class PayloadTooLargeExceptionMapper
+        implements ExceptionMapper<PayloadTooLargeException>
+{
+    private static final String ERROR_CODE = "PAYLOAD_TOO_LARGE";
+
+    @Override
+    public Response toResponse(PayloadTooLargeException e)
+    {
+        return Response.status(Response.Status.REQUEST_ENTITY_TOO_LARGE)
+                .type(APPLICATION_JSON_TYPE)
+                .entity(new JsonError(ERROR_CODE, e.getMessage()))
+                .build();
+    }
+}

--- a/jaxrs/src/main/java/io/airlift/jaxrs/YamlParsingConfig.java
+++ b/jaxrs/src/main/java/io/airlift/jaxrs/YamlParsingConfig.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.jaxrs;
+
+import io.airlift.units.DataSize;
+
+import java.util.Optional;
+
+public record YamlParsingConfig(Optional<DataSize> maxPayloadSize)
+{
+    public YamlParsingConfig
+    {
+        maxPayloadSize = maxPayloadSize == null ? Optional.empty() : maxPayloadSize;
+    }
+
+    public static YamlParsingConfig unbounded()
+    {
+        return new YamlParsingConfig(Optional.empty());
+    }
+}

--- a/jaxrs/src/main/java/io/airlift/jaxrs/YamlParsingException.java
+++ b/jaxrs/src/main/java/io/airlift/jaxrs/YamlParsingException.java
@@ -1,0 +1,12 @@
+package io.airlift.jaxrs;
+
+import java.io.IOException;
+
+public class YamlParsingException
+        extends IOException
+{
+    public YamlParsingException(Throwable cause)
+    {
+        super(cause);
+    }
+}

--- a/jaxrs/src/main/java/io/airlift/jaxrs/YamlParsingExceptionMapper.java
+++ b/jaxrs/src/main/java/io/airlift/jaxrs/YamlParsingExceptionMapper.java
@@ -1,0 +1,26 @@
+package io.airlift.jaxrs;
+
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+
+import static com.google.common.base.Throwables.getRootCause;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
+import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
+
+@Provider
+public class YamlParsingExceptionMapper
+        implements ExceptionMapper<YamlParsingException>
+{
+    private static final String SERIALIZATION_ERROR_CODE = "YAML_PARSING_ERROR";
+
+    @Override
+    public Response toResponse(YamlParsingException e)
+    {
+        // Errors are returned as JSON regardless of the request format (common convention across various public APIs).
+        return Response.status(BAD_REQUEST)
+                .type(APPLICATION_JSON_TYPE)
+                .entity(new JsonError(SERIALIZATION_ERROR_CODE, getRootCause(e).getMessage()))
+                .build();
+    }
+}

--- a/jaxrs/src/main/java/io/airlift/jaxrs/YamlParsingFeature.java
+++ b/jaxrs/src/main/java/io/airlift/jaxrs/YamlParsingFeature.java
@@ -1,0 +1,63 @@
+package io.airlift.jaxrs;
+
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import jakarta.ws.rs.core.Feature;
+import jakarta.ws.rs.core.FeatureContext;
+
+import java.lang.annotation.Annotation;
+import java.util.Optional;
+
+import static io.airlift.jaxrs.BinderUtils.qualifiedKey;
+import static io.airlift.jaxrs.YamlParsingFeature.MappingEnabled.DISABLED;
+import static java.util.Objects.requireNonNull;
+
+public record YamlParsingFeature(MappingEnabled enabled)
+        implements Feature
+{
+    public enum MappingEnabled
+    {
+        ENABLED,
+        DISABLED,
+    }
+
+    public YamlParsingFeature
+    {
+        requireNonNull(enabled, "enabled is null");
+    }
+
+    @Override
+    public boolean configure(FeatureContext context)
+    {
+        if (enabled == DISABLED) {
+            return false;
+        }
+
+        context.register(new YamlParsingExceptionMapper());
+        return true;
+    }
+
+    public static class Provider
+            implements com.google.inject.Provider<YamlParsingFeature>
+    {
+        private final Optional<Class<? extends Annotation>> qualifier;
+        private Injector injector;
+
+        public Provider(Optional<Class<? extends Annotation>> qualifier)
+        {
+            this.qualifier = requireNonNull(qualifier, "qualifier is null");
+        }
+
+        @Inject
+        public void setInjector(Injector injector)
+        {
+            this.injector = requireNonNull(injector, "injector is null");
+        }
+
+        @Override
+        public YamlParsingFeature get()
+        {
+            return new YamlParsingFeature(injector.getInstance(qualifiedKey(qualifier, MappingEnabled.class)));
+        }
+    }
+}

--- a/jaxrs/src/test/java/io/airlift/jaxrs/TestJaxRsYamlMapper.java
+++ b/jaxrs/src/test/java/io/airlift/jaxrs/TestJaxRsYamlMapper.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.jaxrs;
+
+import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
+import com.google.common.net.HttpHeaders;
+import com.google.common.reflect.TypeToken;
+import io.airlift.jaxrs.testing.GuavaMultivaluedMap;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MultivaluedMap;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.zip.ZipException;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
+
+public class TestJaxRsYamlMapper
+{
+    private static final JaxRsYamlMapper yamlMapper = new JaxRsYamlMapper();
+
+    @Test
+    public void testSuccess()
+            throws IOException
+    {
+        assertRoundTrip("value");
+        assertRoundTrip("multi\nline\nstring");
+    }
+
+    private static void assertRoundTrip(String value)
+            throws IOException
+    {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+        MultivaluedMap<String, Object> headers = new GuavaMultivaluedMap<>();
+        yamlMapper.writeTo(value, String.class, null, null, null, headers, outputStream);
+
+        Object roundTripped = yamlMapper.readFrom(
+                Object.class,
+                String.class,
+                null,
+                null,
+                null,
+                new ByteArrayInputStream(outputStream.toByteArray()));
+        assertThat(roundTripped).isEqualTo(value);
+        assertThat(headers.getFirst(HttpHeaders.X_CONTENT_TYPE_OPTIONS)).isEqualTo("nosniff");
+    }
+
+    @Test
+    public void testYamlEofExceptionMapping()
+    {
+        // A truncated mapping (`name:` with no continuation) is interpreted as EOF.
+        assertThatThrownBy(() -> yamlMapper.readFrom(
+                Object.class,
+                ExamplePojo.class,
+                null,
+                null,
+                null,
+                new ByteArrayInputStream("name:\n  unfinished:".getBytes(UTF_8))))
+                .isInstanceOf(YamlParsingException.class);
+    }
+
+    @Test
+    public void testYamlBindingExceptionMapping()
+    {
+        assertThatThrownBy(() -> yamlMapper.readFrom(
+                Object.class,
+                ExamplePojo.class,
+                null,
+                null,
+                null,
+                new ByteArrayInputStream("value: [not, a, string]".getBytes(UTF_8))))
+                .isInstanceOf(YamlParsingException.class);
+    }
+
+    @Test
+    public void testYamlWriteExceptionMapping()
+    {
+        try {
+            ByteArrayOutputStream stream = new ByteArrayOutputStream(1);
+            yamlMapper.writeTo(new OtherExamplePojo("nah", "bro"), List.class, new TypeToken<List<String>>() {}.getType(), null, null, new GuavaMultivaluedMap<>(), stream);
+            fail("Should have thrown an Exception");
+        }
+        catch (InvalidDefinitionException e) {
+            // intended
+        }
+        catch (IOException e) {
+            if (e instanceof YamlParsingException) {
+                fail("yamlMapper.writeTo() should not throw YamlParsingException");
+            }
+            throw new AssertionError(e);
+        }
+    }
+
+    @Test
+    public void testOtherIOExceptionThrowsIOException()
+    {
+        try {
+            assertThatThrownBy(() -> yamlMapper.readFrom(Object.class, Object.class, null, null, null, new InputStream()
+            {
+                @Override
+                public int read()
+                        throws IOException
+                {
+                    throw new ZipException("forced ZipException");
+                }
+
+                @Override
+                public int read(byte[] b)
+                        throws IOException
+                {
+                    throw new ZipException("forced ZipException");
+                }
+
+                @Override
+                public int read(byte[] b, int off, int len)
+                        throws IOException
+                {
+                    throw new ZipException("forced ZipException");
+                }
+            })).isInstanceOf(ZipException.class);
+        }
+        catch (WebApplicationException e) {
+            fail("Should not have received a WebApplicationException", e);
+        }
+    }
+
+    @Test
+    public void testParsingExceptionMapperReturnsJsonContentType()
+    {
+        // Errors are returned as JSON regardless of the request format.
+        YamlParsingExceptionMapper mapper = new YamlParsingExceptionMapper();
+        YamlParsingException exception = new YamlParsingException(new IOException("boom"));
+
+        try (jakarta.ws.rs.core.Response response = mapper.toResponse(exception)) {
+            assertThat(response.getStatus()).isEqualTo(400);
+            assertThat(response.getMediaType().toString()).isEqualTo(jakarta.ws.rs.core.MediaType.APPLICATION_JSON);
+            assertThat(response.getEntity()).isInstanceOf(JsonError.class);
+        }
+    }
+
+    private record ExamplePojo(String value) {}
+
+    private record OtherExamplePojo(String value, String value2) {}
+}

--- a/jaxrs/src/test/java/io/airlift/jaxrs/programmatic/ResourceWithYaml.java
+++ b/jaxrs/src/test/java/io/airlift/jaxrs/programmatic/ResourceWithYaml.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.jaxrs.programmatic;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@Path("/")
+public class ResourceWithYaml
+{
+    public record YamlModel(String name) {}
+
+    @POST
+    @Path("/yaml")
+    @Consumes({"application/yaml", "application/x-yaml", "text/yaml", "text/x-yaml"})
+    public String takeYaml(YamlModel model)
+    {
+        return model.name();
+    }
+
+    @POST
+    @Path("/badyaml")
+    @Consumes("application/yaml")
+    public void takeBadYaml(YamlModel ignore)
+    {
+        // do nothing
+    }
+
+    @POST
+    @Path("/jsononly")
+    @Consumes(APPLICATION_JSON)
+    public void takeJsonOnly(YamlModel ignore)
+    {
+        // do nothing
+    }
+
+    @GET
+    @Path("/both")
+    @Produces({APPLICATION_JSON, "application/yaml"})
+    public YamlModel getBoth()
+    {
+        return new YamlModel("dain");
+    }
+}

--- a/jaxrs/src/test/java/io/airlift/jaxrs/programmatic/TestPayloadSizeLimit.java
+++ b/jaxrs/src/test/java/io/airlift/jaxrs/programmatic/TestPayloadSizeLimit.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.jaxrs.programmatic;
+
+import com.google.inject.Injector;
+import io.airlift.bootstrap.Bootstrap;
+import io.airlift.bootstrap.LifeCycleManager;
+import io.airlift.http.client.HttpClientConfig;
+import io.airlift.http.client.Request;
+import io.airlift.http.client.StringResponseHandler.StringResponse;
+import io.airlift.http.client.jetty.JettyHttpClient;
+import io.airlift.http.server.testing.TestingHttpServer;
+import io.airlift.http.server.testing.TestingHttpServerModule;
+import io.airlift.jaxrs.JaxrsBinder;
+import io.airlift.jaxrs.JaxrsModule;
+import io.airlift.jaxrs.JsonError;
+import io.airlift.json.JsonModule;
+import io.airlift.node.testing.TestingNodeModule;
+import io.airlift.units.DataSize;
+import io.airlift.yaml.YamlModule;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.function.Consumer;
+
+import static io.airlift.http.client.HeaderNames.CONTENT_TYPE;
+import static io.airlift.http.client.Request.Builder.preparePost;
+import static io.airlift.http.client.StaticBodyGenerator.createStaticBodyGenerator;
+import static io.airlift.http.client.StringResponseHandler.createStringResponseHandler;
+import static io.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
+import static io.airlift.units.DataSize.Unit.KILOBYTE;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestPayloadSizeLimit
+{
+    @Path("/")
+    public static class Resource
+    {
+        public record Payload(String value) {}
+
+        @POST
+        @Path("/json")
+        @Consumes("application/json")
+        public String takeJson(Payload payload)
+        {
+            return payload.value();
+        }
+
+        @POST
+        @Path("/yaml")
+        @Consumes("application/yaml")
+        public String takeYaml(Payload payload)
+        {
+            return payload.value();
+        }
+    }
+
+    @Test
+    public void testJsonOverLimitReturns413()
+    {
+        try (Harness harness = new Harness(jaxrsBinder -> jaxrsBinder.withJsonMaxPayloadSize(DataSize.of(1, KILOBYTE)))) {
+            String body = "{\"value\":\"%s\"}".formatted("x".repeat(2048));
+            StringResponse response = harness.post("/json", "application/json", body);
+
+            assertThat(response.getStatusCode()).isEqualTo(413);
+            assertThat(response.getHeader(CONTENT_TYPE)).hasValue(APPLICATION_JSON_TYPE.toString());
+            JsonError error = JsonError.codec().fromJson(response.getBody());
+            assertThat(error.code()).isEqualTo("PAYLOAD_TOO_LARGE");
+        }
+    }
+
+    @Test
+    public void testYamlOverLimitReturns413()
+    {
+        try (Harness harness = new Harness(jaxrsBinder -> jaxrsBinder.withYamlMaxPayloadSize(DataSize.of(1, KILOBYTE)))) {
+            String body = "value: %s\n".formatted("x".repeat(2048));
+            StringResponse response = harness.post("/yaml", "application/yaml", body);
+
+            assertThat(response.getStatusCode()).isEqualTo(413);
+            assertThat(response.getHeader(CONTENT_TYPE)).hasValue(APPLICATION_JSON_TYPE.toString());
+            JsonError error = JsonError.codec().fromJson(response.getBody());
+            assertThat(error.code()).isEqualTo("PAYLOAD_TOO_LARGE");
+        }
+    }
+
+    @Test
+    public void testJsonUnderLimitSucceeds()
+    {
+        try (Harness harness = new Harness(jaxrsBinder -> jaxrsBinder.withJsonMaxPayloadSize(DataSize.of(1, KILOBYTE)))) {
+            StringResponse response = harness.post("/json", "application/json", "{\"value\":\"small\"}");
+            assertThat(response.getStatusCode()).isEqualTo(200);
+            assertThat(response.getBody()).isEqualTo("small");
+        }
+    }
+
+    @Test
+    public void testYamlUnderLimitSucceeds()
+    {
+        try (Harness harness = new Harness(jaxrsBinder -> jaxrsBinder.withYamlMaxPayloadSize(DataSize.of(1, KILOBYTE)))) {
+            StringResponse response = harness.post("/yaml", "application/yaml", "value: small\n");
+            assertThat(response.getStatusCode()).isEqualTo(200);
+            assertThat(response.getBody()).isEqualTo("small");
+        }
+    }
+
+    @Test
+    public void testDefaultIsUnbounded()
+    {
+        // No limit configured. Arbitrarily large JSON payload accepted.
+        try (Harness harness = new Harness(_ -> {})) {
+            String body = "{\"value\":\"%s\"}".formatted("x".repeat(64 * 1024));
+            StringResponse response = harness.post("/json", "application/json", body);
+            assertThat(response.getStatusCode()).isEqualTo(200);
+        }
+    }
+
+    private static final class Harness
+            implements AutoCloseable
+    {
+        private final Injector injector;
+        private final URI baseUri;
+        private final JettyHttpClient client;
+
+        Harness(Consumer<JaxrsBinder> configure)
+        {
+            try {
+                injector = new Bootstrap(
+                        binder -> {
+                            JaxrsBinder jaxrsBinder = jaxrsBinder(binder);
+                            jaxrsBinder.bind(Resource.class);
+                            configure.accept(jaxrsBinder);
+                        },
+                        new TestingNodeModule(),
+                        new JaxrsModule(),
+                        new JsonModule(),
+                        new YamlModule(),
+                        new TestingHttpServerModule(getClass().getName()))
+                        .quiet()
+                        .doNotInitializeLogging()
+                        .initialize();
+            }
+            catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            baseUri = injector.getInstance(TestingHttpServer.class).getBaseUrl();
+            client = new JettyHttpClient(new HttpClientConfig());
+        }
+
+        StringResponse post(String path, String contentType, String body)
+        {
+            Request request = preparePost()
+                    .setUri(baseUri.resolve(path))
+                    .setHeader(CONTENT_TYPE, contentType)
+                    .setBodyGenerator(createStaticBodyGenerator(body, UTF_8))
+                    .build();
+            return client.execute(request, createStringResponseHandler());
+        }
+
+        @Override
+        public void close()
+        {
+            client.close();
+            injector.getInstance(LifeCycleManager.class).stop();
+        }
+    }
+}

--- a/jaxrs/src/test/java/io/airlift/jaxrs/programmatic/TestYamlResource.java
+++ b/jaxrs/src/test/java/io/airlift/jaxrs/programmatic/TestYamlResource.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.jaxrs.programmatic;
+
+import com.google.inject.Injector;
+import io.airlift.bootstrap.Bootstrap;
+import io.airlift.bootstrap.LifeCycleManager;
+import io.airlift.http.client.HttpClientConfig;
+import io.airlift.http.client.Request;
+import io.airlift.http.client.StringResponseHandler.StringResponse;
+import io.airlift.http.client.jetty.JettyHttpClient;
+import io.airlift.http.server.testing.TestingHttpServer;
+import io.airlift.http.server.testing.TestingHttpServerModule;
+import io.airlift.jaxrs.JaxrsBinder;
+import io.airlift.jaxrs.JaxrsModule;
+import io.airlift.jaxrs.JsonError;
+import io.airlift.json.JsonModule;
+import io.airlift.node.testing.TestingNodeModule;
+import io.airlift.yaml.YamlModule;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.net.URI;
+
+import static io.airlift.http.client.HeaderNames.ACCEPT;
+import static io.airlift.http.client.HeaderNames.CONTENT_TYPE;
+import static io.airlift.http.client.Request.Builder.preparePost;
+import static io.airlift.http.client.StaticBodyGenerator.createStaticBodyGenerator;
+import static io.airlift.http.client.StringResponseHandler.createStringResponseHandler;
+import static io.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestYamlResource
+{
+    @ParameterizedTest
+    @ValueSource(strings = {"application/yaml", "application/x-yaml", "text/yaml", "text/x-yaml"})
+    public void testYamlConsumesAllAliases(String contentType)
+    {
+        try (Harness harness = new Harness(true)) {
+            Request request = preparePost().setUri(harness.baseUri.resolve("/yaml"))
+                    .setHeader(CONTENT_TYPE, contentType)
+                    .setBodyGenerator(createStaticBodyGenerator("name: dain\n", UTF_8))
+                    .build();
+
+            StringResponse response = harness.client.execute(request, createStringResponseHandler());
+            assertThat(response.getStatusCode()).isEqualTo(200);
+            assertThat(response.getBody()).isEqualTo("dain");
+        }
+    }
+
+    @Test
+    public void testJsonOnlyResourceRejectsYaml()
+    {
+        try (Harness harness = new Harness(true)) {
+            Request request = preparePost().setUri(harness.baseUri.resolve("/jsononly"))
+                    .setHeader(CONTENT_TYPE, "application/yaml")
+                    .setBodyGenerator(createStaticBodyGenerator("name: dain\n", UTF_8))
+                    .build();
+
+            StringResponse response = harness.client.execute(request, createStringResponseHandler());
+            assertThat(response.getStatusCode()).isEqualTo(415);
+        }
+    }
+
+    @Test
+    public void testYamlParsingErrorReturnsJsonContentType()
+    {
+        try (Harness harness = new Harness(true)) {
+            Request request = preparePost().setUri(harness.baseUri.resolve("/badyaml"))
+                    .setHeader(CONTENT_TYPE, "application/yaml")
+                    .setBodyGenerator(createStaticBodyGenerator("name:\n  unfinished:", UTF_8))
+                    .build();
+
+            StringResponse response = harness.client.execute(request, createStringResponseHandler());
+            assertThat(response.getStatusCode()).isEqualTo(400);
+            assertThat(response.getHeader(CONTENT_TYPE)).hasValue(APPLICATION_JSON_TYPE.toString());
+            JsonError error = JsonError.codec().fromJson(response.getBody());
+            assertThat(error.code()).isEqualTo("YAML_PARSING_ERROR");
+        }
+    }
+
+    @Test
+    public void testYamlParsingExceptionMapperCanBeDisabled()
+    {
+        try (Harness harness = new Harness(false)) {
+            Request request = preparePost().setUri(harness.baseUri.resolve("/badyaml"))
+                    .setHeader(CONTENT_TYPE, "application/yaml")
+                    .setBodyGenerator(createStaticBodyGenerator("name:\n  unfinished:", UTF_8))
+                    .build();
+
+            StringResponse response = harness.client.execute(request, createStringResponseHandler());
+            assertThat(response.getStatusCode()).isEqualTo(500);
+        }
+    }
+
+    @Test
+    public void testAcceptHeaderChoosesYaml()
+    {
+        try (Harness harness = new Harness(true)) {
+            Request request = Request.Builder.prepareGet().setUri(harness.baseUri.resolve("/both"))
+                    .setHeader(ACCEPT, "application/yaml")
+                    .build();
+
+            StringResponse response = harness.client.execute(request, createStringResponseHandler());
+            assertThat(response.getStatusCode()).isEqualTo(200);
+            assertThat(response.getHeader(CONTENT_TYPE)).hasValueSatisfying(value -> assertThat(value).startsWith("application/yaml"));
+            assertThat(response.getBody()).contains("name: dain");
+        }
+    }
+
+    @Test
+    public void testAcceptHeaderChoosesJson()
+    {
+        try (Harness harness = new Harness(true)) {
+            Request request = Request.Builder.prepareGet().setUri(harness.baseUri.resolve("/both"))
+                    .setHeader(ACCEPT, "application/json")
+                    .build();
+
+            StringResponse response = harness.client.execute(request, createStringResponseHandler());
+            assertThat(response.getStatusCode()).isEqualTo(200);
+            assertThat(response.getHeader(CONTENT_TYPE)).hasValueSatisfying(value -> assertThat(value).startsWith("application/json"));
+            assertThat(response.getBody()).contains("\"name\"").contains("\"dain\"");
+        }
+    }
+
+    private static final class Harness
+            implements AutoCloseable
+    {
+        private final Injector injector;
+        final URI baseUri;
+        final JettyHttpClient client;
+
+        Harness(boolean yamlMapperEnabled)
+        {
+            try {
+                injector = new Bootstrap(
+                        binder -> {
+                            JaxrsBinder jaxrsBinder = jaxrsBinder(binder);
+                            if (!yamlMapperEnabled) {
+                                jaxrsBinder.disableYamlExceptionMapper();
+                            }
+                            jaxrsBinder.bind(ResourceWithYaml.class);
+                        },
+                        new TestingNodeModule(),
+                        new JaxrsModule(),
+                        new JsonModule(),
+                        new YamlModule(),
+                        new TestingHttpServerModule(getClass().getName()))
+                        .quiet()
+                        .doNotInitializeLogging()
+                        .initialize();
+            }
+            catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            baseUri = injector.getInstance(TestingHttpServer.class).getBaseUrl();
+            client = new JettyHttpClient(new HttpClientConfig());
+        }
+
+        @Override
+        public void close()
+        {
+            client.close();
+            injector.getInstance(LifeCycleManager.class).stop();
+        }
+    }
+}

--- a/json/src/main/java/io/airlift/json/BaseJacksonProvider.java
+++ b/json/src/main/java/io/airlift/json/BaseJacksonProvider.java
@@ -43,7 +43,7 @@ public abstract class BaseJacksonProvider<V, U extends BaseJacksonProvider<V, U>
     private Map<Class<?>, JsonSerializer<?>> jsonSerializers;
     private Map<Class<?>, JsonDeserializer<?>> jsonDeserializers;
 
-    private final Set<JsonSubType> jsonSubTypes = new HashSet<>();
+    private final Set<JacksonSubType> jacksonSubTypes = new HashSet<>();
 
     protected BaseJacksonProvider(JsonFactoryBuilder jsonFactoryBuilder)
     {
@@ -193,14 +193,14 @@ public abstract class BaseJacksonProvider<V, U extends BaseJacksonProvider<V, U>
     }
 
     @Inject(optional = true)
-    public void setJsonSubTypes(Set<JsonSubType> jsonSubTypes)
+    public void setJacksonSubTypes(Set<JacksonSubType> jacksonSubTypes)
     {
-        this.jsonSubTypes.addAll(jsonSubTypes);
+        this.jacksonSubTypes.addAll(jacksonSubTypes);
     }
 
-    public U withJsonSubTypes(Set<JsonSubType> jsonSubTypes)
+    public U withJacksonSubTypes(Set<JacksonSubType> jacksonSubTypes)
     {
-        setJsonSubTypes(jsonSubTypes);
+        setJacksonSubTypes(jacksonSubTypes);
         return (U) this;
     }
 
@@ -231,8 +231,8 @@ public abstract class BaseJacksonProvider<V, U extends BaseJacksonProvider<V, U>
             jsonMapper.addModule(module);
         }
 
-        for (JsonSubType jsonSubType : jsonSubTypes) {
-            jsonSubType.modules()
+        for (JacksonSubType jacksonSubType : jacksonSubTypes) {
+            jacksonSubType.modules()
                     .forEach(jsonMapper::addModule);
         }
 

--- a/json/src/main/java/io/airlift/json/BaseJacksonProvider.java
+++ b/json/src/main/java/io/airlift/json/BaseJacksonProvider.java
@@ -2,12 +2,11 @@ package io.airlift.json;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonFactoryBuilder;
-import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.fasterxml.jackson.core.StreamReadFeature;
 import com.fasterxml.jackson.core.StreamWriteConstraints;
 import com.fasterxml.jackson.core.StreamWriteFeature;
+import com.fasterxml.jackson.core.TSFBuilder;
 import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.core.util.JsonRecyclerPools;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -16,8 +15,9 @@ import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.KeyDeserializer;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.cfg.MapperBuilder;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
@@ -32,11 +32,15 @@ import com.google.inject.Provider;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 
-public abstract class BaseJacksonProvider<V, U extends BaseJacksonProvider<V, U>>
-        implements Provider<V>
+public abstract class BaseJacksonProvider<
+        M extends ObjectMapper,
+        B extends MapperBuilder<? extends M, B>,
+        U extends BaseJacksonProvider<M, B, U>>
+        implements Provider<M>
 {
-    private final JsonMapper.Builder jsonMapper;
+    private final B mapperBuilder;
 
     private Map<Class<?>, JsonSerializer<?>> keySerializers;
     private Map<Class<?>, KeyDeserializer> keyDeserializers;
@@ -45,10 +49,12 @@ public abstract class BaseJacksonProvider<V, U extends BaseJacksonProvider<V, U>
 
     private final Set<JacksonSubType> jacksonSubTypes = new HashSet<>();
 
-    protected BaseJacksonProvider(JsonFactoryBuilder jsonFactoryBuilder)
+    protected <F extends JsonFactory> BaseJacksonProvider(
+            TSFBuilder<F, ?> factoryBuilder,
+            Function<F, B> mapperBuilderFactory)
     {
         // Disable the length limit, caller will be responsible for validating the input length
-        jsonFactoryBuilder.streamReadConstraints(StreamReadConstraints
+        factoryBuilder.streamReadConstraints(StreamReadConstraints
                 .builder()
                 .maxStringLength(Integer.MAX_VALUE)
                 .maxNestingDepth(Integer.MAX_VALUE)
@@ -56,14 +62,14 @@ public abstract class BaseJacksonProvider<V, U extends BaseJacksonProvider<V, U>
                 .maxDocumentLength(Long.MAX_VALUE)
                 .build());
 
-        jsonFactoryBuilder.streamWriteConstraints(StreamWriteConstraints
+        factoryBuilder.streamWriteConstraints(StreamWriteConstraints
                 .builder()
                 .maxNestingDepth(Integer.MAX_VALUE)
                 .build());
 
-        jsonFactoryBuilder.enable(StreamWriteFeature.USE_FAST_DOUBLE_WRITER);
-        jsonFactoryBuilder.enable(StreamReadFeature.USE_FAST_BIG_NUMBER_PARSER);
-        jsonFactoryBuilder.enable(StreamReadFeature.USE_FAST_DOUBLE_PARSER);
+        factoryBuilder.enable(StreamWriteFeature.USE_FAST_DOUBLE_WRITER);
+        factoryBuilder.enable(StreamReadFeature.USE_FAST_BIG_NUMBER_PARSER);
+        factoryBuilder.enable(StreamReadFeature.USE_FAST_DOUBLE_PARSER);
 
         /*
          * When multiple threads deserialize JSON responses concurrently,
@@ -77,59 +83,59 @@ public abstract class BaseJacksonProvider<V, U extends BaseJacksonProvider<V, U>
          *
          * See: https://github.com/FasterXML/jackson-core/issues/332.
          */
-        jsonFactoryBuilder.disable(JsonFactory.Feature.INTERN_FIELD_NAMES);
-        jsonFactoryBuilder.recyclerPool(JsonRecyclerPools.threadLocalPool());
+        factoryBuilder.disable(JsonFactory.Feature.INTERN_FIELD_NAMES);
+        factoryBuilder.recyclerPool(JsonRecyclerPools.threadLocalPool());
 
-        jsonMapper = JsonMapper.builder(jsonFactoryBuilder.build());
+        mapperBuilder = mapperBuilderFactory.apply(factoryBuilder.build());
 
         // ignore unknown fields (for backwards compatibility)
-        jsonMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+        mapperBuilder.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 
         // do not allow converting a float to an integer
-        jsonMapper.disable(DeserializationFeature.ACCEPT_FLOAT_AS_INT);
+        mapperBuilder.disable(DeserializationFeature.ACCEPT_FLOAT_AS_INT);
 
         // use ISO dates
-        jsonMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        mapperBuilder.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
         // Fail if there are trailing tokens after entity was read and mapped
-        jsonMapper.enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
-
-        // When serialization fails in the middle, it's better to return a truncated (invalid) JSON
-        // than something that could be interpreted as a valid (but incorrect) result.
-        // This is especially applicable to server endpoints that return JSON responses.
-        jsonMapper.disable(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT);
+        mapperBuilder.enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
 
         // Skip fields that are null or absent (Optional) when serializing objects.
         // This only applies to mapped object fields, not containers like Map or List.
-        jsonMapper.defaultPropertyInclusion(JsonInclude.Value.construct(JsonInclude.Include.NON_ABSENT, JsonInclude.Include.ALWAYS));
+        mapperBuilder.defaultPropertyInclusion(JsonInclude.Value.construct(JsonInclude.Include.NON_ABSENT, JsonInclude.Include.ALWAYS));
 
         // disable auto detection of json properties... all properties must be explicit
-        jsonMapper.disable(MapperFeature.AUTO_DETECT_CREATORS);
-        jsonMapper.disable(MapperFeature.AUTO_DETECT_FIELDS);
-        jsonMapper.disable(MapperFeature.AUTO_DETECT_SETTERS);
-        jsonMapper.disable(MapperFeature.AUTO_DETECT_GETTERS);
-        jsonMapper.disable(MapperFeature.AUTO_DETECT_IS_GETTERS);
-        jsonMapper.disable(MapperFeature.USE_GETTERS_AS_SETTERS);
-        jsonMapper.disable(MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS);
-        jsonMapper.disable(MapperFeature.INFER_PROPERTY_MUTATORS);
-        jsonMapper.disable(MapperFeature.ALLOW_FINAL_FIELDS_AS_MUTATORS);
+        mapperBuilder.disable(MapperFeature.AUTO_DETECT_CREATORS);
+        mapperBuilder.disable(MapperFeature.AUTO_DETECT_FIELDS);
+        mapperBuilder.disable(MapperFeature.AUTO_DETECT_SETTERS);
+        mapperBuilder.disable(MapperFeature.AUTO_DETECT_GETTERS);
+        mapperBuilder.disable(MapperFeature.AUTO_DETECT_IS_GETTERS);
+        mapperBuilder.disable(MapperFeature.USE_GETTERS_AS_SETTERS);
+        mapperBuilder.disable(MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS);
+        mapperBuilder.disable(MapperFeature.INFER_PROPERTY_MUTATORS);
+        mapperBuilder.disable(MapperFeature.ALLOW_FINAL_FIELDS_AS_MUTATORS);
 
-        jsonMapper.addModule(new Jdk8Module());
-        jsonMapper.addModule(new JavaTimeModule());
-        jsonMapper.addModule(new GuavaModule());
-        jsonMapper.addModule(new ParameterNamesModule());
-        jsonMapper.addModule(new RecordAutoDetectModule());
+        mapperBuilder.addModule(new Jdk8Module());
+        mapperBuilder.addModule(new JavaTimeModule());
+        mapperBuilder.addModule(new GuavaModule());
+        mapperBuilder.addModule(new ParameterNamesModule());
+        mapperBuilder.addModule(new RecordAutoDetectModule());
         // Replace reflection-based bean access with runtime-generated accessors (LambdaMetafactory).
         // Property detection is unchanged (still driven by explicit annotations above); only the
         // get/set mechanism is faster, reducing CPU and allocation on serialization/deserialization.
-        jsonMapper.addModule(new BlackbirdModule());
+        mapperBuilder.addModule(new BlackbirdModule());
 
         try {
             getClass().getClassLoader().loadClass("org.joda.time.DateTime");
-            jsonMapper.addModule(new JodaModule());
+            mapperBuilder.addModule(new JodaModule());
         }
         catch (ClassNotFoundException ignored) {
         }
+    }
+
+    protected final B mapperBuilder()
+    {
+        return mapperBuilder;
     }
 
     @Inject(optional = true)
@@ -183,7 +189,7 @@ public abstract class BaseJacksonProvider<V, U extends BaseJacksonProvider<V, U>
     @Inject(optional = true)
     public void setModules(Set<com.fasterxml.jackson.databind.Module> modules)
     {
-        modules.forEach(jsonMapper::addModule);
+        modules.forEach(mapperBuilder::addModule);
     }
 
     public U withModules(Set<Module> modules)
@@ -204,7 +210,7 @@ public abstract class BaseJacksonProvider<V, U extends BaseJacksonProvider<V, U>
         return (U) this;
     }
 
-    protected JsonMapper create()
+    protected M create()
     {
         if (jsonSerializers != null || jsonDeserializers != null || keySerializers != null || keyDeserializers != null) {
             SimpleModule module = new SimpleModule(getClass().getName(), new Version(1, 0, 0, null, null, null));
@@ -228,15 +234,15 @@ public abstract class BaseJacksonProvider<V, U extends BaseJacksonProvider<V, U>
                     module.addKeyDeserializer(entry.getKey(), entry.getValue());
                 }
             }
-            jsonMapper.addModule(module);
+            mapperBuilder.addModule(module);
         }
 
         for (JacksonSubType jacksonSubType : jacksonSubTypes) {
             jacksonSubType.modules()
-                    .forEach(jsonMapper::addModule);
+                    .forEach(mapperBuilder::addModule);
         }
 
-        return jsonMapper.build();
+        return mapperBuilder.build();
     }
 
     //

--- a/json/src/main/java/io/airlift/json/JacksonSubType.java
+++ b/json/src/main/java/io/airlift/json/JacksonSubType.java
@@ -54,11 +54,11 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.util.Objects.requireNonNull;
 
-public class JsonSubType
+public class JacksonSubType
 {
     private final Set<Module> modules;
 
-    public static JsonSubType.Builder builder()
+    public static JacksonSubType.Builder builder()
     {
         return new Builder();
     }
@@ -81,7 +81,7 @@ public class JsonSubType
 
         <T> SubTypeSubBuilder<T> forBase(Class<T> baseClass, String propertyName);
 
-        JsonSubType build();
+        JacksonSubType build();
     }
 
     public static class Builder
@@ -124,9 +124,9 @@ public class JsonSubType
                 }
 
                 @Override
-                public JsonSubType build()
+                public JacksonSubType build()
                 {
-                    return new JsonSubType(modules.build());
+                    return new JacksonSubType(modules.build());
                 }
             };
         }
@@ -137,7 +137,7 @@ public class JsonSubType
         return modules;
     }
 
-    private JsonSubType(Set<Module> modules)
+    private JacksonSubType(Set<Module> modules)
     {
         this.modules = modules;
     }

--- a/json/src/main/java/io/airlift/json/JacksonSubTypeBinder.java
+++ b/json/src/main/java/io/airlift/json/JacksonSubTypeBinder.java
@@ -18,22 +18,22 @@ import com.google.inject.multibindings.Multibinder;
 
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
 
-public class JsonSubTypeBinder
+public class JacksonSubTypeBinder
 {
-    private final Multibinder<JsonSubType> subTypeBinder;
+    private final Multibinder<JacksonSubType> subTypeBinder;
 
-    public static JsonSubTypeBinder jsonSubTypeBinder(Binder binder)
+    public static JacksonSubTypeBinder jacksonSubTypeBinder(Binder binder)
     {
-        return new JsonSubTypeBinder(binder);
+        return new JacksonSubTypeBinder(binder);
     }
 
-    public void bindJsonSubType(JsonSubType jsonSubType)
+    public void bindJacksonSubType(JacksonSubType jacksonSubType)
     {
-        subTypeBinder.addBinding().toInstance(jsonSubType);
+        subTypeBinder.addBinding().toInstance(jacksonSubType);
     }
 
-    private JsonSubTypeBinder(Binder binder)
+    private JacksonSubTypeBinder(Binder binder)
     {
-        subTypeBinder = newSetBinder(binder, JsonSubType.class);
+        subTypeBinder = newSetBinder(binder, JacksonSubType.class);
     }
 }

--- a/json/src/main/java/io/airlift/json/JsonCodec.java
+++ b/json/src/main/java/io/airlift/json/JsonCodec.java
@@ -16,10 +16,10 @@
 package io.airlift.json;
 
 import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
-import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.google.common.base.Suppliers;
 import com.google.common.reflect.TypeParameter;
 import com.google.common.reflect.TypeToken;
@@ -42,7 +42,7 @@ import static java.util.Objects.requireNonNull;
 @ThreadSafe
 public class JsonCodec<T>
 {
-    private static final JsonMapper JSON_MAPPER = new JsonMapperProvider().get()
+    private static final ObjectMapper JSON_MAPPER = new JsonMapperProvider().get()
             .rebuild()
             .enable(INDENT_OUTPUT)
             .build();
@@ -114,7 +114,7 @@ public class JsonCodec<T>
     private final Supplier<ObjectWriter> writer;
     private final Supplier<ObjectReader> reader;
 
-    JsonCodec(JsonMapper mapper, Type type)
+    JsonCodec(ObjectMapper mapper, Type type)
     {
         JavaType javaType = mapper.constructType(type);
         this.typeToken = (TypeToken<T>) TypeToken.of(type);

--- a/json/src/main/java/io/airlift/json/JsonCodecFactory.java
+++ b/json/src/main/java/io/airlift/json/JsonCodecFactory.java
@@ -15,6 +15,7 @@
  */
 package io.airlift.json;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.google.common.reflect.TypeParameter;
 import com.google.common.reflect.TypeToken;
@@ -30,7 +31,7 @@ import static java.util.Objects.requireNonNull;
 
 public class JsonCodecFactory
 {
-    private final JsonMapper jsonMapper;
+    private final ObjectMapper jsonMapper;
 
     public JsonCodecFactory()
     {
@@ -40,7 +41,7 @@ public class JsonCodecFactory
     @Inject
     public JsonCodecFactory(JsonMapper jsonMapper)
     {
-        this.jsonMapper = requireNonNull(jsonMapper, "jsonMapper is null");
+        this((ObjectMapper) jsonMapper);
     }
 
     @Deprecated
@@ -53,6 +54,11 @@ public class JsonCodecFactory
     public JsonCodecFactory(Provider<JsonMapper> jsonMapperProvider, boolean prettyPrint)
     {
         this(withPrettyPrint(jsonMapperProvider.get(), prettyPrint));
+    }
+
+    private JsonCodecFactory(ObjectMapper jsonMapper)
+    {
+        this.jsonMapper = requireNonNull(jsonMapper, "jsonMapper is null");
     }
 
     public JsonCodecFactory prettyPrint()
@@ -129,14 +135,11 @@ public class JsonCodecFactory
         return new JsonCodec<>(jsonMapper, mapType);
     }
 
-    private static JsonMapper withPrettyPrint(JsonMapper mapper, boolean prettyPrint)
+    private static ObjectMapper withPrettyPrint(ObjectMapper mapper, boolean prettyPrint)
     {
         if (!prettyPrint) {
             return mapper;
         }
-        return mapper
-                .rebuild()
-                .configure(INDENT_OUTPUT, true)
-                .build();
+        return mapper.copy().enable(INDENT_OUTPUT);
     }
 }

--- a/json/src/main/java/io/airlift/json/JsonMapperProvider.java
+++ b/json/src/main/java/io/airlift/json/JsonMapperProvider.java
@@ -17,12 +17,13 @@ package io.airlift.json;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonFactoryBuilder;
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 
 import static java.util.Objects.requireNonNull;
 
 public class JsonMapperProvider
-        extends BaseJacksonProvider<JsonMapper, JsonMapperProvider>
+        extends BaseJacksonProvider<JsonMapper, JsonMapper.Builder, JsonMapperProvider>
 {
     public JsonMapperProvider()
     {
@@ -36,7 +37,12 @@ public class JsonMapperProvider
 
     private JsonMapperProvider(JsonFactoryBuilder jsonFactoryBuilder)
     {
-        super(jsonFactoryBuilder);
+        super(jsonFactoryBuilder, JsonMapper::builder);
+
+        // When serialization fails in the middle, it's better to return a truncated (invalid) JSON
+        // than something that could be interpreted as a valid (but incorrect) result.
+        // This is especially applicable to server endpoints that return JSON responses.
+        mapperBuilder().disable(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT);
     }
 
     @Override

--- a/json/src/main/java/io/airlift/json/LengthLimitedWriter.java
+++ b/json/src/main/java/io/airlift/json/LengthLimitedWriter.java
@@ -5,7 +5,7 @@ import java.io.Writer;
 
 import static java.util.Objects.requireNonNull;
 
-class LengthLimitedWriter
+public class LengthLimitedWriter
         extends Writer
 {
     private final Writer writer;

--- a/json/src/main/java/io/airlift/json/ObjectMapperProvider.java
+++ b/json/src/main/java/io/airlift/json/ObjectMapperProvider.java
@@ -2,7 +2,9 @@ package io.airlift.json;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonFactoryBuilder;
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 
 import static java.util.Objects.requireNonNull;
 
@@ -11,7 +13,7 @@ import static java.util.Objects.requireNonNull;
  */
 @Deprecated
 public class ObjectMapperProvider
-        extends BaseJacksonProvider<ObjectMapper, ObjectMapperProvider>
+        extends BaseJacksonProvider<ObjectMapper, JsonMapper.Builder, ObjectMapperProvider>
 {
     public ObjectMapperProvider()
     {
@@ -25,7 +27,12 @@ public class ObjectMapperProvider
 
     private ObjectMapperProvider(JsonFactoryBuilder jsonFactoryBuilder)
     {
-        super(jsonFactoryBuilder);
+        super(jsonFactoryBuilder, JsonMapper::builder);
+
+        // When serialization fails in the middle, it's better to return a truncated (invalid) JSON
+        // than something that could be interpreted as a valid (but incorrect) result.
+        // This is especially applicable to server endpoints that return JSON responses.
+        mapperBuilder().disable(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT);
     }
 
     @Override

--- a/json/src/test/java/io/airlift/json/subtype/TestJacksonSubType.java
+++ b/json/src/test/java/io/airlift/json/subtype/TestJacksonSubType.java
@@ -21,22 +21,22 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import io.airlift.json.JacksonSubType;
 import io.airlift.json.JsonCodec;
 import io.airlift.json.JsonCodecFactory;
 import io.airlift.json.JsonMapperProvider;
 import io.airlift.json.JsonModule;
-import io.airlift.json.JsonSubType;
 import io.airlift.json.subtype.Employee.Manager;
 import io.airlift.json.subtype.Employee.Programmer;
 import io.airlift.json.subtype.Part.Container;
 import io.airlift.json.subtype.Part.Item;
 import org.junit.jupiter.api.Test;
 
-import static io.airlift.json.JsonSubTypeBinder.jsonSubTypeBinder;
+import static io.airlift.json.JacksonSubTypeBinder.jacksonSubTypeBinder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class TestJsonSubType
+public class TestJacksonSubType
 {
     private static final Employee programmer1 = new Programmer("Joe");
     private static final Employee programmer2 = new Programmer("Rachel");
@@ -52,12 +52,12 @@ public class TestJsonSubType
     public void testAddBinding()
             throws Exception
     {
-        JsonSubType jsonSubType = JsonSubType.builder()
+        JacksonSubType jacksonSubType = JacksonSubType.builder()
                 .forBase(Employee.class, "type")
                 .add(Programmer.class)
                 .add(Manager.class)
                 .build();
-        Injector injector = Guice.createInjector(new JsonModule(), binder -> jsonSubTypeBinder(binder).bindJsonSubType(jsonSubType));
+        Injector injector = Guice.createInjector(new JsonModule(), binder -> jacksonSubTypeBinder(binder).bindJacksonSubType(jacksonSubType));
         JsonMapper jsonMapper = injector.getInstance(JsonMapper.class);
 
         internalTest(jsonMapper);
@@ -67,12 +67,12 @@ public class TestJsonSubType
     public void testAddBindingSpecifiedNames()
             throws Exception
     {
-        JsonSubType jsonSubType = JsonSubType.builder()
+        JacksonSubType jacksonSubType = JacksonSubType.builder()
                 .forBase(Employee.class, "specified")
                 .add(Programmer.class, "foo")
                 .add(Manager.class, "bar")
                 .build();
-        Injector injector = Guice.createInjector(new JsonModule(), binder -> jsonSubTypeBinder(binder).bindJsonSubType(jsonSubType));
+        Injector injector = Guice.createInjector(new JsonModule(), binder -> jacksonSubTypeBinder(binder).bindJacksonSubType(jacksonSubType));
         JsonMapper jsonMapper = injector.getInstance(JsonMapper.class);
 
         internalTest(jsonMapper);
@@ -82,11 +82,11 @@ public class TestJsonSubType
     public void testAddPermittedSubClassBindings()
             throws Exception
     {
-        JsonSubType jsonSubType = JsonSubType.builder()
+        JacksonSubType jacksonSubType = JacksonSubType.builder()
                 .forBase(Employee.class, "type")
                 .addPermittedSubClasses()
                 .build();
-        Injector injector = Guice.createInjector(new JsonModule(), binder -> jsonSubTypeBinder(binder).bindJsonSubType(jsonSubType));
+        Injector injector = Guice.createInjector(new JsonModule(), binder -> jacksonSubTypeBinder(binder).bindJacksonSubType(jacksonSubType));
         JsonMapper jsonMapper = injector.getInstance(JsonMapper.class);
 
         internalTest(jsonMapper);
@@ -96,11 +96,11 @@ public class TestJsonSubType
     public void testAddPermittedSubClassBindingsSpecifiedNames()
             throws Exception
     {
-        JsonSubType jsonSubType = JsonSubType.builder()
+        JacksonSubType jacksonSubType = JacksonSubType.builder()
                 .forBase(Employee.class, "bogus")
                 .addPermittedSubClasses(clazz -> "xxx__" + clazz.getName() + "__XXX")
                 .build();
-        Injector injector = Guice.createInjector(new JsonModule(), binder -> jsonSubTypeBinder(binder).bindJsonSubType(jsonSubType));
+        Injector injector = Guice.createInjector(new JsonModule(), binder -> jacksonSubTypeBinder(binder).bindJacksonSubType(jacksonSubType));
         JsonMapper jsonMapper = injector.getInstance(JsonMapper.class);
 
         internalTest(jsonMapper);
@@ -118,11 +118,11 @@ public class TestJsonSubType
     @Test
     public void testFailsWhenMissingBindings()
     {
-        JsonSubType jsonSubType = JsonSubType.builder()
+        JacksonSubType jacksonSubType = JacksonSubType.builder()
                 .forBase(Employee.class, "type")
                 .add(Programmer.class)
                 .build();
-        Injector injector = Guice.createInjector(new JsonModule(), binder -> jsonSubTypeBinder(binder).bindJsonSubType(jsonSubType));
+        Injector injector = Guice.createInjector(new JsonModule(), binder -> jacksonSubTypeBinder(binder).bindJacksonSubType(jacksonSubType));
         JsonMapper jsonMapper = injector.getInstance(JsonMapper.class);
 
         assertThatThrownBy(() -> internalTest(jsonMapper))
@@ -133,14 +133,14 @@ public class TestJsonSubType
     public void testBuildMultipleTypes()
             throws Exception
     {
-        JsonSubType jsonSubType = JsonSubType.builder()
+        JacksonSubType jacksonSubType = JacksonSubType.builder()
                 .forBase(Employee.class, "type")
                 .addPermittedSubClasses()
                 .forBase(Part.class, "category")
                 .addPermittedSubClasses()
                 .build();
 
-        Injector injector = Guice.createInjector(new JsonModule(), binder -> jsonSubTypeBinder(binder).bindJsonSubType(jsonSubType));
+        Injector injector = Guice.createInjector(new JsonModule(), binder -> jacksonSubTypeBinder(binder).bindJacksonSubType(jacksonSubType));
         JsonMapper jsonMapper = injector.getInstance(JsonMapper.class);
 
         internalTest(jsonMapper);
@@ -171,13 +171,13 @@ public class TestJsonSubType
     public void testStandalone()
             throws Exception
     {
-        JsonSubType jsonSubType = JsonSubType.builder()
+        JacksonSubType jacksonSubType = JacksonSubType.builder()
                 .forBase(Employee.class, "type")
                 .add(Programmer.class)
                 .add(Manager.class)
                 .build();
 
-        JsonMapperProvider jsonMapperProvider = new JsonMapperProvider().withJsonSubTypes(ImmutableSet.of(jsonSubType));
+        JsonMapperProvider jsonMapperProvider = new JsonMapperProvider().withJacksonSubTypes(ImmutableSet.of(jacksonSubType));
 
         internalTest(jsonMapperProvider.get());
     }
@@ -186,21 +186,21 @@ public class TestJsonSubType
     public void testExpectedJson()
             throws Exception
     {
-        JsonSubType jsonSubType1 = JsonSubType.builder()
+        JacksonSubType jacksonSubType1 = JacksonSubType.builder()
                 .forBase(Employee.class, "type")
                 .add(Programmer.class)
                 .add(Manager.class)
                 .build();
-        JsonMapper jsonMapper1 = new JsonMapperProvider().withJsonSubTypes(ImmutableSet.of(jsonSubType1)).get();
+        JsonMapper jsonMapper1 = new JsonMapperProvider().withJacksonSubTypes(ImmutableSet.of(jacksonSubType1)).get();
         String programmer1Json = jsonMapper1.writeValueAsString(programmer1);
         String manager1Json = jsonMapper1.writeValueAsString(manager1);
 
-        JsonSubType jsonSubType2 = JsonSubType.builder()
+        JacksonSubType jacksonSubType2 = JacksonSubType.builder()
                 .forBase(Employee.class, "category")
                 .add(Programmer.class)
                 .add(Manager.class)
                 .build();
-        JsonMapper jsonMapper2 = new JsonMapperProvider().withJsonSubTypes(ImmutableSet.of(jsonSubType2)).get();
+        JsonMapper jsonMapper2 = new JsonMapperProvider().withJacksonSubTypes(ImmutableSet.of(jacksonSubType2)).get();
         String programmer2Json = jsonMapper2.writeValueAsString(programmer1);
         String manager2Json = jsonMapper2.writeValueAsString(manager1);
 

--- a/mcp/src/main/java/io/airlift/mcp/McpModule.java
+++ b/mcp/src/main/java/io/airlift/mcp/McpModule.java
@@ -15,8 +15,8 @@ import com.google.inject.multibindings.Multibinder;
 import com.google.inject.multibindings.OptionalBinder;
 import com.google.inject.name.Names;
 import com.google.inject.util.Types;
-import io.airlift.json.JsonSubType;
-import io.airlift.json.JsonSubTypeBinder;
+import io.airlift.json.JacksonSubType;
+import io.airlift.json.JacksonSubTypeBinder;
 import io.airlift.mcp.handler.CompletionEntry;
 import io.airlift.mcp.handler.PromptEntry;
 import io.airlift.mcp.handler.ResourceEntry;
@@ -71,8 +71,8 @@ import static com.google.inject.Scopes.SINGLETON;
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.configuration.ConfigBinder.configBinder;
+import static io.airlift.json.JacksonSubTypeBinder.jacksonSubTypeBinder;
 import static io.airlift.json.JsonBinder.jsonBinder;
-import static io.airlift.json.JsonSubTypeBinder.jsonSubTypeBinder;
 import static io.airlift.mcp.reflection.ReflectionHelper.forAllInClass;
 import static io.airlift.mcp.reflection.SkillsHelper.resourceFromSkill;
 import static io.airlift.mcp.reflection.SkillsHelper.resourceTemplateFromSkillTemplate;
@@ -151,9 +151,9 @@ public class McpModule
     }
 
     @VisibleForTesting
-    public static JsonSubType buildJsonSubType()
+    public static JacksonSubType buildJacksonSubType()
     {
-        return JsonSubType.builder()
+        return JacksonSubType.builder()
                 .forBase(Content.class, "type")
                 .add(TextContent.class, "text")
                 .add(ImageContent.class, "image")
@@ -352,7 +352,7 @@ public class McpModule
         bindPrompts(binder);
         bindResources(binder);
         bindResourceTemplates(binder);
-        bindJsonSubTypes(binder);
+        bindJacksonSubTypes(binder);
         bindIdentityMapper(binder);
         bindCompletions(binder);
         bindSessions(binder);
@@ -446,11 +446,11 @@ public class McpModule
         tools.forEach(tool -> toolsBinder.addBinding().toProvider(tool).in(SINGLETON));
     }
 
-    private void bindJsonSubTypes(Binder binder)
+    private void bindJacksonSubTypes(Binder binder)
     {
-        JsonSubType jsonSubType = buildJsonSubType();
+        JacksonSubType jacksonSubType = buildJacksonSubType();
 
-        JsonSubTypeBinder jsonSubTypeBinder = jsonSubTypeBinder(binder);
-        jsonSubTypeBinder.bindJsonSubType(jsonSubType);
+        JacksonSubTypeBinder jacksonSubTypeBinder = jacksonSubTypeBinder(binder);
+        jacksonSubTypeBinder.bindJacksonSubType(jacksonSubType);
     }
 }

--- a/mcp/src/test/java/io/airlift/mcp/TestSerializationEdgeCases.java
+++ b/mcp/src/test/java/io/airlift/mcp/TestSerializationEdgeCases.java
@@ -6,8 +6,8 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import io.airlift.json.JacksonSubType;
 import io.airlift.json.JsonMapperProvider;
-import io.airlift.json.JsonSubType;
 import io.airlift.log.Logger;
 import io.airlift.mcp.model.CallToolRequest;
 import io.airlift.mcp.model.GetPromptRequest;
@@ -50,9 +50,9 @@ public class TestSerializationEdgeCases
 
     public TestSerializationEdgeCases()
     {
-        JsonSubType jsonSubType = McpModule.buildJsonSubType();
+        JacksonSubType jacksonSubType = McpModule.buildJacksonSubType();
         JsonMapperProvider jsonMapperProvider = new JsonMapperProvider()
-                .withJsonSubTypes(ImmutableSet.of(jsonSubType));
+                .withJacksonSubTypes(ImmutableSet.of(jacksonSubType));
         jsonMapper = jsonMapperProvider.get();
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -316,6 +316,12 @@
             </dependency>
 
             <dependency>
+                <groupId>io.airlift</groupId>
+                <artifactId>yaml</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>io.github.wasabithumb</groupId>
                 <artifactId>jtoml-all</artifactId>
                 <version>1.5.2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
         <module>stats</module>
         <module>testing</module>
         <module>tracing</module>
+        <module>yaml</module>
     </modules>
 
     <scm>
@@ -385,6 +386,12 @@
                         <artifactId>jakarta.activation-api</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+                <version>2.5</version>
             </dependency>
 
         </dependencies>

--- a/yaml/pom.xml
+++ b/yaml/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.airlift</groupId>
+        <artifactId>airlift</artifactId>
+        <version>435-SNAPSHOT</version>
+    </parent>
+    <artifactId>yaml</artifactId>
+    <packaging>jar</packaging>
+    <name>yaml</name>
+    <description>Airlift - YAML support</description>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+            <classifier>classes</classifier>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+        </dependency>
+
+        <!-- for testing -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/yaml/src/main/java/io/airlift/yaml/YamlBinder.java
+++ b/yaml/src/main/java/io/airlift/yaml/YamlBinder.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.yaml;
+
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.KeyDeserializer;
+import com.fasterxml.jackson.databind.Module;
+import com.google.inject.Binder;
+import com.google.inject.binder.LinkedBindingBuilder;
+import io.airlift.json.JsonBinder;
+
+import static io.airlift.json.JsonBinder.jsonBinder;
+
+/**
+ * Facade over {@link JsonBinder} for callers that want to bind Jackson customizations from
+ * code that already works with YAML. Bindings registered here go into the same multibinders the
+ * JSON mapper reads. Modules, serializers, deserializers, and key serdes registered through
+ * either binder are visible to both the {@code JsonMapper} and the {@code YAMLMapper}.
+ *
+ * <p>If a need arises to bind a customization to one format only we can add a format-qualified
+ * binding path instead of separate binders.
+ */
+public class YamlBinder
+{
+    private final JsonBinder delegate;
+
+    public static YamlBinder yamlBinder(Binder binder)
+    {
+        return new YamlBinder(binder);
+    }
+
+    private YamlBinder(Binder binder)
+    {
+        this.delegate = jsonBinder(binder);
+    }
+
+    public LinkedBindingBuilder<JsonSerializer<?>> addKeySerializerBinding(Class<?> type)
+    {
+        return delegate.addKeySerializerBinding(type);
+    }
+
+    public LinkedBindingBuilder<KeyDeserializer> addKeyDeserializerBinding(Class<?> type)
+    {
+        return delegate.addKeyDeserializerBinding(type);
+    }
+
+    public LinkedBindingBuilder<JsonSerializer<?>> addSerializerBinding(Class<?> type)
+    {
+        return delegate.addSerializerBinding(type);
+    }
+
+    public LinkedBindingBuilder<JsonDeserializer<?>> addDeserializerBinding(Class<?> type)
+    {
+        return delegate.addDeserializerBinding(type);
+    }
+
+    public LinkedBindingBuilder<Module> addModuleBinding()
+    {
+        return delegate.addModuleBinding();
+    }
+
+    public <T> void bindSerializer(JsonSerializer<T> jsonSerializer)
+    {
+        delegate.bindSerializer(jsonSerializer);
+    }
+}

--- a/yaml/src/main/java/io/airlift/yaml/YamlCodec.java
+++ b/yaml/src/main/java/io/airlift/yaml/YamlCodec.java
@@ -1,0 +1,221 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.yaml;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+import com.google.common.base.Suppliers;
+import com.google.common.reflect.TypeParameter;
+import com.google.common.reflect.TypeToken;
+import com.google.errorprone.annotations.ThreadSafe;
+import io.airlift.json.LengthLimitedWriter;
+import io.airlift.json.LengthLimitedWriter.LengthLimitExceededException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.io.StringWriter;
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static java.util.Objects.requireNonNull;
+
+@ThreadSafe
+public class YamlCodec<T>
+{
+    private static final ObjectMapper YAML_MAPPER = new YamlMapperProvider().get();
+
+    public static <T> YamlCodec<T> yamlCodec(Class<T> type)
+    {
+        requireNonNull(type, "type is null");
+
+        return new YamlCodec<>(YAML_MAPPER, type);
+    }
+
+    public static <T> YamlCodec<T> yamlCodec(TypeToken<T> type)
+    {
+        requireNonNull(type, "type is null");
+
+        return new YamlCodec<>(YAML_MAPPER, type.getType());
+    }
+
+    public static <T> YamlCodec<List<T>> listYamlCodec(Class<T> type)
+    {
+        requireNonNull(type, "type is null");
+
+        Type listType = new TypeToken<List<T>>() {}
+                .where(new TypeParameter<>() {}, type)
+                .getType();
+
+        return new YamlCodec<>(YAML_MAPPER, listType);
+    }
+
+    public static <T> YamlCodec<List<T>> listYamlCodec(YamlCodec<T> type)
+    {
+        requireNonNull(type, "type is null");
+
+        Type listType = new TypeToken<List<T>>() {}
+                .where(new TypeParameter<>() {}, type.getTypeToken())
+                .getType();
+
+        return new YamlCodec<>(YAML_MAPPER, listType);
+    }
+
+    public static <K, V> YamlCodec<Map<K, V>> mapYamlCodec(Class<K> keyType, Class<V> valueType)
+    {
+        requireNonNull(keyType, "keyType is null");
+        requireNonNull(valueType, "valueType is null");
+
+        Type mapType = new TypeToken<Map<K, V>>() {}
+                .where(new TypeParameter<>() {}, keyType)
+                .where(new TypeParameter<>() {}, valueType)
+                .getType();
+
+        return new YamlCodec<>(YAML_MAPPER, mapType);
+    }
+
+    public static <K, V> YamlCodec<Map<K, V>> mapYamlCodec(Class<K> keyType, YamlCodec<V> valueType)
+    {
+        requireNonNull(keyType, "keyType is null");
+        requireNonNull(valueType, "valueType is null");
+
+        Type mapType = new TypeToken<Map<K, V>>() {}
+                .where(new TypeParameter<>() {}, keyType)
+                .where(new TypeParameter<>() {}, valueType.getTypeToken())
+                .getType();
+
+        return new YamlCodec<>(YAML_MAPPER, mapType);
+    }
+
+    private final TypeToken<T> typeToken;
+    private final Type type;
+    private final Supplier<ObjectWriter> writer;
+    private final Supplier<ObjectReader> reader;
+
+    YamlCodec(ObjectMapper mapper, Type type)
+    {
+        JavaType javaType = mapper.constructType(type);
+        this.typeToken = (TypeToken<T>) TypeToken.of(type);
+        this.type = javaType;
+        this.writer = Suppliers.memoize(() -> mapper.writerFor(javaType));
+        this.reader = Suppliers.memoize(() -> mapper.readerFor(javaType));
+    }
+
+    public Type getType()
+    {
+        return type;
+    }
+
+    public T fromYaml(String yaml)
+            throws IllegalArgumentException
+    {
+        try {
+            return reader.get().readValue(yaml);
+        }
+        catch (Exception e) {
+            throw mapException(e, "string", type);
+        }
+    }
+
+    public String toYaml(T instance)
+            throws IllegalArgumentException
+    {
+        try {
+            return writer.get().writeValueAsString(instance);
+        }
+        catch (IOException e) {
+            throw new IllegalArgumentException("%s could not be converted to YAML".formatted(instance.getClass().getName()), e);
+        }
+    }
+
+    public Optional<String> toYamlWithLengthLimit(T instance, int lengthLimit)
+    {
+        try (StringWriter stringWriter = new StringWriter();
+                LengthLimitedWriter lengthLimitedWriter = new LengthLimitedWriter(stringWriter, lengthLimit)) {
+            writer.get().writeValue(lengthLimitedWriter, instance);
+            return Optional.of(stringWriter.getBuffer().toString());
+        }
+        catch (LengthLimitExceededException e) {
+            return Optional.empty();
+        }
+        catch (IOException e) {
+            throw new IllegalArgumentException("%s could not be converted to YAML".formatted(instance.getClass().getName()), e);
+        }
+    }
+
+    public T fromYaml(byte[] yaml)
+            throws IllegalArgumentException
+    {
+        try {
+            return reader.get().readValue(yaml);
+        }
+        catch (Exception e) {
+            throw mapException(e, "bytes", type);
+        }
+    }
+
+    public byte[] toYamlBytes(T instance)
+            throws IllegalArgumentException
+    {
+        try {
+            return writer.get().writeValueAsBytes(instance);
+        }
+        catch (IOException e) {
+            throw new IllegalArgumentException("%s could not be converted to YAML".formatted(instance.getClass().getName()), e);
+        }
+    }
+
+    public T fromYaml(InputStream yaml)
+            throws IllegalArgumentException
+    {
+        try {
+            return reader.get().readValue(yaml);
+        }
+        catch (Exception e) {
+            throw mapException(e, "stream", type);
+        }
+    }
+
+    public T fromYaml(Reader yaml)
+            throws IllegalArgumentException
+    {
+        try {
+            return reader.get().readValue(yaml);
+        }
+        catch (Exception e) {
+            throw mapException(e, "characters", type);
+        }
+    }
+
+    private static IllegalArgumentException mapException(Exception e, String source, Type type)
+    {
+        return switch (e) {
+            case MismatchedInputException mismatchedInputException when mismatchedInputException.getMessage().contains("not allowed as per `DeserializationFeature.FAIL_ON_TRAILING_TOKENS`") -> new IllegalArgumentException("Found characters after the expected end of input", e);
+            case IllegalArgumentException iae -> iae;
+            default -> new IllegalArgumentException("Invalid YAML %s for %s".formatted(source, type), e);
+        };
+    }
+
+    @SuppressWarnings("unchecked")
+    TypeToken<T> getTypeToken()
+    {
+        return typeToken;
+    }
+}

--- a/yaml/src/main/java/io/airlift/yaml/YamlCodecBinder.java
+++ b/yaml/src/main/java/io/airlift/yaml/YamlCodecBinder.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.yaml;
+
+import com.google.inject.Binder;
+import com.google.inject.Key;
+import com.google.inject.Scopes;
+import com.google.inject.TypeLiteral;
+import com.google.inject.internal.MoreTypes.ParameterizedTypeImpl;
+
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+public class YamlCodecBinder
+{
+    private final Binder binder;
+
+    public static YamlCodecBinder yamlCodecBinder(Binder binder)
+    {
+        return new YamlCodecBinder(binder);
+    }
+
+    private YamlCodecBinder(Binder binder)
+    {
+        this.binder = requireNonNull(binder, "binder is null").skipSources(getClass());
+    }
+
+    public void bindYamlCodec(Class<?> type)
+    {
+        requireNonNull(type, "type is null");
+
+        binder.bind(getYamlCodecKey(type)).toProvider(new YamlCodecProvider(type)).in(Scopes.SINGLETON);
+    }
+
+    public void bindYamlCodec(TypeLiteral<?> type)
+    {
+        requireNonNull(type, "type is null");
+
+        binder.bind(getYamlCodecKey(type.getType())).toProvider(new YamlCodecProvider(type.getType())).in(Scopes.SINGLETON);
+    }
+
+    public void bindListYamlCodec(Class<?> type)
+    {
+        requireNonNull(type, "type is null");
+
+        ParameterizedTypeImpl listType = new ParameterizedTypeImpl(null, List.class, type);
+        binder.bind(getYamlCodecKey(listType)).toProvider(new YamlCodecProvider(listType)).in(Scopes.SINGLETON);
+    }
+
+    public void bindListYamlCodec(YamlCodec<?> type)
+    {
+        requireNonNull(type, "type is null");
+
+        ParameterizedTypeImpl listType = new ParameterizedTypeImpl(null, List.class, type.getTypeToken().getType());
+        binder.bind(getYamlCodecKey(listType)).toProvider(new YamlCodecProvider(listType)).in(Scopes.SINGLETON);
+    }
+
+    public void bindMapYamlCodec(Class<?> keyType, Class<?> valueType)
+    {
+        requireNonNull(keyType, "keyType is null");
+        requireNonNull(valueType, "valueType is null");
+
+        ParameterizedTypeImpl mapType = new ParameterizedTypeImpl(null, Map.class, keyType, valueType);
+        binder.bind(getYamlCodecKey(mapType)).toProvider(new YamlCodecProvider(mapType)).in(Scopes.SINGLETON);
+    }
+
+    public void bindMapYamlCodec(Class<?> keyType, YamlCodec<?> valueType)
+    {
+        requireNonNull(keyType, "keyType is null");
+        requireNonNull(valueType, "valueType is null");
+
+        ParameterizedTypeImpl mapType = new ParameterizedTypeImpl(null, Map.class, keyType, valueType.getTypeToken().getType());
+        binder.bind(getYamlCodecKey(mapType)).toProvider(new YamlCodecProvider(mapType)).in(Scopes.SINGLETON);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Key<YamlCodec<?>> getYamlCodecKey(Type type)
+    {
+        return (Key<YamlCodec<?>>) Key.get(new ParameterizedTypeImpl(null, YamlCodec.class, type));
+    }
+}

--- a/yaml/src/main/java/io/airlift/yaml/YamlCodecFactory.java
+++ b/yaml/src/main/java/io/airlift/yaml/YamlCodecFactory.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.yaml;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import com.google.common.reflect.TypeParameter;
+import com.google.common.reflect.TypeToken;
+import com.google.inject.Inject;
+
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+public class YamlCodecFactory
+{
+    private final ObjectMapper yamlMapper;
+
+    public YamlCodecFactory()
+    {
+        this(new YamlMapperProvider().get());
+    }
+
+    @Inject
+    public YamlCodecFactory(YAMLMapper yamlMapper)
+    {
+        this((ObjectMapper) yamlMapper);
+    }
+
+    private YamlCodecFactory(ObjectMapper yamlMapper)
+    {
+        this.yamlMapper = requireNonNull(yamlMapper, "yamlMapper is null");
+    }
+
+    /**
+     * No-op for symmetry with JsonCodecFactory. YAML output is block-formatted regardless of
+     * SerializationFeature.INDENT_OUTPUT, so there is no practical difference between a default
+     * and a "pretty" YAML codec.
+     */
+    public YamlCodecFactory prettyPrint()
+    {
+        return this;
+    }
+
+    public <T> YamlCodec<T> yamlCodec(Class<T> type)
+    {
+        requireNonNull(type, "type is null");
+
+        return new YamlCodec<>(yamlMapper, type);
+    }
+
+    public <T> YamlCodec<T> yamlCodec(Type type)
+    {
+        requireNonNull(type, "type is null");
+
+        return new YamlCodec<>(yamlMapper, type);
+    }
+
+    public <T> YamlCodec<T> yamlCodec(TypeToken<T> type)
+    {
+        requireNonNull(type, "type is null");
+
+        return new YamlCodec<>(yamlMapper, type.getType());
+    }
+
+    public <T> YamlCodec<List<T>> listYamlCodec(Class<T> type)
+    {
+        requireNonNull(type, "type is null");
+
+        Type listType = new TypeToken<List<T>>() {}
+                .where(new TypeParameter<>() {}, type)
+                .getType();
+
+        return new YamlCodec<>(yamlMapper, listType);
+    }
+
+    public <T> YamlCodec<List<T>> listYamlCodec(YamlCodec<T> type)
+    {
+        requireNonNull(type, "type is null");
+
+        Type listType = new TypeToken<List<T>>() {}
+                .where(new TypeParameter<>() {}, type.getTypeToken())
+                .getType();
+
+        return new YamlCodec<>(yamlMapper, listType);
+    }
+
+    public <K, V> YamlCodec<Map<K, V>> mapYamlCodec(Class<K> keyType, Class<V> valueType)
+    {
+        requireNonNull(keyType, "keyType is null");
+        requireNonNull(valueType, "valueType is null");
+
+        Type mapType = new TypeToken<Map<K, V>>() {}
+                .where(new TypeParameter<>() {}, keyType)
+                .where(new TypeParameter<>() {}, valueType)
+                .getType();
+
+        return new YamlCodec<>(yamlMapper, mapType);
+    }
+
+    public <K, V> YamlCodec<Map<K, V>> mapYamlCodec(Class<K> keyType, YamlCodec<V> valueType)
+    {
+        requireNonNull(keyType, "keyType is null");
+        requireNonNull(valueType, "valueType is null");
+
+        Type mapType = new TypeToken<Map<K, V>>() {}
+                .where(new TypeParameter<>() {}, keyType)
+                .where(new TypeParameter<>() {}, valueType.getTypeToken())
+                .getType();
+
+        return new YamlCodec<>(yamlMapper, mapType);
+    }
+}

--- a/yaml/src/main/java/io/airlift/yaml/YamlCodecProvider.java
+++ b/yaml/src/main/java/io/airlift/yaml/YamlCodecProvider.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.yaml;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+
+import java.lang.reflect.Type;
+
+class YamlCodecProvider
+        implements Provider<YamlCodec<?>>
+{
+    private final Type type;
+    private YamlCodecFactory yamlCodecFactory;
+
+    public YamlCodecProvider(Type type)
+    {
+        this.type = type;
+    }
+
+    @Inject
+    public void setYamlCodecFactory(YamlCodecFactory yamlCodecFactory)
+    {
+        this.yamlCodecFactory = yamlCodecFactory;
+    }
+
+    @Override
+    public YamlCodec<?> get()
+    {
+        return yamlCodecFactory.yamlCodec(type);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        YamlCodecProvider that = (YamlCodecProvider) o;
+
+        if (!type.equals(that.type)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return type.hashCode();
+    }
+}

--- a/yaml/src/main/java/io/airlift/yaml/YamlMapperProvider.java
+++ b/yaml/src/main/java/io/airlift/yaml/YamlMapperProvider.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.yaml;
+
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactoryBuilder;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import io.airlift.json.BaseJacksonProvider;
+import org.yaml.snakeyaml.LoaderOptions;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+public class YamlMapperProvider
+        extends BaseJacksonProvider<YAMLMapper, YAMLMapper.Builder, YamlMapperProvider>
+{
+    public YamlMapperProvider()
+    {
+        this(yamlFactoryBuilder());
+    }
+
+    private YamlMapperProvider(YAMLFactoryBuilder yamlFactoryBuilder)
+    {
+        super(yamlFactoryBuilder, YAMLMapper::builder);
+
+        // YAML defaults tuned for human-readable output
+        Map<YAMLGenerator.Feature, Boolean> defaults = new EnumMap<>(YAMLGenerator.Feature.class);
+        // Emit unquoted strings where YAML grammar allows
+        defaults.put(YAMLGenerator.Feature.MINIMIZE_QUOTES, true);
+        // Use `|` for multi-line strings
+        defaults.put(YAMLGenerator.Feature.LITERAL_BLOCK_STYLE, true);
+        // Do not wrap long lines
+        defaults.put(YAMLGenerator.Feature.SPLIT_LINES, false);
+        // Indent nested arrays for readability
+        defaults.put(YAMLGenerator.Feature.INDENT_ARRAYS, true);
+        defaults.put(YAMLGenerator.Feature.INDENT_ARRAYS_WITH_INDICATOR, true);
+        // Do not emit `---` at the top of documents
+        defaults.put(YAMLGenerator.Feature.WRITE_DOC_START_MARKER, false);
+        // SnakeYAML truncates keys over 128 chars by default
+        defaults.put(YAMLGenerator.Feature.ALLOW_LONG_KEYS, true);
+
+        defaults.forEach((feature, enabled) -> {
+            if (enabled) {
+                mapperBuilder().enable(feature);
+            }
+            else {
+                mapperBuilder().disable(feature);
+            }
+        });
+    }
+
+    public YamlMapperProvider withGeneratorFeature(YAMLGenerator.Feature feature, boolean enabled)
+    {
+        requireNonNull(feature, "feature is null");
+        if (enabled) {
+            mapperBuilder().enable(feature);
+        }
+        else {
+            mapperBuilder().disable(feature);
+        }
+        return this;
+    }
+
+    @Override
+    public YAMLMapper get()
+    {
+        return create();
+    }
+
+    private static YAMLFactoryBuilder yamlFactoryBuilder()
+    {
+        // SnakeYAML enforces its own limits independent of Jackson's StreamReadConstraints.
+        // Lift the codepoint limit so callers control input length (consistent with the JSON
+        // base provider) and disallow duplicate keys for correctness.
+        LoaderOptions loaderOptions = new LoaderOptions();
+        loaderOptions.setCodePointLimit(Integer.MAX_VALUE);
+        loaderOptions.setAllowDuplicateKeys(false);
+
+        YAMLFactoryBuilder builder = YAMLFactory.builder();
+        builder.loaderOptions(loaderOptions);
+        return builder;
+    }
+}

--- a/yaml/src/main/java/io/airlift/yaml/YamlModule.java
+++ b/yaml/src/main/java/io/airlift/yaml/YamlModule.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.yaml;
+
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+
+public class YamlModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        // NOTE: this MUST NOT be a singleton because ObjectMappers are mutable. This means
+        // one component could reconfigure the mapper and break all other components.
+        binder.bind(YAMLMapper.class).toProvider(YamlMapperProvider.class);
+        binder.bind(YamlCodecFactory.class).in(Scopes.SINGLETON);
+    }
+}

--- a/yaml/src/test/java/io/airlift/yaml/Person.java
+++ b/yaml/src/test/java/io/airlift/yaml/Person.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.yaml;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+
+public class Person
+{
+    private String name;
+    private boolean rocks;
+    private Optional<String> lastName;
+
+    @JsonProperty
+    public String getName()
+    {
+        return name;
+    }
+
+    @JsonProperty
+    public Person setName(String name)
+    {
+        this.name = name;
+        return this;
+    }
+
+    @JsonProperty
+    public boolean isRocks()
+    {
+        return rocks;
+    }
+
+    @JsonProperty
+    public Person setRocks(boolean rocks)
+    {
+        this.rocks = rocks;
+        return this;
+    }
+
+    @JsonProperty
+    public Optional<String> getLastName()
+    {
+        return lastName;
+    }
+
+    @JsonProperty
+    public void setLastName(Optional<String> lastName)
+    {
+        this.lastName = lastName;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        Person o = (Person) obj;
+        return Objects.equals(this.name, o.name) &&
+                this.rocks == o.rocks;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(name, rocks);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("name", name)
+                .add("rocks", rocks)
+                .add("lastName", lastName)
+                .toString();
+    }
+}

--- a/yaml/src/test/java/io/airlift/yaml/TestYamlCodec.java
+++ b/yaml/src/test/java/io/airlift/yaml/TestYamlCodec.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.yaml;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStreamReader;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.airlift.yaml.YamlCodec.listYamlCodec;
+import static io.airlift.yaml.YamlCodec.mapYamlCodec;
+import static io.airlift.yaml.YamlCodec.yamlCodec;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestYamlCodec
+{
+    @Test
+    public void testYamlCodec()
+    {
+        YamlCodec<Person> codec = yamlCodec(Person.class);
+
+        Person expected = new Person().setName("dain").setRocks(true);
+        expected.setLastName(Optional.of("Awesome"));
+
+        String yaml = codec.toYaml(expected);
+        assertThat(yaml).contains("name");
+        assertThat(yaml).contains("lastName");
+        assertThat(codec.fromYaml(yaml)).isEqualTo(expected);
+
+        byte[] bytes = codec.toYamlBytes(expected);
+        assertThat(codec.fromYaml(bytes)).isEqualTo(expected);
+        assertThat(codec.fromYaml(new ByteArrayInputStream(bytes))).isEqualTo(expected);
+        assertThat(codec.fromYaml(new InputStreamReader(new ByteArrayInputStream(bytes), UTF_8))).isEqualTo(expected);
+    }
+
+    @Test
+    public void testListYamlCodec()
+    {
+        YamlCodec<List<Person>> codec = listYamlCodec(Person.class);
+
+        ImmutableList<Person> expected = ImmutableList.of(
+                new Person().setName("dain").setRocks(true),
+                new Person().setName("martin").setRocks(true));
+
+        String yaml = codec.toYaml(expected);
+        assertThat(codec.fromYaml(yaml)).isEqualTo(expected);
+    }
+
+    @Test
+    public void testMapYamlCodec()
+    {
+        YamlCodec<Map<String, Person>> codec = mapYamlCodec(String.class, Person.class);
+
+        ImmutableMap<String, Person> expected = ImmutableMap.<String, Person>builder()
+                .put("dain", new Person().setName("dain").setRocks(true))
+                .put("martin", new Person().setName("martin").setRocks(true))
+                .build();
+
+        String yaml = codec.toYaml(expected);
+        assertThat(codec.fromYaml(yaml)).isEqualTo(expected);
+    }
+
+    @Test
+    public void testTypeToken()
+    {
+        YamlCodec<List<Person>> codec = yamlCodec(new TypeToken<>() {});
+
+        ImmutableList<Person> expected = ImmutableList.of(
+                new Person().setName("dain").setRocks(true),
+                new Person().setName("martin").setRocks(true));
+
+        assertThat(codec.fromYaml(codec.toYaml(expected))).isEqualTo(expected);
+    }
+
+    @Test
+    public void testMultiDocumentYamlIsRejected()
+    {
+        // FAIL_ON_TRAILING_TOKENS is inherited from the JSON base provider.
+        // Multi-document YAML (a `---`-separated second document) counts as trailing tokens.
+        String multiDoc =
+                """
+                name: dain
+                rocks: true
+                ---
+                name: martin
+                rocks: true
+                """;
+
+        YamlCodec<Person> codec = yamlCodec(Person.class);
+        assertThatThrownBy(() -> codec.fromYaml(multiDoc))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void testDuplicateKeyYamlIsRejected()
+    {
+        // SnakeYAML setAllowDuplicateKeys(false), duplicate keys are a correctness bug.
+        String duplicate =
+                """
+                name: dain
+                name: martin
+                rocks: true
+                """;
+
+        YamlCodec<Person> codec = yamlCodec(Person.class);
+        assertThatThrownBy(() -> codec.fromYaml(duplicate))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void testLargeYamlInputIsAccepted()
+    {
+        // SnakeYAML's default codepoint limit is 3MB. Use ~4MB to prove that it's removed.
+        String bigValue = "x".repeat(4 * 1024 * 1024);
+        Person expected = new Person().setName(bigValue).setRocks(true);
+
+        YamlCodec<Person> codec = yamlCodec(Person.class);
+        String yaml = codec.toYaml(expected);
+        assertThat(codec.fromYaml(yaml)).isEqualTo(expected);
+    }
+
+    @Test
+    public void testPrettyPrintIsNoOp()
+    {
+        // YAML output is block-formatted regardless of SerializationFeature.INDENT_OUTPUT.
+        // The prettyPrint() method is provided for API symmetry with JsonCodecFactory.
+        YamlCodecFactory plain = new YamlCodecFactory();
+        YamlCodecFactory pretty = plain.prettyPrint();
+
+        Person expected = new Person().setName("dain").setRocks(true);
+        String plainYaml = plain.yamlCodec(Person.class).toYaml(expected);
+        String prettyYaml = pretty.yamlCodec(Person.class).toYaml(expected);
+
+        assertThat(prettyYaml).isEqualTo(plainYaml);
+    }
+
+    @Test
+    public void testGeneratorFeatureDefaults()
+    {
+        // Snapshot the human-readable defaults the provider sets so a future change is visible.
+        Person expected = new Person().setName("dain").setRocks(true);
+
+        String yaml = yamlCodec(Person.class).toYaml(expected);
+
+        // WRITE_DOC_START_MARKER = false (no `---` prefix).
+        assertThat(yaml).doesNotStartWith("---");
+        // MINIMIZE_QUOTES = true ("dain" emits unquoted).
+        assertThat(yaml).contains("name: dain");
+        assertThat(yaml).doesNotContain("name: \"dain\"");
+    }
+}

--- a/yaml/src/test/java/io/airlift/yaml/TestYamlCodecBinder.java
+++ b/yaml/src/test/java/io/airlift/yaml/TestYamlCodecBinder.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.yaml;
+
+import com.google.inject.Guice;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.Scopes;
+import com.google.inject.TypeLiteral;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static io.airlift.yaml.YamlCodec.listYamlCodec;
+import static io.airlift.yaml.YamlCodecBinder.yamlCodecBinder;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestYamlCodecBinder
+{
+    @Test
+    public void ignoresRepeatedBinding()
+    {
+        Injector injector = Guice.createInjector(
+                new YamlModule(),
+                binder -> {
+                    yamlCodecBinder(binder).bindYamlCodec(Integer.class);
+                    yamlCodecBinder(binder).bindYamlCodec(Integer.class);
+
+                    binder.bind(Dummy.class).in(Scopes.SINGLETON);
+                });
+
+        assertThat(injector.getInstance(Dummy.class).getCodec()).isNotNull();
+    }
+
+    @Test
+    public void testMapListYamlCodec()
+    {
+        Injector injector = Guice.createInjector(
+                new YamlModule(),
+                binder -> yamlCodecBinder(binder).bindMapYamlCodec(String.class, listYamlCodec(Dummy.class)));
+
+        assertThat(injector.getInstance(Key.get(new TypeLiteral<YamlCodec<Map<String, List<Dummy>>>>() {})))
+                .isNotNull();
+    }
+
+    private static class Dummy
+    {
+        private final YamlCodec<Integer> codec;
+
+        @Inject
+        public Dummy(YamlCodec<Integer> codec)
+        {
+            this.codec = codec;
+        }
+
+        public YamlCodec<Integer> getCodec()
+        {
+            return codec;
+        }
+    }
+}

--- a/yaml/src/test/java/io/airlift/yaml/TestYamlModule.java
+++ b/yaml/src/test/java/io/airlift/yaml/TestYamlModule.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.yaml;
+
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static io.airlift.yaml.YamlBinder.yamlBinder;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestYamlModule
+{
+    @Test
+    public void testYamlCodecFactoryBinding()
+    {
+        Injector injector = Guice.createInjector(new YamlModule());
+        YamlCodecFactory codecFactory = injector.getInstance(YamlCodecFactory.class);
+
+        Person expected = new Person().setName("dain").setRocks(true);
+        expected.setLastName(Optional.of("Awesome"));
+
+        YamlCodec<Person> codec = codecFactory.yamlCodec(Person.class);
+        assertThat(codec.fromYaml(codec.toYaml(expected))).isEqualTo(expected);
+
+        YamlCodec<List<Person>> listCodec = codecFactory.listYamlCodec(Person.class);
+        assertThat(listCodec.fromYaml(listCodec.toYaml(List.of(expected)))).containsExactly(expected);
+    }
+
+    @Test
+    public void testYamlBinderSharesSerializersWithJson()
+    {
+        // YamlBinder delegates to JsonBinder's shared multibinders. A serializer registered through
+        // YamlBinder is visible to the YAML mapper (and would also be visible to the JSON mapper
+        // if it were bound).
+        Injector injector = Guice.createInjector(
+                new YamlModule(),
+                binder -> yamlBinder(binder)
+                        .addSerializerBinding(BoxedName.class)
+                        .toInstance(ToStringSerializer.instance));
+
+        YAMLMapper mapper = injector.getInstance(YAMLMapper.class);
+        BoxedName expected = new BoxedName("dain");
+
+        try {
+            String yaml = mapper.writeValueAsString(expected);
+            assertThat(yaml).contains("dain");
+        }
+        catch (Exception e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    public static class BoxedName
+    {
+        private final String name;
+
+        public BoxedName(String name)
+        {
+            this.name = name;
+        }
+
+        @Override
+        public String toString()
+        {
+            return name;
+        }
+    }
+}


### PR DESCRIPTION
Preparatory refactors that make the `json` module's internals reusable across
Jackson formats (JSON, YAML, ...), with no behavior change. This unblocks the
YAML work that follows.

### Changes
- **Rename `JsonSubType` to `JacksonSubType`** (and `JsonSubTypeBinder` to
  `JacksonSubTypeBinder`). The subtype-binding API uses Jackson's underlying
  machinery, not JSON specifically. Callers in `mcp` and `api` are updated.
- **Generalize `BaseJacksonProvider`** from concrete `JsonFactoryBuilder` /
  `JsonMapper.Builder` to `TSFBuilder` / `MapperBuilder` so subclasses can supply
  any Jackson factory/mapper (e.g. a YAML one). The JSON-specific
  `AUTO_CLOSE_JSON_CONTENT` disable moves into the JSON providers where it applies.
- **Widen `JsonCodec`'s internal mapper type to `ObjectMapper`** so a future
  `YamlCodec` can mirror the structure without a second base class.

> **Stack (1/5)** - this is the base of the YAML support stack:
> - json refactors (this PR) #2032
> - YAML core #2033
> - JAX-RS #2034
> - http-client #2035
> - payload limit #2036

# Airlift contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [x] All automated tests are passing.
 - [ ] Pull request was categorized using one of the existing labels.
