### PR TITLE
Add native OpenTelemetry metrics export

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -119,6 +119,12 @@
 
             <dependency>
                 <groupId>io.airlift</groupId>
+                <artifactId>metrics</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.airlift</groupId>
                 <artifactId>node</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/docs/add_metrics.md
+++ b/docs/add_metrics.md
@@ -144,3 +144,22 @@ mvn exec:java -Dexec.mainClass=example.Service -Dnode.environment=test
 
 Open `jconsole` or your preferred JMX tool and locate the "example" MBean. You will see the count
 increment for each time you `curl http://localhost:8080/v1/service`.
+
+### Metrics backend
+
+Airlift statistics objects such as `CounterStat`, `TimeStat`, `TimeDistribution`,
+`DistributionStat`, and `Distribution` use the Airlift metrics backend by default. This backend
+maintains the existing decayed windows and JMX/OpenMetrics compatibility behavior.
+
+Services that export directly to OpenTelemetry can select the OpenTelemetry stats backend with the
+system property:
+
+```
+-Dio.airlift.stats.backend=open-telemetry
+```
+
+The backend must be selected before any Airlift stats object is created. In OpenTelemetry mode,
+histogram-shaped stats collect into native base-2 exponential histograms, and counters keep only
+their total count. Decayed windows such as one-minute, five-minute, and fifteen-minute stats are not
+created in this mode. Use the default Airlift backend when JMX or the OpenMetrics endpoint needs the
+full decayed-window view.

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -8,10 +8,10 @@
         <version>437-SNAPSHOT</version>
     </parent>
 
-    <artifactId>openmetrics</artifactId>
+    <artifactId>metrics</artifactId>
     <packaging>jar</packaging>
-    <name>openmetrics</name>
-    <description>Airlift - OpenMetrics support</description>
+    <name>metrics</name>
+    <description>Airlift - Metrics discovery</description>
 
     <dependencies>
         <dependency>
@@ -27,12 +27,17 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
-            <artifactId>jaxrs</artifactId>
+            <artifactId>configuration</artifactId>
         </dependency>
 
         <dependency>
             <groupId>io.airlift</groupId>
-            <artifactId>metrics</artifactId>
+            <artifactId>log</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>node</artifactId>
         </dependency>
 
         <dependency>
@@ -41,8 +46,14 @@
         </dependency>
 
         <dependency>
-            <groupId>jakarta.ws.rs</groupId>
-            <artifactId>jakarta.ws.rs-api</artifactId>
+            <groupId>org.weakref</groupId>
+            <artifactId>jmxutils</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>configuration-testing</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/metrics/src/main/java/io/airlift/metrics/CollectedMetricGroup.java
+++ b/metrics/src/main/java/io/airlift/metrics/CollectedMetricGroup.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.metrics;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+public record CollectedMetricGroup(MetricSource source, Map<String, String> labels, List<Attribute> attributes)
+{
+    public CollectedMetricGroup
+    {
+        requireNonNull(source, "source is null");
+        labels = ImmutableMap.copyOf(requireNonNull(labels, "labels is null"));
+        attributes = ImmutableList.copyOf(requireNonNull(attributes, "attributes is null"));
+    }
+
+    public record Attribute(List<String> path, Object value, String description)
+    {
+        public Attribute
+        {
+            path = ImmutableList.copyOf(requireNonNull(path, "path is null"));
+            requireNonNull(value, "value is null");
+        }
+    }
+}

--- a/metrics/src/main/java/io/airlift/metrics/MetricSource.java
+++ b/metrics/src/main/java/io/airlift/metrics/MetricSource.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.metrics;
+
+import javax.management.ObjectName;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public sealed interface MetricSource
+{
+    record JmxMetricSource(ObjectName name)
+            implements MetricSource
+    {
+        public JmxMetricSource
+        {
+            requireNonNull(name, "name is null");
+        }
+    }
+
+    record ManagedMetricSource(String name, Optional<Class<?>> exportedType, Optional<String> originalName, Map<String, String> originalProperties)
+            implements MetricSource
+    {
+        public ManagedMetricSource(String name)
+        {
+            this(name, Optional.empty(), Optional.empty(), Map.of());
+        }
+
+        public ManagedMetricSource
+        {
+            requireNonNull(name, "name is null");
+            requireNonNull(exportedType, "exportedType is null");
+            requireNonNull(originalName, "originalName is null");
+            originalProperties = Map.copyOf(requireNonNull(originalProperties, "originalProperties is null"));
+        }
+    }
+}

--- a/metrics/src/main/java/io/airlift/metrics/MetricsCollector.java
+++ b/metrics/src/main/java/io/airlift/metrics/MetricsCollector.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.metrics;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import io.airlift.log.Logger;
+import io.airlift.metrics.MetricSource.JmxMetricSource;
+import io.airlift.metrics.MetricSource.ManagedMetricSource;
+import io.airlift.node.NodeInfo;
+import io.airlift.stats.CounterStat;
+import io.airlift.stats.Distribution;
+import io.airlift.stats.DistributionStat;
+import io.airlift.stats.TimeDistribution;
+import io.airlift.stats.TimeStat;
+import org.weakref.jmx.MBeanExporter;
+import org.weakref.jmx.ManagedClass;
+import org.weakref.jmx.ManagedObjectExport;
+
+import javax.management.InstanceNotFoundException;
+import javax.management.IntrospectionException;
+import javax.management.JMException;
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanInfo;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import javax.management.ReflectionException;
+import javax.management.openmbean.CompositeData;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+/// Discovers Airlift managed metrics and configured JMX metrics in their native form.
+public class MetricsCollector
+{
+    private static final Logger log = Logger.get(MetricsCollector.class);
+
+    private final MBeanServer mbeanServer;
+    private final MBeanExporter mbeanExporter;
+    private final List<ObjectName> allMetricsObjectNames;
+    private final Map<String, String> labels;
+
+    @Inject
+    public MetricsCollector(MBeanServer mbeanServer, MBeanExporter mbeanExporter, MetricsConfig metricsConfig, NodeInfo nodeInfo)
+    {
+        this.mbeanServer = requireNonNull(mbeanServer, "mbeanServer is null");
+        this.mbeanExporter = requireNonNull(mbeanExporter, "mbeanExporter is null");
+        requireNonNull(metricsConfig, "metricsConfig is null");
+        requireNonNull(nodeInfo, "nodeInfo is null");
+        this.allMetricsObjectNames = ImmutableList.copyOf(metricsConfig.getJmxObjectNames());
+        this.labels = ImmutableMap.copyOf(nodeInfo.getAnnotations());
+    }
+
+    public List<CollectedMetricGroup> collect()
+    {
+        return ImmutableList.<CollectedMetricGroup>builder()
+                .addAll(collectManagedClasses())
+                .addAll(collectMBeans())
+                .build();
+    }
+
+    private List<CollectedMetricGroup> collectManagedClasses()
+    {
+        return mbeanExporter.getManagedObjectExports().values().stream()
+                .map(export -> new CollectedMetricGroup(
+                        managedMetricSource(export),
+                        labels,
+                        collectManagedClassAttributes(List.of(), export.getManagedClass())))
+                .filter(group -> !group.attributes().isEmpty())
+                .collect(toImmutableList());
+    }
+
+    private static ManagedMetricSource managedMetricSource(ManagedObjectExport export)
+    {
+        return new ManagedMetricSource(
+                export.getObjectName().toString(),
+                export.getExportedType(),
+                export.getOriginalName(),
+                export.getOriginalProperties());
+    }
+
+    private static List<CollectedMetricGroup.Attribute> collectManagedClassAttributes(List<String> path, ManagedClass managedClass)
+    {
+        ImmutableList.Builder<CollectedMetricGroup.Attribute> metrics = ImmutableList.builder();
+
+        Map<String, ManagedClass> children = managedClass.getChildren();
+        for (String attributeName : managedClass.getAttributeNames()) {
+            List<String> attributePath = managedClass.isAttributeFlatten(attributeName) ? path : append(path, attributeName);
+            try {
+                String attributeDescription = managedClass.getAttributeDescription(attributeName);
+
+                ManagedClass child = children.get(attributeName);
+                if (child != null) {
+                    try {
+                        Object target = child.getTarget();
+                        if (isRawStat(target)) {
+                            metrics.add(new CollectedMetricGroup.Attribute(attributePath, target, attributeDescription));
+                            continue;
+                        }
+                    }
+                    catch (IllegalStateException _) {
+                    }
+                    metrics.addAll(collectManagedClassAttributes(attributePath, child));
+                }
+                else {
+                    Object attributeValue = managedClass.invokeAttribute(attributeName);
+                    if (attributeValue instanceof Number || attributeValue instanceof Boolean) {
+                        metrics.add(new CollectedMetricGroup.Attribute(attributePath, attributeValue, attributeDescription));
+                    }
+                }
+            }
+            catch (ReflectiveOperationException e) {
+                log.debug(e, "Unable to invoke getter for managed attribute %s on %s, skipping", String.join(".", attributePath), managedClass.getTargetClass().getName());
+            }
+        }
+
+        return metrics.build();
+    }
+
+    private static boolean isRawStat(Object value)
+    {
+        return value instanceof CounterStat ||
+                value instanceof TimeDistribution ||
+                value instanceof TimeStat ||
+                value instanceof Distribution ||
+                value instanceof DistributionStat;
+    }
+
+    private List<CollectedMetricGroup> collectMBeans()
+    {
+        return allMetricsObjectNames.stream()
+                .map(objectName -> mbeanServer.queryNames(objectName, null))
+                .flatMap(Set::stream)
+                .distinct()
+                .map(this::collectMBean)
+                .flatMap(Optional::stream)
+                .toList();
+    }
+
+    private Optional<CollectedMetricGroup> collectMBean(ObjectName objectName)
+    {
+        ImmutableList.Builder<CollectedMetricGroup.Attribute> attributes = ImmutableList.builder();
+        try {
+            MBeanInfo mbeanInfo = mbeanServer.getMBeanInfo(objectName);
+            for (MBeanAttributeInfo mBeanAttributeInfo : mbeanInfo.getAttributes()) {
+                collectMBeanAttribute(objectName, mBeanAttributeInfo.getName(), mBeanAttributeInfo.getDescription())
+                        .ifPresent(attributes::add);
+            }
+        }
+        catch (InstanceNotFoundException | IntrospectionException | ReflectionException e) {
+            log.debug(e, "Unable to get MBeanInfo for object %s, skipping", objectName.getCanonicalName());
+        }
+
+        List<CollectedMetricGroup.Attribute> collectedAttributes = attributes.build();
+        if (collectedAttributes.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(new CollectedMetricGroup(new JmxMetricSource(objectName), labels, collectedAttributes));
+    }
+
+    private Optional<CollectedMetricGroup.Attribute> collectMBeanAttribute(ObjectName objectName, String attributeName, String description)
+    {
+        try {
+            Object attributeValue = mbeanServer.getAttribute(objectName, attributeName);
+            return switch (attributeValue) {
+                case Number _, CompositeData _ -> Optional.of(new CollectedMetricGroup.Attribute(List.of(attributeName), attributeValue, description));
+                case null, default -> Optional.empty();
+            };
+        }
+        catch (JMException | RuntimeException e) {
+            log.debug(e, "Unable to get Metric for ObjectName %s and Attribute %s, skipping", objectName.getCanonicalName(), attributeName);
+            return Optional.empty();
+        }
+    }
+
+    private static List<String> append(List<String> path, String attributeName)
+    {
+        return ImmutableList.<String>builderWithExpectedSize(path.size() + 1)
+                .addAll(path)
+                .add(attributeName)
+                .build();
+    }
+}

--- a/metrics/src/main/java/io/airlift/metrics/MetricsConfig.java
+++ b/metrics/src/main/java/io/airlift/metrics/MetricsConfig.java
@@ -11,12 +11,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.airlift.openmetrics;
+package io.airlift.metrics;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
+import io.airlift.configuration.LegacyConfig;
 
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
@@ -36,7 +37,8 @@ public class MetricsConfig
         return jmxObjectNames;
     }
 
-    @Config("openmetrics.jmx-object-names")
+    @Config("metrics.jmx-object-names")
+    @LegacyConfig("openmetrics.jmx-object-names")
     @ConfigDescription("JMX object names to include when retrieving all metrics, separated by '|'")
     public MetricsConfig setJmxObjectNames(String names)
     {

--- a/metrics/src/main/java/io/airlift/metrics/MetricsModule.java
+++ b/metrics/src/main/java/io/airlift/metrics/MetricsModule.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.metrics;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+
+import static com.google.inject.Scopes.SINGLETON;
+import static io.airlift.configuration.ConfigBinder.configBinder;
+
+public class MetricsModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        configBinder(binder).bindConfig(MetricsConfig.class);
+        binder.bind(MetricsCollector.class).in(SINGLETON);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        return obj != null && obj.getClass() == getClass();
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return getClass().hashCode();
+    }
+}

--- a/metrics/src/test/java/io/airlift/metrics/TestMetricsCollector.java
+++ b/metrics/src/test/java/io/airlift/metrics/TestMetricsCollector.java
@@ -1,0 +1,358 @@
+package io.airlift.metrics;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.metrics.MetricSource.JmxMetricSource;
+import io.airlift.metrics.MetricSource.ManagedMetricSource;
+import io.airlift.node.NodeInfo;
+import io.airlift.stats.CounterStat;
+import io.airlift.stats.Distribution;
+import io.airlift.stats.DistributionStat;
+import io.airlift.stats.TimeDistribution;
+import io.airlift.stats.TimeStat;
+import io.airlift.testing.TestingTicker;
+import org.junit.jupiter.api.Test;
+import org.weakref.jmx.Flatten;
+import org.weakref.jmx.MBeanExporter;
+import org.weakref.jmx.Managed;
+import org.weakref.jmx.Nested;
+
+import javax.management.MBeanServer;
+import javax.management.MBeanServerFactory;
+import javax.management.ObjectName;
+import javax.management.StandardMBean;
+import javax.management.openmbean.CompositeData;
+import javax.management.openmbean.CompositeDataSupport;
+import javax.management.openmbean.CompositeType;
+import javax.management.openmbean.OpenType;
+import javax.management.openmbean.SimpleType;
+
+import java.util.List;
+import java.util.Map;
+
+import static io.airlift.node.NodeConfig.AddressSource.IP;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestMetricsCollector
+{
+    @Test
+    public void testCollectManagedNumericMetric()
+            throws Exception
+    {
+        MetricsCollector collector = createTestingCollector();
+
+        assertThat(collector.collect())
+                .anySatisfy(group -> {
+                    assertThat(group.source()).isEqualTo(new ManagedMetricSource("io.airlift.metrics.test:name=managed"));
+                    assertThat(group.labels()).isEqualTo(ImmutableMap.of("region", "b", "team", "a"));
+                    assertThat(group.attributes()).hasSizeGreaterThan(1);
+                });
+
+        assertThat(attributes(collector))
+                .anySatisfy(metric -> {
+                    assertThat(metric.path()).containsExactly("NumericGauge");
+                    assertThat(metric.value()).isEqualTo(7);
+                    assertThat(metric.description()).isEqualTo("numeric gauge");
+                });
+    }
+
+    @Test
+    public void testCollectManagedNestedAttributePaths()
+            throws Exception
+    {
+        MetricsCollector collector = createTestingCollector();
+
+        assertThat(attributes(collector))
+                .anySatisfy(metric -> {
+                    assertThat(metric.path()).containsExactly("Count");
+                    assertThat(metric.value()).isEqualTo(31);
+                })
+                .anySatisfy(metric -> {
+                    assertThat(metric.path()).containsExactly("NestedStats", "Count");
+                    assertThat(metric.value()).isEqualTo(41);
+                });
+    }
+
+    @Test
+    public void testCollectManagedCounterStat()
+            throws Exception
+    {
+        MetricsCollector collector = createTestingCollector();
+
+        assertThat(attributes(collector))
+                .anySatisfy(metric -> {
+                    assertThat(metric.path()).containsExactly("Requests");
+                    assertThat(metric.value()).isInstanceOfSatisfying(CounterStat.class, counter -> assertThat(counter.getTotalCount()).isEqualTo(11));
+                    assertThat(metric.description()).isEqualTo("request counter");
+                });
+    }
+
+    @Test
+    public void testCollectManagedTimeDistribution()
+            throws Exception
+    {
+        MetricsCollector collector = createTestingCollector();
+
+        assertThat(attributes(collector))
+                .anySatisfy(metric -> {
+                    assertThat(metric.path()).containsExactly("Latency");
+                    assertThat(metric.value()).isInstanceOfSatisfying(TimeDistribution.class, distribution -> assertThat(distribution.getCount()).isEqualTo(2));
+                    assertThat(metric.description()).isEqualTo("request latency");
+                });
+    }
+
+    @Test
+    public void testCollectManagedTimeStat()
+            throws Exception
+    {
+        MetricsCollector collector = createTestingCollector();
+
+        assertThat(attributes(collector))
+                .anySatisfy(metric -> {
+                    assertThat(metric.path()).containsExactly("RequestTime");
+                    assertThat(metric.value()).isInstanceOfSatisfying(TimeStat.class, stat -> assertThat(stat.getAllTime().getCount()).isEqualTo(2));
+                    assertThat(metric.description()).isEqualTo("request time");
+                });
+    }
+
+    @Test
+    public void testCollectManagedDistribution()
+            throws Exception
+    {
+        MetricsCollector collector = createTestingCollector();
+
+        assertThat(attributes(collector))
+                .anySatisfy(metric -> {
+                    assertThat(metric.path()).containsExactly("QueuedRequests");
+                    assertThat(metric.value()).isInstanceOfSatisfying(Distribution.class, distribution -> assertThat(distribution.getCount()).isEqualTo(2));
+                    assertThat(metric.description()).isEqualTo("queued requests");
+                });
+    }
+
+    @Test
+    public void testCollectManagedDistributionStat()
+            throws Exception
+    {
+        MetricsCollector collector = createTestingCollector();
+
+        assertThat(attributes(collector))
+                .anySatisfy(metric -> {
+                    assertThat(metric.path()).containsExactly("ReadBytes");
+                    assertThat(metric.value()).isInstanceOfSatisfying(DistributionStat.class, stat -> assertThat(stat.getAllTime().getCount()).isEqualTo(2));
+                    assertThat(metric.description()).isEqualTo("read bytes");
+                });
+    }
+
+    @Test
+    public void testCollectConfiguredJmxMetrics()
+            throws Exception
+    {
+        MetricsCollector collector = createTestingCollector();
+
+        assertThat(collector.collect())
+                .anySatisfy(group -> assertThat(group.source()).isEqualTo(new JmxMetricSource(new ObjectName("io.airlift.metrics.test:name=configured,type=Test"))));
+
+        assertThat(attributes(collector))
+                .anySatisfy(metric -> {
+                    assertThat(metric.path()).containsExactly("Count");
+                    assertThat(metric.value()).isEqualTo(23);
+                })
+                .anySatisfy(metric -> {
+                    assertThat(metric.path()).containsExactly("Memory");
+                    assertThat(metric.value()).isInstanceOfSatisfying(CompositeData.class, memory -> {
+                        assertThat(memory.get("used")).isEqualTo(100L);
+                        assertThat(memory.get("committed")).isEqualTo(200L);
+                        assertThat(memory.get("max")).isEqualTo(1000L);
+                    });
+                });
+    }
+
+    private static List<CollectedMetricGroup.Attribute> attributes(MetricsCollector collector)
+    {
+        return collector.collect().stream()
+                .flatMap(group -> group.attributes().stream())
+                .toList();
+    }
+
+    private static MetricsCollector createTestingCollector()
+            throws Exception
+    {
+        MBeanServer mbeanServer = MBeanServerFactory.newMBeanServer();
+        MBeanExporter mbeanExporter = new MBeanExporter(mbeanServer);
+
+        ManagedMetrics managedMetrics = new ManagedMetrics();
+        managedMetrics.getRequests().update(11);
+        managedMetrics.getLatency().add(100);
+        managedMetrics.getLatency().add(200);
+        managedMetrics.getRequestTime().addNanos(100);
+        managedMetrics.getRequestTime().addNanos(200);
+        managedMetrics.getQueuedRequests().add(5);
+        managedMetrics.getQueuedRequests().add(10);
+        managedMetrics.getReadBytes().add(100);
+        managedMetrics.getReadBytes().add(200);
+        managedMetrics.forceLatencyMerge();
+        mbeanExporter.export(new ObjectName("io.airlift.metrics.test:name=managed"), managedMetrics);
+
+        ObjectName configuredObjectName = new ObjectName("io.airlift.metrics.test:name=configured,type=Test");
+        mbeanServer.registerMBean(new StandardMBean(new ConfiguredMetrics(), ConfiguredMetricsMBean.class), configuredObjectName);
+
+        MetricsConfig metricsConfig = new MetricsConfig().setJmxObjectNames(List.of(configuredObjectName));
+        NodeInfo nodeInfo = new NodeInfo(
+                "test",
+                "pool",
+                "nodeInfo",
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                IP,
+                null,
+                ImmutableMap.of("team", "a", "region", "b"),
+                false);
+
+        return new MetricsCollector(mbeanServer, mbeanExporter, metricsConfig, nodeInfo);
+    }
+
+    public static class ManagedMetrics
+    {
+        private final NestedMetrics flattenedStats = new NestedMetrics(31);
+        private final NestedMetrics nestedStats = new NestedMetrics(41);
+        private final CounterStat requests = new CounterStat();
+        private final TestingTicker ticker = new TestingTicker();
+        private final TimeDistribution latency = new TimeDistribution(ticker);
+        private final TimeStat requestTime = new TimeStat(ticker);
+        private final Distribution queuedRequests = new Distribution();
+        private final DistributionStat readBytes = new DistributionStat();
+
+        @Managed(description = "numeric gauge")
+        public int getNumericGauge()
+        {
+            return 7;
+        }
+
+        @Flatten
+        @Managed
+        public NestedMetrics getFlattenedStats()
+        {
+            return flattenedStats;
+        }
+
+        @Managed
+        @Nested
+        public NestedMetrics getNestedStats()
+        {
+            return nestedStats;
+        }
+
+        @Managed(description = "request counter")
+        @Nested
+        public CounterStat getRequests()
+        {
+            return requests;
+        }
+
+        @Managed(description = "request latency")
+        @Nested
+        public TimeDistribution getLatency()
+        {
+            return latency;
+        }
+
+        @Managed(description = "request time")
+        @Nested
+        public TimeStat getRequestTime()
+        {
+            return requestTime;
+        }
+
+        @Managed(description = "queued requests")
+        @Nested
+        public Distribution getQueuedRequests()
+        {
+            return queuedRequests;
+        }
+
+        @Managed(description = "read bytes")
+        @Nested
+        public DistributionStat getReadBytes()
+        {
+            return readBytes;
+        }
+
+        private void forceLatencyMerge()
+        {
+            ticker.increment(1, SECONDS);
+            latency.getCount();
+            requestTime.getAllTime().getCount();
+        }
+    }
+
+    public static class NestedMetrics
+    {
+        private final int count;
+
+        public NestedMetrics(int count)
+        {
+            this.count = count;
+        }
+
+        @Managed
+        public int getCount()
+        {
+            return count;
+        }
+    }
+
+    public interface ConfiguredMetricsMBean
+    {
+        int getCount();
+
+        CompositeData getMemory();
+
+        String getUnsupported();
+    }
+
+    public static class ConfiguredMetrics
+            implements ConfiguredMetricsMBean
+    {
+        @Override
+        public int getCount()
+        {
+            return 23;
+        }
+
+        @Override
+        public CompositeData getMemory()
+        {
+            return createMemoryUsageCompositeData(100, 200, 1000);
+        }
+
+        @Override
+        public String getUnsupported()
+        {
+            return "ignored";
+        }
+    }
+
+    private static CompositeData createMemoryUsageCompositeData(long used, long committed, long max)
+    {
+        try {
+            String[] itemNames = {"used", "committed", "max"};
+            OpenType<?>[] itemTypes = {SimpleType.LONG, SimpleType.LONG, SimpleType.LONG};
+            CompositeType compositeType = new CompositeType("MemoryUsage", "Memory Usage", itemNames, itemNames, itemTypes);
+
+            Map<String, Object> values = ImmutableMap.<String, Object>builder()
+                    .put("used", used)
+                    .put("committed", committed)
+                    .put("max", max)
+                    .buildOrThrow();
+
+            return new CompositeDataSupport(compositeType, values);
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/metrics/src/test/java/io/airlift/metrics/TestMetricsConfig.java
+++ b/metrics/src/test/java/io/airlift/metrics/TestMetricsConfig.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.airlift.openmetrics;
+package io.airlift.metrics;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -21,6 +21,7 @@ import javax.management.ObjectName;
 
 import java.util.Map;
 
+import static io.airlift.configuration.testing.ConfigAssertions.assertDeprecatedEquivalence;
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
@@ -39,7 +40,7 @@ public class TestMetricsConfig
             throws Exception
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
-                .put("openmetrics.jmx-object-names", "foo.bar:name=baz,type=qux|baz.bar:*")
+                .put("metrics.jmx-object-names", "foo.bar:name=baz,type=qux|baz.bar:*")
                 .build();
 
         MetricsConfig expected = new MetricsConfig()
@@ -48,5 +49,19 @@ public class TestMetricsConfig
                         new ObjectName("baz.bar:*")));
 
         assertFullMapping(properties, expected);
+    }
+
+    @Test
+    public void testDeprecatedProperties()
+    {
+        Map<String, String> currentProperties = new ImmutableMap.Builder<String, String>()
+                .put("metrics.jmx-object-names", "foo.bar:name=baz,type=qux|baz.bar:*")
+                .build();
+
+        Map<String, String> oldProperties = new ImmutableMap.Builder<String, String>()
+                .put("openmetrics.jmx-object-names", "foo.bar:name=baz,type=qux|baz.bar:*")
+                .build();
+
+        assertDeprecatedEquivalence(MetricsConfig.class, currentProperties, oldProperties);
     }
 }

--- a/openmetrics/src/main/java/io/airlift/openmetrics/JmxOpenMetricsModule.java
+++ b/openmetrics/src/main/java/io/airlift/openmetrics/JmxOpenMetricsModule.java
@@ -15,12 +15,12 @@ package io.airlift.openmetrics;
 
 import com.google.inject.Binder;
 import com.google.inject.Module;
+import io.airlift.metrics.MetricsModule;
 
 import java.lang.annotation.Annotation;
 import java.util.Optional;
 
 import static com.google.inject.Scopes.SINGLETON;
-import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
 import static java.util.Objects.requireNonNull;
 
@@ -42,7 +42,7 @@ public class JmxOpenMetricsModule
     @Override
     public void configure(Binder binder)
     {
-        configBinder(binder).bindConfig(MetricsConfig.class);
+        binder.install(new MetricsModule());
         binder.bind(OpenMetricsCollector.class).in(SINGLETON);
         annotation
                 .map(value -> jaxrsBinder(binder, value))

--- a/openmetrics/src/main/java/io/airlift/openmetrics/OpenMetricsCollector.java
+++ b/openmetrics/src/main/java/io/airlift/openmetrics/OpenMetricsCollector.java
@@ -15,34 +15,27 @@ package io.airlift.openmetrics;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.CharMatcher;
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
-import io.airlift.log.Logger;
-import io.airlift.node.NodeInfo;
+import io.airlift.metrics.CollectedMetricGroup;
+import io.airlift.metrics.CollectedMetricGroup.Attribute;
+import io.airlift.metrics.MetricSource;
+import io.airlift.metrics.MetricsCollector;
 import io.airlift.openmetrics.types.CompositeMetric;
 import io.airlift.openmetrics.types.Counter;
 import io.airlift.openmetrics.types.Gauge;
 import io.airlift.openmetrics.types.Metric;
 import io.airlift.openmetrics.types.Summary;
 import io.airlift.stats.CounterStat;
+import io.airlift.stats.Distribution;
+import io.airlift.stats.DistributionStat;
 import io.airlift.stats.TimeDistribution;
-import org.weakref.jmx.MBeanExporter;
-import org.weakref.jmx.ManagedClass;
+import io.airlift.stats.TimeStat;
 
-import javax.management.InstanceNotFoundException;
-import javax.management.IntrospectionException;
-import javax.management.JMException;
-import javax.management.MBeanAttributeInfo;
-import javax.management.MBeanInfo;
-import javax.management.MBeanServer;
-import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
-import javax.management.ReflectionException;
 import javax.management.openmbean.CompositeData;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -56,7 +49,6 @@ import static java.util.Objects.requireNonNull;
  */
 public class OpenMetricsCollector
 {
-    private static final Logger log = Logger.get(OpenMetricsCollector.class);
     private static final String ATTRIBUTE_SEPARATOR = "_ATTRIBUTE_";
     private static final String TYPE_SEPARATOR = "_TYPE_";
     private static final String NAME_SEPARATOR = "_NAME_";
@@ -68,30 +60,17 @@ public class OpenMetricsCollector
             .negate()
             .precomputed();
 
-    private final MBeanServer mbeanServer;
-    private final MBeanExporter mbeanExporter;
-    private final List<ObjectName> allMetricsObjectNames;
-    private final Map<String, String> labels;
+    private final MetricsCollector collector;
 
     @Inject
-    public OpenMetricsCollector(MBeanServer mbeanServer, MBeanExporter mbeanExporter, MetricsConfig metricsConfig, NodeInfo nodeInfo)
+    public OpenMetricsCollector(MetricsCollector collector)
     {
-        this.mbeanServer = requireNonNull(mbeanServer, "mbeanServer is null");
-        this.mbeanExporter = requireNonNull(mbeanExporter, "mbeanExporter is null");
-        requireNonNull(metricsConfig, "metricsConfig is null");
-        requireNonNull(nodeInfo, "nodeInfo is null");
-        this.allMetricsObjectNames = metricsConfig.getJmxObjectNames();
-        this.labels = nodeInfo.getAnnotations();
+        this.collector = requireNonNull(collector, "collector is null");
     }
 
     public List<Metric> collect()
     {
-        ImmutableList.Builder<Metric> metrics = ImmutableList.builder();
-        metrics.addAll(getManagedMetrics());
-        for (ObjectName metricObjectNames : allMetricsObjectNames) {
-            mbeanServer.queryNames(metricObjectNames, null).forEach(objectName -> metrics.addAll(inferAttributesForObjectName(objectName)));
-        }
-        return metrics.build();
+        return toOpenMetrics(collector.collect());
     }
 
     public List<Metric> collect(List<String> filters)
@@ -99,68 +78,151 @@ public class OpenMetricsCollector
         if (filters == null || filters.isEmpty()) {
             return collect();
         }
-
-        ImmutableList.Builder<Metric> metrics = ImmutableList.builder();
-        Supplier<List<Metric>> managedMetrics = Suppliers.memoize(this::getManagedMetrics);
-        for (String metricName : filters) {
-            findMetric(managedMetrics, metricName).ifPresent(metrics::add);
-        }
-        return metrics.build();
+        return filterMetrics(toOpenMetrics(collector.collect()), ImmutableSet.copyOf(filters));
     }
 
     public Optional<Metric> findMetric(String metricName)
     {
-        return findMetric(Suppliers.memoize(this::getManagedMetrics), metricName);
+        return findMetric(collect(List.of(metricName)), metricName);
     }
 
-    private Set<ObjectName> objectNamesFromMetricName(String metricName)
-            throws MalformedObjectNameException
+    @VisibleForTesting
+    static Optional<Metric> findMetric(List<Metric> metrics, String metricName)
     {
-        int nameStart = metricName.indexOf(NAME_SEPARATOR);
-        int typeStart = metricName.indexOf(TYPE_SEPARATOR);
-        int attributeStart = metricName.indexOf(ATTRIBUTE_SEPARATOR);
-
-        String domain;
-
-        if (nameStart != -1) {
-            domain = metricName.substring(0, nameStart).replace("_", ".");
+        Optional<Metric> metric = metrics.stream()
+                .filter(candidate -> candidate.metricName().equals(metricName))
+                .findFirst();
+        if (metric.isPresent()) {
+            return metric;
         }
-        else if (typeStart != -1) {
-            domain = metricName.substring(0, typeStart).replace("_", ".");
-        }
-        else {
-            domain = metricName.substring(0, attributeStart).replace("_", ".");
-        }
-
-        StringBuilder objectNameBuilder = new StringBuilder(domain).append(":");
-
-        if (nameStart != -1) {
-            objectNameBuilder.append("name=")
-                    .append(metricName, nameStart + NAME_SEPARATOR.length(), typeStart == -1 ? attributeStart : typeStart)
-                    .append(",");
-        }
-        if (typeStart != -1) {
-            objectNameBuilder.append("type=")
-                    .append(metricName.substring(typeStart + TYPE_SEPARATOR.length(), attributeStart).replace("_", "$"))
-                    .append(",");
-        }
-
-        return mbeanServer.queryNames(ObjectName.getInstance(objectNameBuilder.append("*").toString()), null);
+        return metrics.stream()
+                .flatMap(OpenMetricsCollector::flattenMetric)
+                .filter(candidate -> candidate.metricName().equals(metricName))
+                .findFirst();
     }
 
-    private String attributeNameFromMetricName(String metricName)
+    private static java.util.stream.Stream<Metric> flattenMetric(Metric metric)
     {
-        int attributeNameStart = metricName.indexOf(ATTRIBUTE_SEPARATOR);
-        if (attributeNameStart == -1) {
-            throw new RuntimeException("Metric name invalid, no attribute separator %s".formatted(metricName));
+        if (metric instanceof CompositeMetric compositeMetric) {
+            return compositeMetric.subMetrics().stream();
         }
-        return metricName.substring(attributeNameStart + ATTRIBUTE_SEPARATOR.length()).replace("_", ".");
+        return java.util.stream.Stream.of(metric);
     }
 
-    private String mBeanNameToMetricName(ObjectName objectName, String attributeName)
+    @VisibleForTesting
+    static List<Metric> toOpenMetrics(List<CollectedMetricGroup> collectedMetricGroups)
+    {
+        ImmutableList.Builder<Metric> metrics = ImmutableList.builder();
+        collectedMetricGroups.stream()
+                .flatMap(group -> group.attributes().stream()
+                        .map(attribute -> toOpenMetric(openMetricsMetricName(group, attribute), attribute, group.labels())))
+                .flatMap(Optional::stream)
+                .forEach(metrics::add);
+        return metrics.build();
+    }
+
+    @VisibleForTesting
+    static List<Metric> filterMetrics(List<Metric> metrics, Set<String> filters)
+    {
+        ImmutableList.Builder<Metric> filtered = ImmutableList.builder();
+        for (Metric metric : metrics) {
+            if (metric instanceof CompositeMetric compositeMetric) {
+                if (filters.contains(compositeMetric.metricName())) {
+                    filtered.add(compositeMetric);
+                    continue;
+                }
+                List<Metric> filteredSubMetrics = compositeMetric.subMetrics().stream()
+                        .filter(subMetric -> filters.contains(subMetric.metricName()))
+                        .collect(toImmutableList());
+                if (!filteredSubMetrics.isEmpty()) {
+                    filtered.add(new CompositeMetric(compositeMetric.metricName(), compositeMetric.labels(), compositeMetric.help(), filteredSubMetrics));
+                }
+            }
+            else if (filters.contains(metric.metricName())) {
+                filtered.add(metric);
+            }
+        }
+        return filtered.build();
+    }
+
+    @VisibleForTesting
+    static Optional<Metric> toOpenMetric(Attribute attribute, Map<String, String> labels)
+    {
+        return toOpenMetric(openMetricsMetricName(attribute.path()), attribute, labels);
+    }
+
+    private static Optional<Metric> toOpenMetric(String metricName, Attribute attribute, Map<String, String> labels)
+    {
+        Object value = attribute.value();
+        return switch (value) {
+            case Number number -> Optional.of(Gauge.from(metricName, number, labels, attribute.description()));
+            case Boolean bool -> Optional.of(Gauge.from(metricName, bool ? 1 : 0, labels, attribute.description()));
+            case CompositeData compositeData -> Optional.of(CompositeMetric.from(metricName, compositeData, labels, attribute.description()));
+            case CounterStat counterStat -> Optional.of(Counter.from(metricName, counterStat, labels, attribute.description()));
+            case TimeDistribution timeDistribution -> Optional.of(Summary.from(metricName, timeDistribution, labels, attribute.description()));
+            case TimeStat timeStat -> Optional.of(timeStatToOpenMetrics(metricName, timeStat, attribute, labels));
+            case Distribution distribution -> Optional.of(Summary.from(metricName, distribution, labels, attribute.description()));
+            case DistributionStat distributionStat -> Optional.of(distributionStatToOpenMetrics(metricName, distributionStat, attribute, labels));
+            case null, default -> Optional.empty();
+        };
+    }
+
+    private static CompositeMetric timeStatToOpenMetrics(String metricName, TimeStat timeStat, Attribute attribute, Map<String, String> labels)
+    {
+        ImmutableList.Builder<Metric> metrics = ImmutableList.builder();
+        if (timeStat.getOneMinute() != null) {
+            metrics.add(Summary.from(metricName + "_OneMinute", timeStat.getOneMinute(), labels, attribute.description()));
+        }
+        if (timeStat.getFiveMinutes() != null) {
+            metrics.add(Summary.from(metricName + "_FiveMinutes", timeStat.getFiveMinutes(), labels, attribute.description()));
+        }
+        if (timeStat.getFifteenMinutes() != null) {
+            metrics.add(Summary.from(metricName + "_FifteenMinutes", timeStat.getFifteenMinutes(), labels, attribute.description()));
+        }
+        metrics.add(Summary.from(metricName + "_AllTime", timeStat.getAllTime(), labels, attribute.description()));
+        return new CompositeMetric(metricName, labels, attribute.description(), metrics.build());
+    }
+
+    private static CompositeMetric distributionStatToOpenMetrics(String metricName, DistributionStat distributionStat, Attribute attribute, Map<String, String> labels)
+    {
+        ImmutableList.Builder<Metric> metrics = ImmutableList.builder();
+        if (distributionStat.getOneMinute() != null) {
+            metrics.add(Summary.from(metricName + "_OneMinute", distributionStat.getOneMinute(), labels, attribute.description()));
+        }
+        if (distributionStat.getFiveMinutes() != null) {
+            metrics.add(Summary.from(metricName + "_FiveMinutes", distributionStat.getFiveMinutes(), labels, attribute.description()));
+        }
+        if (distributionStat.getFifteenMinutes() != null) {
+            metrics.add(Summary.from(metricName + "_FifteenMinutes", distributionStat.getFifteenMinutes(), labels, attribute.description()));
+        }
+        metrics.add(Summary.from(metricName + "_AllTime", distributionStat.getAllTime(), labels, attribute.description()));
+        return new CompositeMetric(metricName, labels, attribute.description(), metrics.build());
+    }
+
+    @VisibleForTesting
+    static String sanitizeMetricName(String name)
+    {
+        return NON_ALLOWED_LABEL_CHARACTERS.collapseFrom(name, '_');
+    }
+
+    private static String openMetricsMetricName(CollectedMetricGroup group, Attribute attribute)
+    {
+        String attributeName = openMetricsMetricName(attribute.path());
+        return switch (group.source()) {
+            case MetricSource.JmxMetricSource jmxMetricSource -> jmxMetricNamePrefix(jmxMetricSource.name()) + ATTRIBUTE_SEPARATOR + attributeName;
+            case MetricSource.ManagedMetricSource managedMetricSource -> {
+                String metricName = sanitizeMetricName(managedMetricSource.name());
+                if (attributeName.isEmpty()) {
+                    yield metricName;
+                }
+                yield metricName + "_" + attributeName;
+            }
+        };
+    }
+
+    private static String jmxMetricNamePrefix(ObjectName objectName)
     {
         if (objectName.getDomain().contains("_")) {
-            log.warn("Unable to expose JMX metric with domain name %s, package names with underscores are unsupported.", objectName.getDomain());
             throw new RuntimeException("Bad domain name %s".formatted(objectName.getDomain()));
         }
 
@@ -177,150 +239,11 @@ public class OpenMetricsCollector
                     .append(objectName.getKeyProperty("type"));
         }
 
-        metricNameBuilder.append(ATTRIBUTE_SEPARATOR)
-                .append(attributeName);
-
         return sanitizeMetricName(metricNameBuilder.toString());
     }
 
-    private Optional<Metric> findMetric(Supplier<List<Metric>> managedMetricsSupplier, String metricName)
+    private static String openMetricsMetricName(List<String> path)
     {
-        if (metricName.startsWith("JMX_")) {
-            final String jmxMetricName = metricName.substring(4);
-            try {
-                String attributeName = attributeNameFromMetricName(jmxMetricName);
-                return objectNamesFromMetricName(jmxMetricName).stream()
-                        .map(objectName -> getMetric(objectName, attributeName, jmxMetricName, ""))
-                        .flatMap(Optional::stream)
-                        .findFirst();
-            }
-            catch (MalformedObjectNameException e) {
-                log.warn(e, "Unable to retrieve metric %s.", metricName);
-                return Optional.empty();
-            }
-        }
-        else {
-            return managedMetricsSupplier.get()
-                    .stream()
-                    .filter(metric -> metric.metricName().equals(metricName))
-                    .findFirst();
-        }
-    }
-
-    private Optional<Metric> getMetric(ObjectName objectName, String attributeName, String metricName, String description)
-    {
-        try {
-            Object attributeValue = mbeanServer.getAttribute(objectName, attributeName);
-            return switch (attributeValue) {
-                case Number number -> Optional.of(Gauge.from(metricName, number, labels, description));
-                case CompositeData compositeData -> Optional.of(CompositeMetric.from(metricName, compositeData, labels, description));
-                case null, default -> Optional.empty();
-            };
-        }
-        catch (JMException ex) {
-            log.debug(ex, "Unable to get metric for ObjectName %s and Attribute %s.", objectName.getCanonicalName(), attributeName);
-            return Optional.empty();
-        }
-    }
-
-    private List<Metric> inferAttributesForObjectName(ObjectName objectName)
-    {
-        List<Metric> metrics = new ArrayList<>();
-        try {
-            MBeanInfo mbeanInfo = mbeanServer.getMBeanInfo(objectName);
-            for (MBeanAttributeInfo mBeanAttributeInfo : mbeanInfo.getAttributes()) {
-                String attributeName = mBeanAttributeInfo.getName();
-                String description = mBeanAttributeInfo.getDescription();
-                try {
-                    getMetric(objectName, attributeName, mBeanNameToMetricName(objectName, attributeName), description)
-                            .ifPresent(metrics::add);
-                }
-                catch (RuntimeException e) {
-                    log.debug(e, "Unable to get Metric for ObjectName %s and Attribute %s, skipping", objectName.getCanonicalName(), attributeName);
-                }
-            }
-        }
-        catch (InstanceNotFoundException | IntrospectionException | ReflectionException e) {
-            log.debug(e, "Unable to get MBeanInfo for object %s, skipping", objectName.getCanonicalName());
-        }
-        return metrics;
-    }
-
-    @VisibleForTesting
-    static String sanitizeMetricName(String name)
-    {
-        return NON_ALLOWED_LABEL_CHARACTERS.collapseFrom(name, '_');
-    }
-
-    private List<Metric> getMetricsRecursively(String prefix, ManagedClass managedClass)
-    {
-        String metricName = sanitizeMetricName(prefix);
-
-        ImmutableList.Builder<Metric> metrics = ImmutableList.builder();
-
-        for (String attributeName : managedClass.getAttributeNames()) {
-            try {
-                String metricAndAttribute = managedClass.isAttributeFlatten(attributeName) ? metricName : metricName + "_" + attributeName;
-                String attributeDescription = managedClass.getAttributeDescription(attributeName);
-
-                if (managedClass.getChildren().get(attributeName) instanceof ManagedClass child) {
-                    // The managed class is directly translatable to an openmetrics type, don't recurse any further
-                    Optional<Metric> metricFromTarget = getMetricFromTarget(child, metricAndAttribute, attributeDescription);
-                    if (metricFromTarget.isPresent()) {
-                        metrics.add(metricFromTarget.orElseThrow());
-                    }
-                    else {
-                        // Recurse this nested child
-                        metrics.addAll(getMetricsRecursively(metricAndAttribute, child));
-                    }
-                }
-                else {
-                    // Attempt to infer a numeric gauge
-                    Object attributeValue = managedClass.invokeAttribute(attributeName);
-                    if (attributeValue instanceof Number) {
-                        metrics.add(Gauge.from(metricAndAttribute, (Number) attributeValue, labels, attributeDescription));
-                    }
-                    if (attributeValue instanceof Boolean) {
-                        metrics.add(Gauge.from(metricAndAttribute, (Boolean) attributeValue ? 1 : 0, labels, attributeDescription));
-                    }
-                }
-            }
-            catch (ReflectiveOperationException e) {
-                log.debug("Unable to invoke getter for managed attribute : " + attributeName);
-            }
-        }
-
-        return metrics.build();
-    }
-
-    private Optional<Metric> getMetricFromTarget(ManagedClass managedClass, String metricName, String description)
-    {
-        Object target;
-        try {
-            target = managedClass.getTarget();
-        }
-        catch (IllegalStateException ignored) {
-            return Optional.empty();
-        }
-
-        if (target instanceof CounterStat counterStat) {
-            return Optional.of(Counter.from(metricName, counterStat, labels, description));
-        }
-
-        if (target instanceof TimeDistribution timeDistribution) {
-            return Optional.of(Summary.from(metricName, timeDistribution, labels, description));
-        }
-
-        return Optional.empty();
-    }
-
-    private List<Metric> getManagedMetrics()
-    {
-        Map<String, ManagedClass> managedClasses = this.mbeanExporter.getManagedClasses();
-
-        return managedClasses.entrySet().stream()
-                .map(entry -> getMetricsRecursively(entry.getKey(), entry.getValue()))
-                .flatMap(List::stream)
-                .collect(toImmutableList());
+        return sanitizeMetricName(String.join("_", path));
     }
 }

--- a/openmetrics/src/main/java/io/airlift/openmetrics/types/Summary.java
+++ b/openmetrics/src/main/java/io/airlift/openmetrics/types/Summary.java
@@ -14,6 +14,8 @@
 package io.airlift.openmetrics.types;
 
 import com.google.common.collect.ImmutableMap;
+import io.airlift.stats.Distribution;
+import io.airlift.stats.Distribution.DistributionSnapshot;
 import io.airlift.stats.TimeDistribution;
 import io.airlift.stats.TimeDistribution.TimeDistributionSnapshot;
 
@@ -39,6 +41,29 @@ public record Summary(String metricName, Long count, Double sum, Double created,
                 snapshot.avg() * snapshot.count(),
                 null,
                 ImmutableMap.<Double, Double>builder()
+                        .put(0.5, snapshot.p50())
+                        .put(0.75, snapshot.p75())
+                        .put(0.9, snapshot.p90())
+                        .put(0.95, snapshot.p95())
+                        .put(0.99, snapshot.p99())
+                        .build(),
+                labels,
+                help);
+    }
+
+    public static Summary from(String metricName, Distribution distribution, Map<String, String> labels, String help)
+    {
+        DistributionSnapshot snapshot = distribution.snapshot();
+        return new Summary(
+                metricName,
+                (long) snapshot.count(),
+                snapshot.total(),
+                null,
+                ImmutableMap.<Double, Double>builder()
+                        .put(0.01, snapshot.p01())
+                        .put(0.05, snapshot.p05())
+                        .put(0.10, snapshot.p10())
+                        .put(0.25, snapshot.p25())
                         .put(0.5, snapshot.p50())
                         .put(0.75, snapshot.p75())
                         .put(0.9, snapshot.p90())

--- a/openmetrics/src/test/java/io/airlift/openmetrics/TestJmxOpenMetricsModule.java
+++ b/openmetrics/src/test/java/io/airlift/openmetrics/TestJmxOpenMetricsModule.java
@@ -6,6 +6,8 @@ import com.google.inject.Key;
 import com.google.inject.TypeLiteral;
 import com.google.inject.spi.Element;
 import com.google.inject.spi.Elements;
+import io.airlift.metrics.MetricsCollector;
+import io.airlift.metrics.MetricsConfig;
 import org.junit.jupiter.api.Test;
 
 import java.lang.annotation.Retention;
@@ -22,6 +24,9 @@ public class TestJmxOpenMetricsModule
     {
         List<Element> elements = Elements.getElements(new JmxOpenMetricsModule(ForTesting.class));
 
+        assertThat(hasBinding(elements, Key.get(MetricsConfig.class))).isTrue();
+        assertThat(hasBinding(elements, Key.get(MetricsCollector.class))).isTrue();
+        assertThat(hasBinding(elements, Key.get(OpenMetricsCollector.class))).isTrue();
         assertThat(hasBinding(elements, Key.get(new TypeLiteral<Set<Object>>() {}))).isFalse();
         assertThat(hasBinding(elements, Key.get(new TypeLiteral<Set<Object>>() {}, ForTesting.class))).isTrue();
     }

--- a/openmetrics/src/test/java/io/airlift/openmetrics/TestOpenMetricsCollector.java
+++ b/openmetrics/src/test/java/io/airlift/openmetrics/TestOpenMetricsCollector.java
@@ -1,283 +1,258 @@
 package io.airlift.openmetrics;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import io.airlift.node.NodeInfo;
+import io.airlift.metrics.CollectedMetricGroup;
+import io.airlift.metrics.CollectedMetricGroup.Attribute;
+import io.airlift.metrics.MetricSource.JmxMetricSource;
+import io.airlift.metrics.MetricSource.ManagedMetricSource;
 import io.airlift.openmetrics.types.CompositeMetric;
 import io.airlift.openmetrics.types.Counter;
 import io.airlift.openmetrics.types.Gauge;
 import io.airlift.openmetrics.types.Metric;
 import io.airlift.openmetrics.types.Summary;
 import io.airlift.stats.CounterStat;
+import io.airlift.stats.Distribution;
+import io.airlift.stats.DistributionStat;
 import io.airlift.stats.TimeDistribution;
+import io.airlift.stats.TimeStat;
 import io.airlift.testing.TestingTicker;
 import org.junit.jupiter.api.Test;
-import org.weakref.jmx.MBeanExporter;
-import org.weakref.jmx.Managed;
-import org.weakref.jmx.Nested;
 
-import javax.management.MBeanServer;
-import javax.management.MBeanServerFactory;
 import javax.management.ObjectName;
-import javax.management.StandardMBean;
 import javax.management.openmbean.CompositeData;
 import javax.management.openmbean.CompositeDataSupport;
 import javax.management.openmbean.CompositeType;
 import javax.management.openmbean.OpenType;
 import javax.management.openmbean.SimpleType;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.StringWriter;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
-import static io.airlift.node.NodeConfig.AddressSource.IP;
-import static io.airlift.openmetrics.MetricsUtils.renderMetricsExpositions;
-import static io.airlift.openmetrics.MetricsUtils.writeMetricsExpositions;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
 public class TestOpenMetricsCollector
 {
-    @Test
-    public void testCollectManagedNumericGauge()
-            throws Exception
-    {
-        OpenMetricsCollector collector = createTestingCollector();
-
-        assertThat(collector.collect())
-                .filteredOn(Gauge.class::isInstance)
-                .map(Gauge.class::cast)
-                .anySatisfy(metric -> {
-                    assertThat(metric.metricName()).endsWith("_NumericGauge");
-                    assertThat(metric.value()).isEqualTo(7.0);
-                    assertThat(metric.labels()).isEqualTo(ImmutableMap.of("region", "b", "team", "a"));
-                    assertThat(metric.help()).isEqualTo("numeric gauge");
-                });
-    }
+    private static final Map<String, String> LABELS = ImmutableMap.of("region", "b", "team", "a");
 
     @Test
-    public void testCollectManagedCounterStat()
+    public void testConvertGroupNames()
             throws Exception
     {
-        OpenMetricsCollector collector = createTestingCollector();
+        ObjectName objectName = new ObjectName("io.airlift.metrics.test:name=configured,type=Test");
 
-        assertThat(collector.collect())
-                .filteredOn(Counter.class::isInstance)
-                .map(Counter.class::cast)
-                .anySatisfy(metric -> {
-                    assertThat(metric.metricName()).endsWith("_Requests");
-                    assertThat(metric.value()).isEqualTo(11);
-                    assertThat(metric.labels()).isEqualTo(ImmutableMap.of("region", "b", "team", "a"));
-                    assertThat(metric.help()).isEqualTo("request counter");
-                });
-    }
-
-    @Test
-    public void testCollectManagedTimeDistribution()
-            throws Exception
-    {
-        OpenMetricsCollector collector = createTestingCollector();
-
-        assertThat(collector.collect())
-                .filteredOn(Summary.class::isInstance)
-                .map(Summary.class::cast)
-                .anySatisfy(metric -> {
-                    assertThat(metric.metricName()).endsWith("_Latency");
-                    assertThat(metric.count()).isEqualTo(2);
-                    assertThat(metric.labels()).isEqualTo(ImmutableMap.of("region", "b", "team", "a"));
-                    assertThat(metric.help()).isEqualTo("request latency");
-                });
-    }
-
-    @Test
-    public void testCollectConfiguredJmxNumericAttribute()
-            throws Exception
-    {
-        OpenMetricsCollector collector = createTestingCollector();
-
-        assertThat(collector.collect())
-                .filteredOn(Gauge.class::isInstance)
-                .map(Gauge.class::cast)
-                .anySatisfy(metric -> {
-                    assertThat(metric.metricName()).isEqualTo("JMX_io_airlift_openmetrics_test_NAME_configured_TYPE_Test_ATTRIBUTE_Count");
-                    assertThat(metric.value()).isEqualTo(23.0);
-                    assertThat(metric.labels()).isEqualTo(ImmutableMap.of("region", "b", "team", "a"));
-                });
-    }
-
-    @Test
-    public void testCollectConfiguredJmxCompositeAttribute()
-            throws Exception
-    {
-        OpenMetricsCollector collector = createTestingCollector();
-
-        Optional<CompositeMetric> memoryMetric = collector.collect().stream()
-                .filter(CompositeMetric.class::isInstance)
-                .map(CompositeMetric.class::cast)
-                .filter(metric -> metric.metricName().equals("JMX_io_airlift_openmetrics_test_NAME_configured_TYPE_Test_ATTRIBUTE_Memory"))
-                .findFirst();
-
-        assertThat(memoryMetric).isPresent();
-        assertThat(memoryMetric.orElseThrow().labels()).isEqualTo(ImmutableMap.of("region", "b", "team", "a"));
-        assertThat(memoryMetric.orElseThrow().subMetrics())
-                .filteredOn(Gauge.class::isInstance)
-                .map(Gauge.class::cast)
-                .extracting(Gauge::metricName, Gauge::value)
-                .contains(
-                        tuple("JMX_io_airlift_openmetrics_test_NAME_configured_TYPE_Test_ATTRIBUTE_Memory_committed", 200.0),
-                        tuple("JMX_io_airlift_openmetrics_test_NAME_configured_TYPE_Test_ATTRIBUTE_Memory_max", 1000.0),
-                        tuple("JMX_io_airlift_openmetrics_test_NAME_configured_TYPE_Test_ATTRIBUTE_Memory_used", 100.0));
-    }
-
-    @Test
-    public void testResourceOutputMatchesCollectorRendering()
-            throws Exception
-    {
-        OpenMetricsCollector collector = createTestingCollector();
-        MetricsResource resource = new MetricsResource(collector);
-
-        StringWriter writer = new StringWriter();
-        writeMetricsExpositions(writer, collector.collect());
-        writer.append("# EOF\n");
-
-        assertThat(getMetrics(resource, ImmutableList.of())).isEqualTo(writer.toString());
-    }
-
-    @Test
-    public void testFilteredMetricLookupCompatibility()
-            throws Exception
-    {
-        OpenMetricsCollector collector = createTestingCollector();
-        MetricsResource resource = new MetricsResource(collector);
-        String managedMetricName = collector.collect().stream()
-                .map(Metric::metricName)
-                .filter(name -> name.endsWith("_NumericGauge"))
-                .findFirst()
-                .orElseThrow();
-        String jmxMetricName = "JMX_io_airlift_openmetrics_test_NAME_configured_TYPE_Test_ATTRIBUTE_Count";
-
-        assertThat(collector.collect(ImmutableList.of(managedMetricName)))
+        assertThat(OpenMetricsCollector.toOpenMetrics(List.of(
+                new CollectedMetricGroup(
+                        new ManagedMetricSource("io.airlift.metrics.test:name=managed"),
+                        LABELS,
+                        List.of(new Attribute(List.of("NumericGauge"), 7, "metric help"))),
+                new CollectedMetricGroup(
+                        new JmxMetricSource(objectName),
+                        LABELS,
+                        List.of(new Attribute(List.of("Count"), 23, "metric help"))))))
                 .extracting(Metric::metricName)
-                .containsExactly(managedMetricName);
-        assertThat(getMetrics(resource, ImmutableList.of(managedMetricName)))
-                .isEqualTo(renderMetricsExpositions(collector.collect(ImmutableList.of(managedMetricName)), true));
-
-        Metric filteredJmxMetric = collector.findMetric(jmxMetricName).orElseThrow();
-        assertThat(filteredJmxMetric.metricName()).isEqualTo("io_airlift_openmetrics_test_NAME_configured_TYPE_Test_ATTRIBUTE_Count");
-        assertThat(getMetrics(resource, ImmutableList.of(jmxMetricName)))
-                .isEqualTo(renderMetricsExpositions(collector.collect(ImmutableList.of(jmxMetricName)), true));
+                .containsExactly(
+                        "io_airlift_metrics_test_name_managed_NumericGauge",
+                        "JMX_io_airlift_metrics_test_NAME_configured_TYPE_Test_ATTRIBUTE_Count");
     }
 
-    private static String getMetrics(MetricsResource resource, List<String> filter)
-            throws IOException
+    @Test
+    public void testConvertNumberToGauge()
     {
-        ByteArrayOutputStream output = new ByteArrayOutputStream();
-        resource.getMetrics(filter).write(output);
-        return output.toString(UTF_8);
+        Optional<Metric> metric = OpenMetricsCollector.toOpenMetric(new Attribute(List.of("metric_name"), 7, "metric help"), LABELS);
+
+        assertThat(metric).isPresent();
+        assertThat(metric.orElseThrow()).isInstanceOfSatisfying(Gauge.class, gauge -> {
+            assertThat(gauge.metricName()).isEqualTo("metric_name");
+            assertThat(gauge.value()).isEqualTo(7.0);
+            assertThat(gauge.labels()).isEqualTo(LABELS);
+            assertThat(gauge.help()).isEqualTo("metric help");
+        });
     }
 
-    private static OpenMetricsCollector createTestingCollector()
-            throws Exception
+    @Test
+    public void testConvertBooleanToGauge()
     {
-        MBeanServer mbeanServer = MBeanServerFactory.newMBeanServer();
-        MBeanExporter mbeanExporter = new MBeanExporter(mbeanServer);
+        Optional<Metric> metric = OpenMetricsCollector.toOpenMetric(new Attribute(List.of("metric_name"), true, "metric help"), LABELS);
 
-        ManagedMetrics managedMetrics = new ManagedMetrics();
-        managedMetrics.getRequests().update(11);
-        managedMetrics.getLatency().add(100);
-        managedMetrics.getLatency().add(200);
-        managedMetrics.forceLatencyMerge();
-        mbeanExporter.export(new ObjectName("io.airlift.openmetrics.test:name=managed"), managedMetrics);
-
-        ObjectName configuredObjectName = new ObjectName("io.airlift.openmetrics.test:name=configured,type=Test");
-        mbeanServer.registerMBean(new StandardMBean(new ConfiguredMetrics(), ConfiguredMetricsMBean.class), configuredObjectName);
-
-        MetricsConfig metricsConfig = new MetricsConfig().setJmxObjectNames(ImmutableList.of(configuredObjectName));
-        NodeInfo nodeInfo = new NodeInfo(
-                "test",
-                "pool",
-                "nodeInfo",
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                IP,
-                null,
-                ImmutableMap.of("team", "a", "region", "b"),
-                false);
-
-        return new OpenMetricsCollector(mbeanServer, mbeanExporter, metricsConfig, nodeInfo);
+        assertThat(metric).isPresent();
+        assertThat(metric.orElseThrow()).isInstanceOfSatisfying(Gauge.class, gauge -> {
+            assertThat(gauge.metricName()).isEqualTo("metric_name");
+            assertThat(gauge.value()).isEqualTo(1.0);
+            assertThat(gauge.labels()).isEqualTo(LABELS);
+            assertThat(gauge.help()).isEqualTo("metric help");
+        });
     }
 
-    public static class ManagedMetrics
+    @Test
+    public void testConvertCompositeDataToCompositeMetric()
     {
-        private final CounterStat requests = new CounterStat();
-        private final TestingTicker ticker = new TestingTicker();
-        private final TimeDistribution latency = new TimeDistribution(ticker);
+        Optional<Metric> metric = OpenMetricsCollector.toOpenMetric(new Attribute(List.of("metric_name"), createMemoryUsageCompositeData(100, 200, 1000), "metric help"), LABELS);
 
-        @Managed(description = "numeric gauge")
-        public int getNumericGauge()
-        {
-            return 7;
-        }
-
-        @Managed(description = "request counter")
-        @Nested
-        public CounterStat getRequests()
-        {
-            return requests;
-        }
-
-        @Managed(description = "request latency")
-        @Nested
-        public TimeDistribution getLatency()
-        {
-            return latency;
-        }
-
-        private void forceLatencyMerge()
-        {
-            ticker.increment(1, SECONDS);
-            latency.getCount();
-        }
+        assertThat(metric).isPresent();
+        assertThat(metric.orElseThrow()).isInstanceOfSatisfying(CompositeMetric.class, compositeMetric -> {
+            assertThat(compositeMetric.metricName()).isEqualTo("metric_name");
+            assertThat(compositeMetric.labels()).isEqualTo(LABELS);
+            assertThat(compositeMetric.help()).isEqualTo("metric help");
+            assertThat(compositeMetric.subMetrics())
+                    .filteredOn(Gauge.class::isInstance)
+                    .map(Gauge.class::cast)
+                    .extracting(Gauge::metricName, Gauge::value)
+                    .contains(
+                            tuple("metric_name_committed", 200.0),
+                            tuple("metric_name_max", 1000.0),
+                            tuple("metric_name_used", 100.0));
+        });
     }
 
-    public interface ConfiguredMetricsMBean
+    @Test
+    public void testConvertCounterStatToCounter()
     {
-        int getCount();
+        CounterStat counterStat = new CounterStat();
+        counterStat.update(11);
 
-        CompositeData getMemory();
+        Optional<Metric> metric = OpenMetricsCollector.toOpenMetric(new Attribute(List.of("metric_name"), counterStat, "metric help"), LABELS);
 
-        String getUnsupported();
+        assertThat(metric).isPresent();
+        assertThat(metric.orElseThrow()).isInstanceOfSatisfying(Counter.class, counter -> {
+            assertThat(counter.metricName()).isEqualTo("metric_name");
+            assertThat(counter.value()).isEqualTo(11);
+            assertThat(counter.labels()).isEqualTo(LABELS);
+            assertThat(counter.help()).isEqualTo("metric help");
+        });
     }
 
-    public static class ConfiguredMetrics
-            implements ConfiguredMetricsMBean
+    @Test
+    public void testConvertTimeDistributionToSummary()
     {
-        @Override
-        public int getCount()
-        {
-            return 23;
-        }
+        TestingTicker ticker = new TestingTicker();
+        TimeDistribution timeDistribution = new TimeDistribution(ticker);
+        timeDistribution.add(100);
+        timeDistribution.add(200);
+        ticker.increment(1, SECONDS);
+        timeDistribution.getCount();
 
-        @Override
-        public CompositeData getMemory()
-        {
-            return createMemoryUsageCompositeData(100, 200, 1000);
-        }
+        Optional<Metric> metric = OpenMetricsCollector.toOpenMetric(new Attribute(List.of("metric_name"), timeDistribution, "metric help"), LABELS);
 
-        @Override
-        public String getUnsupported()
-        {
-            return "ignored";
-        }
+        assertThat(metric).isPresent();
+        assertThat(metric.orElseThrow()).isInstanceOfSatisfying(Summary.class, summary -> {
+            assertThat(summary.metricName()).isEqualTo("metric_name");
+            assertThat(summary.count()).isEqualTo(2);
+            assertThat(summary.labels()).isEqualTo(LABELS);
+            assertThat(summary.help()).isEqualTo("metric help");
+        });
+    }
+
+    @Test
+    public void testConvertDistributionToSummary()
+    {
+        Distribution distribution = new Distribution();
+        distribution.add(100);
+        distribution.add(200);
+
+        Optional<Metric> metric = OpenMetricsCollector.toOpenMetric(new Attribute(List.of("metric_name"), distribution, "metric help"), LABELS);
+
+        assertThat(metric).isPresent();
+        assertThat(metric.orElseThrow()).isInstanceOfSatisfying(Summary.class, summary -> {
+            assertThat(summary.metricName()).isEqualTo("metric_name");
+            assertThat(summary.count()).isEqualTo(2);
+            assertThat(summary.sum()).isEqualTo(300);
+            assertThat(summary.quantiles()).containsKeys(0.01, 0.5, 0.99);
+            assertThat(summary.labels()).isEqualTo(LABELS);
+            assertThat(summary.help()).isEqualTo("metric help");
+        });
+    }
+
+    @Test
+    public void testConvertTimeStatToSummaries()
+    {
+        TestingTicker ticker = new TestingTicker();
+        TimeStat timeStat = new TimeStat(ticker);
+        timeStat.addNanos(100);
+        timeStat.addNanos(200);
+        ticker.increment(1, SECONDS);
+
+        Optional<Metric> metric = OpenMetricsCollector.toOpenMetric(new Attribute(List.of("metric_name"), timeStat, "metric help"), LABELS);
+
+        assertThat(metric).isPresent();
+        assertThat(metric.orElseThrow()).isInstanceOfSatisfying(CompositeMetric.class, compositeMetric -> {
+            assertThat(compositeMetric.subMetrics())
+                    .filteredOn(Summary.class::isInstance)
+                    .map(Summary.class::cast)
+                    .extracting(Summary::metricName, Summary::count)
+                    .containsExactlyInAnyOrder(
+                            tuple("metric_name_OneMinute", 2L),
+                            tuple("metric_name_FiveMinutes", 2L),
+                            tuple("metric_name_FifteenMinutes", 2L),
+                            tuple("metric_name_AllTime", 2L));
+        });
+    }
+
+    @Test
+    public void testConvertDistributionStatToSummaries()
+    {
+        DistributionStat distributionStat = new DistributionStat();
+        distributionStat.add(100);
+        distributionStat.add(200);
+
+        Optional<Metric> metric = OpenMetricsCollector.toOpenMetric(new Attribute(List.of("metric_name"), distributionStat, "metric help"), LABELS);
+
+        assertThat(metric).isPresent();
+        assertThat(metric.orElseThrow()).isInstanceOfSatisfying(CompositeMetric.class, compositeMetric -> {
+            assertThat(compositeMetric.subMetrics())
+                    .filteredOn(Summary.class::isInstance)
+                    .map(Summary.class::cast)
+                    .extracting(Summary::metricName, Summary::count)
+                    .containsExactlyInAnyOrder(
+                            tuple("metric_name_OneMinute", 2L),
+                            tuple("metric_name_FiveMinutes", 2L),
+                            tuple("metric_name_FifteenMinutes", 2L),
+                            tuple("metric_name_AllTime", 2L));
+        });
+    }
+
+    @Test
+    public void testFilterCompositeSubMetric()
+    {
+        CompositeMetric compositeMetric = new CompositeMetric(
+                "metric_name",
+                LABELS,
+                "metric help",
+                List.of(
+                        new Summary("metric_name_OneMinute", 1L, 1.0, null, Map.of(), LABELS, "metric help"),
+                        new Summary("metric_name_AllTime", 2L, 2.0, null, Map.of(), LABELS, "metric help")));
+
+        assertThat(OpenMetricsCollector.filterMetrics(List.of(compositeMetric), Set.of("metric_name_AllTime")))
+                .singleElement()
+                .isInstanceOfSatisfying(CompositeMetric.class, filteredMetric -> assertThat(filteredMetric.subMetrics())
+                        .singleElement()
+                        .isInstanceOfSatisfying(Summary.class, summary -> assertThat(summary.metricName()).isEqualTo("metric_name_AllTime")));
+    }
+
+    @Test
+    public void testFindCompositeMetricRoot()
+    {
+        CompositeMetric compositeMetric = new CompositeMetric(
+                "metric_name",
+                LABELS,
+                "metric help",
+                List.of(
+                        new Summary("metric_name_OneMinute", 1L, 1.0, null, Map.of(), LABELS, "metric help"),
+                        new Summary("metric_name_AllTime", 2L, 2.0, null, Map.of(), LABELS, "metric help")));
+
+        assertThat(OpenMetricsCollector.findMetric(List.of(compositeMetric), "metric_name"))
+                .containsSame(compositeMetric);
+        assertThat(OpenMetricsCollector.findMetric(List.of(compositeMetric), "metric_name_AllTime"))
+                .containsInstanceOf(Summary.class);
+    }
+
+    @Test
+    public void testIgnoreUnsupportedValue()
+    {
+        assertThat(OpenMetricsCollector.toOpenMetric(new Attribute(List.of("metric_name"), "ignored", "metric help"), LABELS)).isEmpty();
     }
 
     private static CompositeData createMemoryUsageCompositeData(long used, long committed, long max)

--- a/opentelemetry/README.md
+++ b/opentelemetry/README.md
@@ -1,0 +1,277 @@
+# OpenTelemetry Metrics
+
+The OpenTelemetry metrics exporter converts objects exported through jmxutils into OpenTelemetry
+`MetricData`. In normal Airlift applications, metrics are exposed by marking Java objects and
+attributes as managed, exporting those objects through jmxutils, and letting the exporter derive
+OpenTelemetry metric data from the exported type, managed attribute path, and export identity.
+
+The exporter can also include raw platform MBeans when `metrics.jmx-object-names` is explicitly
+configured. Those metrics do not have the same jmxutils export metadata, so they use a separate
+best-effort conversion from `ObjectName`.
+
+## Installing
+
+Applications normally install the OpenTelemetry modules in Guice and configure the exporter to send
+data to an OpenTelemetry collector:
+
+```java
+new Bootstrap(
+        new OpenTelemetryModule("trino", nodeVersion),
+        new OpenTelemetryExporterModule(),
+        new OpenTelemetryMetricsExporterModule(),
+        ...);
+```
+
+`OpenTelemetryModule` creates the OpenTelemetry SDK objects and resource attributes.
+`OpenTelemetryExporterModule` configures OTLP export for traces, metrics, and logs.
+`OpenTelemetryMetricsExporterModule` adds the jmxutils managed-metrics producer to the
+OpenTelemetry meter provider.
+
+Common exporter configuration:
+
+```properties
+otel.exporter.endpoint=http://otel-collector.example.com:4317
+otel.exporter.protocol=grpc
+otel.exporter.interval=10s
+```
+
+## Native OpenTelemetry Stats
+
+Applications that use OpenTelemetry as their primary metrics path should usually configure the stats
+backend before any stats objects are created:
+
+```text
+-Dio.airlift.stats.backend=opentelemetry
+```
+
+This may also be set from `main` before creating the Airlift bootstrap:
+
+```java
+System.setProperty("io.airlift.stats.backend", "opentelemetry");
+```
+
+The default Airlift stats backend keeps the traditional Airlift distribution state, including decay
+windows for `TimeStat` and `DistributionStat`. When those values are exported to OpenTelemetry,
+they are converted to summary metrics containing count, sum, and exported percentiles.
+
+The OpenTelemetry stats backend records distribution values directly into OpenTelemetry-compatible
+exponential histograms. The exporter emits those values as OpenTelemetry exponential histogram
+metrics instead of summaries. In this mode, `TimeStat` and `DistributionStat` export one native
+histogram at the metric name itself; the Airlift backend exports separate summary metrics such as
+`.OneMinute`, `.FiveMinutes`, `.FifteenMinutes`, and `.AllTime`.
+
+Example for a managed `TimeStat` attribute named `Time`:
+
+```text
+metric name: io.trino.sql.planner.optimizations.PlanOptimizer.Time
+metric type: exponential histogram
+unit: ns
+```
+
+## jmxutils Managed Exports
+
+Managed exports are objects exported through jmxutils `MBeanExporter`. For these metrics, jmxutils
+provides both the original export inputs and the final `ObjectName` after the configured
+`ObjectNameGenerator` runs.
+
+The OpenTelemetry exporter uses this information as follows:
+
+* The metric name starts with the full exported Java type name.
+* The managed attribute path is appended to the metric name with dots. Flattened managed attributes
+  omit the flattened getter's Java bean property name, but still include the child attribute names.
+  Non-flattened nested attributes include each Java bean property name in the path.
+* The final `ObjectName` key properties become OpenTelemetry attributes.
+* `type=<simple type name>` is removed from the attributes because the exported type is already
+  represented in the metric name.
+* A default unqualified `name=<simple type name>` is removed for the same reason.
+* An explicit generated name is kept as an attribute because it identifies the exported instance.
+* Properties added by an `ObjectNameGenerator`, such as a Trino connector catalog, are kept as
+  attributes because they identify the exported instance.
+
+The attribute rule starts from the final `ObjectName` after the configured `ObjectNameGenerator`
+runs. The exporter removes only object-kind properties already represented by the metric name, such
+as the default `type` or unqualified `name`. All remaining properties are kept as OpenTelemetry
+attributes, including properties added by an `ObjectNameGenerator`.
+
+### Default Export
+
+Export:
+
+```java
+newExporter(binder).export(NodeInfo.class).withGeneratedName();
+```
+
+Export metadata:
+
+```text
+exported type: io.airlift.node.NodeInfo
+final ObjectName: io.airlift.node:name=NodeInfo
+managed attribute path: Environment
+```
+
+OpenTelemetry output:
+
+```text
+metric name: io.airlift.node.NodeInfo.Environment
+attributes: {}
+```
+
+The final `name=NodeInfo` property is not emitted as an attribute because it is the default object
+kind name.
+
+### Qualified Export
+
+Export:
+
+```java
+newExporter(binder)
+        .export(HttpClient.class)
+        .annotatedWith(ForDiscoveryClient.class)
+        .withGeneratedName();
+```
+
+Export metadata:
+
+```text
+exported type: io.airlift.http.client.HttpClient
+final ObjectName: io.airlift.http.client:type=HttpClient,name=ForDiscoveryClient
+managed attribute path: AllResponse
+```
+
+OpenTelemetry output:
+
+```text
+metric name: io.airlift.http.client.HttpClient.AllResponse
+attributes:
+  name = ForDiscoveryClient
+```
+
+The final `type=HttpClient` property is not emitted as an attribute because it is the object kind.
+The `name=ForDiscoveryClient` property is emitted because it identifies the qualified binding. In
+this example, the managed getter is `getStats()` with `@Flatten`, so the `Stats` property name is not
+included in the metric name.
+
+### Nested Attribute Path
+
+For a non-flattened nested managed getter, the Java bean property name is included in the managed
+attribute path.
+
+Managed object:
+
+```java
+class Server
+{
+    @Managed
+    @Nested
+    public ThreadPoolStats getThreadPool()
+    {
+        return threadPool;
+    }
+}
+
+class ThreadPoolStats
+{
+    @Managed
+    public int getQueuedRequests()
+    {
+        return queuedRequests;
+    }
+}
+```
+
+Export metadata:
+
+```text
+exported type: io.airlift.http.server.Server
+managed attribute path: ThreadPool.QueuedRequests
+```
+
+OpenTelemetry output:
+
+```text
+metric name: io.airlift.http.server.Server.ThreadPool.QueuedRequests
+```
+
+### Property Map Export
+
+Export:
+
+```java
+exporter.exportWithGeneratedName(
+        optimizerStats,
+        PlanOptimizer.class,
+        Map.of(
+                "name", PlanOptimizer.class.getSimpleName(),
+                "optimizer", "PredicatePushDown"));
+```
+
+Export metadata:
+
+```text
+exported type: io.trino.sql.planner.optimizations.PlanOptimizer
+final ObjectName: trino.sql.planner:name=PlanOptimizer,optimizer=PredicatePushDown
+original properties: name=PlanOptimizer, optimizer=PredicatePushDown
+managed attribute path: Time
+```
+
+OpenTelemetry output:
+
+```text
+metric name: io.trino.sql.planner.optimizations.PlanOptimizer.Time
+attributes:
+  optimizer = PredicatePushDown
+```
+
+The final `name=PlanOptimizer` property is not emitted as an attribute because the original
+properties used it as the object kind name.
+
+### Generator-Added Identity
+
+Trino connector object name generators add catalog identity to the final `ObjectName`.
+
+Export metadata:
+
+```text
+exported type: io.trino.plugin.hive.HiveSplitManager
+final ObjectName: trino.plugin.hive:type=HiveSplitManager,name=hive,catalog=hive
+managed attribute path: QueuedSplits
+```
+
+OpenTelemetry output:
+
+```text
+metric name: io.trino.plugin.hive.HiveSplitManager.QueuedSplits
+attributes:
+  catalog = hive
+  name = hive
+```
+
+The generated `catalog` property is preserved because it distinguishes one connector instance from
+another.
+
+## Configured JMX Metrics
+
+Metrics collected from `metrics.jmx-object-names` are read directly from the platform MBean server.
+They may not have jmxutils export metadata, so the exporter falls back to the final `ObjectName`:
+
+* If the object name has a `type` property, that is used as the metric base and removed from
+  attributes.
+* Otherwise, if the object name has a `name` property, that is used as the metric base and removed
+  from attributes.
+* Otherwise, the object name domain is used as the metric base and all key properties are kept as
+  attributes.
+
+Example:
+
+```text
+final ObjectName: trino.execution.scheduler:segment=foo
+managed attribute path: PlacementFailures
+```
+
+OpenTelemetry output:
+
+```text
+metric name: trino.execution.scheduler.PlacementFailures
+attributes:
+  segment = foo
+```

--- a/opentelemetry/pom.xml
+++ b/opentelemetry/pom.xml
@@ -31,12 +31,27 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>log</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>metrics</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>node</artifactId>
         </dependency>
 
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>security</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>stats</artifactId>
         </dependency>
 
         <dependency>

--- a/opentelemetry/src/main/java/io/airlift/opentelemetry/OpenTelemetryMetricDataConverter.java
+++ b/opentelemetry/src/main/java/io/airlift/opentelemetry/OpenTelemetryMetricDataConverter.java
@@ -1,0 +1,572 @@
+package io.airlift.opentelemetry;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.CharMatcher;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import io.airlift.log.Logger;
+import io.airlift.metrics.CollectedMetricGroup;
+import io.airlift.metrics.CollectedMetricGroup.Attribute;
+import io.airlift.metrics.MetricSource;
+import io.airlift.metrics.MetricSource.ManagedMetricSource;
+import io.airlift.stats.CounterStat;
+import io.airlift.stats.Distribution;
+import io.airlift.stats.Distribution.DistributionSnapshot;
+import io.airlift.stats.DistributionStat;
+import io.airlift.stats.ExponentialHistogram.Buckets;
+import io.airlift.stats.ExponentialHistogram.ExponentialHistogramSnapshot;
+import io.airlift.stats.TimeDistribution;
+import io.airlift.stats.TimeDistribution.TimeDistributionSnapshot;
+import io.airlift.stats.TimeStat;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.DoublePointData;
+import io.opentelemetry.sdk.metrics.data.ExponentialHistogramBuckets;
+import io.opentelemetry.sdk.metrics.data.ExponentialHistogramData;
+import io.opentelemetry.sdk.metrics.data.ExponentialHistogramPointData;
+import io.opentelemetry.sdk.metrics.data.GaugeData;
+import io.opentelemetry.sdk.metrics.data.LongPointData;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.data.SumData;
+import io.opentelemetry.sdk.metrics.data.SummaryData;
+import io.opentelemetry.sdk.metrics.data.SummaryPointData;
+import io.opentelemetry.sdk.metrics.data.ValueAtQuantile;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableMetricData;
+import io.opentelemetry.sdk.resources.Resource;
+
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import javax.management.openmbean.CompositeData;
+import javax.management.openmbean.CompositeType;
+import javax.management.openmbean.TabularData;
+import javax.management.openmbean.TabularType;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.joining;
+
+public class OpenTelemetryMetricDataConverter
+{
+    private static final int DEFAULT_MAX_POINTS_PER_METRIC_FAMILY = 2_000;
+    private static final int DEFAULT_MAX_POINTS_PER_SCRAPE = 100_000;
+    private static final Logger log = Logger.get(OpenTelemetryMetricDataConverter.class);
+    private static final String NANOSECOND_UNIT = "ns";
+    private static final Comparator<MetricPoint> METRIC_POINT_ORDERING = Comparator
+            .comparing((MetricPoint metricPoint) -> attributesComparisonKey(metricPoint.attributes()))
+            .thenComparing(metricPoint -> String.valueOf(metricPoint.description()))
+            .thenComparing(metricPoint -> String.valueOf(metricPoint.value()));
+    private static final CharMatcher NON_ALLOWED_METRIC_NAME_CHARACTERS = CharMatcher
+            .inRange('a', 'z')
+            .or(CharMatcher.inRange('A', 'Z'))
+            .or(CharMatcher.inRange('0', '9'))
+            .or(CharMatcher.anyOf("._-"))
+            .negate()
+            .precomputed();
+
+    private final int maxPointsPerMetricFamily;
+    private final int maxPointsPerScrape;
+
+    public OpenTelemetryMetricDataConverter()
+    {
+        this(DEFAULT_MAX_POINTS_PER_METRIC_FAMILY, DEFAULT_MAX_POINTS_PER_SCRAPE);
+    }
+
+    @VisibleForTesting
+    OpenTelemetryMetricDataConverter(int maxPointsPerMetricFamily, int maxPointsPerScrape)
+    {
+        checkArgument(maxPointsPerMetricFamily > 0, "maxPointsPerMetricFamily must be positive");
+        checkArgument(maxPointsPerScrape > 0, "maxPointsPerScrape must be positive");
+        this.maxPointsPerMetricFamily = maxPointsPerMetricFamily;
+        this.maxPointsPerScrape = maxPointsPerScrape;
+    }
+
+    ConversionResult convertWithDroppedPoints(Collection<CollectedMetricGroup> metricGroups, Resource resource, long startEpochNanos, long epochNanos)
+    {
+        Map<MetricFamilyKey, List<MetricPoint>> metricFamilies = metricGroups.stream()
+                .flatMap(OpenTelemetryMetricDataConverter::toMetricPoints)
+                .collect(groupingBy(MetricPoint::family));
+
+        List<Map.Entry<MetricFamilyKey, List<MetricPoint>>> sortedMetricFamilies = metricFamilies.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey(Comparator.comparing(MetricFamilyKey::name)
+                        .thenComparing(MetricFamilyKey::kind)
+                        .thenComparing(MetricFamilyKey::unit)))
+                .toList();
+        ImmutableList.Builder<MetricData> metricData = ImmutableList.builderWithExpectedSize(sortedMetricFamilies.size());
+        long droppedPoints = 0;
+        int remainingPoints = maxPointsPerScrape;
+        for (Map.Entry<MetricFamilyKey, List<MetricPoint>> entry : sortedMetricFamilies) {
+            List<MetricPoint> metricFamily = entry.getValue();
+            if (remainingPoints == 0) {
+                droppedPoints += metricFamily.size();
+                continue;
+            }
+
+            int pointLimit = Math.min(maxPointsPerMetricFamily, remainingPoints);
+            int pointCount = Math.min(metricFamily.size(), pointLimit);
+            List<MetricPoint> selectedMetricFamily = selectMetricPoints(metricFamily, pointCount);
+            Optional<MetricData> convertedMetricData = convertMetricFamily(entry.getKey(), selectedMetricFamily, resource, startEpochNanos, epochNanos);
+            if (convertedMetricData.isEmpty()) {
+                continue;
+            }
+
+            metricData.add(convertedMetricData.orElseThrow());
+            remainingPoints -= pointCount;
+            droppedPoints += metricFamily.size() - pointCount;
+        }
+        return new ConversionResult(metricData.build(), droppedPoints);
+    }
+
+    private static List<MetricPoint> selectMetricPoints(List<MetricPoint> metricFamily, int pointCount)
+    {
+        if (pointCount == metricFamily.size()) {
+            return metricFamily;
+        }
+        return metricFamily.stream()
+                .sorted(METRIC_POINT_ORDERING)
+                .limit(pointCount)
+                .toList();
+    }
+
+    private static String attributesComparisonKey(Attributes attributes)
+    {
+        return attributes.asMap().entrySet().stream()
+                .sorted(Comparator.comparing((Map.Entry<AttributeKey<?>, Object> entry) -> entry.getKey().getKey())
+                        .thenComparing(entry -> String.valueOf(entry.getValue())))
+                .map(entry -> entry.getKey().getKey() + "=" + entry.getValue())
+                .collect(joining("|"));
+    }
+
+    private static Optional<MetricData> convertMetricFamily(
+            MetricFamilyKey metricFamilyKey,
+            List<MetricPoint> selectedMetricFamily,
+            Resource resource,
+            long startEpochNanos,
+            long epochNanos)
+    {
+        try {
+            return Optional.of(toMetricData(metricFamilyKey, selectedMetricFamily, resource, startEpochNanos, epochNanos));
+        }
+        catch (RuntimeException e) {
+            log.warn(e, "Unable to convert OpenTelemetry metric family %s", metricFamilyKey.name());
+            return Optional.empty();
+        }
+    }
+
+    private static MetricData toMetricData(
+            MetricFamilyKey metricFamilyKey,
+            List<MetricPoint> selectedMetricFamily,
+            Resource resource,
+            long startEpochNanos,
+            long epochNanos)
+    {
+        MetricPoint firstMetric = selectedMetricFamily.getFirst();
+        return switch (metricFamilyKey.kind()) {
+            case DOUBLE_GAUGE -> toDoubleGauge(metricFamilyKey.name(), selectedMetricFamily, firstMetric, resource, startEpochNanos, epochNanos);
+            case LONG_SUM -> toLongSum(metricFamilyKey.name(), selectedMetricFamily, firstMetric, resource, startEpochNanos, epochNanos);
+            case SUMMARY -> toSummary(metricFamilyKey.name(), selectedMetricFamily, firstMetric, resource, startEpochNanos, epochNanos);
+            case EXPONENTIAL_HISTOGRAM -> toExponentialHistogram(metricFamilyKey.name(), selectedMetricFamily, firstMetric, resource, startEpochNanos, epochNanos);
+        };
+    }
+
+    private static MetricData toDoubleGauge(String metricName, List<MetricPoint> metricFamily, MetricPoint firstMetric, Resource resource, long startEpochNanos, long epochNanos)
+    {
+        List<DoublePointData> points = metricFamily.stream()
+                .map(metric -> DoublePointData.create(startEpochNanos, epochNanos, metric.attributes(), (double) metric.value(), List.of()))
+                .collect(toImmutableList());
+        return ImmutableMetricData.createDoubleGauge(
+                resource,
+                OpenTelemetryMetricProducer.INSTRUMENTATION_SCOPE,
+                metricName,
+                firstMetric.description(),
+                firstMetric.unit(),
+                GaugeData.createDoubleGaugeData(points));
+    }
+
+    private static MetricData toLongSum(String metricName, List<MetricPoint> metricFamily, MetricPoint firstMetric, Resource resource, long startEpochNanos, long epochNanos)
+    {
+        List<LongPointData> points = metricFamily.stream()
+                .map(metric -> LongPointData.create(startEpochNanos, epochNanos, metric.attributes(), (long) metric.value()))
+                .collect(toImmutableList());
+        return ImmutableMetricData.createLongSum(
+                resource,
+                OpenTelemetryMetricProducer.INSTRUMENTATION_SCOPE,
+                metricName,
+                firstMetric.description(),
+                firstMetric.unit(),
+                SumData.createLongSumData(true, AggregationTemporality.CUMULATIVE, points));
+    }
+
+    private static MetricData toSummary(String metricName, List<MetricPoint> metricFamily, MetricPoint firstMetric, Resource resource, long startEpochNanos, long epochNanos)
+    {
+        List<SummaryPointData> points = metricFamily.stream()
+                .map(metric -> {
+                    SummaryValue summary = (SummaryValue) metric.value();
+                    return SummaryPointData.create(
+                            startEpochNanos,
+                            epochNanos,
+                            metric.attributes(),
+                            summary.count(),
+                            summary.sum(),
+                            summary.valuesAtQuantiles());
+                })
+                .collect(toImmutableList());
+        return ImmutableMetricData.createDoubleSummary(
+                resource,
+                OpenTelemetryMetricProducer.INSTRUMENTATION_SCOPE,
+                metricName,
+                firstMetric.description(),
+                firstMetric.unit(),
+                SummaryData.create(points));
+    }
+
+    private static MetricData toExponentialHistogram(String metricName, List<MetricPoint> metricFamily, MetricPoint firstMetric, Resource resource, long startEpochNanos, long epochNanos)
+    {
+        List<ExponentialHistogramPointData> points = metricFamily.stream()
+                .map(metric -> toExponentialHistogramPoint((ExponentialHistogramSnapshot) metric.value(), metric.attributes(), startEpochNanos, epochNanos))
+                .collect(toImmutableList());
+        return ImmutableMetricData.createExponentialHistogram(
+                resource,
+                OpenTelemetryMetricProducer.INSTRUMENTATION_SCOPE,
+                metricName,
+                firstMetric.description(),
+                firstMetric.unit(),
+                ExponentialHistogramData.create(AggregationTemporality.CUMULATIVE, points));
+    }
+
+    private static ExponentialHistogramPointData toExponentialHistogramPoint(
+            ExponentialHistogramSnapshot snapshot,
+            Attributes attributes,
+            long startEpochNanos,
+            long epochNanos)
+    {
+        boolean hasMinMax = snapshot.count() > 0;
+        return ExponentialHistogramPointData.create(
+                snapshot.scale(),
+                snapshot.sum(),
+                snapshot.zeroCount(),
+                hasMinMax,
+                hasMinMax ? snapshot.min() : 0,
+                hasMinMax,
+                hasMinMax ? snapshot.max() : 0,
+                toExponentialHistogramBuckets(snapshot.scale(), snapshot.positiveBuckets()),
+                toExponentialHistogramBuckets(snapshot.scale(), snapshot.negativeBuckets()),
+                startEpochNanos,
+                epochNanos,
+                attributes,
+                List.of());
+    }
+
+    private static ExponentialHistogramBuckets toExponentialHistogramBuckets(int scale, Buckets buckets)
+    {
+        return ExponentialHistogramBuckets.create(
+                scale,
+                buckets.offset(),
+                Arrays.stream(buckets.counts())
+                        .boxed()
+                        .collect(toImmutableList()));
+    }
+
+    private static Stream<MetricPoint> toMetricPoints(CollectedMetricGroup metricGroup)
+    {
+        return metricGroup.attributes().stream()
+                .flatMap(attribute -> {
+                    MetricIdentity metricIdentity = metricIdentity(metricGroup.source(), attribute);
+                    return toMetricPoints(metricIdentity.name(), attribute, attributes(metricGroup.labels(), metricIdentity.labels()));
+                });
+    }
+
+    private static MetricIdentity metricIdentity(MetricSource source, Attribute attribute)
+    {
+        return switch (source) {
+            case MetricSource.JmxMetricSource jmxMetricSource -> metricIdentity(jmxMetricSource.name(), attribute);
+            case MetricSource.ManagedMetricSource managedMetricSource -> metricIdentity(managedMetricSource, attribute);
+        };
+    }
+
+    private static MetricIdentity metricIdentity(ManagedMetricSource source, Attribute attribute)
+    {
+        Optional<ObjectName> objectName = parseObjectName(source.name());
+        if (source.exportedType().isPresent()) {
+            Class<?> exportedType = source.exportedType().orElseThrow();
+            String baseName = exportedType.getName();
+            return new MetricIdentity(metricName(baseName, attribute), managedMetricLabels(source, objectName, exportedType.getSimpleName()));
+        }
+
+        return objectName
+                .map(name -> metricIdentity(name, attribute))
+                .orElseGet(() -> new MetricIdentity(metricName(source.name(), attribute), Map.of()));
+    }
+
+    private static Map<String, String> managedMetricLabels(ManagedMetricSource source, Optional<ObjectName> objectName, String typeName)
+    {
+        Map<String, String> labels = objectName
+                .<Map<String, String>>map(name -> new LinkedHashMap<>(name.getKeyPropertyList()))
+                .orElseGet(LinkedHashMap::new);
+
+        // The final ObjectName properties are the source of labels because ObjectNameGenerators can
+        // add identity such as Trino connector catalogs. The original export inputs only tell us
+        // which final properties are object-kind metadata already represented by the metric name.
+        labels.remove("type", typeName);
+        if (isObjectKindName(source, labels.get("name"), typeName)) {
+            labels.remove("name");
+        }
+        return labels;
+    }
+
+    private static boolean isObjectKindName(ManagedMetricSource source, String name, String typeName)
+    {
+        if (!typeName.equals(name)) {
+            return false;
+        }
+
+        // An explicit generated name is identity, even when it happens to equal the type name. The
+        // default unqualified export and property-map exports that set name=<type> are object-kind
+        // metadata and should not become labels.
+        return source.originalName().isEmpty() &&
+                (source.originalProperties().isEmpty() || typeName.equals(source.originalProperties().get("name")));
+    }
+
+    private static Optional<ObjectName> parseObjectName(String name)
+    {
+        try {
+            return Optional.of(new ObjectName(name));
+        }
+        catch (MalformedObjectNameException e) {
+            return Optional.empty();
+        }
+    }
+
+    private static MetricIdentity metricIdentity(ObjectName objectName, Attribute attribute)
+    {
+        Map<String, String> labels = new LinkedHashMap<>(objectName.getKeyPropertyList());
+
+        String baseName = objectName.getKeyProperty("type");
+        if (baseName != null) {
+            labels.remove("type");
+            return new MetricIdentity(metricName(baseName, attribute), labels);
+        }
+
+        baseName = objectName.getKeyProperty("name");
+        if (baseName != null) {
+            labels.remove("name");
+            return new MetricIdentity(metricName(baseName, attribute), labels);
+        }
+
+        return new MetricIdentity(metricName(objectName.getDomain(), attribute), labels);
+    }
+
+    private static String metricName(String baseName, Attribute attribute)
+    {
+        String attributeName = sanitizeMetricName(String.join(".", attribute.path()));
+        String metricName = sanitizeMetricName(baseName);
+        if (attributeName.isEmpty()) {
+            return metricName;
+        }
+        if (metricName.isEmpty()) {
+            return attributeName;
+        }
+        return metricName + "." + attributeName;
+    }
+
+    private static String sanitizeMetricName(String name)
+    {
+        return NON_ALLOWED_METRIC_NAME_CHARACTERS.collapseFrom(name, '_');
+    }
+
+    private static Stream<MetricPoint> toMetricPoints(String metricName, Attribute attribute, Attributes attributes)
+    {
+        return toMetricPoints(metricName, attribute.value(), attributes, attribute.description());
+    }
+
+    private static Stream<MetricPoint> toMetricPoints(String metricName, Object value, Attributes attributes, String description)
+    {
+        return switch (value) {
+            case Number number -> Stream.of(new MetricPoint(new MetricFamilyKey(metricName, MetricKind.DOUBLE_GAUGE, ""), number.doubleValue(), attributes, description));
+            case Boolean bool -> Stream.of(new MetricPoint(new MetricFamilyKey(metricName, MetricKind.DOUBLE_GAUGE, ""), bool ? 1.0 : 0.0, attributes, description));
+            case CompositeData compositeData -> compositeDataPoints(metricName, compositeData, attributes, description);
+            case TabularData tabularData -> tabularDataPoints(metricName, tabularData, attributes, description);
+            case CounterStat counterStat -> Stream.of(new MetricPoint(new MetricFamilyKey(metricName, MetricKind.LONG_SUM, ""), counterStat.getTotalCount(), attributes, description));
+            case TimeDistribution timeDistribution -> timeDistribution.exponentialHistogramSnapshot()
+                    .map(snapshot -> Stream.of(new MetricPoint(new MetricFamilyKey(metricName, MetricKind.EXPONENTIAL_HISTOGRAM, NANOSECOND_UNIT), snapshot, attributes, description)))
+                    .orElseGet(() -> Stream.of(timeSummary(metricName, timeDistribution, attributes, description)));
+            case TimeStat timeStat -> timeStat.exponentialHistogramSnapshot()
+                    .map(snapshot -> Stream.of(new MetricPoint(new MetricFamilyKey(metricName, MetricKind.EXPONENTIAL_HISTOGRAM, NANOSECOND_UNIT), snapshot, attributes, description)))
+                    .orElseGet(() -> timeStatSummaries(metricName, timeStat, attributes, description));
+            case Distribution distribution -> distribution.exponentialHistogramSnapshot()
+                    .map(snapshot -> Stream.of(new MetricPoint(new MetricFamilyKey(metricName, MetricKind.EXPONENTIAL_HISTOGRAM, ""), snapshot, attributes, description)))
+                    .orElseGet(() -> Stream.of(new MetricPoint(new MetricFamilyKey(metricName, MetricKind.SUMMARY, ""), toSummary(distribution), attributes, description)));
+            case DistributionStat distributionStat -> distributionStat.exponentialHistogramSnapshot()
+                    .map(snapshot -> Stream.of(new MetricPoint(new MetricFamilyKey(metricName, MetricKind.EXPONENTIAL_HISTOGRAM, ""), snapshot, attributes, description)))
+                    .orElseGet(() -> distributionStatSummaries(metricName, distributionStat, attributes, description));
+            case null, default -> Stream.of();
+        };
+    }
+
+    private static Stream<MetricPoint> compositeDataPoints(String metricName, CompositeData compositeData, Attributes attributes, String description)
+    {
+        CompositeType compositeType = compositeData.getCompositeType();
+        return compositeType.keySet().stream()
+                .flatMap(itemName -> toMetricPoints(metricName + "." + sanitizeMetricName(itemName), compositeData.get(itemName), attributes, description));
+    }
+
+    private static Stream<MetricPoint> tabularDataPoints(String metricName, TabularData tabularData, Attributes attributes, String description)
+    {
+        if (tabularData.isEmpty()) {
+            return Stream.of();
+        }
+
+        TabularType tabularType = tabularData.getTabularType();
+        ImmutableSet<String> indexNames = ImmutableSet.copyOf(tabularType.getIndexNames());
+        return tabularData.values().stream()
+                .filter(CompositeData.class::isInstance)
+                .map(CompositeData.class::cast)
+                .flatMap(compositeData -> {
+                    AttributesBuilder rowAttributes = attributes.toBuilder();
+                    for (String indexName : indexNames) {
+                        if (compositeData.containsKey(indexName)) {
+                            rowAttributes.put(indexName, compositeData.get(indexName).toString());
+                        }
+                    }
+
+                    Attributes builtAttributes = rowAttributes.build();
+                    return Sets.difference(compositeData.getCompositeType().keySet(), indexNames).stream()
+                            .flatMap(itemName -> toMetricPoints(metricName + "." + sanitizeMetricName(itemName), compositeData.get(itemName), builtAttributes, description));
+                });
+    }
+
+    private static Stream<MetricPoint> timeStatSummaries(String metricName, TimeStat timeStat, Attributes attributes, String description)
+    {
+        ImmutableList.Builder<MetricPoint> metrics = ImmutableList.builder();
+        if (timeStat.getOneMinute() != null) {
+            metrics.add(timeSummary(metricName + ".OneMinute", timeStat.getOneMinute(), attributes, description));
+        }
+        if (timeStat.getFiveMinutes() != null) {
+            metrics.add(timeSummary(metricName + ".FiveMinutes", timeStat.getFiveMinutes(), attributes, description));
+        }
+        if (timeStat.getFifteenMinutes() != null) {
+            metrics.add(timeSummary(metricName + ".FifteenMinutes", timeStat.getFifteenMinutes(), attributes, description));
+        }
+        metrics.add(timeSummary(metricName + ".AllTime", timeStat.getAllTime(), attributes, description));
+        return metrics.build().stream();
+    }
+
+    private static MetricPoint timeSummary(String metricName, TimeDistribution timeDistribution, Attributes attributes, String description)
+    {
+        return new MetricPoint(new MetricFamilyKey(metricName, MetricKind.SUMMARY, timeUnit(timeDistribution.getUnit())), toSummary(timeDistribution), attributes, description);
+    }
+
+    private static String timeUnit(TimeUnit unit)
+    {
+        return switch (unit) {
+            case NANOSECONDS -> NANOSECOND_UNIT;
+            case MICROSECONDS -> "us";
+            case MILLISECONDS -> "ms";
+            case SECONDS -> "s";
+            case MINUTES -> "min";
+            case HOURS -> "h";
+            case DAYS -> "d";
+        };
+    }
+
+    private static Stream<MetricPoint> distributionStatSummaries(String metricName, DistributionStat distributionStat, Attributes attributes, String description)
+    {
+        ImmutableList.Builder<MetricPoint> metrics = ImmutableList.builder();
+        if (distributionStat.getOneMinute() != null) {
+            metrics.add(new MetricPoint(new MetricFamilyKey(metricName + ".OneMinute", MetricKind.SUMMARY, ""), toSummary(distributionStat.getOneMinute()), attributes, description));
+        }
+        if (distributionStat.getFiveMinutes() != null) {
+            metrics.add(new MetricPoint(new MetricFamilyKey(metricName + ".FiveMinutes", MetricKind.SUMMARY, ""), toSummary(distributionStat.getFiveMinutes()), attributes, description));
+        }
+        if (distributionStat.getFifteenMinutes() != null) {
+            metrics.add(new MetricPoint(new MetricFamilyKey(metricName + ".FifteenMinutes", MetricKind.SUMMARY, ""), toSummary(distributionStat.getFifteenMinutes()), attributes, description));
+        }
+        metrics.add(new MetricPoint(new MetricFamilyKey(metricName + ".AllTime", MetricKind.SUMMARY, ""), toSummary(distributionStat.getAllTime()), attributes, description));
+        return metrics.build().stream();
+    }
+
+    private static SummaryValue toSummary(TimeDistribution timeDistribution)
+    {
+        TimeDistributionSnapshot snapshot = timeDistribution.snapshot();
+        return new SummaryValue(
+                (long) snapshot.count(),
+                snapshot.count() == 0 ? 0 : snapshot.avg() * snapshot.count(),
+                ImmutableList.of(
+                        ValueAtQuantile.create(0.5, snapshot.p50()),
+                        ValueAtQuantile.create(0.75, snapshot.p75()),
+                        ValueAtQuantile.create(0.9, snapshot.p90()),
+                        ValueAtQuantile.create(0.95, snapshot.p95()),
+                        ValueAtQuantile.create(0.99, snapshot.p99())));
+    }
+
+    private static SummaryValue toSummary(Distribution distribution)
+    {
+        DistributionSnapshot snapshot = distribution.snapshot();
+        return new SummaryValue(
+                (long) snapshot.count(),
+                snapshot.total(),
+                ImmutableList.of(
+                        ValueAtQuantile.create(0.01, snapshot.p01()),
+                        ValueAtQuantile.create(0.05, snapshot.p05()),
+                        ValueAtQuantile.create(0.10, snapshot.p10()),
+                        ValueAtQuantile.create(0.25, snapshot.p25()),
+                        ValueAtQuantile.create(0.5, snapshot.p50()),
+                        ValueAtQuantile.create(0.75, snapshot.p75()),
+                        ValueAtQuantile.create(0.9, snapshot.p90()),
+                        ValueAtQuantile.create(0.95, snapshot.p95()),
+                        ValueAtQuantile.create(0.99, snapshot.p99())));
+    }
+
+    private static Attributes attributes(Map<String, String> labels, Map<String, String> metricLabels)
+    {
+        if (labels.isEmpty() && metricLabels.isEmpty()) {
+            return Attributes.empty();
+        }
+
+        AttributesBuilder builder = Attributes.builder();
+        labels.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .forEach(entry -> builder.put(entry.getKey(), entry.getValue()));
+        metricLabels.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .forEach(entry -> builder.put(entry.getKey(), entry.getValue()));
+        return builder.build();
+    }
+
+    private enum MetricKind
+    {
+        DOUBLE_GAUGE,
+        LONG_SUM,
+        SUMMARY,
+        EXPONENTIAL_HISTOGRAM,
+    }
+
+    private record MetricFamilyKey(String name, MetricKind kind, String unit) {}
+
+    private record MetricIdentity(String name, Map<String, String> labels) {}
+
+    private record MetricPoint(MetricFamilyKey family, Object value, Attributes attributes, String description)
+    {
+        public String unit()
+        {
+            return family.unit();
+        }
+    }
+
+    private record SummaryValue(long count, double sum, List<ValueAtQuantile> valuesAtQuantiles) {}
+
+    record ConversionResult(List<MetricData> metricData, long droppedPoints) {}
+}

--- a/opentelemetry/src/main/java/io/airlift/opentelemetry/OpenTelemetryMetricProducer.java
+++ b/opentelemetry/src/main/java/io/airlift/opentelemetry/OpenTelemetryMetricProducer.java
@@ -1,0 +1,84 @@
+package io.airlift.opentelemetry;
+
+import com.google.inject.Inject;
+import io.airlift.log.Logger;
+import io.airlift.metrics.CollectedMetricGroup;
+import io.airlift.metrics.MetricsCollector;
+import io.airlift.opentelemetry.OpenTelemetryMetricDataConverter.ConversionResult;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.LongPointData;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.data.SumData;
+import io.opentelemetry.sdk.metrics.export.MetricProducer;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableMetricData;
+import io.opentelemetry.sdk.resources.Resource;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static java.lang.System.currentTimeMillis;
+import static java.lang.System.nanoTime;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+public class OpenTelemetryMetricProducer
+        implements MetricProducer
+{
+    static final InstrumentationScopeInfo INSTRUMENTATION_SCOPE =
+            InstrumentationScopeInfo.builder("io.airlift.opentelemetry.metrics").build();
+
+    private static final Logger log = Logger.get(OpenTelemetryMetricProducer.class);
+    private static final String DROPPED_POINTS_METRIC_NAME = "opentelemetry_metrics_dropped_points";
+
+    private final MetricsCollector collector;
+    private final OpenTelemetryMetricDataConverter converter;
+    private final AtomicLong droppedPoints = new AtomicLong();
+    private final long epochNanoOffset;
+    private final long startEpochNanos;
+
+    @Inject
+    public OpenTelemetryMetricProducer(MetricsCollector collector, OpenTelemetryMetricDataConverter converter)
+    {
+        this.collector = requireNonNull(collector, "collector is null");
+        this.converter = requireNonNull(converter, "converter is null");
+        epochNanoOffset = MILLISECONDS.toNanos(currentTimeMillis()) - nanoTime();
+        startEpochNanos = epochNanoOffset + nanoTime();
+    }
+
+    @Override
+    public Collection<MetricData> produce(Resource resource)
+    {
+        try {
+            long epochNanos = epochNanoOffset + nanoTime();
+            List<CollectedMetricGroup> metrics = collector.collect();
+            ConversionResult conversionResult = converter.convertWithDroppedPoints(metrics, resource, startEpochNanos, epochNanos);
+            long totalDroppedPoints = droppedPoints.addAndGet(conversionResult.droppedPoints());
+
+            List<MetricData> metricData = new ArrayList<>(conversionResult.metricData());
+            metricData.add(droppedPointsMetric(resource, startEpochNanos, epochNanos, totalDroppedPoints));
+            return metricData;
+        }
+        catch (RuntimeException e) {
+            log.warn(e, "Unable to produce OpenTelemetry metric data");
+            return List.of();
+        }
+    }
+
+    private static MetricData droppedPointsMetric(Resource resource, long startEpochNanos, long epochNanos, long totalDroppedPoints)
+    {
+        return ImmutableMetricData.createLongSum(
+                resource,
+                INSTRUMENTATION_SCOPE,
+                DROPPED_POINTS_METRIC_NAME,
+                "OpenTelemetry metric points dropped by the metric producer due to point limits.",
+                "",
+                SumData.createLongSumData(
+                        true,
+                        AggregationTemporality.CUMULATIVE,
+                        List.of(LongPointData.create(startEpochNanos, epochNanos, Attributes.empty(), totalDroppedPoints))));
+    }
+}

--- a/opentelemetry/src/main/java/io/airlift/opentelemetry/OpenTelemetryMetricsExporterModule.java
+++ b/opentelemetry/src/main/java/io/airlift/opentelemetry/OpenTelemetryMetricsExporterModule.java
@@ -1,0 +1,23 @@
+package io.airlift.opentelemetry;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import io.airlift.metrics.MetricsModule;
+import io.opentelemetry.sdk.metrics.export.MetricProducer;
+
+import static com.google.inject.Scopes.SINGLETON;
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
+
+public class OpenTelemetryMetricsExporterModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        binder.install(new MetricsModule());
+        binder.bind(OpenTelemetryMetricDataConverter.class).in(SINGLETON);
+        newSetBinder(binder, MetricProducer.class).addBinding()
+                .to(OpenTelemetryMetricProducer.class)
+                .in(SINGLETON);
+    }
+}

--- a/opentelemetry/src/test/java/io/airlift/opentelemetry/TestOpenTelemetryMetricDataConverter.java
+++ b/opentelemetry/src/test/java/io/airlift/opentelemetry/TestOpenTelemetryMetricDataConverter.java
@@ -1,0 +1,415 @@
+package io.airlift.opentelemetry;
+
+import io.airlift.metrics.CollectedMetricGroup;
+import io.airlift.metrics.MetricSource;
+import io.airlift.metrics.MetricSource.JmxMetricSource;
+import io.airlift.metrics.MetricSource.ManagedMetricSource;
+import io.airlift.node.NodeInfo;
+import io.airlift.stats.CounterStat;
+import io.airlift.stats.Distribution;
+import io.airlift.stats.DistributionStat;
+import io.airlift.stats.StatsBackendFactory;
+import io.airlift.stats.TimeDistribution;
+import io.airlift.stats.TimeStat;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.DoublePointData;
+import io.opentelemetry.sdk.metrics.data.ExponentialHistogramPointData;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.data.MetricDataType;
+import io.opentelemetry.sdk.metrics.data.SummaryPointData;
+import io.opentelemetry.sdk.resources.Resource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.base.Throwables.throwIfUnchecked;
+import static com.google.common.collect.MoreCollectors.onlyElement;
+import static io.airlift.stats.StatsBackend.AIRLIFT;
+import static io.airlift.stats.StatsBackend.OPENTELEMETRY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
+
+@Isolated
+@Execution(SAME_THREAD)
+class TestOpenTelemetryMetricDataConverter
+{
+    private static final Resource RESOURCE = Resource.empty();
+    private static final long START_EPOCH_NANOS = 1_000;
+    private static final long EPOCH_NANOS = 2_000;
+
+    @BeforeEach
+    void resetBackendBeforeTest()
+            throws Exception
+    {
+        resetStatsBackend();
+        StatsBackendFactory.setBackend(AIRLIFT);
+    }
+
+    @AfterEach
+    void resetBackendAfterTest()
+            throws Exception
+    {
+        resetStatsBackend();
+    }
+
+    @Test
+    void testCounterStat()
+    {
+        CounterStat counter = new CounterStat();
+        counter.update(7);
+
+        MetricData metric = convert("counter", counter, Map.of("node", "test"), "counter help")
+                .stream()
+                .collect(onlyElement());
+
+        assertThat(metric.getType()).isEqualTo(MetricDataType.LONG_SUM);
+        assertThat(metric.getName()).isEqualTo("counter");
+        assertThat(metric.getDescription()).isEqualTo("counter help");
+        assertThat(metric.getLongSumData().isMonotonic()).isTrue();
+        assertThat(metric.getLongSumData().getAggregationTemporality()).isEqualTo(AggregationTemporality.CUMULATIVE);
+        assertThat(metric.getLongSumData().getPoints()).singleElement()
+                .satisfies(point -> {
+                    assertThat(point.getStartEpochNanos()).isEqualTo(START_EPOCH_NANOS);
+                    assertThat(point.getEpochNanos()).isEqualTo(EPOCH_NANOS);
+                    assertThat(point.getValue()).isEqualTo(7);
+                    assertThat(point.getAttributes().get(io.opentelemetry.api.common.AttributeKey.stringKey("node"))).isEqualTo("test");
+                });
+    }
+
+    @Test
+    void testUnqualifiedObjectName()
+    {
+        MetricData metric = convert(
+                managedSource("io.airlift.node:name=NodeInfo", NodeInfo.class),
+                List.of("Environment"),
+                1,
+                Map.of("node", "test"),
+                "node help")
+                .stream()
+                .collect(onlyElement());
+
+        assertThat(metric.getName()).isEqualTo("io.airlift.node.NodeInfo.Environment");
+
+        DoublePointData point = metric.getDoubleGaugeData().getPoints().stream()
+                .collect(onlyElement());
+        assertThat(point.getAttributes().get(AttributeKey.stringKey("node"))).isEqualTo("test");
+        assertThat(point.getAttributes().asMap()).doesNotContainKey(AttributeKey.stringKey("name"));
+    }
+
+    @Test
+    void testQualifiedObjectName()
+    {
+        MetricData metric = convert(
+                managedSource("io.airlift.stats:type=CounterStat,name=ForDiscoveryClient", CounterStat.class, "ForDiscoveryClient"),
+                List.of("RequestStats", "AllResponse"),
+                1,
+                Map.of("node", "test"),
+                "client help")
+                .stream()
+                .collect(onlyElement());
+
+        assertThat(metric.getName()).isEqualTo("io.airlift.stats.CounterStat.RequestStats.AllResponse");
+
+        DoublePointData point = metric.getDoubleGaugeData().getPoints().stream()
+                .collect(onlyElement());
+        assertThat(point.getAttributes().get(AttributeKey.stringKey("name"))).isEqualTo("ForDiscoveryClient");
+        assertThat(point.getAttributes().get(AttributeKey.stringKey("node"))).isEqualTo("test");
+        assertThat(point.getAttributes().asMap()).doesNotContainKey(AttributeKey.stringKey("type"));
+    }
+
+    @Test
+    void testConnectorObjectName()
+    {
+        MetricData metric = convert(
+                managedSource("trino.plugin.hive:type=Distribution,name=hive,catalog=hive", Distribution.class, "hive"),
+                List.of("QueuedSplits"),
+                1,
+                Map.of(),
+                "connector help")
+                .stream()
+                .collect(onlyElement());
+
+        assertThat(metric.getName()).isEqualTo("io.airlift.stats.Distribution.QueuedSplits");
+
+        DoublePointData point = metric.getDoubleGaugeData().getPoints().stream()
+                .collect(onlyElement());
+        assertThat(point.getAttributes().get(AttributeKey.stringKey("catalog"))).isEqualTo("hive");
+        assertThat(point.getAttributes().get(AttributeKey.stringKey("name"))).isEqualTo("hive");
+        assertThat(point.getAttributes().asMap()).doesNotContainKey(AttributeKey.stringKey("type"));
+    }
+
+    @Test
+    void testManagedObjectNameWithoutTypeOrNameUsesExportedType()
+    {
+        MetricData metric = convert(
+                managedSource("trino.execution.scheduler:segment=foo", TimeStat.class, Map.of("segment", "foo")),
+                List.of("PlacementFailures"),
+                1,
+                Map.of(),
+                "scheduler help")
+                .stream()
+                .collect(onlyElement());
+
+        assertThat(metric.getName()).isEqualTo("io.airlift.stats.TimeStat.PlacementFailures");
+
+        DoublePointData point = metric.getDoubleGaugeData().getPoints().stream()
+                .collect(onlyElement());
+        assertThat(point.getAttributes().get(AttributeKey.stringKey("segment"))).isEqualTo("foo");
+    }
+
+    @Test
+    void testJmxObjectNameWithoutTypeOrNameFallsBackToDomain()
+            throws MalformedObjectNameException
+    {
+        MetricData metric = convert(
+                new JmxMetricSource(new ObjectName("trino.execution.scheduler:segment=foo")),
+                List.of("PlacementFailures"),
+                1,
+                Map.of(),
+                "scheduler help")
+                .stream()
+                .collect(onlyElement());
+
+        assertThat(metric.getName()).isEqualTo("trino.execution.scheduler.PlacementFailures");
+
+        DoublePointData point = metric.getDoubleGaugeData().getPoints().stream()
+                .collect(onlyElement());
+        assertThat(point.getAttributes().get(AttributeKey.stringKey("segment"))).isEqualTo("foo");
+    }
+
+    @Test
+    void testDistributionWithExponentialHistogram()
+    {
+        StatsBackendFactory.setBackend(OPENTELEMETRY);
+        Distribution distribution = new Distribution();
+        distribution.add(10);
+        distribution.add(20, 2);
+
+        MetricData metric = convert("distribution", distribution, Map.of(), "distribution help")
+                .stream()
+                .collect(onlyElement());
+
+        assertThat(metric.getType()).isEqualTo(MetricDataType.EXPONENTIAL_HISTOGRAM);
+        assertThat(metric.getName()).isEqualTo("distribution");
+        assertThat(metric.getDescription()).isEqualTo("distribution help");
+        assertThat(metric.getUnit()).isEmpty();
+        assertThat(metric.getExponentialHistogramData().getAggregationTemporality()).isEqualTo(AggregationTemporality.CUMULATIVE);
+
+        ExponentialHistogramPointData point = metric.getExponentialHistogramData().getPoints().stream()
+                .collect(onlyElement());
+        assertThat(point.getStartEpochNanos()).isEqualTo(START_EPOCH_NANOS);
+        assertThat(point.getEpochNanos()).isEqualTo(EPOCH_NANOS);
+        assertThat(point.getCount()).isEqualTo(3);
+        assertThat(point.getSum()).isEqualTo(50);
+        assertThat(point.hasMin()).isTrue();
+        assertThat(point.getMin()).isEqualTo(10);
+        assertThat(point.hasMax()).isTrue();
+        assertThat(point.getMax()).isEqualTo(20);
+        assertThat(point.getPositiveBuckets().getTotalCount()).isEqualTo(3);
+    }
+
+    @Test
+    void testTimeStatWithExponentialHistogram()
+    {
+        StatsBackendFactory.setBackend(OPENTELEMETRY);
+        TimeStat timeStat = new TimeStat();
+        timeStat.addNanos(100);
+        timeStat.addNanos(200);
+
+        MetricData metric = convert("timer", timeStat, Map.of(), "timer help")
+                .stream()
+                .collect(onlyElement());
+
+        assertThat(metric.getType()).isEqualTo(MetricDataType.EXPONENTIAL_HISTOGRAM);
+        assertThat(metric.getName()).isEqualTo("timer");
+        assertThat(metric.getUnit()).isEqualTo("ns");
+
+        ExponentialHistogramPointData point = metric.getExponentialHistogramData().getPoints().stream()
+                .collect(onlyElement());
+        assertThat(point.getCount()).isEqualTo(2);
+        assertThat(point.getSum()).isEqualTo(300);
+        assertThat(point.getMin()).isEqualTo(100);
+        assertThat(point.getMax()).isEqualTo(200);
+    }
+
+    @Test
+    void testDistributionStatWithExponentialHistogram()
+    {
+        StatsBackendFactory.setBackend(OPENTELEMETRY);
+        DistributionStat distributionStat = new DistributionStat();
+        distributionStat.add(10);
+        distributionStat.add(20);
+
+        MetricData metric = convert("distribution", distributionStat, Map.of(), "distribution help")
+                .stream()
+                .collect(onlyElement());
+
+        assertThat(metric.getType()).isEqualTo(MetricDataType.EXPONENTIAL_HISTOGRAM);
+        assertThat(metric.getName()).isEqualTo("distribution");
+
+        ExponentialHistogramPointData point = metric.getExponentialHistogramData().getPoints().stream()
+                .collect(onlyElement());
+        assertThat(point.getCount()).isEqualTo(2);
+        assertThat(point.getSum()).isEqualTo(30);
+    }
+
+    @Test
+    void testTimeStatWithSummaryFallback()
+    {
+        StatsBackendFactory.setBackend(AIRLIFT);
+        TimeStat timeStat = new TimeStat();
+        timeStat.addNanos(100);
+        timeStat.addNanos(200);
+
+        List<MetricData> metrics = convert("timer", timeStat, Map.of(), "timer help");
+
+        assertThat(metrics)
+                .extracting(MetricData::getName)
+                .containsExactly(
+                        "timer.AllTime",
+                        "timer.FifteenMinutes",
+                        "timer.FiveMinutes",
+                        "timer.OneMinute");
+        assertThat(metrics)
+                .allSatisfy(metric -> assertThat(metric.getType()).isEqualTo(MetricDataType.SUMMARY));
+        assertThat(metrics)
+                .allSatisfy(metric -> assertThat(metric.getUnit()).isEqualTo("s"));
+
+        SummaryPointData allTime = metrics.stream()
+                .filter(metric -> metric.getName().equals("timer.AllTime"))
+                .collect(onlyElement())
+                .getSummaryData()
+                .getPoints()
+                .stream()
+                .collect(onlyElement());
+        assertThat(allTime.getCount()).isEqualTo(2);
+        assertThat(allTime.getSum()).isEqualTo(3.0e-7);
+    }
+
+    @Test
+    void testTimeDistributionSummaryFallbackUnit()
+    {
+        StatsBackendFactory.setBackend(AIRLIFT);
+        TimeDistribution distribution = new TimeDistribution(TimeUnit.MILLISECONDS);
+        distribution.add(TimeUnit.MILLISECONDS.toNanos(10));
+        distribution.add(TimeUnit.MILLISECONDS.toNanos(20));
+
+        MetricData metric = convert("timer", distribution, Map.of(), "timer help")
+                .stream()
+                .collect(onlyElement());
+
+        assertThat(metric.getType()).isEqualTo(MetricDataType.SUMMARY);
+        assertThat(metric.getUnit()).isEqualTo("ms");
+
+        SummaryPointData point = metric.getSummaryData().getPoints().stream()
+                .collect(onlyElement());
+        assertThat(point.getCount()).isEqualTo(2);
+        assertThat(point.getSum()).isEqualTo(30);
+    }
+
+    @Test
+    void testDroppedPointsAreDeterministic()
+    {
+        OpenTelemetryMetricDataConverter converter = new OpenTelemetryMetricDataConverter(2, 100);
+
+        List<MetricData> forwardOrder = converter.convertWithDroppedPoints(
+                        List.of(
+                                metricGroup("metric", "c", 3),
+                                metricGroup("metric", "a", 1),
+                                metricGroup("metric", "b", 2)),
+                        RESOURCE,
+                        START_EPOCH_NANOS,
+                        EPOCH_NANOS)
+                .metricData();
+        List<MetricData> reverseOrder = converter.convertWithDroppedPoints(
+                        List.of(
+                                metricGroup("metric", "b", 2),
+                                metricGroup("metric", "a", 1),
+                                metricGroup("metric", "c", 3)),
+                        RESOURCE,
+                        START_EPOCH_NANOS,
+                        EPOCH_NANOS)
+                .metricData();
+
+        assertThat(pointIds(forwardOrder)).containsExactly("a", "b");
+        assertThat(pointIds(reverseOrder)).containsExactly("a", "b");
+    }
+
+    private static List<MetricData> convert(String metricName, Object value, Map<String, String> labels, String description)
+    {
+        return convert(new ManagedMetricSource(metricName), List.of(), value, labels, description);
+    }
+
+    private static List<MetricData> convert(MetricSource source, List<String> path, Object value, Map<String, String> labels, String description)
+    {
+        CollectedMetricGroup metricGroup = new CollectedMetricGroup(
+                source,
+                labels,
+                List.of(new CollectedMetricGroup.Attribute(path, value, description)));
+        return new OpenTelemetryMetricDataConverter()
+                .convertWithDroppedPoints(List.of(metricGroup), RESOURCE, START_EPOCH_NANOS, EPOCH_NANOS)
+                .metricData();
+    }
+
+    private static CollectedMetricGroup metricGroup(String metricName, String id, double value)
+    {
+        return new CollectedMetricGroup(
+                new ManagedMetricSource(metricName),
+                Map.of("id", id),
+                List.of(new CollectedMetricGroup.Attribute(List.of(), value, "help")));
+    }
+
+    private static List<String> pointIds(List<MetricData> metrics)
+    {
+        return metrics.stream()
+                .collect(onlyElement())
+                .getDoubleGaugeData()
+                .getPoints()
+                .stream()
+                .map(point -> point.getAttributes().get(AttributeKey.stringKey("id")))
+                .toList();
+    }
+
+    private static ManagedMetricSource managedSource(String objectName, Class<?> exportedType)
+    {
+        return new ManagedMetricSource(objectName, Optional.of(exportedType), Optional.empty(), Map.of());
+    }
+
+    private static ManagedMetricSource managedSource(String objectName, Class<?> exportedType, String originalName)
+    {
+        return new ManagedMetricSource(objectName, Optional.of(exportedType), Optional.of(originalName), Map.of());
+    }
+
+    private static ManagedMetricSource managedSource(String objectName, Class<?> exportedType, Map<String, String> originalProperties)
+    {
+        return new ManagedMetricSource(objectName, Optional.of(exportedType), Optional.empty(), originalProperties);
+    }
+
+    private static void resetStatsBackend()
+            throws Exception
+    {
+        Method method = StatsBackendFactory.class.getDeclaredMethod("resetForTesting");
+        method.setAccessible(true);
+        try {
+            method.invoke(null);
+        }
+        catch (InvocationTargetException e) {
+            Throwable cause = e.getCause();
+            throwIfUnchecked(cause);
+            throw e;
+        }
+    }
+}

--- a/opentelemetry/src/test/java/io/airlift/opentelemetry/TestOpenTelemetryMetricsExporterModule.java
+++ b/opentelemetry/src/test/java/io/airlift/opentelemetry/TestOpenTelemetryMetricsExporterModule.java
@@ -1,0 +1,44 @@
+package io.airlift.opentelemetry;
+
+import com.google.inject.Binding;
+import com.google.inject.Key;
+import com.google.inject.TypeLiteral;
+import com.google.inject.spi.Element;
+import com.google.inject.spi.Elements;
+import com.google.inject.spi.LinkedKeyBinding;
+import io.airlift.metrics.MetricsCollector;
+import io.opentelemetry.sdk.metrics.export.MetricProducer;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestOpenTelemetryMetricsExporterModule
+{
+    @Test
+    void testBindings()
+    {
+        List<Element> elements = Elements.getElements(new OpenTelemetryMetricsExporterModule());
+
+        assertThat(hasBinding(elements, Key.get(MetricsCollector.class))).isTrue();
+        assertThat(hasBinding(elements, Key.get(OpenTelemetryMetricDataConverter.class))).isTrue();
+        assertThat(hasBinding(elements, Key.get(new TypeLiteral<Set<MetricProducer>>() {}))).isTrue();
+        assertThat(hasLinkedBinding(elements, MetricProducer.class, OpenTelemetryMetricProducer.class)).isTrue();
+    }
+
+    private static boolean hasBinding(List<Element> elements, Key<?> key)
+    {
+        return elements.stream()
+                .anyMatch(element -> element instanceof Binding<?> binding && binding.getKey().equals(key));
+    }
+
+    private static boolean hasLinkedBinding(List<Element> elements, Class<?> keyType, Class<?> linkedKeyType)
+    {
+        return elements.stream()
+                .anyMatch(element -> element instanceof LinkedKeyBinding<?> binding &&
+                        binding.getKey().getTypeLiteral().getRawType().equals(keyType) &&
+                        binding.getLinkedKey().getTypeLiteral().getRawType().equals(linkedKeyType));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
         <module>log</module>
         <module>log-manager</module>
         <module>mcp</module>
+        <module>metrics</module>
         <module>node</module>
         <module>openmetrics</module>
         <module>opentelemetry</module>
@@ -105,6 +106,7 @@
         <dep.openapi-generator-maven-plugin.version>7.21.0</dep.openapi-generator-maven-plugin.version>
         <dep.jersey.version>4.0.2</dep.jersey.version>
         <dep.jjwt.version>0.13.0</dep.jjwt.version>
+        <dep.jmxutils.version>1.29</dep.jmxutils.version>
         <dep.classmate.version>1.7.3</dep.classmate.version>
     </properties>
 
@@ -245,6 +247,12 @@
             <dependency>
                 <groupId>io.airlift</groupId>
                 <artifactId>mcp</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.airlift</groupId>
+                <artifactId>metrics</artifactId>
                 <version>${project.version}</version>
             </dependency>
 

--- a/stats/src/main/java/io/airlift/stats/AirliftDistribution.java
+++ b/stats/src/main/java/io/airlift/stats/AirliftDistribution.java
@@ -1,0 +1,213 @@
+package io.airlift.stats;
+
+import io.airlift.stats.ExponentialHistogram.ExponentialHistogramSnapshot;
+import jakarta.annotation.Nullable;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.base.Verify.verify;
+import static java.util.Objects.requireNonNull;
+
+final class AirliftDistribution
+        implements DistributionImplementation
+{
+    private static final double[] SNAPSHOT_QUANTILES = new double[] {0.01, 0.05, 0.10, 0.25, 0.5, 0.75, 0.9, 0.95, 0.99};
+    private static final double[] PERCENTILES;
+
+    static {
+        PERCENTILES = new double[100];
+        for (int i = 0; i < 100; ++i) {
+            PERCENTILES[i] = (i / 100.0);
+        }
+    }
+
+    // immutable config shared by every sub-structure; null when this distribution does not decay
+    @Nullable
+    private final DecayConfig config;
+    private DecayTDigest digest;
+
+    private final DecayCounter total;
+
+    AirliftDistribution(@Nullable DecayConfig config)
+    {
+        this(config, new DecayTDigest(TDigest.DEFAULT_COMPRESSION, config), new DecayCounter(config));
+    }
+
+    private AirliftDistribution(@Nullable DecayConfig config, DecayTDigest digest, DecayCounter total)
+    {
+        this.config = config;
+        this.digest = requireNonNull(digest, "digest is null");
+        this.total = requireNonNull(total, "total is null");
+    }
+
+    @Override
+    public synchronized void add(long value)
+    {
+        digest.add(value);
+        total.add(value);
+    }
+
+    @Override
+    public synchronized void add(long value, long count)
+    {
+        digest.add(value, count);
+        total.add(value * count);
+    }
+
+    @Override
+    public synchronized DistributionImplementation duplicate()
+    {
+        // the config is immutable and freely shared; digest/total keep their own landmark-preserving copies
+        return new AirliftDistribution(config, digest.duplicate(), total.duplicate());
+    }
+
+    @Override
+    public synchronized void reset()
+    {
+        total.reset();
+        digest = new DecayTDigest(TDigest.DEFAULT_COMPRESSION, config);
+    }
+
+    @Override
+    public synchronized double getCount()
+    {
+        return digest.getCount();
+    }
+
+    @Override
+    public synchronized double getTotal()
+    {
+        return total.getCount();
+    }
+
+    @Override
+    public synchronized double getP01()
+    {
+        return digest.valueAt(0.01);
+    }
+
+    @Override
+    public synchronized double getP05()
+    {
+        return digest.valueAt(0.05);
+    }
+
+    @Override
+    public synchronized double getP10()
+    {
+        return digest.valueAt(0.10);
+    }
+
+    @Override
+    public synchronized double getP25()
+    {
+        return digest.valueAt(0.25);
+    }
+
+    @Override
+    public synchronized double getP50()
+    {
+        return digest.valueAt(0.5);
+    }
+
+    @Override
+    public synchronized double getP75()
+    {
+        return digest.valueAt(0.75);
+    }
+
+    @Override
+    public synchronized double getP90()
+    {
+        return digest.valueAt(0.90);
+    }
+
+    @Override
+    public synchronized double getP95()
+    {
+        return digest.valueAt(0.95);
+    }
+
+    @Override
+    public synchronized double getP99()
+    {
+        return digest.valueAt(0.99);
+    }
+
+    @Override
+    public synchronized double getMin()
+    {
+        return digest.getMin();
+    }
+
+    @Override
+    public synchronized double getMax()
+    {
+        return digest.getMax();
+    }
+
+    @Override
+    public synchronized double getAvg()
+    {
+        return getTotal() / getCount();
+    }
+
+    @Override
+    public Map<Double, Double> getPercentiles()
+    {
+        double[] values;
+        synchronized (this) {
+            values = digest.valuesAt(PERCENTILES);
+        }
+
+        verify(values.length == PERCENTILES.length, "result length mismatch");
+
+        Map<Double, Double> result = new LinkedHashMap<>(values.length);
+        for (int i = 0; i < values.length; ++i) {
+            result.put(PERCENTILES[i], values[i]);
+        }
+
+        return result;
+    }
+
+    @Override
+    public Distribution.DistributionSnapshot snapshot()
+    {
+        double totalCount;
+        double digestCount;
+        double min;
+        double max;
+        double[] quantiles;
+        synchronized (this) {
+            totalCount = total.getCount();
+            digestCount = digest.getCount();
+            min = digest.getMin();
+            max = digest.getMax();
+            quantiles = digest.valuesAt(SNAPSHOT_QUANTILES);
+        }
+        double average = totalCount / digestCount;
+        return new Distribution.DistributionSnapshot(
+                digestCount,
+                totalCount,
+                quantiles[0], // p01
+                quantiles[1], // p05
+                quantiles[2], // p10
+                quantiles[3], // p25
+                quantiles[4], // p50
+                quantiles[5], // p75
+                quantiles[6], // p90
+                quantiles[7], // p95
+                quantiles[8], // p99
+                min,
+                max,
+                average);
+    }
+
+    @Override
+    public Optional<ExponentialHistogramSnapshot> exponentialHistogramSnapshot()
+    {
+        return Optional.empty();
+    }
+}

--- a/stats/src/main/java/io/airlift/stats/AirliftTimeDistribution.java
+++ b/stats/src/main/java/io/airlift/stats/AirliftTimeDistribution.java
@@ -1,0 +1,279 @@
+package io.airlift.stats;
+
+import com.google.common.base.Ticker;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
+import io.airlift.stats.ExponentialHistogram.ExponentialHistogramSnapshot;
+import jakarta.annotation.Nullable;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.base.Verify.verify;
+import static java.lang.Math.clamp;
+import static java.lang.Math.floorMod;
+
+final class AirliftTimeDistribution
+        implements TimeDistributionImplementation
+{
+    private static final double[] SNAPSHOT_QUANTILES = new double[] {0.5, 0.75, 0.9, 0.95, 0.99};
+    private static final double[] PERCENTILES;
+    private static final int STRIPES = clamp(Runtime.getRuntime().availableProcessors(), 2, 16);
+
+    static {
+        PERCENTILES = new double[100];
+        for (int i = 0; i < 100; ++i) {
+            PERCENTILES[i] = (i / 100.0);
+        }
+    }
+
+    private final Ticker ticker;
+    // immutable config shared by every sub-structure; null when this distribution does not decay
+    @Nullable
+    private final DecayConfig config;
+    private final Object[] locks = new Object[STRIPES];
+    // @GuardedBy("locks[i]") for partials[i]
+    private final DecayTDigest[] partials = new DecayTDigest[STRIPES];
+    @GuardedBy("this")
+    private DecayTDigest merged;
+    @GuardedBy("this")
+    private long lastMerge;
+    private final DecayCounter total;
+    private final DecayCounter partialTotal;
+    private final TimeUnit unit;
+
+    AirliftTimeDistribution(Ticker ticker, @Nullable DecayConfig config, TimeUnit unit)
+    {
+        // the config is immutable and shared; each sub-structure derives its own decay state
+        this.config = config;
+        merged = new DecayTDigest(TDigest.DEFAULT_COMPRESSION, config);
+        for (int i = 0; i < STRIPES; i++) {
+            locks[i] = new Object();
+        }
+        total = new DecayCounter(config);
+        partialTotal = new DecayCounter(config);
+        this.ticker = ticker;
+        this.unit = unit;
+        this.lastMerge = ticker.read(); // do not merge immediately
+    }
+
+    @Override
+    public void add(long value)
+    {
+        int segment = floorMod(Thread.currentThread().threadId(), STRIPES);
+        synchronized (locks[segment]) {
+            if (partials[segment] == null) {
+                partials[segment] = new DecayTDigest(TDigest.DEFAULT_COMPRESSION, config);
+            }
+            partials[segment].add(value);
+        }
+        partialTotal.add(value); // Fine outside of lock as DecayCounter is thread safe
+    }
+
+    @Override
+    public double getCount()
+    {
+        synchronized (this) {
+            mergeIfNeeded();
+            return merged.getCount();
+        }
+    }
+
+    @Override
+    public double getP50()
+    {
+        double p50;
+        synchronized (this) {
+            mergeIfNeeded();
+            p50 = merged.valueAt(0.5);
+        }
+        return convertToUnit(p50, unit);
+    }
+
+    @Override
+    public double getP75()
+    {
+        double p75;
+        synchronized (this) {
+            mergeIfNeeded();
+            p75 = merged.valueAt(0.75);
+        }
+        return convertToUnit(p75, unit);
+    }
+
+    @Override
+    public double getP90()
+    {
+        double p90;
+        synchronized (this) {
+            mergeIfNeeded();
+            p90 = merged.valueAt(0.90);
+        }
+        return convertToUnit(p90, unit);
+    }
+
+    @Override
+    public double getP95()
+    {
+        double p95;
+        synchronized (this) {
+            mergeIfNeeded();
+            p95 = merged.valueAt(0.95);
+        }
+        return convertToUnit(p95, unit);
+    }
+
+    @Override
+    public double getP99()
+    {
+        double p99;
+        synchronized (this) {
+            mergeIfNeeded();
+            p99 = merged.valueAt(0.99);
+        }
+        return convertToUnit(p99, unit);
+    }
+
+    @Override
+    public double getMin()
+    {
+        double min;
+        synchronized (this) {
+            mergeIfNeeded();
+            min = merged.getMin();
+        }
+        return convertToUnit(min, unit);
+    }
+
+    @Override
+    public double getMax()
+    {
+        double max;
+        synchronized (this) {
+            mergeIfNeeded();
+            max = merged.getMax();
+        }
+        return convertToUnit(max, unit);
+    }
+
+    @Override
+    public double getAvg()
+    {
+        double digestCount;
+        double totalCount;
+        synchronized (this) {
+            mergeIfNeeded();
+            digestCount = merged.getCount();
+            totalCount = total.getCount();
+        }
+        return convertToUnit(totalCount, unit) / digestCount;
+    }
+
+    @Override
+    public TimeUnit getUnit()
+    {
+        return unit;
+    }
+
+    @Override
+    public Map<Double, Double> getPercentiles()
+    {
+        double[] values;
+        synchronized (this) {
+            mergeIfNeeded(true);
+            values = merged.valuesAt(PERCENTILES);
+        }
+
+        verify(values.length == PERCENTILES.length, "values length mismatch");
+
+        Map<Double, Double> result = new LinkedHashMap<>(values.length);
+        for (int i = 0; i < values.length; ++i) {
+            result.put(PERCENTILES[i], values[i]);
+        }
+
+        return result;
+    }
+
+    private void mergeIfNeeded()
+    {
+        mergeIfNeeded(false);
+    }
+
+    private void mergeIfNeeded(boolean forceMerge)
+    {
+        synchronized (this) {
+            if (forceMerge || ticker.read() - lastMerge >= TimeDistribution.MERGE_THRESHOLD_NANOS) {
+                for (int i = 0; i < STRIPES; i++) {
+                    synchronized (locks[i]) {
+                        if (partials[i] == null) {
+                            continue;
+                        }
+                        merged.merge(partials[i]);
+                        // Reset the partial
+                        partials[i] = null;
+                    }
+                }
+                total.merge(partialTotal);
+                partialTotal.reset();
+                lastMerge = ticker.read();
+            }
+        }
+    }
+
+    @Override
+    public TimeDistribution.TimeDistributionSnapshot snapshot()
+    {
+        double totalCount;
+        double digestCount;
+        double min;
+        double max;
+        double[] quantiles;
+        synchronized (this) {
+            mergeIfNeeded(true);
+            DecayTDigest digest = merged;
+            totalCount = total.getCount();
+            digestCount = digest.getCount();
+            min = digest.getMin();
+            max = digest.getMax();
+            quantiles = digest.valuesAt(SNAPSHOT_QUANTILES);
+        }
+        double average = convertToUnit(totalCount, unit) / digestCount;
+        return new TimeDistribution.TimeDistributionSnapshot(
+                digestCount,
+                convertToUnit(quantiles[0], unit), // p50
+                convertToUnit(quantiles[1], unit), // p75
+                convertToUnit(quantiles[2], unit), // p90
+                convertToUnit(quantiles[3], unit), // p95
+                convertToUnit(quantiles[4], unit), // p99
+                convertToUnit(min, unit),
+                convertToUnit(max, unit),
+                average,
+                unit);
+    }
+
+    @Override
+    public Optional<ExponentialHistogramSnapshot> exponentialHistogramSnapshot()
+    {
+        return Optional.empty();
+    }
+
+    @Override
+    public synchronized void reset()
+    {
+        total.reset();
+        partialTotal.reset();
+        merged = new DecayTDigest(TDigest.DEFAULT_COMPRESSION, config);
+        // Reset all partial digests (stripes) to avoid stale data
+        for (int i = 0; i < partials.length; i++) {
+            synchronized (locks[i]) {
+                partials[i] = null;
+            }
+        }
+    }
+
+    private static double convertToUnit(double nanos, TimeUnit unit)
+    {
+        return nanos / unit.toNanos(1);
+    }
+}

--- a/stats/src/main/java/io/airlift/stats/CounterStat.java
+++ b/stats/src/main/java/io/airlift/stats/CounterStat.java
@@ -19,11 +19,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.ThreadSafe;
 import io.airlift.stats.DecayCounter.DecayCounterSnapshot;
+import jakarta.annotation.Nullable;
 import org.weakref.jmx.Managed;
 import org.weakref.jmx.Nested;
 
 import java.util.concurrent.atomic.LongAdder;
 
+import static io.airlift.stats.StatsBackend.AIRLIFT;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -37,24 +39,46 @@ import static java.util.Objects.requireNonNull;
 public final class CounterStat
 {
     private final LongAdder count = new LongAdder();
-    private final DecayCounter oneMinute = new DecayCounter(DecayConfig.oneMinute());
-    private final DecayCounter fiveMinute = new DecayCounter(DecayConfig.fiveMinutes());
-    private final DecayCounter fifteenMinute = new DecayCounter(DecayConfig.fifteenMinutes());
+    @Nullable
+    private final DecayCounter oneMinute;
+    @Nullable
+    private final DecayCounter fiveMinute;
+    @Nullable
+    private final DecayCounter fifteenMinute;
+
+    public CounterStat()
+    {
+        if (StatsBackendFactory.getBackend() == AIRLIFT) {
+            oneMinute = new DecayCounter(DecayConfig.oneMinute());
+            fiveMinute = new DecayCounter(DecayConfig.fiveMinutes());
+            fifteenMinute = new DecayCounter(DecayConfig.fifteenMinutes());
+        }
+        else {
+            oneMinute = null;
+            fiveMinute = null;
+            fifteenMinute = null;
+        }
+    }
 
     public void update(long count)
     {
-        oneMinute.add(count);
-        fiveMinute.add(count);
-        fifteenMinute.add(count);
+        if (oneMinute != null && fiveMinute != null && fifteenMinute != null) {
+            oneMinute.add(count);
+            fiveMinute.add(count);
+            fifteenMinute.add(count);
+        }
         this.count.add(count);
     }
 
     public void merge(CounterStat counterStat)
     {
         requireNonNull(counterStat, "counterStat is null");
-        oneMinute.merge(counterStat.getOneMinute());
-        fiveMinute.merge(counterStat.getFiveMinute());
-        fifteenMinute.merge(counterStat.getFifteenMinute());
+        if (oneMinute != null && fiveMinute != null && fifteenMinute != null &&
+                counterStat.getOneMinute() != null && counterStat.getFiveMinute() != null && counterStat.getFifteenMinute() != null) {
+            oneMinute.merge(counterStat.getOneMinute());
+            fiveMinute.merge(counterStat.getFiveMinute());
+            fifteenMinute.merge(counterStat.getFifteenMinute());
+        }
         count.add(counterStat.getTotalCount());
     }
 
@@ -68,9 +92,11 @@ public final class CounterStat
     @Managed
     public void reset()
     {
-        oneMinute.reset();
-        fiveMinute.reset();
-        fifteenMinute.reset();
+        if (oneMinute != null && fiveMinute != null && fifteenMinute != null) {
+            oneMinute.reset();
+            fiveMinute.reset();
+            fifteenMinute.reset();
+        }
         count.reset();
     }
 
@@ -80,9 +106,13 @@ public final class CounterStat
     @Deprecated
     public void resetTo(CounterStat counterStat)
     {
-        oneMinute.resetTo(counterStat.getOneMinute());
-        fiveMinute.resetTo(counterStat.getFiveMinute());
-        fifteenMinute.resetTo(counterStat.getFifteenMinute());
+        requireNonNull(counterStat, "counterStat is null");
+        if (oneMinute != null && fiveMinute != null && fifteenMinute != null &&
+                counterStat.getOneMinute() != null && counterStat.getFiveMinute() != null && counterStat.getFifteenMinute() != null) {
+            oneMinute.resetTo(counterStat.getOneMinute());
+            fiveMinute.resetTo(counterStat.getFiveMinute());
+            fifteenMinute.resetTo(counterStat.getFifteenMinute());
+        }
 
         synchronized (count) {
             count.reset();
@@ -98,6 +128,7 @@ public final class CounterStat
 
     @Managed
     @Nested
+    @Nullable
     public DecayCounter getOneMinute()
     {
         return oneMinute;
@@ -105,6 +136,7 @@ public final class CounterStat
 
     @Managed
     @Nested
+    @Nullable
     public DecayCounter getFiveMinute()
     {
         return fiveMinute;
@@ -112,6 +144,7 @@ public final class CounterStat
 
     @Managed
     @Nested
+    @Nullable
     public DecayCounter getFifteenMinute()
     {
         return fifteenMinute;
@@ -119,21 +152,31 @@ public final class CounterStat
 
     public CounterStatSnapshot snapshot()
     {
-        return new CounterStatSnapshot(getTotalCount(), getOneMinute().snapshot(), getFiveMinute().snapshot(), getFifteenMinute().snapshot());
+        return new CounterStatSnapshot(
+                getTotalCount(),
+                oneMinute == null ? null : oneMinute.snapshot(),
+                fiveMinute == null ? null : fiveMinute.snapshot(),
+                fifteenMinute == null ? null : fifteenMinute.snapshot());
     }
 
     public static class CounterStatSnapshot
     {
         private final long totalCount;
+        @Nullable
         private final DecayCounterSnapshot oneMinute;
+        @Nullable
         private final DecayCounterSnapshot fiveMinute;
+        @Nullable
         private final DecayCounterSnapshot fifteenMinute;
 
         @JsonCreator
         public CounterStatSnapshot(
                 @JsonProperty("totalCount") long totalCount,
+                @Nullable
                 @JsonProperty("oneMinute") DecayCounterSnapshot oneMinute,
+                @Nullable
                 @JsonProperty("fiveMinute") DecayCounterSnapshot fiveMinute,
+                @Nullable
                 @JsonProperty("fifteenMinute") DecayCounterSnapshot fifteenMinute)
         {
             this.totalCount = totalCount;
@@ -149,18 +192,21 @@ public final class CounterStat
         }
 
         @JsonProperty
+        @Nullable
         public DecayCounterSnapshot getOneMinute()
         {
             return oneMinute;
         }
 
         @JsonProperty
+        @Nullable
         public DecayCounterSnapshot getFiveMinute()
         {
             return fiveMinute;
         }
 
         @JsonProperty
+        @Nullable
         public DecayCounterSnapshot getFifteenMinute()
         {
             return fifteenMinute;

--- a/stats/src/main/java/io/airlift/stats/Distribution.java
+++ b/stats/src/main/java/io/airlift/stats/Distribution.java
@@ -1,36 +1,26 @@
 package io.airlift.stats;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Ticker;
 import com.google.errorprone.annotations.ThreadSafe;
-import com.google.errorprone.annotations.concurrent.GuardedBy;
+import io.airlift.stats.ExponentialHistogram.ExponentialHistogramSnapshot;
 import jakarta.annotation.Nullable;
 import org.weakref.jmx.Managed;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
 
-import static com.google.common.base.Verify.verify;
+import static com.google.common.base.Ticker.systemTicker;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 @ThreadSafe
 public class Distribution
 {
-    private static final double[] SNAPSHOT_QUANTILES = new double[] {0.01, 0.05, 0.10, 0.25, 0.5, 0.75, 0.9, 0.95, 0.99};
-    private static final double[] PERCENTILES;
+    @VisibleForTesting
+    static final long MERGE_THRESHOLD_NANOS = MILLISECONDS.toNanos(100);
 
-    static {
-        PERCENTILES = new double[100];
-        for (int i = 0; i < 100; ++i) {
-            PERCENTILES[i] = (i / 100.0);
-        }
-    }
-
-    // immutable config shared by every sub-structure; null when this distribution does not decay
-    @Nullable
-    private final DecayConfig config;
-    @GuardedBy("this")
-    private DecayTDigest digest;
-
-    private final DecayCounter total;
+    private final DistributionImplementation implementation;
 
     public Distribution()
     {
@@ -47,173 +37,147 @@ public class Distribution
      */
     public Distribution(@Nullable DecayConfig config)
     {
-        this(config, new DecayTDigest(TDigest.DEFAULT_COMPRESSION, config), new DecayCounter(config));
+        this(systemTicker(), config);
     }
 
-    private Distribution(@Nullable DecayConfig config, DecayTDigest digest, DecayCounter total)
+    @VisibleForTesting
+    Distribution(Ticker ticker)
     {
-        this.config = config;
-        this.digest = requireNonNull(digest, "digest is null");
-        this.total = requireNonNull(total, "total is null");
+        this(ticker, null);
     }
 
-    public synchronized void add(long value)
+    private Distribution(Ticker ticker, @Nullable DecayConfig config)
     {
-        digest.add(value);
-        total.add(value);
+        implementation = switch (StatsBackendFactory.getBackend()) {
+            case AIRLIFT -> new AirliftDistribution(config);
+            case OPENTELEMETRY -> new OpenTelemetryDistribution(ticker);
+        };
     }
 
-    public synchronized void add(long value, long count)
+    private Distribution(DistributionImplementation implementation)
     {
-        digest.add(value, count);
-        total.add(value * count);
+        this.implementation = requireNonNull(implementation, "implementation is null");
     }
 
-    public synchronized Distribution duplicate()
+    public void add(long value)
     {
-        // the config is immutable and freely shared; digest/total keep their own landmark-preserving copies
-        return new Distribution(config, digest.duplicate(), total.duplicate());
+        implementation.add(value);
     }
 
-    @Managed
-    public synchronized void reset()
+    public void add(long value, long count)
     {
-        total.reset();
-        digest = new DecayTDigest(TDigest.DEFAULT_COMPRESSION, config);
+        implementation.add(value, count);
     }
 
-    @Managed
-    public synchronized double getCount()
+    public Distribution duplicate()
     {
-        return digest.getCount();
+        return new Distribution(implementation.duplicate());
     }
 
     @Managed
-    public synchronized double getTotal()
+    public void reset()
     {
-        return total.getCount();
+        implementation.reset();
     }
 
     @Managed
-    public synchronized double getP01()
+    public double getCount()
     {
-        return digest.valueAt(0.01);
+        return implementation.getCount();
     }
 
     @Managed
-    public synchronized double getP05()
+    public double getTotal()
     {
-        return digest.valueAt(0.05);
+        return implementation.getTotal();
     }
 
     @Managed
-    public synchronized double getP10()
+    public double getP01()
     {
-        return digest.valueAt(0.10);
+        return implementation.getP01();
     }
 
     @Managed
-    public synchronized double getP25()
+    public double getP05()
     {
-        return digest.valueAt(0.25);
+        return implementation.getP05();
     }
 
     @Managed
-    public synchronized double getP50()
+    public double getP10()
     {
-        return digest.valueAt(0.5);
+        return implementation.getP10();
     }
 
     @Managed
-    public synchronized double getP75()
+    public double getP25()
     {
-        return digest.valueAt(0.75);
+        return implementation.getP25();
     }
 
     @Managed
-    public synchronized double getP90()
+    public double getP50()
     {
-        return digest.valueAt(0.90);
+        return implementation.getP50();
     }
 
     @Managed
-    public synchronized double getP95()
+    public double getP75()
     {
-        return digest.valueAt(0.95);
+        return implementation.getP75();
     }
 
     @Managed
-    public synchronized double getP99()
+    public double getP90()
     {
-        return digest.valueAt(0.99);
+        return implementation.getP90();
     }
 
     @Managed
-    public synchronized double getMin()
+    public double getP95()
     {
-        return digest.getMin();
+        return implementation.getP95();
     }
 
     @Managed
-    public synchronized double getMax()
+    public double getP99()
     {
-        return digest.getMax();
+        return implementation.getP99();
     }
 
     @Managed
-    public synchronized double getAvg()
+    public double getMin()
     {
-        return getTotal() / getCount();
+        return implementation.getMin();
+    }
+
+    @Managed
+    public double getMax()
+    {
+        return implementation.getMax();
+    }
+
+    @Managed
+    public double getAvg()
+    {
+        return implementation.getAvg();
     }
 
     @Managed
     public Map<Double, Double> getPercentiles()
     {
-        double[] values;
-        synchronized (this) {
-            values = digest.valuesAt(PERCENTILES);
-        }
-
-        verify(values.length == PERCENTILES.length, "result length mismatch");
-
-        Map<Double, Double> result = new LinkedHashMap<>(values.length);
-        for (int i = 0; i < values.length; ++i) {
-            result.put(PERCENTILES[i], values[i]);
-        }
-
-        return result;
+        return implementation.getPercentiles();
     }
 
     public DistributionSnapshot snapshot()
     {
-        double totalCount;
-        double digestCount;
-        double min;
-        double max;
-        double[] quantiles;
-        synchronized (this) {
-            totalCount = total.getCount();
-            digestCount = digest.getCount();
-            min = digest.getMin();
-            max = digest.getMax();
-            quantiles = digest.valuesAt(SNAPSHOT_QUANTILES);
-        }
-        double average = totalCount / digestCount;
-        return new DistributionSnapshot(
-                digestCount,
-                totalCount,
-                quantiles[0], // p01
-                quantiles[1], // p05
-                quantiles[2], // p10
-                quantiles[3], // p25
-                quantiles[4], // p50
-                quantiles[5], // p75
-                quantiles[6], // p90
-                quantiles[7], // p95
-                quantiles[8], // p99
-                min,
-                max,
-                average);
+        return implementation.snapshot();
+    }
+
+    public Optional<ExponentialHistogramSnapshot> exponentialHistogramSnapshot()
+    {
+        return implementation.exponentialHistogramSnapshot();
     }
 
     public record DistributionSnapshot(

--- a/stats/src/main/java/io/airlift/stats/DistributionImplementation.java
+++ b/stats/src/main/java/io/airlift/stats/DistributionImplementation.java
@@ -1,0 +1,52 @@
+package io.airlift.stats;
+
+import io.airlift.stats.ExponentialHistogram.ExponentialHistogramSnapshot;
+
+import java.util.Map;
+import java.util.Optional;
+
+sealed interface DistributionImplementation
+        permits AirliftDistribution, OpenTelemetryDistribution
+{
+    void add(long value);
+
+    void add(long value, long count);
+
+    DistributionImplementation duplicate();
+
+    void reset();
+
+    double getCount();
+
+    double getTotal();
+
+    double getP01();
+
+    double getP05();
+
+    double getP10();
+
+    double getP25();
+
+    double getP50();
+
+    double getP75();
+
+    double getP90();
+
+    double getP95();
+
+    double getP99();
+
+    double getMin();
+
+    double getMax();
+
+    double getAvg();
+
+    Map<Double, Double> getPercentiles();
+
+    Distribution.DistributionSnapshot snapshot();
+
+    Optional<ExponentialHistogramSnapshot> exponentialHistogramSnapshot();
+}

--- a/stats/src/main/java/io/airlift/stats/DistributionStat.java
+++ b/stats/src/main/java/io/airlift/stats/DistributionStat.java
@@ -1,44 +1,64 @@
 package io.airlift.stats;
 
 import io.airlift.stats.Distribution.DistributionSnapshot;
+import io.airlift.stats.ExponentialHistogram.ExponentialHistogramSnapshot;
+import jakarta.annotation.Nullable;
 import org.weakref.jmx.Managed;
 import org.weakref.jmx.Nested;
 
+import java.util.Optional;
+
+import static io.airlift.stats.StatsBackend.AIRLIFT;
 import static java.util.Objects.requireNonNull;
 
 public class DistributionStat
 {
+    @Nullable
     private final Distribution oneMinute;
+    @Nullable
     private final Distribution fiveMinutes;
+    @Nullable
     private final Distribution fifteenMinutes;
     private final Distribution allTime;
 
     public DistributionStat()
     {
-        oneMinute = new Distribution(DecayConfig.oneMinute());
-        fiveMinutes = new Distribution(DecayConfig.fiveMinutes());
-        fifteenMinutes = new Distribution(DecayConfig.fifteenMinutes());
+        if (StatsBackendFactory.getBackend() == AIRLIFT) {
+            oneMinute = new Distribution(DecayConfig.oneMinute());
+            fiveMinutes = new Distribution(DecayConfig.fiveMinutes());
+            fifteenMinutes = new Distribution(DecayConfig.fifteenMinutes());
+        }
+        else {
+            oneMinute = null;
+            fiveMinutes = null;
+            fifteenMinutes = null;
+        }
         allTime = new Distribution();
     }
 
     public void add(long value)
     {
-        oneMinute.add(value);
-        fiveMinutes.add(value);
-        fifteenMinutes.add(value);
+        if (oneMinute != null && fiveMinutes != null && fifteenMinutes != null) {
+            oneMinute.add(value);
+            fiveMinutes.add(value);
+            fifteenMinutes.add(value);
+        }
         allTime.add(value);
     }
 
     public void add(long value, long count)
     {
-        oneMinute.add(value, count);
-        fiveMinutes.add(value, count);
-        fifteenMinutes.add(value, count);
+        if (oneMinute != null && fiveMinutes != null && fifteenMinutes != null) {
+            oneMinute.add(value, count);
+            fiveMinutes.add(value, count);
+            fifteenMinutes.add(value, count);
+        }
         allTime.add(value, count);
     }
 
     @Managed
     @Nested
+    @Nullable
     public Distribution getOneMinute()
     {
         return oneMinute;
@@ -46,6 +66,7 @@ public class DistributionStat
 
     @Managed
     @Nested
+    @Nullable
     public Distribution getFiveMinutes()
     {
         return fiveMinutes;
@@ -53,6 +74,7 @@ public class DistributionStat
 
     @Managed
     @Nested
+    @Nullable
     public Distribution getFifteenMinutes()
     {
         return fifteenMinutes;
@@ -68,23 +90,28 @@ public class DistributionStat
     public DistributionStatSnapshot snapshot()
     {
         return new DistributionStatSnapshot(
-                getOneMinute().snapshot(),
-                getFiveMinutes().snapshot(),
-                getFifteenMinutes().snapshot(),
+                oneMinute == null ? null : oneMinute.snapshot(),
+                fiveMinutes == null ? null : fiveMinutes.snapshot(),
+                fifteenMinutes == null ? null : fifteenMinutes.snapshot(),
                 getAllTime().snapshot());
     }
 
+    public Optional<ExponentialHistogramSnapshot> exponentialHistogramSnapshot()
+    {
+        return getAllTime().exponentialHistogramSnapshot();
+    }
+
     public record DistributionStatSnapshot(
+            @Nullable
             DistributionSnapshot oneMinute,
+            @Nullable
             DistributionSnapshot fiveMinute,
+            @Nullable
             DistributionSnapshot fifteenMinute,
             DistributionSnapshot allTime)
     {
         public DistributionStatSnapshot
         {
-            requireNonNull(oneMinute, "oneMinute is null");
-            requireNonNull(fiveMinute, "fiveMinute is null");
-            requireNonNull(fifteenMinute, "fifteenMinute is null");
             requireNonNull(allTime, "allTime is null");
         }
     }

--- a/stats/src/main/java/io/airlift/stats/ExponentialHistogram.java
+++ b/stats/src/main/java/io/airlift/stats/ExponentialHistogram.java
@@ -1,0 +1,632 @@
+package io.airlift.stats;
+
+import com.google.errorprone.annotations.ThreadSafe;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.Double.isFinite;
+import static java.lang.Math.ceil;
+import static java.lang.Math.log;
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+import static java.lang.Math.scalb;
+import static java.util.Arrays.stream;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Records values into base-2 exponential buckets.
+ * <p>
+ * Bucket boundaries are computed from a scale. At scale 0, buckets are powers of two:
+ *
+ * <pre>
+ * ..., (0.25, 0.5], (0.5, 1], (1, 2], (2, 4], ...
+ * </pre>
+ *
+ * Higher scales add more buckets between adjacent powers of two. In general, {@code base =
+ * 2^(2^-scale)} and bucket {@code i} covers {@code (base^i, base^(i + 1)]}. The histogram starts at
+ * the configured scale for high precision. When the observed bucket range no longer fits within the
+ * configured maximum bucket count, the histogram lowers its scale and merges adjacent buckets. This
+ * keeps the full observed range while reducing precision.
+ * <p>
+ * Positive and negative values are stored in separate bucket ranges. Negative values are bucketed by
+ * their absolute magnitude, and zero values are counted separately.
+ * <p>
+ * This design follows the OpenTelemetry exponential histogram data model and is intentionally
+ * aligned with the OpenTelemetry Java SDK's base-2 exponential histogram aggregation.
+ */
+@ThreadSafe
+public final class ExponentialHistogram
+{
+    public static final int DEFAULT_SCALE = 20;
+    public static final int DEFAULT_MAX_BUCKETS = 160;
+    public static final int MIN_SCALE = -10;
+    public static final int MAX_SCALE = 20;
+
+    private static final long EXPONENT_BIT_MASK = 0x7FF0000000000000L;
+    private static final long SIGNIFICAND_BIT_MASK = 0xFFFFFFFFFFFFFL;
+    private static final int EXPONENT_BIAS = 1023;
+    private static final int SIGNIFICAND_WIDTH = 52;
+    private static final int EXPONENT_WIDTH = 11;
+    private static final double LOG_2 = log(2);
+    private static final int LOOKUP_MAX_SCALE = 10;
+    private static final LookupBucketIndexer[] LOOKUP_BUCKET_INDEXERS = createLookupBucketIndexers();
+    private static final int MIN_BUCKETS_FOR_FULL_FINITE_RANGE = bucketIndex(Double.MAX_VALUE, MIN_SCALE) - bucketIndex(Double.MIN_VALUE, MIN_SCALE) + 1;
+
+    private final int initialScale;
+    private final int maxBuckets;
+
+    @GuardedBy("this")
+    private int scale;
+    @GuardedBy("this")
+    private long count;
+    @GuardedBy("this")
+    private double sum;
+    @GuardedBy("this")
+    private double min = Double.NaN;
+    @GuardedBy("this")
+    private double max = Double.NaN;
+    @GuardedBy("this")
+    private long zeroCount;
+    @GuardedBy("this")
+    private BucketCounts positiveBuckets = new BucketCounts();
+    @GuardedBy("this")
+    private BucketCounts negativeBuckets = new BucketCounts();
+
+    public ExponentialHistogram()
+    {
+        this(DEFAULT_SCALE, DEFAULT_MAX_BUCKETS);
+    }
+
+    public ExponentialHistogram(int scale, int maxBuckets)
+    {
+        checkArgument(scale >= MIN_SCALE && scale <= MAX_SCALE, "scale must be between %s and %s", MIN_SCALE, MAX_SCALE);
+        checkArgument(maxBuckets >= MIN_BUCKETS_FOR_FULL_FINITE_RANGE, "maxBuckets must be at least %s", MIN_BUCKETS_FOR_FULL_FINITE_RANGE);
+        this.initialScale = scale;
+        this.scale = scale;
+        this.maxBuckets = maxBuckets;
+    }
+
+    ExponentialHistogram(ExponentialHistogramSnapshot snapshot, int maxBuckets)
+    {
+        requireNonNull(snapshot, "snapshot is null");
+        checkArgument(maxBuckets >= MIN_BUCKETS_FOR_FULL_FINITE_RANGE, "maxBuckets must be at least %s", MIN_BUCKETS_FOR_FULL_FINITE_RANGE);
+        checkArgument(snapshot.positiveBuckets().counts().length <= maxBuckets, "positive bucket count exceeds maxBuckets");
+        checkArgument(snapshot.negativeBuckets().counts().length <= maxBuckets, "negative bucket count exceeds maxBuckets");
+        this.initialScale = snapshot.scale();
+        this.maxBuckets = maxBuckets;
+        this.scale = snapshot.scale();
+        this.count = snapshot.count();
+        this.sum = snapshot.sum();
+        this.min = snapshot.min();
+        this.max = snapshot.max();
+        this.zeroCount = snapshot.zeroCount();
+        this.positiveBuckets = new BucketCounts(snapshot.positiveBuckets());
+        this.negativeBuckets = new BucketCounts(snapshot.negativeBuckets());
+    }
+
+    public synchronized void record(double value)
+    {
+        record(value, 1);
+    }
+
+    public synchronized void record(double value, long occurrences)
+    {
+        checkArgument(occurrences >= 0, "occurrences is negative");
+        if (occurrences == 0) {
+            return;
+        }
+        if (!isFinite(value)) {
+            return;
+        }
+
+        count += occurrences;
+        sum += value * occurrences;
+        min = Double.isNaN(min) ? value : min(min, value);
+        max = Double.isNaN(max) ? value : max(max, value);
+
+        if (value == 0) {
+            zeroCount += occurrences;
+            return;
+        }
+
+        BucketCounts buckets = value > 0 ? positiveBuckets : negativeBuckets;
+        double magnitude = Math.abs(value);
+        int bucketIndex = bucketIndex(magnitude, scale);
+        int scaleReduction = buckets.scaleReduction(bucketIndex, maxBuckets);
+        if (scaleReduction > 0) {
+            downscale(scaleReduction);
+            bucketIndex = bucketIndex(magnitude, scale);
+        }
+        buckets.increment(bucketIndex, occurrences);
+    }
+
+    public synchronized void reset()
+    {
+        scale = initialScale;
+        count = 0;
+        sum = 0;
+        min = Double.NaN;
+        max = Double.NaN;
+        zeroCount = 0;
+        positiveBuckets = new BucketCounts();
+        negativeBuckets = new BucketCounts();
+    }
+
+    public synchronized ExponentialHistogramSnapshot snapshot()
+    {
+        return new ExponentialHistogramSnapshot(
+                scale,
+                count,
+                sum,
+                min,
+                max,
+                zeroCount,
+                positiveBuckets.snapshot(),
+                negativeBuckets.snapshot());
+    }
+
+    public synchronized void downscaleToAtMost(int targetScale)
+    {
+        checkArgument(targetScale >= MIN_SCALE && targetScale <= MAX_SCALE, "targetScale must be between %s and %s", MIN_SCALE, MAX_SCALE);
+        if (scale > targetScale) {
+            downscale(scale - targetScale);
+        }
+    }
+
+    public static double bucketLowerBound(int scale, int index)
+    {
+        checkArgument(scale >= MIN_SCALE && scale <= MAX_SCALE, "scale must be between %s and %s", MIN_SCALE, MAX_SCALE);
+        return Math.pow(2, scalb(index, -scale));
+    }
+
+    public static double bucketUpperBound(int scale, int index)
+    {
+        checkArgument(scale >= MIN_SCALE && scale <= MAX_SCALE, "scale must be between %s and %s", MIN_SCALE, MAX_SCALE);
+        return Math.pow(2, scalb(index + 1, -scale));
+    }
+
+    static double[] valuesAt(ExponentialHistogramSnapshot snapshot, double[] percentiles)
+    {
+        requireNonNull(snapshot, "snapshot is null");
+        requireNonNull(percentiles, "percentiles is null");
+
+        double[] values = new double[percentiles.length];
+        if (snapshot.count() == 0) {
+            Arrays.fill(values, Double.NaN);
+            return values;
+        }
+
+        long[] ranks = new long[percentiles.length];
+        for (int i = 0; i < percentiles.length; i++) {
+            if (percentiles[i] <= 0) {
+                ranks[i] = 1;
+            }
+            else if (percentiles[i] >= 1) {
+                ranks[i] = snapshot.count();
+            }
+            else {
+                ranks[i] = (long) ceil(percentiles[i] * snapshot.count());
+            }
+        }
+
+        long seen = 0;
+        int percentileIndex = 0;
+        long[] negativeCounts = snapshot.negativeBuckets().counts();
+        for (int i = negativeCounts.length - 1; i >= 0; i--) {
+            seen += negativeCounts[i];
+            double value = -bucketUpperBound(snapshot.scale(), snapshot.negativeBuckets().offset() + i);
+            while (percentileIndex < ranks.length && seen >= ranks[percentileIndex]) {
+                values[percentileIndex] = value;
+                percentileIndex++;
+            }
+        }
+
+        seen += snapshot.zeroCount();
+        while (percentileIndex < ranks.length && seen >= ranks[percentileIndex]) {
+            values[percentileIndex] = 0;
+            percentileIndex++;
+        }
+
+        long[] positiveCounts = snapshot.positiveBuckets().counts();
+        for (int i = 0; i < positiveCounts.length; i++) {
+            seen += positiveCounts[i];
+            double value = bucketUpperBound(snapshot.scale(), snapshot.positiveBuckets().offset() + i);
+            while (percentileIndex < ranks.length && seen >= ranks[percentileIndex]) {
+                values[percentileIndex] = value;
+                percentileIndex++;
+            }
+        }
+
+        while (percentileIndex < values.length) {
+            values[percentileIndex] = snapshot.max();
+            percentileIndex++;
+        }
+        return values;
+    }
+
+    @GuardedBy("this")
+    private void downscale(int by)
+    {
+        if (by == 0) {
+            return;
+        }
+        if (scale - by < MIN_SCALE) {
+            throw new IllegalStateException("bucket range exceeds maxBuckets at minimum scale");
+        }
+        scale -= by;
+        positiveBuckets.downscale(by);
+        negativeBuckets.downscale(by);
+    }
+
+    private static int bucketIndex(double value, int scale)
+    {
+        if (scale == 0) {
+            return mapToIndexScaleZero(value);
+        }
+        if (scale < 0) {
+            return mapToIndexScaleZero(value) >> -scale;
+        }
+        if (scale <= LOOKUP_MAX_SCALE) {
+            return LOOKUP_BUCKET_INDEXERS[scale].bucketIndex(value);
+        }
+
+        return logarithmicBucketIndex(value, scale);
+    }
+
+    private static int logarithmicBucketIndex(double value, int scale)
+    {
+        int index = (int) ceil(log(value) / LOG_2 * scalb(1.0, scale)) - 1;
+        while (value <= bucketLowerBound(scale, index)) {
+            index--;
+        }
+        while (value > bucketUpperBound(scale, index)) {
+            index++;
+        }
+        return index;
+    }
+
+    private static int mapToIndexScaleZero(double value)
+    {
+        long rawBits = Double.doubleToLongBits(value);
+        long rawExponent = (rawBits & EXPONENT_BIT_MASK) >> SIGNIFICAND_WIDTH;
+        long rawSignificand = rawBits & SIGNIFICAND_BIT_MASK;
+        if (rawExponent == 0) {
+            rawExponent -= Long.numberOfLeadingZeros(rawSignificand - 1) - EXPONENT_WIDTH - 1;
+        }
+        int ieeeExponent = (int) (rawExponent - EXPONENT_BIAS);
+        if (rawSignificand == 0) {
+            return ieeeExponent - 1;
+        }
+        return ieeeExponent;
+    }
+
+    private static LookupBucketIndexer[] createLookupBucketIndexers()
+    {
+        LookupBucketIndexer[] indexers = new LookupBucketIndexer[LOOKUP_MAX_SCALE + 1];
+        for (int scale = 1; scale <= LOOKUP_MAX_SCALE; scale++) {
+            indexers[scale] = new LookupBucketIndexer(scale);
+        }
+        return indexers;
+    }
+
+    public record ExponentialHistogramSnapshot(
+            int scale,
+            long count,
+            double sum,
+            double min,
+            double max,
+            long zeroCount,
+            Buckets positiveBuckets,
+            Buckets negativeBuckets)
+    {
+        public ExponentialHistogramSnapshot
+        {
+            checkArgument(scale >= MIN_SCALE && scale <= MAX_SCALE, "scale must be between %s and %s", MIN_SCALE, MAX_SCALE);
+            checkArgument(count >= 0, "count is negative");
+            checkArgument(zeroCount >= 0, "zeroCount is negative");
+            requireNonNull(positiveBuckets, "positiveBuckets is null");
+            requireNonNull(negativeBuckets, "negativeBuckets is null");
+            validateBucketRange(scale, positiveBuckets);
+            validateBucketRange(scale, negativeBuckets);
+        }
+
+        public static ExponentialHistogramSnapshot merge(List<ExponentialHistogramSnapshot> snapshots)
+        {
+            return merge(snapshots, DEFAULT_MAX_BUCKETS);
+        }
+
+        public static ExponentialHistogramSnapshot merge(List<ExponentialHistogramSnapshot> snapshots, int maxBuckets)
+        {
+            requireNonNull(snapshots, "snapshots is null");
+            checkArgument(maxBuckets >= MIN_BUCKETS_FOR_FULL_FINITE_RANGE, "maxBuckets must be at least %s", MIN_BUCKETS_FOR_FULL_FINITE_RANGE);
+
+            int targetScale = snapshots.stream()
+                    .map(snapshot -> requireNonNull(snapshot, "snapshot is null").scale())
+                    .min(Integer::compareTo)
+                    .orElse(DEFAULT_SCALE);
+
+            long count = 0;
+            double sum = 0;
+            double min = Double.NaN;
+            double max = Double.NaN;
+            long zeroCount = 0;
+            for (ExponentialHistogramSnapshot snapshot : snapshots) {
+                count += snapshot.count();
+                sum += snapshot.sum();
+                zeroCount += snapshot.zeroCount();
+                if (snapshot.count() > 0) {
+                    min = Double.isNaN(min) ? snapshot.min() : Math.min(min, snapshot.min());
+                    max = Double.isNaN(max) ? snapshot.max() : Math.max(max, snapshot.max());
+                }
+            }
+
+            targetScale = targetScaleFor(snapshots, targetScale, maxBuckets);
+            return new ExponentialHistogramSnapshot(
+                    targetScale,
+                    count,
+                    sum,
+                    min,
+                    max,
+                    zeroCount,
+                    mergeBuckets(snapshots, targetScale, maxBuckets, ExponentialHistogramSnapshot::positiveBuckets),
+                    mergeBuckets(snapshots, targetScale, maxBuckets, ExponentialHistogramSnapshot::negativeBuckets));
+        }
+    }
+
+    private static int targetScaleFor(List<ExponentialHistogramSnapshot> snapshots, int targetScale, int maxBuckets)
+    {
+        while (bucketRangeLength(snapshots, targetScale, ExponentialHistogramSnapshot::positiveBuckets) > maxBuckets ||
+                bucketRangeLength(snapshots, targetScale, ExponentialHistogramSnapshot::negativeBuckets) > maxBuckets) {
+            checkArgument(targetScale > MIN_SCALE, "bucket range exceeds maxBuckets at minimum scale");
+            targetScale--;
+        }
+        return targetScale;
+    }
+
+    private static long bucketRangeLength(List<ExponentialHistogramSnapshot> snapshots, int targetScale, BucketSelector bucketSelector)
+    {
+        long firstIndex = Long.MAX_VALUE;
+        long lastIndex = Long.MIN_VALUE;
+        for (ExponentialHistogramSnapshot snapshot : snapshots) {
+            Buckets buckets = bucketSelector.buckets(snapshot);
+            if (buckets.isEmpty()) {
+                continue;
+            }
+
+            int scaleReduction = snapshot.scale() - targetScale;
+            firstIndex = min(firstIndex, downscaleBucketIndex(buckets.offset(), scaleReduction));
+            lastIndex = max(lastIndex, downscaleBucketIndex(lastIndex(buckets), scaleReduction));
+        }
+        if (firstIndex == Long.MAX_VALUE) {
+            return 0;
+        }
+        return lastIndex - firstIndex + 1;
+    }
+
+    private static Buckets mergeBuckets(List<ExponentialHistogramSnapshot> snapshots, int targetScale, int maxBuckets, BucketSelector bucketSelector)
+    {
+        long firstIndex = Long.MAX_VALUE;
+        long lastIndex = Long.MIN_VALUE;
+        for (ExponentialHistogramSnapshot snapshot : snapshots) {
+            Buckets buckets = bucketSelector.buckets(snapshot);
+            if (buckets.isEmpty()) {
+                continue;
+            }
+
+            int scaleReduction = snapshot.scale() - targetScale;
+            firstIndex = min(firstIndex, downscaleBucketIndex(buckets.offset(), scaleReduction));
+            lastIndex = max(lastIndex, downscaleBucketIndex(lastIndex(buckets), scaleReduction));
+        }
+        if (firstIndex == Long.MAX_VALUE) {
+            return new Buckets(0, new long[0]);
+        }
+
+        long length = lastIndex - firstIndex + 1;
+        checkArgument(length <= maxBuckets, "merged bucket range exceeds maxBuckets");
+        long[] counts = new long[(int) length];
+        for (ExponentialHistogramSnapshot snapshot : snapshots) {
+            Buckets buckets = bucketSelector.buckets(snapshot);
+            int scaleReduction = snapshot.scale() - targetScale;
+            long[] bucketCounts = buckets.counts;
+            for (int i = 0; i < bucketCounts.length; i++) {
+                counts[(int) (downscaleBucketIndex((long) buckets.offset() + i, scaleReduction) - firstIndex)] += bucketCounts[i];
+            }
+        }
+        return new Buckets((int) firstIndex, counts);
+    }
+
+    private static long downscaleBucketIndex(long index, int scaleReduction)
+    {
+        return index >> scaleReduction;
+    }
+
+    private static void validateBucketRange(int scale, Buckets buckets)
+    {
+        if (buckets.isEmpty()) {
+            return;
+        }
+        checkArgument(
+                buckets.offset() >= bucketIndex(Double.MIN_VALUE, scale) &&
+                        lastIndex(buckets) <= bucketIndex(Double.MAX_VALUE, scale),
+                "bucket range exceeds finite value range for scale %s",
+                scale);
+    }
+
+    private static long lastIndex(Buckets buckets)
+    {
+        return (long) buckets.offset() + buckets.counts.length - 1;
+    }
+
+    private interface BucketSelector
+    {
+        Buckets buckets(ExponentialHistogramSnapshot snapshot);
+    }
+
+    /**
+     * @param offset bucket index for {@code counts[0]}, or 0 when {@code counts} is empty
+     * @param counts bucket counts starting at {@code offset}
+     */
+    public record Buckets(int offset, long[] counts)
+    {
+        public Buckets
+        {
+            counts = requireNonNull(counts, "counts is null").clone();
+            stream(counts).forEach(count -> checkArgument(count >= 0, "bucket count is negative"));
+        }
+
+        public boolean isEmpty()
+        {
+            return counts.length == 0;
+        }
+
+        @Override
+        public long[] counts()
+        {
+            return counts.clone();
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            return obj instanceof Buckets other &&
+                    offset == other.offset &&
+                    Arrays.equals(counts, other.counts);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return 31 * Integer.hashCode(offset) + Arrays.hashCode(counts);
+        }
+
+        @Override
+        public String toString()
+        {
+            return "Buckets[offset=" + offset + ", counts=" + Arrays.toString(counts) + "]";
+        }
+    }
+
+    private static final class BucketCounts
+    {
+        private int offset;
+        private long[] counts = new long[0];
+
+        private BucketCounts() {}
+
+        private BucketCounts(Buckets buckets)
+        {
+            requireNonNull(buckets, "buckets is null");
+            offset = buckets.offset();
+            counts = buckets.counts();
+        }
+
+        public int scaleReduction(int index, int maxBuckets)
+        {
+            if (counts.length == 0) {
+                return 0;
+            }
+
+            long newOffset = min(index, offset);
+            long newLastIndex = max(index, lastIndex());
+            int scaleReduction = 0;
+            // Match the OpenTelemetry reduction rule by shifting the proposed inclusive bucket
+            // range until it fits. This runs only when a new value expands the current bucket
+            // window, and is bounded by MAX_SCALE - MIN_SCALE.
+            while (newLastIndex - newOffset + 1 > maxBuckets) {
+                newOffset >>= 1;
+                newLastIndex >>= 1;
+                scaleReduction++;
+            }
+            return scaleReduction;
+        }
+
+        public void increment(int index, long count)
+        {
+            if (counts.length == 0) {
+                offset = index;
+                counts = new long[] {count};
+                return;
+            }
+
+            int newOffset = min(offset, index);
+            int newLastIndex = max(lastIndex(), index);
+            if (newOffset != offset || newLastIndex != lastIndex()) {
+                long[] newCounts = new long[newLastIndex - newOffset + 1];
+                System.arraycopy(counts, 0, newCounts, offset - newOffset, counts.length);
+                counts = newCounts;
+                offset = newOffset;
+            }
+            counts[index - offset] += count;
+        }
+
+        public void downscale(int by)
+        {
+            if (by == 0 || counts.length == 0) {
+                return;
+            }
+
+            int newOffset = offset >> by;
+            long[] newCounts = new long[(lastIndex() >> by) - newOffset + 1];
+            for (int i = 0; i < counts.length; i++) {
+                newCounts[((offset + i) >> by) - newOffset] += counts[i];
+            }
+            offset = newOffset;
+            counts = newCounts;
+        }
+
+        public Buckets snapshot()
+        {
+            if (counts.length == 0) {
+                return new Buckets(0, new long[0]);
+            }
+            return new Buckets(offset, counts);
+        }
+
+        private int lastIndex()
+        {
+            return offset + counts.length - 1;
+        }
+    }
+
+    private static final class LookupBucketIndexer
+    {
+        private final int scale;
+        private final long[] significandUpperBounds;
+
+        private LookupBucketIndexer(int scale)
+        {
+            this.scale = scale;
+
+            int bucketsPerPowerOfTwo = 1 << scale;
+            significandUpperBounds = new long[bucketsPerPowerOfTwo - 1];
+            for (int i = 0; i < significandUpperBounds.length; i++) {
+                double upperBound = Math.pow(2, scalb(i + 1, -scale));
+                significandUpperBounds[i] = Double.doubleToRawLongBits(upperBound) & SIGNIFICAND_BIT_MASK;
+            }
+        }
+
+        private int bucketIndex(double value)
+        {
+            long rawBits = Double.doubleToRawLongBits(value);
+            long rawExponent = (rawBits & EXPONENT_BIT_MASK) >> SIGNIFICAND_WIDTH;
+            if (rawExponent == 0) {
+                return logarithmicBucketIndex(value, scale);
+            }
+
+            int ieeeExponent = (int) (rawExponent - EXPONENT_BIAS);
+            long rawSignificand = rawBits & SIGNIFICAND_BIT_MASK;
+            if (rawSignificand == 0) {
+                return (ieeeExponent << scale) - 1;
+            }
+
+            int position = Arrays.binarySearch(significandUpperBounds, rawSignificand);
+            if (position < 0) {
+                position = -position - 1;
+            }
+            return (ieeeExponent << scale) + position;
+        }
+    }
+}

--- a/stats/src/main/java/io/airlift/stats/OpenTelemetryDistribution.java
+++ b/stats/src/main/java/io/airlift/stats/OpenTelemetryDistribution.java
@@ -1,0 +1,220 @@
+package io.airlift.stats;
+
+import com.google.common.base.Ticker;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
+import io.airlift.stats.ExponentialHistogram.ExponentialHistogramSnapshot;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.base.Ticker.systemTicker;
+import static java.util.Objects.requireNonNull;
+
+final class OpenTelemetryDistribution
+        implements DistributionImplementation
+{
+    private static final double[] SNAPSHOT_QUANTILES = new double[] {0.01, 0.05, 0.10, 0.25, 0.5, 0.75, 0.9, 0.95, 0.99};
+    private static final double[] PERCENTILES;
+
+    static {
+        PERCENTILES = new double[100];
+        for (int i = 0; i < 100; ++i) {
+            PERCENTILES[i] = (i / 100.0);
+        }
+    }
+
+    private final StripedExponentialHistogram histogram;
+    private final Ticker ticker;
+
+    @GuardedBy("this")
+    private ExponentialHistogramSnapshot cachedSnapshot;
+    @GuardedBy("this")
+    private long lastSnapshot;
+
+    OpenTelemetryDistribution(Ticker ticker)
+    {
+        this.ticker = requireNonNull(ticker, "ticker is null");
+        histogram = new StripedExponentialHistogram();
+    }
+
+    private OpenTelemetryDistribution(ExponentialHistogramSnapshot snapshot)
+    {
+        ticker = systemTicker();
+        histogram = new StripedExponentialHistogram(snapshot, ExponentialHistogram.DEFAULT_MAX_BUCKETS);
+    }
+
+    @Override
+    public void add(long value)
+    {
+        histogram.record(value);
+    }
+
+    @Override
+    public void add(long value, long count)
+    {
+        histogram.record(value, count);
+    }
+
+    @Override
+    public DistributionImplementation duplicate()
+    {
+        return new OpenTelemetryDistribution(histogram.snapshot());
+    }
+
+    @Override
+    public void reset()
+    {
+        synchronized (this) {
+            histogram.reset();
+            cachedSnapshot = null;
+            lastSnapshot = ticker.read();
+        }
+    }
+
+    @Override
+    public double getCount()
+    {
+        return snapshotIfNeeded().count();
+    }
+
+    @Override
+    public double getTotal()
+    {
+        return snapshotIfNeeded().sum();
+    }
+
+    @Override
+    public double getP01()
+    {
+        return valueAt(0.01);
+    }
+
+    @Override
+    public double getP05()
+    {
+        return valueAt(0.05);
+    }
+
+    @Override
+    public double getP10()
+    {
+        return valueAt(0.10);
+    }
+
+    @Override
+    public double getP25()
+    {
+        return valueAt(0.25);
+    }
+
+    @Override
+    public double getP50()
+    {
+        return valueAt(0.50);
+    }
+
+    @Override
+    public double getP75()
+    {
+        return valueAt(0.75);
+    }
+
+    @Override
+    public double getP90()
+    {
+        return valueAt(0.90);
+    }
+
+    @Override
+    public double getP95()
+    {
+        return valueAt(0.95);
+    }
+
+    @Override
+    public double getP99()
+    {
+        return valueAt(0.99);
+    }
+
+    @Override
+    public double getMin()
+    {
+        return snapshotIfNeeded().min();
+    }
+
+    @Override
+    public double getMax()
+    {
+        return snapshotIfNeeded().max();
+    }
+
+    @Override
+    public double getAvg()
+    {
+        ExponentialHistogramSnapshot snapshot = snapshotIfNeeded();
+        if (snapshot.count() == 0) {
+            return Double.NaN;
+        }
+        return snapshot.sum() / snapshot.count();
+    }
+
+    @Override
+    public Map<Double, Double> getPercentiles()
+    {
+        double[] values = ExponentialHistogram.valuesAt(snapshot(true), PERCENTILES);
+        Map<Double, Double> result = new LinkedHashMap<>(PERCENTILES.length);
+        for (int i = 0; i < PERCENTILES.length; i++) {
+            result.put(PERCENTILES[i], values[i]);
+        }
+        return result;
+    }
+
+    @Override
+    public Distribution.DistributionSnapshot snapshot()
+    {
+        ExponentialHistogramSnapshot snapshot = snapshot(true);
+        double[] quantiles = ExponentialHistogram.valuesAt(snapshot, SNAPSHOT_QUANTILES);
+        return new Distribution.DistributionSnapshot(
+                snapshot.count(),
+                snapshot.sum(),
+                quantiles[0], // p01
+                quantiles[1], // p05
+                quantiles[2], // p10
+                quantiles[3], // p25
+                quantiles[4], // p50
+                quantiles[5], // p75
+                quantiles[6], // p90
+                quantiles[7], // p95
+                quantiles[8], // p99
+                snapshot.min(),
+                snapshot.max(),
+                snapshot.count() == 0 ? Double.NaN : snapshot.sum() / snapshot.count());
+    }
+
+    @Override
+    public Optional<ExponentialHistogramSnapshot> exponentialHistogramSnapshot()
+    {
+        return Optional.of(snapshot(true));
+    }
+
+    private double valueAt(double percentile)
+    {
+        return ExponentialHistogram.valuesAt(snapshotIfNeeded(), new double[] {percentile})[0];
+    }
+
+    private ExponentialHistogramSnapshot snapshotIfNeeded()
+    {
+        return snapshot(false);
+    }
+
+    private synchronized ExponentialHistogramSnapshot snapshot(boolean forceSnapshot)
+    {
+        if (forceSnapshot || cachedSnapshot == null || ticker.read() - lastSnapshot >= Distribution.MERGE_THRESHOLD_NANOS) {
+            cachedSnapshot = histogram.snapshot();
+            lastSnapshot = ticker.read();
+        }
+        return cachedSnapshot;
+    }
+}

--- a/stats/src/main/java/io/airlift/stats/OpenTelemetryTimeDistribution.java
+++ b/stats/src/main/java/io/airlift/stats/OpenTelemetryTimeDistribution.java
@@ -1,0 +1,177 @@
+package io.airlift.stats;
+
+import com.google.common.base.Ticker;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
+import io.airlift.stats.ExponentialHistogram.ExponentialHistogramSnapshot;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+final class OpenTelemetryTimeDistribution
+        implements TimeDistributionImplementation
+{
+    private static final double[] SNAPSHOT_QUANTILES = new double[] {0.5, 0.75, 0.9, 0.95, 0.99};
+    private static final double[] PERCENTILES;
+
+    static {
+        PERCENTILES = new double[100];
+        for (int i = 0; i < 100; ++i) {
+            PERCENTILES[i] = (i / 100.0);
+        }
+    }
+
+    private final StripedExponentialHistogram histogram = new StripedExponentialHistogram();
+    private final Ticker ticker;
+    private final TimeUnit unit;
+    @GuardedBy("this")
+    private ExponentialHistogramSnapshot cachedSnapshot;
+    @GuardedBy("this")
+    private long lastSnapshot;
+
+    OpenTelemetryTimeDistribution(Ticker ticker, TimeUnit unit)
+    {
+        this.ticker = ticker;
+        this.unit = unit;
+        lastSnapshot = ticker.read(); // do not snapshot immediately
+    }
+
+    @Override
+    public void add(long value)
+    {
+        histogram.record(value);
+    }
+
+    @Override
+    public double getCount()
+    {
+        return snapshotIfNeeded().count();
+    }
+
+    @Override
+    public double getP50()
+    {
+        return valueAt(0.50);
+    }
+
+    @Override
+    public double getP75()
+    {
+        return valueAt(0.75);
+    }
+
+    @Override
+    public double getP90()
+    {
+        return valueAt(0.90);
+    }
+
+    @Override
+    public double getP95()
+    {
+        return valueAt(0.95);
+    }
+
+    @Override
+    public double getP99()
+    {
+        return valueAt(0.99);
+    }
+
+    @Override
+    public double getMin()
+    {
+        return convertToUnit(snapshotIfNeeded().min(), unit);
+    }
+
+    @Override
+    public double getMax()
+    {
+        return convertToUnit(snapshotIfNeeded().max(), unit);
+    }
+
+    @Override
+    public double getAvg()
+    {
+        ExponentialHistogramSnapshot snapshot = snapshotIfNeeded();
+        if (snapshot.count() == 0) {
+            return Double.NaN;
+        }
+        return convertToUnit(snapshot.sum(), unit) / snapshot.count();
+    }
+
+    @Override
+    public TimeUnit getUnit()
+    {
+        return unit;
+    }
+
+    @Override
+    public Map<Double, Double> getPercentiles()
+    {
+        ExponentialHistogramSnapshot snapshot = snapshot(true);
+        double[] values = ExponentialHistogram.valuesAt(snapshot, PERCENTILES);
+        Map<Double, Double> result = new LinkedHashMap<>(PERCENTILES.length);
+        for (int i = 0; i < PERCENTILES.length; i++) {
+            result.put(PERCENTILES[i], values[i]);
+        }
+        return result;
+    }
+
+    @Override
+    public TimeDistribution.TimeDistributionSnapshot snapshot()
+    {
+        ExponentialHistogramSnapshot snapshot = snapshot(true);
+        double[] quantiles = ExponentialHistogram.valuesAt(snapshot, SNAPSHOT_QUANTILES);
+        return new TimeDistribution.TimeDistributionSnapshot(
+                snapshot.count(),
+                convertToUnit(quantiles[0], unit), // p50
+                convertToUnit(quantiles[1], unit), // p75
+                convertToUnit(quantiles[2], unit), // p90
+                convertToUnit(quantiles[3], unit), // p95
+                convertToUnit(quantiles[4], unit), // p99
+                convertToUnit(snapshot.min(), unit),
+                convertToUnit(snapshot.max(), unit),
+                snapshot.count() == 0 ? Double.NaN : convertToUnit(snapshot.sum(), unit) / snapshot.count(),
+                unit);
+    }
+
+    @Override
+    public Optional<ExponentialHistogramSnapshot> exponentialHistogramSnapshot()
+    {
+        return Optional.of(snapshot(true));
+    }
+
+    @Override
+    public synchronized void reset()
+    {
+        histogram.reset();
+        cachedSnapshot = null;
+        lastSnapshot = ticker.read();
+    }
+
+    private double valueAt(double percentile)
+    {
+        return convertToUnit(ExponentialHistogram.valuesAt(snapshotIfNeeded(), new double[] {percentile})[0], unit);
+    }
+
+    private ExponentialHistogramSnapshot snapshotIfNeeded()
+    {
+        return snapshot(false);
+    }
+
+    private synchronized ExponentialHistogramSnapshot snapshot(boolean forceSnapshot)
+    {
+        if (forceSnapshot || cachedSnapshot == null || ticker.read() - lastSnapshot >= TimeDistribution.MERGE_THRESHOLD_NANOS) {
+            cachedSnapshot = histogram.snapshot();
+            lastSnapshot = ticker.read();
+        }
+        return cachedSnapshot;
+    }
+
+    private static double convertToUnit(double nanos, TimeUnit unit)
+    {
+        return nanos / unit.toNanos(1);
+    }
+}

--- a/stats/src/main/java/io/airlift/stats/StatsBackend.java
+++ b/stats/src/main/java/io/airlift/stats/StatsBackend.java
@@ -1,0 +1,25 @@
+package io.airlift.stats;
+
+import java.util.Locale;
+
+import static java.util.Objects.requireNonNull;
+
+public enum StatsBackend
+{
+    AIRLIFT,
+    OPENTELEMETRY;
+
+    static StatsBackend fromPropertyValue(String value)
+    {
+        String normalized = requireNonNull(value, "value is null")
+                .trim()
+                .replace("-", "")
+                .replace("_", "")
+                .toUpperCase(Locale.ROOT);
+        return switch (normalized) {
+            case "AIRLIFT" -> AIRLIFT;
+            case "OPENTELEMETRY", "OTEL" -> OPENTELEMETRY;
+            default -> throw new IllegalArgumentException("Unknown stats backend: " + value);
+        };
+    }
+}

--- a/stats/src/main/java/io/airlift/stats/StatsBackendFactory.java
+++ b/stats/src/main/java/io/airlift/stats/StatsBackendFactory.java
@@ -1,0 +1,50 @@
+package io.airlift.stats;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
+
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+public final class StatsBackendFactory
+{
+    public static final String STATS_BACKEND_PROPERTY = "io.airlift.stats.backend";
+
+    private static final Object lock = new Object();
+
+    @GuardedBy("lock")
+    private static StatsBackend backend;
+    @GuardedBy("lock")
+    private static boolean frozen;
+
+    private StatsBackendFactory() {}
+
+    public static StatsBackend getBackend()
+    {
+        synchronized (lock) {
+            if (backend == null) {
+                backend = StatsBackend.fromPropertyValue(System.getProperty(STATS_BACKEND_PROPERTY, "airlift"));
+            }
+            frozen = true;
+            return backend;
+        }
+    }
+
+    public static void setBackend(StatsBackend backend)
+    {
+        requireNonNull(backend, "backend is null");
+        synchronized (lock) {
+            checkState(!frozen, "stats backend is already initialized");
+            StatsBackendFactory.backend = backend;
+        }
+    }
+
+    @VisibleForTesting
+    static void resetForTesting()
+    {
+        synchronized (lock) {
+            backend = null;
+            frozen = false;
+        }
+    }
+}

--- a/stats/src/main/java/io/airlift/stats/StripedExponentialHistogram.java
+++ b/stats/src/main/java/io/airlift/stats/StripedExponentialHistogram.java
@@ -1,0 +1,82 @@
+package io.airlift.stats;
+
+import com.google.errorprone.annotations.ThreadSafe;
+import io.airlift.stats.ExponentialHistogram.ExponentialHistogramSnapshot;
+
+import java.util.Arrays;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.Math.clamp;
+import static java.lang.Math.floorMod;
+
+@ThreadSafe
+public final class StripedExponentialHistogram
+{
+    private static final int DEFAULT_STRIPES = clamp(Runtime.getRuntime().availableProcessors(), 2, 16);
+
+    private final ExponentialHistogram[] stripes;
+    private final int maxBuckets;
+
+    public StripedExponentialHistogram()
+    {
+        this(ExponentialHistogram.DEFAULT_SCALE, ExponentialHistogram.DEFAULT_MAX_BUCKETS, DEFAULT_STRIPES);
+    }
+
+    public StripedExponentialHistogram(int scale, int maxBuckets)
+    {
+        this(scale, maxBuckets, DEFAULT_STRIPES);
+    }
+
+    public StripedExponentialHistogram(int scale, int maxBuckets, int stripes)
+    {
+        checkArgument(stripes > 0, "stripes must be positive");
+        this.stripes = new ExponentialHistogram[stripes];
+        this.maxBuckets = maxBuckets;
+        for (int i = 0; i < stripes; i++) {
+            this.stripes[i] = new ExponentialHistogram(scale, maxBuckets);
+        }
+    }
+
+    StripedExponentialHistogram(ExponentialHistogramSnapshot snapshot, int maxBuckets)
+    {
+        this.stripes = new ExponentialHistogram[] {new ExponentialHistogram(snapshot, maxBuckets)};
+        this.maxBuckets = maxBuckets;
+    }
+
+    public void record(double value)
+    {
+        stripe().record(value);
+    }
+
+    public void record(double value, long occurrences)
+    {
+        stripe().record(value, occurrences);
+    }
+
+    public ExponentialHistogramSnapshot snapshot()
+    {
+        ExponentialHistogramSnapshot[] snapshots = Arrays.stream(stripes)
+                .map(ExponentialHistogram::snapshot)
+                .toArray(ExponentialHistogramSnapshot[]::new);
+
+        ExponentialHistogramSnapshot merged = ExponentialHistogramSnapshot.merge(Arrays.asList(snapshots), maxBuckets);
+        for (int i = 0; i < snapshots.length; i++) {
+            if (snapshots[i].scale() != merged.scale()) {
+                stripes[i].downscaleToAtMost(merged.scale());
+            }
+        }
+        return merged;
+    }
+
+    public void reset()
+    {
+        for (ExponentialHistogram stripe : stripes) {
+            stripe.reset();
+        }
+    }
+
+    private ExponentialHistogram stripe()
+    {
+        return stripes[floorMod(Thread.currentThread().threadId(), stripes.length)];
+    }
+}

--- a/stats/src/main/java/io/airlift/stats/TimeDistribution.java
+++ b/stats/src/main/java/io/airlift/stats/TimeDistribution.java
@@ -2,18 +2,15 @@ package io.airlift.stats;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Ticker;
-import com.google.errorprone.annotations.concurrent.GuardedBy;
+import io.airlift.stats.ExponentialHistogram.ExponentialHistogramSnapshot;
 import jakarta.annotation.Nullable;
 import org.weakref.jmx.Managed;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static com.google.common.base.Ticker.systemTicker;
-import static com.google.common.base.Verify.verify;
-import static java.lang.Math.clamp;
-import static java.lang.Math.floorMod;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -22,31 +19,8 @@ public class TimeDistribution
 {
     @VisibleForTesting
     static final long MERGE_THRESHOLD_NANOS = MILLISECONDS.toNanos(100);
-    private static final double[] SNAPSHOT_QUANTILES = new double[] {0.5, 0.75, 0.9, 0.95, 0.99};
-    private static final double[] PERCENTILES;
-    private static final int STRIPES = clamp(Runtime.getRuntime().availableProcessors(), 2, 16);
 
-    static {
-        PERCENTILES = new double[100];
-        for (int i = 0; i < 100; ++i) {
-            PERCENTILES[i] = (i / 100.0);
-        }
-    }
-
-    private final Ticker ticker;
-    // immutable config shared by every sub-structure; null when this distribution does not decay
-    @Nullable
-    private final DecayConfig config;
-    private final Object[] locks = new Object[STRIPES];
-    // @GuardedBy("locks[i]") for partials[i]
-    private final DecayTDigest[] partials = new DecayTDigest[STRIPES];
-    @GuardedBy("this")
-    private DecayTDigest merged;
-    @GuardedBy("this")
-    private long lastMerge;
-    private final DecayCounter total;
-    private final DecayCounter partialTotal;
-    private final TimeUnit unit;
+    private final TimeDistributionImplementation implementation;
 
     public TimeDistribution()
     {
@@ -89,234 +63,97 @@ public class TimeDistribution
     {
         requireNonNull(ticker, "ticker is null");
         requireNonNull(unit, "unit is null");
-        // the config is immutable and shared; each sub-structure derives its own decay state
-        this.config = config;
-        merged = new DecayTDigest(TDigest.DEFAULT_COMPRESSION, config);
-        for (int i = 0; i < STRIPES; i++) {
-            locks[i] = new Object();
-        }
-        total = new DecayCounter(config);
-        partialTotal = new DecayCounter(config);
-        this.ticker = ticker;
-        this.unit = unit;
-        this.lastMerge = ticker.read(); // do not merge immediately
+        implementation = switch (StatsBackendFactory.getBackend()) {
+            case AIRLIFT -> new AirliftTimeDistribution(ticker, config, unit);
+            case OPENTELEMETRY -> new OpenTelemetryTimeDistribution(ticker, unit);
+        };
     }
 
     public void add(long value)
     {
-        int segment = floorMod(Thread.currentThread().threadId(), STRIPES);
-        synchronized (locks[segment]) {
-            if (partials[segment] == null) {
-                partials[segment] = new DecayTDigest(TDigest.DEFAULT_COMPRESSION, config);
-            }
-            partials[segment].add(value);
-        }
-        partialTotal.add(value); // Fine outside of lock as DecayCounter is thread safe
+        implementation.add(value);
     }
 
     @Managed
     public double getCount()
     {
-        synchronized (this) {
-            mergeIfNeeded();
-            return merged.getCount();
-        }
+        return implementation.getCount();
     }
 
     @Managed
     public double getP50()
     {
-        double p50;
-        synchronized (this) {
-            mergeIfNeeded();
-            p50 = merged.valueAt(0.5);
-        }
-        return convertToUnit(p50);
+        return implementation.getP50();
     }
 
     @Managed
     public double getP75()
     {
-        double p75;
-        synchronized (this) {
-            mergeIfNeeded();
-            p75 = merged.valueAt(0.75);
-        }
-        return convertToUnit(p75);
+        return implementation.getP75();
     }
 
     @Managed
     public double getP90()
     {
-        double p90;
-        synchronized (this) {
-            mergeIfNeeded();
-            p90 = merged.valueAt(0.90);
-        }
-        return convertToUnit(p90);
+        return implementation.getP90();
     }
 
     @Managed
     public double getP95()
     {
-        double p95;
-        synchronized (this) {
-            mergeIfNeeded();
-            p95 = merged.valueAt(0.95);
-        }
-        return convertToUnit(p95);
+        return implementation.getP95();
     }
 
     @Managed
     public double getP99()
     {
-        double p99;
-        synchronized (this) {
-            mergeIfNeeded();
-            p99 = merged.valueAt(0.99);
-        }
-        return convertToUnit(p99);
+        return implementation.getP99();
     }
 
     @Managed
     public double getMin()
     {
-        double min;
-        synchronized (this) {
-            mergeIfNeeded();
-            min = merged.getMin();
-        }
-        return convertToUnit(min);
+        return implementation.getMin();
     }
 
     @Managed
     public double getMax()
     {
-        double max;
-        synchronized (this) {
-            mergeIfNeeded();
-            max = merged.getMax();
-        }
-        return convertToUnit(max);
+        return implementation.getMax();
     }
 
     @Managed
     public double getAvg()
     {
-        double digestCount;
-        double totalCount;
-        synchronized (this) {
-            mergeIfNeeded();
-            digestCount = merged.getCount();
-            totalCount = total.getCount();
-        }
-        return convertToUnit(totalCount) / digestCount;
+        return implementation.getAvg();
     }
 
     @Managed
     public TimeUnit getUnit()
     {
-        return unit;
+        return implementation.getUnit();
     }
 
     @Managed
     public Map<Double, Double> getPercentiles()
     {
-        double[] values;
-        synchronized (this) {
-            mergeIfNeeded(true);
-            values = merged.valuesAt(PERCENTILES);
-        }
-
-        verify(values.length == PERCENTILES.length, "values length mismatch");
-
-        Map<Double, Double> result = new LinkedHashMap<>(values.length);
-        for (int i = 0; i < values.length; ++i) {
-            result.put(PERCENTILES[i], values[i]);
-        }
-
-        return result;
-    }
-
-    private void mergeIfNeeded()
-    {
-        mergeIfNeeded(false);
-    }
-
-    private void mergeIfNeeded(boolean forceMerge)
-    {
-        synchronized (this) {
-            if (forceMerge || ticker.read() - lastMerge >= MERGE_THRESHOLD_NANOS) {
-                for (int i = 0; i < STRIPES; i++) {
-                    synchronized (locks[i]) {
-                        if (partials[i] == null) {
-                            continue;
-                        }
-                        merged.merge(partials[i]);
-                        // Reset the partial
-                        partials[i] = null;
-                    }
-                }
-                total.merge(partialTotal);
-                partialTotal.reset();
-                lastMerge = ticker.read();
-            }
-        }
-    }
-
-    private double convertToUnit(double nanos)
-    {
-        return convertToUnit(nanos, (double) unit.toNanos(1));
-    }
-
-    private static double convertToUnit(double nanos, double unitNanos)
-    {
-        return nanos / unitNanos;
+        return implementation.getPercentiles();
     }
 
     public TimeDistributionSnapshot snapshot()
     {
-        double totalCount;
-        double digestCount;
-        double min;
-        double max;
-        double[] quantiles;
-        synchronized (this) {
-            mergeIfNeeded(true);
-            DecayTDigest digest = merged;
-            totalCount = total.getCount();
-            digestCount = digest.getCount();
-            min = digest.getMin();
-            max = digest.getMax();
-            quantiles = digest.valuesAt(SNAPSHOT_QUANTILES);
-        }
-        double unitNanos = (double) unit.toNanos(1);
-        double average = convertToUnit(totalCount, unitNanos) / digestCount;
-        return new TimeDistributionSnapshot(
-                digestCount,
-                convertToUnit(quantiles[0], unitNanos), // p50
-                convertToUnit(quantiles[1], unitNanos), // p75
-                convertToUnit(quantiles[2], unitNanos), // p90
-                convertToUnit(quantiles[3], unitNanos), // p95
-                convertToUnit(quantiles[4], unitNanos), // p99
-                convertToUnit(min, unitNanos),
-                convertToUnit(max, unitNanos),
-                average,
-                unit);
+        return implementation.snapshot();
+    }
+
+    public Optional<ExponentialHistogramSnapshot> exponentialHistogramSnapshot()
+    {
+        return implementation.exponentialHistogramSnapshot();
     }
 
     @Managed
-    public synchronized void reset()
+    public void reset()
     {
-        total.reset();
-        partialTotal.reset();
-        merged = new DecayTDigest(TDigest.DEFAULT_COMPRESSION, config);
-        // Reset all partial digests (stripes) to avoid stale data
-        for (int i = 0; i < partials.length; i++) {
-            synchronized (locks[i]) {
-                partials[i] = null;
-            }
-        }
+        implementation.reset();
     }
 
     public record TimeDistributionSnapshot(

--- a/stats/src/main/java/io/airlift/stats/TimeDistributionImplementation.java
+++ b/stats/src/main/java/io/airlift/stats/TimeDistributionImplementation.java
@@ -1,0 +1,41 @@
+package io.airlift.stats;
+
+import io.airlift.stats.ExponentialHistogram.ExponentialHistogramSnapshot;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+sealed interface TimeDistributionImplementation
+        permits AirliftTimeDistribution, OpenTelemetryTimeDistribution
+{
+    void add(long value);
+
+    double getCount();
+
+    double getP50();
+
+    double getP75();
+
+    double getP90();
+
+    double getP95();
+
+    double getP99();
+
+    double getMin();
+
+    double getMax();
+
+    double getAvg();
+
+    TimeUnit getUnit();
+
+    Map<Double, Double> getPercentiles();
+
+    TimeDistribution.TimeDistributionSnapshot snapshot();
+
+    Optional<ExponentialHistogramSnapshot> exponentialHistogramSnapshot();
+
+    void reset();
+}

--- a/stats/src/main/java/io/airlift/stats/TimeStat.java
+++ b/stats/src/main/java/io/airlift/stats/TimeStat.java
@@ -16,20 +16,27 @@
 package io.airlift.stats;
 
 import com.google.common.base.Ticker;
+import io.airlift.stats.ExponentialHistogram.ExponentialHistogramSnapshot;
 import io.airlift.stats.TimeDistribution.TimeDistributionSnapshot;
 import io.airlift.units.Duration;
+import jakarta.annotation.Nullable;
 import org.weakref.jmx.Managed;
 import org.weakref.jmx.Nested;
 
+import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
+import static io.airlift.stats.StatsBackend.AIRLIFT;
 import static java.util.Objects.requireNonNull;
 
 public class TimeStat
 {
+    @Nullable
     private final TimeDistribution oneMinute;
+    @Nullable
     private final TimeDistribution fiveMinutes;
+    @Nullable
     private final TimeDistribution fifteenMinutes;
     private final TimeDistribution allTime;
     private final Ticker ticker;
@@ -52,9 +59,16 @@ public class TimeStat
     public TimeStat(Ticker ticker, TimeUnit unit)
     {
         this.ticker = ticker;
-        oneMinute = new TimeDistribution(ticker, DecayConfig.oneMinute(), unit);
-        fiveMinutes = new TimeDistribution(ticker, DecayConfig.fiveMinutes(), unit);
-        fifteenMinutes = new TimeDistribution(ticker, DecayConfig.fifteenMinutes(), unit);
+        if (StatsBackendFactory.getBackend() == AIRLIFT) {
+            oneMinute = new TimeDistribution(ticker, DecayConfig.oneMinute(), unit);
+            fiveMinutes = new TimeDistribution(ticker, DecayConfig.fiveMinutes(), unit);
+            fifteenMinutes = new TimeDistribution(ticker, DecayConfig.fifteenMinutes(), unit);
+        }
+        else {
+            oneMinute = null;
+            fiveMinutes = null;
+            fifteenMinutes = null;
+        }
         allTime = new TimeDistribution(ticker, unit);
     }
 
@@ -80,9 +94,11 @@ public class TimeStat
         if (nanos < 0) {
             throw new IllegalArgumentException("value is negative: " + nanos);
         }
-        oneMinute.add(nanos);
-        fiveMinutes.add(nanos);
-        fifteenMinutes.add(nanos);
+        if (oneMinute != null && fiveMinutes != null && fifteenMinutes != null) {
+            oneMinute.add(nanos);
+            fiveMinutes.add(nanos);
+            fifteenMinutes.add(nanos);
+        }
         allTime.add(nanos);
     }
 
@@ -117,6 +133,7 @@ public class TimeStat
 
     @Managed
     @Nested
+    @Nullable
     public TimeDistribution getOneMinute()
     {
         return oneMinute;
@@ -124,6 +141,7 @@ public class TimeStat
 
     @Managed
     @Nested
+    @Nullable
     public TimeDistribution getFiveMinutes()
     {
         return fiveMinutes;
@@ -131,6 +149,7 @@ public class TimeStat
 
     @Managed
     @Nested
+    @Nullable
     public TimeDistribution getFifteenMinutes()
     {
         return fifteenMinutes;
@@ -146,32 +165,39 @@ public class TimeStat
     public TimeDistributionStatSnapshot snapshot()
     {
         return new TimeDistributionStatSnapshot(
-                getOneMinute().snapshot(),
-                getFiveMinutes().snapshot(),
-                getFifteenMinutes().snapshot(),
+                oneMinute == null ? null : oneMinute.snapshot(),
+                fiveMinutes == null ? null : fiveMinutes.snapshot(),
+                fifteenMinutes == null ? null : fifteenMinutes.snapshot(),
                 getAllTime().snapshot());
+    }
+
+    public Optional<ExponentialHistogramSnapshot> exponentialHistogramSnapshot()
+    {
+        return getAllTime().exponentialHistogramSnapshot();
     }
 
     @Managed
     public void reset()
     {
-        oneMinute.reset();
-        fiveMinutes.reset();
-        fifteenMinutes.reset();
+        if (oneMinute != null && fiveMinutes != null && fifteenMinutes != null) {
+            oneMinute.reset();
+            fiveMinutes.reset();
+            fifteenMinutes.reset();
+        }
         allTime.reset();
     }
 
     public record TimeDistributionStatSnapshot(
+            @Nullable
             TimeDistributionSnapshot oneMinute,
+            @Nullable
             TimeDistributionSnapshot fiveMinute,
+            @Nullable
             TimeDistributionSnapshot fifteenMinute,
             TimeDistributionSnapshot allTime)
     {
         public TimeDistributionStatSnapshot
         {
-            requireNonNull(oneMinute, "oneMinute is null");
-            requireNonNull(fiveMinute, "fiveMinute is null");
-            requireNonNull(fifteenMinute, "fifteenMinute is null");
             requireNonNull(allTime, "allTime is null");
         }
     }

--- a/stats/src/test/java/io/airlift/stats/BenchmarkExponentialHistogram.java
+++ b/stats/src/test/java/io/airlift/stats/BenchmarkExponentialHistogram.java
@@ -1,0 +1,190 @@
+package io.airlift.stats;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(3)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+public class BenchmarkExponentialHistogram
+{
+    private static final int NUMBER_OF_ENTRIES = 100_000;
+
+    @State(Scope.Thread)
+    public static class Data
+    {
+        @Param({"zero", "narrow", "wide", "extreme"})
+        private String distribution;
+
+        private double[] values;
+
+        @Setup
+        public void setup()
+        {
+            values = makeValues(distribution);
+        }
+
+        private static double[] makeValues(String distribution)
+        {
+            return switch (distribution) {
+                case "narrow" -> makeNarrowValues();
+                case "zero" -> new double[NUMBER_OF_ENTRIES];
+                case "wide" -> makeWideValues();
+                case "extreme" -> makeExtremeValues();
+                default -> throw new IllegalArgumentException("unsupported distribution: " + distribution);
+            };
+        }
+
+        private static double[] makeNarrowValues()
+        {
+            double[] values = new double[NUMBER_OF_ENTRIES];
+            ThreadLocalRandom random = ThreadLocalRandom.current();
+            for (int i = 0; i < values.length; i++) {
+                values[i] = 1_000_000 + random.nextInt(100_000);
+            }
+            return values;
+        }
+
+        private static double[] makeWideValues()
+        {
+            double[] values = new double[NUMBER_OF_ENTRIES];
+            ThreadLocalRandom random = ThreadLocalRandom.current();
+            for (int i = 0; i < values.length; i++) {
+                values[i] = Math.pow(2, random.nextDouble(-20, 40));
+            }
+            return values;
+        }
+
+        private static double[] makeExtremeValues()
+        {
+            double[] values = makeWideValues();
+            for (int i = 0; i < values.length; i += 10_000) {
+                values[i] = Double.MIN_VALUE;
+                values[i + 1] = Double.MAX_VALUE;
+            }
+            return values;
+        }
+    }
+
+    @State(Scope.Thread)
+    public static class HistogramState
+    {
+        private ExponentialHistogram histogram;
+        private TimeDistribution timeDistribution;
+        private TimeStat timeStat;
+
+        @Setup
+        public void setup(Data data)
+        {
+            histogram = new ExponentialHistogram();
+            timeDistribution = new TimeDistribution(TimeUnit.NANOSECONDS);
+            timeStat = new TimeStat(TimeUnit.NANOSECONDS);
+            for (double value : data.values) {
+                long nanos = toNanos(value);
+                histogram.record(value);
+                timeDistribution.add(nanos);
+                timeStat.addNanos(nanos);
+            }
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(NUMBER_OF_ENTRIES)
+    public ExponentialHistogram benchmarkExponentialHistogramInserts(Data data)
+    {
+        ExponentialHistogram histogram = new ExponentialHistogram();
+        for (double value : data.values) {
+            histogram.record(value);
+        }
+        return histogram;
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(NUMBER_OF_ENTRIES)
+    public ExponentialHistogram benchmarkExponentialHistogramScaleZeroInserts(Data data)
+    {
+        ExponentialHistogram histogram = new ExponentialHistogram(0, ExponentialHistogram.DEFAULT_MAX_BUCKETS);
+        for (double value : data.values) {
+            histogram.record(value);
+        }
+        return histogram;
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(NUMBER_OF_ENTRIES)
+    public TimeDistribution benchmarkTimeDistributionInserts(Data data)
+    {
+        TimeDistribution distribution = new TimeDistribution(TimeUnit.NANOSECONDS);
+        for (double value : data.values) {
+            distribution.add(toNanos(value));
+        }
+        return distribution;
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(NUMBER_OF_ENTRIES)
+    public TimeStat benchmarkTimeStatInserts(Data data)
+    {
+        TimeStat stat = new TimeStat(TimeUnit.NANOSECONDS);
+        for (double value : data.values) {
+            stat.addNanos(toNanos(value));
+        }
+        return stat;
+    }
+
+    @Benchmark
+    public ExponentialHistogram.ExponentialHistogramSnapshot benchmarkExponentialHistogramSnapshot(HistogramState state)
+    {
+        return state.histogram.snapshot();
+    }
+
+    @Benchmark
+    public TimeDistribution.TimeDistributionSnapshot benchmarkTimeDistributionSnapshot(HistogramState state)
+    {
+        return state.timeDistribution.snapshot();
+    }
+
+    @Benchmark
+    public TimeStat.TimeDistributionStatSnapshot benchmarkTimeStatSnapshot(HistogramState state)
+    {
+        return state.timeStat.snapshot();
+    }
+
+    private static long toNanos(double value)
+    {
+        if (value >= Long.MAX_VALUE) {
+            return Long.MAX_VALUE;
+        }
+        return (long) value;
+    }
+
+    public static void main(String[] args)
+            throws RunnerException
+    {
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*\\." + BenchmarkExponentialHistogram.class.getSimpleName() + "\\..*")
+                .addProfiler(GCProfiler.class)
+                .build();
+
+        new Runner(options).run();
+    }
+}

--- a/stats/src/test/java/io/airlift/stats/TestCounterStat.java
+++ b/stats/src/test/java/io/airlift/stats/TestCounterStat.java
@@ -1,0 +1,118 @@
+package io.airlift.stats;
+
+import io.airlift.stats.CounterStat.CounterStatSnapshot;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import static io.airlift.stats.StatsBackend.AIRLIFT;
+import static io.airlift.stats.StatsBackend.OPENTELEMETRY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
+
+@Isolated
+@Execution(SAME_THREAD)
+class TestCounterStat
+{
+    @BeforeEach
+    public void setupStatsBackend()
+    {
+        StatsBackendFactory.resetForTesting();
+        StatsBackendFactory.setBackend(AIRLIFT);
+    }
+
+    @AfterEach
+    public void resetStatsBackend()
+    {
+        StatsBackendFactory.resetForTesting();
+    }
+
+    @Test
+    public void testAirliftBackendCreatesDecayCounters()
+    {
+        CounterStat counter = new CounterStat();
+        counter.update(3);
+
+        CounterStatSnapshot snapshot = counter.snapshot();
+
+        assertThat(counter.getTotalCount()).isEqualTo(3);
+        assertThat(counter.getOneMinute().getCount()).isEqualTo(3);
+        assertThat(counter.getFiveMinute().getCount()).isEqualTo(3);
+        assertThat(counter.getFifteenMinute().getCount()).isEqualTo(3);
+        assertThat(snapshot.getTotalCount()).isEqualTo(3);
+        assertThat(snapshot.getOneMinute()).isNotNull();
+        assertThat(snapshot.getFiveMinute()).isNotNull();
+        assertThat(snapshot.getFifteenMinute()).isNotNull();
+    }
+
+    @Test
+    public void testOpenTelemetryBackendCreatesOnlyTotal()
+    {
+        StatsBackendFactory.setBackend(OPENTELEMETRY);
+        CounterStat counter = new CounterStat();
+        counter.update(3);
+
+        CounterStatSnapshot snapshot = counter.snapshot();
+
+        assertThat(counter.getTotalCount()).isEqualTo(3);
+        assertThat(counter.getOneMinute()).isNull();
+        assertThat(counter.getFiveMinute()).isNull();
+        assertThat(counter.getFifteenMinute()).isNull();
+        assertThat(snapshot.getTotalCount()).isEqualTo(3);
+        assertThat(snapshot.getOneMinute()).isNull();
+        assertThat(snapshot.getFiveMinute()).isNull();
+        assertThat(snapshot.getFifteenMinute()).isNull();
+    }
+
+    @Test
+    public void testOpenTelemetryReset()
+    {
+        StatsBackendFactory.setBackend(OPENTELEMETRY);
+        CounterStat counter = new CounterStat();
+        counter.update(3);
+
+        counter.reset();
+
+        assertThat(counter.getTotalCount()).isEqualTo(0);
+        assertThat(counter.getOneMinute()).isNull();
+        assertThat(counter.getFiveMinute()).isNull();
+        assertThat(counter.getFifteenMinute()).isNull();
+    }
+
+    @Test
+    public void testOpenTelemetryMerge()
+    {
+        StatsBackendFactory.setBackend(OPENTELEMETRY);
+        CounterStat first = new CounterStat();
+        CounterStat second = new CounterStat();
+        first.update(3);
+        second.update(5);
+
+        first.merge(second);
+
+        assertThat(first.getTotalCount()).isEqualTo(8);
+        assertThat(first.getOneMinute()).isNull();
+        assertThat(first.getFiveMinute()).isNull();
+        assertThat(first.getFifteenMinute()).isNull();
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testOpenTelemetryResetTo()
+    {
+        StatsBackendFactory.setBackend(OPENTELEMETRY);
+        CounterStat first = new CounterStat();
+        CounterStat second = new CounterStat();
+        first.update(3);
+        second.update(5);
+
+        first.resetTo(second);
+
+        assertThat(first.getTotalCount()).isEqualTo(5);
+        assertThat(first.getOneMinute()).isNull();
+        assertThat(first.getFiveMinute()).isNull();
+        assertThat(first.getFifteenMinute()).isNull();
+    }
+}

--- a/stats/src/test/java/io/airlift/stats/TestDistribution.java
+++ b/stats/src/test/java/io/airlift/stats/TestDistribution.java
@@ -1,11 +1,37 @@
 package io.airlift.stats;
 
+import io.airlift.stats.ExponentialHistogram.ExponentialHistogramSnapshot;
+import io.airlift.testing.TestingTicker;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.Isolated;
 
+import static io.airlift.stats.Distribution.MERGE_THRESHOLD_NANOS;
+import static io.airlift.stats.StatsBackend.AIRLIFT;
+import static io.airlift.stats.StatsBackend.OPENTELEMETRY;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
+@Isolated
+@Execution(SAME_THREAD)
 public class TestDistribution
 {
+    @BeforeEach
+    public void setupStatsBackend()
+    {
+        StatsBackendFactory.resetForTesting();
+        StatsBackendFactory.setBackend(AIRLIFT);
+    }
+
+    @AfterEach
+    public void resetStatsBackend()
+    {
+        StatsBackendFactory.resetForTesting();
+    }
+
     @Test
     public void testReset()
     {
@@ -32,5 +58,76 @@ public class TestDistribution
 
         assertThat(copy.getCount()).isEqualTo(distribution.getCount());
         assertThat(copy.getTotal()).isEqualTo(distribution.getTotal());
+    }
+
+    @Test
+    public void testAirliftExponentialHistogramSnapshot()
+    {
+        Distribution distribution = new Distribution();
+        distribution.add(1);
+
+        assertThat(distribution.exponentialHistogramSnapshot()).isEmpty();
+    }
+
+    @Test
+    public void testOpenTelemetryBackend()
+    {
+        StatsBackendFactory.setBackend(OPENTELEMETRY);
+        Distribution distribution = new Distribution();
+
+        distribution.add(1);
+        distribution.add(2, 3);
+
+        ExponentialHistogramSnapshot histogramSnapshot = distribution.exponentialHistogramSnapshot().orElseThrow();
+        Distribution.DistributionSnapshot snapshot = distribution.snapshot();
+
+        assertThat(distribution.getCount()).isEqualTo(4);
+        assertThat(distribution.getTotal()).isEqualTo(7);
+        assertThat(distribution.getMin()).isEqualTo(1);
+        assertThat(distribution.getMax()).isEqualTo(2);
+        assertThat(distribution.getAvg()).isEqualTo(1.75);
+        assertThat(distribution.getP50()).isBetween(1.0, 3.0);
+        assertThat(distribution.getPercentiles()).hasSize(100);
+        assertThat(snapshot.count()).isEqualTo(4);
+        assertThat(snapshot.total()).isEqualTo(7);
+        assertThat(histogramSnapshot.count()).isEqualTo(4);
+        assertThat(histogramSnapshot.sum()).isEqualTo(7);
+    }
+
+    @Test
+    public void testOpenTelemetryDuplicate()
+    {
+        StatsBackendFactory.setBackend(OPENTELEMETRY);
+        Distribution distribution = new Distribution();
+        distribution.add(1);
+        distribution.add(2, 3);
+
+        Distribution copy = distribution.duplicate();
+        distribution.add(10);
+
+        assertThat(copy.getCount()).isEqualTo(4);
+        assertThat(copy.getTotal()).isEqualTo(7);
+        assertThat(distribution.getCount()).isEqualTo(5);
+        assertThat(distribution.getTotal()).isEqualTo(17);
+    }
+
+    @Test
+    public void testOpenTelemetryBackendCachesSnapshots()
+    {
+        StatsBackendFactory.setBackend(OPENTELEMETRY);
+        TestingTicker ticker = new TestingTicker();
+        Distribution distribution = new Distribution(ticker);
+
+        distribution.add(1);
+        assertThat(distribution.getCount()).isEqualTo(1);
+
+        distribution.add(2);
+        assertThat(distribution.getCount()).isEqualTo(1);
+
+        ticker.increment(MERGE_THRESHOLD_NANOS, NANOSECONDS);
+        assertThat(distribution.getCount()).isEqualTo(2);
+
+        distribution.reset();
+        assertThat(distribution.getCount()).isEqualTo(0);
     }
 }

--- a/stats/src/test/java/io/airlift/stats/TestDistributionStat.java
+++ b/stats/src/test/java/io/airlift/stats/TestDistributionStat.java
@@ -1,0 +1,71 @@
+package io.airlift.stats;
+
+import io.airlift.stats.DistributionStat.DistributionStatSnapshot;
+import io.airlift.stats.ExponentialHistogram.ExponentialHistogramSnapshot;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import static io.airlift.stats.StatsBackend.AIRLIFT;
+import static io.airlift.stats.StatsBackend.OPENTELEMETRY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
+
+@Isolated
+@Execution(SAME_THREAD)
+class TestDistributionStat
+{
+    @BeforeEach
+    public void setupStatsBackend()
+    {
+        StatsBackendFactory.resetForTesting();
+        StatsBackendFactory.setBackend(AIRLIFT);
+    }
+
+    @AfterEach
+    public void resetStatsBackend()
+    {
+        StatsBackendFactory.resetForTesting();
+    }
+
+    @Test
+    public void testAirliftBackendCreatesAllWindows()
+    {
+        DistributionStat stat = new DistributionStat();
+
+        stat.add(1);
+        stat.add(2, 3);
+
+        assertThat(stat.getOneMinute().getCount()).isEqualTo(4);
+        assertThat(stat.getFiveMinutes().getCount()).isEqualTo(4);
+        assertThat(stat.getFifteenMinutes().getCount()).isEqualTo(4);
+        assertThat(stat.getAllTime().getCount()).isEqualTo(4);
+        assertThat(stat.exponentialHistogramSnapshot()).isEmpty();
+    }
+
+    @Test
+    public void testOpenTelemetryBackendCreatesOnlyAllTime()
+    {
+        StatsBackendFactory.setBackend(OPENTELEMETRY);
+        DistributionStat stat = new DistributionStat();
+
+        stat.add(1);
+        stat.add(2, 3);
+
+        ExponentialHistogramSnapshot histogramSnapshot = stat.exponentialHistogramSnapshot().orElseThrow();
+        DistributionStatSnapshot snapshot = stat.snapshot();
+
+        assertThat(stat.getOneMinute()).isNull();
+        assertThat(stat.getFiveMinutes()).isNull();
+        assertThat(stat.getFifteenMinutes()).isNull();
+        assertThat(stat.getAllTime().getCount()).isEqualTo(4);
+        assertThat(snapshot.oneMinute()).isNull();
+        assertThat(snapshot.fiveMinute()).isNull();
+        assertThat(snapshot.fifteenMinute()).isNull();
+        assertThat(snapshot.allTime().count()).isEqualTo(4);
+        assertThat(histogramSnapshot.count()).isEqualTo(4);
+        assertThat(histogramSnapshot.sum()).isEqualTo(7);
+    }
+}

--- a/stats/src/test/java/io/airlift/stats/TestExponentialHistogram.java
+++ b/stats/src/test/java/io/airlift/stats/TestExponentialHistogram.java
@@ -1,0 +1,387 @@
+package io.airlift.stats;
+
+import io.airlift.stats.ExponentialHistogram.Buckets;
+import io.airlift.stats.ExponentialHistogram.ExponentialHistogramSnapshot;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.data.Offset.offset;
+
+class TestExponentialHistogram
+{
+    @Test
+    public void testEmptySnapshot()
+    {
+        ExponentialHistogramSnapshot snapshot = new ExponentialHistogram(0, 10).snapshot();
+
+        assertThat(snapshot.scale()).isEqualTo(0);
+        assertThat(snapshot.count()).isEqualTo(0);
+        assertThat(snapshot.sum()).isEqualTo(0);
+        assertThat(snapshot.min()).isNaN();
+        assertThat(snapshot.max()).isNaN();
+        assertThat(snapshot.zeroCount()).isEqualTo(0);
+        assertThat(snapshot.positiveBuckets().isEmpty()).isTrue();
+        assertThat(snapshot.negativeBuckets().isEmpty()).isTrue();
+    }
+
+    @Test
+    public void testRecordsPositiveNegativeAndZeroValues()
+    {
+        ExponentialHistogram histogram = new ExponentialHistogram(0, 10);
+
+        histogram.record(0);
+        histogram.record(1);
+        histogram.record(1.5);
+        histogram.record(2);
+        histogram.record(3);
+        histogram.record(-1);
+        histogram.record(-2);
+
+        ExponentialHistogramSnapshot snapshot = histogram.snapshot();
+
+        assertThat(snapshot.scale()).isEqualTo(0);
+        assertThat(snapshot.count()).isEqualTo(7);
+        assertThat(snapshot.sum()).isEqualTo(4.5);
+        assertThat(snapshot.min()).isEqualTo(-2);
+        assertThat(snapshot.max()).isEqualTo(3);
+        assertThat(snapshot.zeroCount()).isEqualTo(1);
+        assertThat(snapshot.positiveBuckets()).isEqualTo(new Buckets(-1, new long[] {1, 2, 1}));
+        assertThat(snapshot.negativeBuckets()).isEqualTo(new Buckets(-1, new long[] {1, 1}));
+    }
+
+    @Test
+    public void testRecordsWeightedValues()
+    {
+        ExponentialHistogram histogram = new ExponentialHistogram(0, 10);
+
+        histogram.record(2, 3);
+        histogram.record(0, 4);
+
+        ExponentialHistogramSnapshot snapshot = histogram.snapshot();
+
+        assertThat(snapshot.count()).isEqualTo(7);
+        assertThat(snapshot.sum()).isEqualTo(6);
+        assertThat(snapshot.min()).isEqualTo(0);
+        assertThat(snapshot.max()).isEqualTo(2);
+        assertThat(snapshot.zeroCount()).isEqualTo(4);
+        assertThat(snapshot.positiveBuckets()).isEqualTo(new Buckets(0, new long[] {3}));
+    }
+
+    @Test
+    public void testDownscalesToFitBucketLimit()
+    {
+        ExponentialHistogram histogram = new ExponentialHistogram(1, 3);
+
+        histogram.record(1);
+        histogram.record(2);
+        histogram.record(4);
+
+        ExponentialHistogramSnapshot snapshot = histogram.snapshot();
+
+        assertThat(snapshot.scale()).isEqualTo(0);
+        assertThat(snapshot.count()).isEqualTo(3);
+        assertThat(snapshot.positiveBuckets()).isEqualTo(new Buckets(-1, new long[] {1, 1, 1}));
+    }
+
+    @Test
+    public void testDownscalesExtremeRange()
+    {
+        ExponentialHistogram histogram = new ExponentialHistogram();
+
+        histogram.record(Double.MIN_VALUE);
+        histogram.record(Double.MAX_VALUE);
+
+        ExponentialHistogramSnapshot snapshot = histogram.snapshot();
+
+        assertThat(snapshot.count()).isEqualTo(2);
+        assertThat(snapshot.scale()).isLessThan(ExponentialHistogram.DEFAULT_SCALE);
+        assertThat(snapshot.positiveBuckets().counts()).hasSizeLessThanOrEqualTo(ExponentialHistogram.DEFAULT_MAX_BUCKETS);
+        assertThat(snapshot.positiveBuckets().counts()).contains(1, 1);
+    }
+
+    @Test
+    public void testSnapshotIsImmutable()
+    {
+        ExponentialHistogram histogram = new ExponentialHistogram(0, 10);
+        histogram.record(1);
+
+        ExponentialHistogramSnapshot snapshot = histogram.snapshot();
+        histogram.record(2);
+
+        assertThat(snapshot.count()).isEqualTo(1);
+        assertThat(snapshot.positiveBuckets()).isEqualTo(new Buckets(-1, new long[] {1}));
+    }
+
+    @Test
+    public void testMergeEmptySnapshots()
+    {
+        ExponentialHistogramSnapshot snapshot = ExponentialHistogramSnapshot.merge(List.of());
+
+        assertThat(snapshot.scale()).isEqualTo(ExponentialHistogram.DEFAULT_SCALE);
+        assertThat(snapshot.count()).isEqualTo(0);
+        assertThat(snapshot.sum()).isEqualTo(0);
+        assertThat(snapshot.min()).isNaN();
+        assertThat(snapshot.max()).isNaN();
+        assertThat(snapshot.zeroCount()).isEqualTo(0);
+        assertThat(snapshot.positiveBuckets().isEmpty()).isTrue();
+        assertThat(snapshot.negativeBuckets().isEmpty()).isTrue();
+    }
+
+    @Test
+    public void testMergeZeroOnlySnapshots()
+    {
+        ExponentialHistogram first = new ExponentialHistogram(5, ExponentialHistogram.DEFAULT_MAX_BUCKETS);
+        ExponentialHistogram second = new ExponentialHistogram(3, ExponentialHistogram.DEFAULT_MAX_BUCKETS);
+        first.record(0);
+        second.record(0);
+
+        ExponentialHistogramSnapshot snapshot = ExponentialHistogramSnapshot.merge(List.of(first.snapshot(), second.snapshot()));
+
+        assertThat(snapshot.scale()).isEqualTo(3);
+        assertThat(snapshot.count()).isEqualTo(2);
+        assertThat(snapshot.sum()).isEqualTo(0);
+        assertThat(snapshot.min()).isEqualTo(0);
+        assertThat(snapshot.max()).isEqualTo(0);
+        assertThat(snapshot.zeroCount()).isEqualTo(2);
+        assertThat(snapshot.positiveBuckets().isEmpty()).isTrue();
+        assertThat(snapshot.negativeBuckets().isEmpty()).isTrue();
+    }
+
+    @Test
+    public void testMergeSameScaleSnapshots()
+    {
+        ExponentialHistogram first = new ExponentialHistogram(0, ExponentialHistogram.DEFAULT_MAX_BUCKETS);
+        ExponentialHistogram second = new ExponentialHistogram(0, ExponentialHistogram.DEFAULT_MAX_BUCKETS);
+        first.record(1);
+        first.record(2);
+        first.record(-1);
+        second.record(2);
+        second.record(4);
+        second.record(-2);
+
+        ExponentialHistogramSnapshot snapshot = ExponentialHistogramSnapshot.merge(List.of(first.snapshot(), second.snapshot()));
+
+        assertThat(snapshot.scale()).isEqualTo(0);
+        assertThat(snapshot.count()).isEqualTo(6);
+        assertThat(snapshot.sum()).isEqualTo(6);
+        assertThat(snapshot.min()).isEqualTo(-2);
+        assertThat(snapshot.max()).isEqualTo(4);
+        assertThat(snapshot.positiveBuckets()).isEqualTo(new Buckets(-1, new long[] {1, 2, 1}));
+        assertThat(snapshot.negativeBuckets()).isEqualTo(new Buckets(-1, new long[] {1, 1}));
+    }
+
+    @Test
+    public void testMergeDifferentScaleSnapshots()
+    {
+        ExponentialHistogram first = new ExponentialHistogram(1, ExponentialHistogram.DEFAULT_MAX_BUCKETS);
+        ExponentialHistogram second = new ExponentialHistogram(0, ExponentialHistogram.DEFAULT_MAX_BUCKETS);
+        first.record(1);
+        first.record(2);
+        second.record(4);
+
+        ExponentialHistogramSnapshot snapshot = ExponentialHistogramSnapshot.merge(List.of(first.snapshot(), second.snapshot()));
+
+        assertThat(snapshot.scale()).isEqualTo(0);
+        assertThat(snapshot.count()).isEqualTo(3);
+        assertThat(snapshot.sum()).isEqualTo(7);
+        assertThat(snapshot.min()).isEqualTo(1);
+        assertThat(snapshot.max()).isEqualTo(4);
+        assertThat(snapshot.positiveBuckets()).isEqualTo(new Buckets(-1, new long[] {1, 1, 1}));
+    }
+
+    @Test
+    public void testMergeDownscalesToFitBucketLimit()
+    {
+        ExponentialHistogram first = new ExponentialHistogram(1, ExponentialHistogram.DEFAULT_MAX_BUCKETS);
+        ExponentialHistogram second = new ExponentialHistogram(1, ExponentialHistogram.DEFAULT_MAX_BUCKETS);
+        first.record(1);
+        second.record(4);
+
+        ExponentialHistogramSnapshot snapshot = ExponentialHistogramSnapshot.merge(List.of(first.snapshot(), second.snapshot()), 3);
+
+        assertThat(snapshot.scale()).isEqualTo(0);
+        assertThat(snapshot.count()).isEqualTo(2);
+        assertThat(snapshot.sum()).isEqualTo(5);
+        assertThat(snapshot.min()).isEqualTo(1);
+        assertThat(snapshot.max()).isEqualTo(4);
+        assertThat(snapshot.positiveBuckets()).isEqualTo(new Buckets(-1, new long[] {1, 0, 1}));
+    }
+
+    @Test
+    public void testMergeRejectsSnapshotRangeThatCannotFitAtMinimumScale()
+    {
+        assertThatThrownBy(() -> new ExponentialHistogramSnapshot(
+                ExponentialHistogram.MIN_SCALE,
+                4,
+                0,
+                0,
+                0,
+                0,
+                new Buckets(0, new long[] {1, 1, 1, 1}),
+                new Buckets(0, new long[0])))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("bucket range exceeds finite value range for scale -10");
+    }
+
+    @Test
+    public void testDownscaleToAtMost()
+    {
+        ExponentialHistogram histogram = new ExponentialHistogram(1, ExponentialHistogram.DEFAULT_MAX_BUCKETS);
+        histogram.record(1);
+        histogram.record(4);
+
+        histogram.downscaleToAtMost(0);
+        histogram.downscaleToAtMost(1);
+
+        ExponentialHistogramSnapshot snapshot = histogram.snapshot();
+        assertThat(snapshot.scale()).isEqualTo(0);
+        assertThat(snapshot.count()).isEqualTo(2);
+        assertThat(snapshot.positiveBuckets()).isEqualTo(new Buckets(-1, new long[] {1, 0, 1}));
+    }
+
+    @Test
+    public void testDownscaleToAtMostLowersEmptyHistogram()
+    {
+        ExponentialHistogram histogram = new ExponentialHistogram(5, ExponentialHistogram.DEFAULT_MAX_BUCKETS);
+
+        histogram.downscaleToAtMost(3);
+
+        ExponentialHistogramSnapshot snapshot = histogram.snapshot();
+        assertThat(snapshot.scale()).isEqualTo(3);
+        assertThat(snapshot.count()).isEqualTo(0);
+        assertThat(snapshot.positiveBuckets().isEmpty()).isTrue();
+        assertThat(snapshot.negativeBuckets().isEmpty()).isTrue();
+    }
+
+    @Test
+    public void testReset()
+    {
+        ExponentialHistogram histogram = new ExponentialHistogram(1, 3);
+        histogram.record(1);
+        histogram.record(4);
+        histogram.record(0);
+        assertThat(histogram.snapshot().scale()).isEqualTo(0);
+
+        histogram.reset();
+
+        ExponentialHistogramSnapshot snapshot = histogram.snapshot();
+        assertThat(snapshot.scale()).isEqualTo(1);
+        assertThat(snapshot.count()).isEqualTo(0);
+        assertThat(snapshot.sum()).isEqualTo(0);
+        assertThat(snapshot.min()).isNaN();
+        assertThat(snapshot.max()).isNaN();
+        assertThat(snapshot.zeroCount()).isEqualTo(0);
+        assertThat(snapshot.positiveBuckets().isEmpty()).isTrue();
+        assertThat(snapshot.negativeBuckets().isEmpty()).isTrue();
+    }
+
+    @Test
+    public void testIgnoresNonFiniteValues()
+    {
+        ExponentialHistogram histogram = new ExponentialHistogram();
+
+        histogram.record(Double.NaN);
+        histogram.record(Double.POSITIVE_INFINITY);
+        histogram.record(Double.NEGATIVE_INFINITY);
+
+        assertThat(histogram.snapshot().count()).isEqualTo(0);
+    }
+
+    @Test
+    public void testRejectsInvalidConfiguration()
+    {
+        assertThatThrownBy(() -> new ExponentialHistogram(ExponentialHistogram.MAX_SCALE + 1, 10))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new ExponentialHistogram(0, 2))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("maxBuckets must be at least 3");
+    }
+
+    @Test
+    public void testBucketBounds()
+    {
+        assertThat(ExponentialHistogram.bucketLowerBound(0, 0)).isEqualTo(1);
+        assertThat(ExponentialHistogram.bucketUpperBound(0, 0)).isEqualTo(2);
+        assertThat(ExponentialHistogram.bucketUpperBound(0, -1)).isEqualTo(1);
+        assertThat(ExponentialHistogram.bucketLowerBound(1, 2)).isEqualTo(2);
+        assertThat(ExponentialHistogram.bucketUpperBound(1, 2)).isCloseTo(Math.sqrt(8), offset(1e-15));
+    }
+
+    @Test
+    public void testPositiveScaleBucketIndexing()
+    {
+        for (int scale = 1; scale <= 10; scale++) {
+            assertPositiveBucketIndex(scale, 1);
+            assertPositiveBucketIndex(scale, 2);
+            assertPositiveBucketIndex(scale, Math.nextUp(1));
+            assertPositiveBucketIndex(scale, 1.1);
+            assertPositiveBucketIndex(scale, 123.456);
+
+            int bucketsPerPowerOfTwo = 1 << scale;
+            for (int bucket = 0; bucket < bucketsPerPowerOfTwo; bucket += Math.max(1, bucketsPerPowerOfTwo / 8)) {
+                double upperBound = ExponentialHistogram.bucketUpperBound(scale, bucket);
+                assertPositiveBucketIndex(scale, upperBound);
+                assertPositiveBucketIndex(scale, Math.nextUp(upperBound));
+            }
+        }
+    }
+
+    @Test
+    public void testConcurrentRecording()
+            throws Exception
+    {
+        ExponentialHistogram histogram = new ExponentialHistogram(0, 10);
+        ExecutorService executor = Executors.newFixedThreadPool(4);
+        try {
+            List<? extends Future<?>> futures = IntStream.range(0, 4)
+                    .mapToObj(_ -> executor.submit(() -> {
+                        for (int i = 0; i < 1_000; i++) {
+                            histogram.record(1);
+                        }
+                    }))
+                    .toList();
+
+            for (Future<?> future : futures) {
+                future.get();
+            }
+        }
+        finally {
+            executor.shutdownNow();
+        }
+
+        ExponentialHistogramSnapshot snapshot = histogram.snapshot();
+
+        assertThat(snapshot.count()).isEqualTo(4_000);
+        assertThat(snapshot.sum()).isEqualTo(4_000);
+        assertThat(snapshot.positiveBuckets()).isEqualTo(new Buckets(-1, new long[] {4_000}));
+    }
+
+    private static void assertPositiveBucketIndex(int scale, double value)
+    {
+        ExponentialHistogram histogram = new ExponentialHistogram(scale, ExponentialHistogram.DEFAULT_MAX_BUCKETS);
+        histogram.record(value);
+
+        assertThat(histogram.snapshot().positiveBuckets().offset())
+                .describedAs("bucket index for scale %s and value %s", scale, value)
+                .isEqualTo(expectedBucketIndex(scale, value));
+    }
+
+    private static int expectedBucketIndex(int scale, double value)
+    {
+        int index = (int) Math.ceil(Math.log(value) / Math.log(2) * Math.scalb(1.0, scale)) - 1;
+        while (value <= ExponentialHistogram.bucketLowerBound(scale, index)) {
+            index--;
+        }
+        while (value > ExponentialHistogram.bucketUpperBound(scale, index)) {
+            index++;
+        }
+        return index;
+    }
+}

--- a/stats/src/test/java/io/airlift/stats/TestStatsBackendFactory.java
+++ b/stats/src/test/java/io/airlift/stats/TestStatsBackendFactory.java
@@ -1,0 +1,83 @@
+package io.airlift.stats;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.Isolated;
+
+import static io.airlift.stats.StatsBackend.AIRLIFT;
+import static io.airlift.stats.StatsBackend.OPENTELEMETRY;
+import static io.airlift.stats.StatsBackendFactory.STATS_BACKEND_PROPERTY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
+
+@Isolated
+@Execution(SAME_THREAD)
+class TestStatsBackendFactory
+{
+    @BeforeEach
+    public void setup()
+    {
+        System.clearProperty(STATS_BACKEND_PROPERTY);
+        StatsBackendFactory.resetForTesting();
+    }
+
+    @AfterEach
+    public void reset()
+    {
+        System.clearProperty(STATS_BACKEND_PROPERTY);
+        StatsBackendFactory.resetForTesting();
+    }
+
+    @Test
+    public void testDefaultsToAirlift()
+    {
+        assertThat(StatsBackendFactory.getBackend()).isEqualTo(AIRLIFT);
+    }
+
+    @Test
+    public void testReadsSystemProperty()
+    {
+        System.setProperty(STATS_BACKEND_PROPERTY, "open-telemetry");
+
+        assertThat(StatsBackendFactory.getBackend()).isEqualTo(OPENTELEMETRY);
+    }
+
+    @Test
+    public void testOpenTelemetryAliases()
+    {
+        assertThat(StatsBackend.fromPropertyValue("open-telemetry")).isEqualTo(OPENTELEMETRY);
+        assertThat(StatsBackend.fromPropertyValue("opentelemetry")).isEqualTo(OPENTELEMETRY);
+        assertThat(StatsBackend.fromPropertyValue("otel")).isEqualTo(OPENTELEMETRY);
+    }
+
+    @Test
+    public void testRejectsUnknownBackend()
+    {
+        System.setProperty(STATS_BACKEND_PROPERTY, "unknown");
+
+        assertThatThrownBy(StatsBackendFactory::getBackend)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Unknown stats backend: unknown");
+    }
+
+    @Test
+    public void testCanSetBackendBeforeFirstRead()
+    {
+        StatsBackendFactory.setBackend(OPENTELEMETRY);
+
+        assertThat(StatsBackendFactory.getBackend()).isEqualTo(OPENTELEMETRY);
+    }
+
+    @Test
+    public void testCannotSetBackendAfterFirstRead()
+    {
+        assertThat(StatsBackendFactory.getBackend()).isEqualTo(AIRLIFT);
+
+        assertThatThrownBy(() -> StatsBackendFactory.setBackend(OPENTELEMETRY))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("stats backend is already initialized");
+    }
+}

--- a/stats/src/test/java/io/airlift/stats/TestStripedExponentialHistogram.java
+++ b/stats/src/test/java/io/airlift/stats/TestStripedExponentialHistogram.java
@@ -1,0 +1,126 @@
+package io.airlift.stats;
+
+import io.airlift.stats.ExponentialHistogram.Buckets;
+import io.airlift.stats.ExponentialHistogram.ExponentialHistogramSnapshot;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TestStripedExponentialHistogram
+{
+    @Test
+    public void testEmptySnapshot()
+    {
+        ExponentialHistogramSnapshot snapshot = new StripedExponentialHistogram(0, 10, 4).snapshot();
+
+        assertThat(snapshot.scale()).isEqualTo(0);
+        assertThat(snapshot.count()).isEqualTo(0);
+        assertThat(snapshot.sum()).isEqualTo(0);
+        assertThat(snapshot.min()).isNaN();
+        assertThat(snapshot.max()).isNaN();
+        assertThat(snapshot.zeroCount()).isEqualTo(0);
+        assertThat(snapshot.positiveBuckets().isEmpty()).isTrue();
+        assertThat(snapshot.negativeBuckets().isEmpty()).isTrue();
+    }
+
+    @Test
+    public void testRecordsPositiveNegativeAndZeroValues()
+    {
+        StripedExponentialHistogram histogram = new StripedExponentialHistogram(0, 10, 4);
+
+        histogram.record(0);
+        histogram.record(1);
+        histogram.record(1.5);
+        histogram.record(2);
+        histogram.record(3);
+        histogram.record(-1);
+        histogram.record(-2);
+
+        ExponentialHistogramSnapshot snapshot = histogram.snapshot();
+
+        assertThat(snapshot.scale()).isEqualTo(0);
+        assertThat(snapshot.count()).isEqualTo(7);
+        assertThat(snapshot.sum()).isEqualTo(4.5);
+        assertThat(snapshot.min()).isEqualTo(-2);
+        assertThat(snapshot.max()).isEqualTo(3);
+        assertThat(snapshot.zeroCount()).isEqualTo(1);
+        assertThat(snapshot.positiveBuckets()).isEqualTo(new Buckets(-1, new long[] {1, 2, 1}));
+        assertThat(snapshot.negativeBuckets()).isEqualTo(new Buckets(-1, new long[] {1, 1}));
+    }
+
+    @Test
+    public void testRecordsWeightedValues()
+    {
+        StripedExponentialHistogram histogram = new StripedExponentialHistogram(0, 10, 4);
+
+        histogram.record(2, 3);
+        histogram.record(0, 4);
+
+        ExponentialHistogramSnapshot snapshot = histogram.snapshot();
+
+        assertThat(snapshot.count()).isEqualTo(7);
+        assertThat(snapshot.sum()).isEqualTo(6);
+        assertThat(snapshot.zeroCount()).isEqualTo(4);
+        assertThat(snapshot.positiveBuckets()).isEqualTo(new Buckets(0, new long[] {3}));
+    }
+
+    @Test
+    public void testSnapshotDownscalesStripes()
+    {
+        StripedExponentialHistogram histogram = new StripedExponentialHistogram(1, 3, 4);
+        histogram.record(1);
+        histogram.record(4);
+
+        ExponentialHistogramSnapshot snapshot = histogram.snapshot();
+        assertThat(snapshot.scale()).isEqualTo(0);
+        assertThat(snapshot.positiveBuckets()).isEqualTo(new Buckets(-1, new long[] {1, 0, 1}));
+
+        histogram.reset();
+        assertThat(histogram.snapshot().scale()).isEqualTo(1);
+    }
+
+    @Test
+    public void testConcurrentRecording()
+            throws Exception
+    {
+        StripedExponentialHistogram histogram = new StripedExponentialHistogram(0, 10, 4);
+        ExecutorService executor = Executors.newFixedThreadPool(4);
+        try {
+            List<? extends Future<?>> futures = IntStream.range(0, 4)
+                    .mapToObj(_ -> executor.submit(() -> {
+                        for (int i = 0; i < 1_000; i++) {
+                            histogram.record(1);
+                        }
+                    }))
+                    .toList();
+
+            for (Future<?> future : futures) {
+                future.get();
+            }
+        }
+        finally {
+            executor.shutdownNow();
+        }
+
+        ExponentialHistogramSnapshot snapshot = histogram.snapshot();
+
+        assertThat(snapshot.count()).isEqualTo(4_000);
+        assertThat(snapshot.sum()).isEqualTo(4_000);
+        assertThat(snapshot.positiveBuckets()).isEqualTo(new Buckets(-1, new long[] {4_000}));
+    }
+
+    @Test
+    public void testRejectsInvalidConfiguration()
+    {
+        assertThatThrownBy(() -> new StripedExponentialHistogram(0, 10, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("stripes must be positive");
+    }
+}

--- a/stats/src/test/java/io/airlift/stats/TestTimeDistribution.java
+++ b/stats/src/test/java/io/airlift/stats/TestTimeDistribution.java
@@ -1,16 +1,39 @@
 package io.airlift.stats;
 
 import io.airlift.testing.TestingTicker;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.Isolated;
 
 import java.util.concurrent.TimeUnit;
 
+import static io.airlift.stats.StatsBackend.AIRLIFT;
+import static io.airlift.stats.StatsBackend.OPENTELEMETRY;
 import static io.airlift.stats.TimeDistribution.MERGE_THRESHOLD_NANOS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
+@Isolated
+@Execution(SAME_THREAD)
 class TestTimeDistribution
 {
+    @BeforeEach
+    public void setupStatsBackend()
+    {
+        StatsBackendFactory.resetForTesting();
+        StatsBackendFactory.setBackend(AIRLIFT);
+    }
+
+    @AfterEach
+    public void resetStatsBackend()
+    {
+        StatsBackendFactory.resetForTesting();
+    }
+
     @Test
     public void testPartialMerging()
     {
@@ -39,5 +62,45 @@ class TestTimeDistribution
 
         assertThat(distribution.getCount()).isEqualTo(3);
         assertThat(distribution.getAvg()).isEqualTo(3);
+    }
+
+    @Test
+    public void testOpenTelemetryBackend()
+    {
+        StatsBackendFactory.setBackend(OPENTELEMETRY);
+        TimeDistribution distribution = new TimeDistribution(NANOSECONDS);
+
+        distribution.add(1);
+        distribution.add(2);
+        distribution.add(4);
+
+        assertThat(distribution.exponentialHistogramSnapshot()).isPresent();
+        assertThat(distribution.exponentialHistogramSnapshot().orElseThrow().count()).isEqualTo(3);
+        assertThat(distribution.getCount()).isEqualTo(3);
+        assertThat(distribution.getMin()).isEqualTo(1);
+        assertThat(distribution.getMax()).isEqualTo(4);
+        assertThat(distribution.getAvg()).isEqualTo(7.0 / 3);
+        assertThat(distribution.getP50()).isBetween(1.0, 4.0);
+        assertThat(distribution.snapshot().count()).isEqualTo(3);
+    }
+
+    @Test
+    public void testOpenTelemetryBackendCachesSnapshots()
+    {
+        StatsBackendFactory.setBackend(OPENTELEMETRY);
+        TestingTicker ticker = new TestingTicker();
+        TimeDistribution distribution = new TimeDistribution(ticker, NANOSECONDS);
+
+        distribution.add(1);
+        assertThat(distribution.getCount()).isEqualTo(1);
+
+        distribution.add(2);
+        assertThat(distribution.getCount()).isEqualTo(1);
+
+        ticker.increment(MERGE_THRESHOLD_NANOS, TimeUnit.NANOSECONDS);
+        assertThat(distribution.getCount()).isEqualTo(2);
+
+        distribution.reset();
+        assertThat(distribution.getCount()).isEqualTo(0);
     }
 }

--- a/stats/src/test/java/io/airlift/stats/TestTimeStat.java
+++ b/stats/src/test/java/io/airlift/stats/TestTimeStat.java
@@ -15,12 +15,16 @@
  */
 package io.airlift.stats;
 
+import io.airlift.stats.ExponentialHistogram.ExponentialHistogramSnapshot;
 import io.airlift.stats.TimeStat.BlockTimer;
+import io.airlift.stats.TimeStat.TimeDistributionStatSnapshot;
 import io.airlift.testing.TestingTicker;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.Isolated;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -28,9 +32,12 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static com.google.common.math.DoubleMath.fuzzyEquals;
+import static io.airlift.stats.StatsBackend.AIRLIFT;
+import static io.airlift.stats.StatsBackend.OPENTELEMETRY;
 import static io.airlift.stats.TimeDistribution.MERGE_THRESHOLD_NANOS;
 import static java.lang.Math.min;
 import static java.util.Comparator.naturalOrder;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
@@ -39,6 +46,7 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
 @TestInstance(PER_CLASS)
+@Isolated
 @Execution(SAME_THREAD)
 public class TestTimeStat
 {
@@ -48,7 +56,15 @@ public class TestTimeStat
     @BeforeEach
     public void setup()
     {
+        StatsBackendFactory.resetForTesting();
+        StatsBackendFactory.setBackend(AIRLIFT);
         ticker = new TestingTicker();
+    }
+
+    @AfterEach
+    public void reset()
+    {
+        StatsBackendFactory.resetForTesting();
     }
 
     @Test
@@ -132,6 +148,48 @@ public class TestTimeStat
         assertThat(stat.getOneMinute().getAvg()).isNaN();
         assertThat(stat.getFiveMinutes().getAvg()).isNaN();
         assertThat(stat.getFifteenMinutes().getAvg()).isNaN();
+    }
+
+    @Test
+    public void testAirliftExponentialHistogramSnapshot()
+    {
+        TimeStat stat = new TimeStat(ticker);
+        stat.addNanos(1);
+
+        assertThat(stat.exponentialHistogramSnapshot()).isEmpty();
+    }
+
+    @Test
+    public void testOpenTelemetryExponentialHistogramSnapshot()
+    {
+        StatsBackendFactory.setBackend(OPENTELEMETRY);
+        TimeStat stat = new TimeStat(ticker, NANOSECONDS);
+        stat.addNanos(1);
+        stat.addNanos(2);
+
+        ExponentialHistogramSnapshot snapshot = stat.exponentialHistogramSnapshot().orElseThrow();
+
+        assertThat(stat.getOneMinute()).isNull();
+        assertThat(stat.getFiveMinutes()).isNull();
+        assertThat(stat.getFifteenMinutes()).isNull();
+        assertThat(stat.getAllTime().getCount()).isEqualTo(2);
+        assertThat(snapshot.count()).isEqualTo(2);
+    }
+
+    @Test
+    public void testOpenTelemetrySnapshotContainsOnlyAllTime()
+    {
+        StatsBackendFactory.setBackend(OPENTELEMETRY);
+        TimeStat stat = new TimeStat(ticker, NANOSECONDS);
+        stat.addNanos(1);
+        stat.addNanos(2);
+
+        TimeDistributionStatSnapshot snapshot = stat.snapshot();
+
+        assertThat(snapshot.oneMinute()).isNull();
+        assertThat(snapshot.fiveMinute()).isNull();
+        assertThat(snapshot.fifteenMinute()).isNull();
+        assertThat(snapshot.allTime().count()).isEqualTo(2);
     }
 
     @Test


### PR DESCRIPTION
## Why
- Applications that push metrics through OpenTelemetry should not need to depend on the OpenMetrics endpoint or scrape rendered text just to observe Airlift metrics.
- Airlift timing and distribution stats currently export cleanly as summary-style percentile data, but those values cannot be merged or summarized correctly by standard OpenTelemetry collection systems.
- Trino and other Airlift applications already construct stats objects widely, so OpenTelemetry support needs to work under the existing stat and managed-export APIs rather than requiring broad call-site changes.

## Approach
- Extract shared managed-metric discovery into a reusable metrics module that preserves structured source metadata for OpenMetrics and OpenTelemetry exporters.
- Add OpenTelemetry-compatible exponential histogram stats and an opt-in stats backend that records timing and distribution data in the native shape.
- Add an OpenTelemetry metrics producer that converts managed Airlift metrics into cumulative OpenTelemetry metric data, using jmxutils export metadata for natural metric names and attributes.

## Notes
- This depend on the unreleased JMXUtils APIs for fetching the original export parameters
- When using the OpenTelemetry backend for stats object, `ExponentialHistogram` is used instead of decayed `TDigest`.  It is expected that the collector system will store and combine histograms over history, so manual decay is not needed.
- Please see `opentelemetry/README.md` for details on how to use this

## Airlift contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [x] All automated tests are passing.
 - [x] Pull request was categorized using one of the existing labels.
