### PR TITLE
Ignore 5xx API status validation

### DIFF
--- a/api/src/main/java/io/airlift/api/binding/JaxrsStatusValidator.java
+++ b/api/src/main/java/io/airlift/api/binding/JaxrsStatusValidator.java
@@ -34,10 +34,13 @@ public class JaxrsStatusValidator
     @Override
     public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
     {
-        if ((responseContext.getStatusInfo().getFamily() != Response.Status.Family.SUCCESSFUL)) {
-            findApiServiceMethod(requestContext, modelServices).ifPresent(modelMethod ->
-                    validateApiError(modelMethod, requestContext.getMethod(), responseContext.getStatus(), requestContext.getUriInfo().getRequestUri()));
+        Response.Status.Family family = responseContext.getStatusInfo().getFamily();
+        if ((family == Response.Status.Family.SUCCESSFUL) || (family == Response.Status.Family.SERVER_ERROR)) {
+            return;
         }
+
+        findApiServiceMethod(requestContext, modelServices).ifPresent(modelMethod ->
+                validateApiError(modelMethod, requestContext.getMethod(), responseContext.getStatus(), requestContext.getUriInfo().getRequestUri()));
     }
 
     private void validateApiError(ModelMethod modelMethod, String httpMethod, int statusCode, URI uri)

--- a/api/src/test/java/io/airlift/api/servertests/standard/StandardService.java
+++ b/api/src/test/java/io/airlift/api/servertests/standard/StandardService.java
@@ -11,11 +11,13 @@ import io.airlift.api.ApiService;
 import io.airlift.api.ApiType;
 import io.airlift.api.ApiUpdate;
 import io.airlift.api.ServiceType;
+import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Request;
 
 import java.util.Optional;
 
+import static jakarta.ws.rs.core.Response.Status.SERVICE_UNAVAILABLE;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -84,6 +86,12 @@ public class StandardService
     public Thing getFromLookup(@ApiParameter LookupId lookupId)
     {
         return new Thing(new ApiResourceVersion(1), new ThingId(), lookupId.toInternal().id(), 0, Optional.empty());
+    }
+
+    @ApiCustom(type = ApiType.GET, verb = "unavailable", description = "Unavailable things")
+    public Thing getUnavailableThing(@ApiParameter ThingId thingId)
+    {
+        throw new WebApplicationException(SERVICE_UNAVAILABLE);
     }
 
     @ApiCreate(description = "dummy")

--- a/api/src/test/java/io/airlift/api/servertests/standard/TestApiMethods.java
+++ b/api/src/test/java/io/airlift/api/servertests/standard/TestApiMethods.java
@@ -25,6 +25,7 @@ import static io.airlift.http.client.HeaderNames.CONTENT_TYPE;
 import static io.airlift.http.client.HttpStatus.BAD_REQUEST;
 import static io.airlift.http.client.HttpStatus.NOT_FOUND;
 import static io.airlift.http.client.HttpStatus.NO_CONTENT;
+import static io.airlift.http.client.HttpStatus.SERVICE_UNAVAILABLE;
 import static io.airlift.http.client.JsonBodyGenerator.jsonBodyGenerator;
 import static io.airlift.http.client.JsonResponseHandler.createJsonResponseHandler;
 import static io.airlift.http.client.Request.Builder.prepareGet;
@@ -317,6 +318,15 @@ public class TestApiMethods
                 .build();
         StringResponse response = httpClient.execute(request, createStringResponseHandler());
         assertThat(response.getStatusCode()).isEqualTo(BAD_REQUEST.code());
+    }
+
+    @Test
+    public void testUnspecifiedServerErrorStatus()
+    {
+        URI uri = UriBuilder.fromUri(baseUri).path("public/api/v1/thing/{thingId}:unavailable").build(new ThingId("12345"));
+        Request request = prepareGet().setUri(uri).build();
+        StatusResponse response = httpClient.execute(request, createStatusResponseHandler());
+        assertThat(response.getStatusCode()).isEqualTo(SERVICE_UNAVAILABLE.code());
     }
 
     private <T> void genericUpdateTest(T thing, ThingId thingId, JsonCodec<T> jsonCodec, int expectedResponseCode)


### PR DESCRIPTION
## Why
- Server error responses are not endpoint-specific API contract outcomes; they can be produced by exception paths, filters, infrastructure, or framework-level failures.
- Treating undeclared 5xx statuses as missing response annotations makes DEBUG mode replace the original failure.
- Warning on undeclared 5xx statuses still suggests every endpoint should document generic server errors, which adds annotation noise without improving client-visible contracts.

## Approach
- Skip undeclared-status validation for server-error response families while leaving existing validation for non-server-error responses intact.