### PR TITLE
Handle raw JMX metric edge cases

### DIFF
--- a/metrics/src/main/java/io/airlift/metrics/MetricsCollector.java
+++ b/metrics/src/main/java/io/airlift/metrics/MetricsCollector.java
@@ -180,7 +180,7 @@ public class MetricsCollector
         try {
             Object attributeValue = mbeanServer.getAttribute(objectName, attributeName);
             return switch (attributeValue) {
-                case Number _, CompositeData _ -> Optional.of(new CollectedMetricGroup.Attribute(List.of(attributeName), attributeValue, description));
+                case Number _, Boolean _, CompositeData _ -> Optional.of(new CollectedMetricGroup.Attribute(List.of(attributeName), attributeValue, description));
                 case null, default -> Optional.empty();
             };
         }

--- a/metrics/src/main/java/io/airlift/metrics/MetricsCollector.java
+++ b/metrics/src/main/java/io/airlift/metrics/MetricsCollector.java
@@ -40,12 +40,14 @@ import javax.management.ReflectionException;
 import javax.management.openmbean.CompositeData;
 import javax.management.openmbean.TabularData;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.Objects.requireNonNull;
 
 /// Discovers Airlift managed metrics and configured JMX metrics in their native form.
@@ -71,15 +73,20 @@ public class MetricsCollector
 
     public List<CollectedMetricGroup> collect()
     {
+        Collection<ManagedObjectExport> managedExports = mbeanExporter.getManagedObjectExports().values();
+        Set<ObjectName> managedObjectNames = managedExports.stream()
+                .map(ManagedObjectExport::getObjectName)
+                .collect(toImmutableSet());
+
         return ImmutableList.<CollectedMetricGroup>builder()
-                .addAll(collectManagedClasses())
-                .addAll(collectMBeans())
+                .addAll(collectManagedClasses(managedExports))
+                .addAll(collectMBeans(managedObjectNames))
                 .build();
     }
 
-    private List<CollectedMetricGroup> collectManagedClasses()
+    private List<CollectedMetricGroup> collectManagedClasses(Collection<ManagedObjectExport> managedExports)
     {
-        return mbeanExporter.getManagedObjectExports().values().stream()
+        return managedExports.stream()
                 .map(export -> new CollectedMetricGroup(
                         managedMetricSource(export),
                         labels,
@@ -144,12 +151,13 @@ public class MetricsCollector
                 value instanceof DistributionStat;
     }
 
-    private List<CollectedMetricGroup> collectMBeans()
+    private List<CollectedMetricGroup> collectMBeans(Set<ObjectName> managedObjectNames)
     {
         return allMetricsObjectNames.stream()
                 .map(objectName -> mbeanServer.queryNames(objectName, null))
                 .flatMap(Set::stream)
                 .distinct()
+                .filter(objectName -> !managedObjectNames.contains(objectName))
                 .map(this::collectMBean)
                 .flatMap(Optional::stream)
                 .toList();

--- a/metrics/src/main/java/io/airlift/metrics/MetricsCollector.java
+++ b/metrics/src/main/java/io/airlift/metrics/MetricsCollector.java
@@ -38,6 +38,7 @@ import javax.management.MBeanServer;
 import javax.management.ObjectName;
 import javax.management.ReflectionException;
 import javax.management.openmbean.CompositeData;
+import javax.management.openmbean.TabularData;
 
 import java.util.List;
 import java.util.Map;
@@ -180,7 +181,7 @@ public class MetricsCollector
         try {
             Object attributeValue = mbeanServer.getAttribute(objectName, attributeName);
             return switch (attributeValue) {
-                case Number _, Boolean _, CompositeData _ -> Optional.of(new CollectedMetricGroup.Attribute(List.of(attributeName), attributeValue, description));
+                case Number _, Boolean _, CompositeData _, TabularData _ -> Optional.of(new CollectedMetricGroup.Attribute(List.of(attributeName), attributeValue, description));
                 case null, default -> Optional.empty();
             };
         }

--- a/metrics/src/test/java/io/airlift/metrics/TestMetricsCollector.java
+++ b/metrics/src/test/java/io/airlift/metrics/TestMetricsCollector.java
@@ -158,6 +158,10 @@ public class TestMetricsCollector
                     assertThat(metric.value()).isEqualTo(23);
                 })
                 .anySatisfy(metric -> {
+                    assertThat(metric.path()).containsExactly("Enabled");
+                    assertThat(metric.value()).isEqualTo(true);
+                })
+                .anySatisfy(metric -> {
                     assertThat(metric.path()).containsExactly("Memory");
                     assertThat(metric.value()).isInstanceOfSatisfying(CompositeData.class, memory -> {
                         assertThat(memory.get("used")).isEqualTo(100L);
@@ -309,6 +313,8 @@ public class TestMetricsCollector
     {
         int getCount();
 
+        boolean isEnabled();
+
         CompositeData getMemory();
 
         String getUnsupported();
@@ -321,6 +327,12 @@ public class TestMetricsCollector
         public int getCount()
         {
             return 23;
+        }
+
+        @Override
+        public boolean isEnabled()
+        {
+            return true;
         }
 
         @Override

--- a/metrics/src/test/java/io/airlift/metrics/TestMetricsCollector.java
+++ b/metrics/src/test/java/io/airlift/metrics/TestMetricsCollector.java
@@ -38,6 +38,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestMetricsCollector
 {
+    private static final ObjectName MANAGED_OBJECT_NAME;
+    private static final ObjectName CONFIGURED_OBJECT_NAME;
+
+    static {
+        try {
+            MANAGED_OBJECT_NAME = new ObjectName("io.airlift.metrics.test:name=managed");
+            CONFIGURED_OBJECT_NAME = new ObjectName("io.airlift.metrics.test:name=configured,type=Test");
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     @Test
     public void testCollectManagedNumericMetric()
             throws Exception
@@ -153,7 +166,7 @@ public class TestMetricsCollector
         MetricsCollector collector = createTestingCollector();
 
         assertThat(collector.collect())
-                .anySatisfy(group -> assertThat(group.source()).isEqualTo(new JmxMetricSource(new ObjectName("io.airlift.metrics.test:name=configured,type=Test"))));
+                .anySatisfy(group -> assertThat(group.source()).isEqualTo(new JmxMetricSource(CONFIGURED_OBJECT_NAME)));
 
         assertThat(attributes(collector))
                 .anySatisfy(metric -> {
@@ -178,6 +191,19 @@ public class TestMetricsCollector
                 });
     }
 
+    @Test
+    public void testConfiguredJmxMetricsSkipManagedObjects()
+            throws Exception
+    {
+        MetricsCollector collector = createTestingCollector(new ObjectName("io.airlift.metrics.test:*"));
+
+        assertThat(collector.collect())
+                .extracting(CollectedMetricGroup::source)
+                .contains(new ManagedMetricSource(MANAGED_OBJECT_NAME.toString()))
+                .contains(new JmxMetricSource(CONFIGURED_OBJECT_NAME))
+                .doesNotContain(new JmxMetricSource(MANAGED_OBJECT_NAME));
+    }
+
     private static List<CollectedMetricGroup.Attribute> attributes(MetricsCollector collector)
     {
         return collector.collect().stream()
@@ -186,6 +212,12 @@ public class TestMetricsCollector
     }
 
     private static MetricsCollector createTestingCollector()
+            throws Exception
+    {
+        return createTestingCollector(CONFIGURED_OBJECT_NAME);
+    }
+
+    private static MetricsCollector createTestingCollector(ObjectName configuredObjectName)
             throws Exception
     {
         MBeanServer mbeanServer = MBeanServerFactory.newMBeanServer();
@@ -202,10 +234,9 @@ public class TestMetricsCollector
         managedMetrics.getReadBytes().add(100);
         managedMetrics.getReadBytes().add(200);
         managedMetrics.forceLatencyMerge();
-        mbeanExporter.export(new ObjectName("io.airlift.metrics.test:name=managed"), managedMetrics);
+        mbeanExporter.export(MANAGED_OBJECT_NAME, managedMetrics);
 
-        ObjectName configuredObjectName = new ObjectName("io.airlift.metrics.test:name=configured,type=Test");
-        mbeanServer.registerMBean(new StandardMBean(new ConfiguredMetrics(), ConfiguredMetricsMBean.class), configuredObjectName);
+        mbeanServer.registerMBean(new StandardMBean(new ConfiguredMetrics(), ConfiguredMetricsMBean.class), CONFIGURED_OBJECT_NAME);
 
         MetricsConfig metricsConfig = new MetricsConfig().setJmxObjectNames(List.of(configuredObjectName));
         NodeInfo nodeInfo = new NodeInfo(

--- a/metrics/src/test/java/io/airlift/metrics/TestMetricsCollector.java
+++ b/metrics/src/test/java/io/airlift/metrics/TestMetricsCollector.java
@@ -25,6 +25,9 @@ import javax.management.openmbean.CompositeDataSupport;
 import javax.management.openmbean.CompositeType;
 import javax.management.openmbean.OpenType;
 import javax.management.openmbean.SimpleType;
+import javax.management.openmbean.TabularData;
+import javax.management.openmbean.TabularDataSupport;
+import javax.management.openmbean.TabularType;
 
 import java.util.List;
 import java.util.Map;
@@ -168,6 +171,10 @@ public class TestMetricsCollector
                         assertThat(memory.get("committed")).isEqualTo(200L);
                         assertThat(memory.get("max")).isEqualTo(1000L);
                     });
+                })
+                .anySatisfy(metric -> {
+                    assertThat(metric.path()).containsExactly("Table");
+                    assertThat(metric.value()).isInstanceOfSatisfying(TabularData.class, table -> assertThat(table.size()).isEqualTo(2));
                 });
     }
 
@@ -317,6 +324,8 @@ public class TestMetricsCollector
 
         CompositeData getMemory();
 
+        TabularData getTable();
+
         String getUnsupported();
     }
 
@@ -342,6 +351,12 @@ public class TestMetricsCollector
         }
 
         @Override
+        public TabularData getTable()
+        {
+            return createTestTabularData();
+        }
+
+        @Override
         public String getUnsupported()
         {
             return "ignored";
@@ -362,6 +377,24 @@ public class TestMetricsCollector
                     .buildOrThrow();
 
             return new CompositeDataSupport(compositeType, values);
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static TabularData createTestTabularData()
+    {
+        try {
+            String[] itemNames = {"name", "value"};
+            OpenType<?>[] itemTypes = {SimpleType.STRING, SimpleType.LONG};
+            CompositeType compositeType = new CompositeType("TestData", "Test Data", itemNames, itemNames, itemTypes);
+            TabularDataSupport tabularData = new TabularDataSupport(new TabularType("TestTable", "Test Table", compositeType, new String[] {"name"}));
+
+            tabularData.put(new CompositeDataSupport(compositeType, ImmutableMap.of("name", "one", "value", 1L)));
+            tabularData.put(new CompositeDataSupport(compositeType, ImmutableMap.of("name", "two", "value", 2L)));
+
+            return tabularData;
         }
         catch (Exception e) {
             throw new RuntimeException(e);

--- a/openmetrics/src/main/java/io/airlift/openmetrics/OpenMetricsCollector.java
+++ b/openmetrics/src/main/java/io/airlift/openmetrics/OpenMetricsCollector.java
@@ -35,6 +35,7 @@ import io.airlift.stats.TimeStat;
 
 import javax.management.ObjectName;
 import javax.management.openmbean.CompositeData;
+import javax.management.openmbean.TabularData;
 
 import java.util.List;
 import java.util.Map;
@@ -158,6 +159,7 @@ public class OpenMetricsCollector
             case Number number -> Optional.of(Gauge.from(metricName, number, labels, attribute.description()));
             case Boolean bool -> Optional.of(Gauge.from(metricName, bool ? 1 : 0, labels, attribute.description()));
             case CompositeData compositeData -> Optional.of(CompositeMetric.from(metricName, compositeData, labels, attribute.description()));
+            case TabularData tabularData -> Optional.of(CompositeMetric.from(metricName, tabularData, labels, attribute.description()));
             case CounterStat counterStat -> Optional.of(Counter.from(metricName, counterStat, labels, attribute.description()));
             case TimeDistribution timeDistribution -> Optional.of(Summary.from(metricName, timeDistribution, labels, attribute.description()));
             case TimeStat timeStat -> Optional.of(timeStatToOpenMetrics(metricName, timeStat, attribute, labels));

--- a/openmetrics/src/main/java/io/airlift/openmetrics/types/CompositeMetric.java
+++ b/openmetrics/src/main/java/io/airlift/openmetrics/types/CompositeMetric.java
@@ -78,6 +78,7 @@ public record CompositeMetric(String metricName, Map<String, String> labels, Str
                     }
                 }
             }
+            case TabularData _ -> {}
             default -> throw new IllegalStateException("Unexpected value: " + value);
         }
     }

--- a/openmetrics/src/test/java/io/airlift/openmetrics/TestOpenMetricsCollector.java
+++ b/openmetrics/src/test/java/io/airlift/openmetrics/TestOpenMetricsCollector.java
@@ -24,6 +24,9 @@ import javax.management.openmbean.CompositeDataSupport;
 import javax.management.openmbean.CompositeType;
 import javax.management.openmbean.OpenType;
 import javax.management.openmbean.SimpleType;
+import javax.management.openmbean.TabularData;
+import javax.management.openmbean.TabularDataSupport;
+import javax.management.openmbean.TabularType;
 
 import java.util.List;
 import java.util.Map;
@@ -106,6 +109,41 @@ public class TestOpenMetricsCollector
                             tuple("metric_name_max", 1000.0),
                             tuple("metric_name_used", 100.0));
         });
+    }
+
+    @Test
+    public void testConvertTabularDataToCompositeMetric()
+    {
+        Optional<Metric> metric = OpenMetricsCollector.toOpenMetric(new Attribute(List.of("metric_name"), createTestTabularData(), "metric help"), LABELS);
+
+        assertThat(metric).isPresent();
+        assertThat(metric.orElseThrow()).isInstanceOfSatisfying(CompositeMetric.class, compositeMetric -> {
+            assertThat(compositeMetric.metricName()).isEqualTo("metric_name");
+            assertThat(compositeMetric.labels()).isEqualTo(LABELS);
+            assertThat(compositeMetric.help()).isEqualTo("metric help");
+            assertThat(compositeMetric.subMetrics())
+                    .filteredOn(Gauge.class::isInstance)
+                    .map(Gauge.class::cast)
+                    .extracting(Gauge::metricName, Gauge::value, Gauge::labels)
+                    .containsExactlyInAnyOrder(
+                            tuple("metric_name_value", 1.0, ImmutableMap.<String, String>builder()
+                                    .putAll(LABELS)
+                                    .put("name", "one")
+                                    .buildOrThrow()),
+                            tuple("metric_name_value", 2.0, ImmutableMap.<String, String>builder()
+                                    .putAll(LABELS)
+                                    .put("name", "two")
+                                    .buildOrThrow()));
+        });
+    }
+
+    @Test
+    public void testConvertEmptyTabularDataToEmptyCompositeMetric()
+    {
+        Optional<Metric> metric = OpenMetricsCollector.toOpenMetric(new Attribute(List.of("metric_name"), createEmptyTestTabularData(), "metric help"), LABELS);
+
+        assertThat(metric).isPresent();
+        assertThat(metric.orElseThrow()).isInstanceOfSatisfying(CompositeMetric.class, compositeMetric -> assertThat(compositeMetric.subMetrics()).isEmpty());
     }
 
     @Test
@@ -269,6 +307,35 @@ public class TestOpenMetricsCollector
                     .buildOrThrow();
 
             return new CompositeDataSupport(compositeType, values);
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static TabularData createTestTabularData()
+    {
+        try {
+            TabularDataSupport tabularData = createEmptyTestTabularData();
+            CompositeType compositeType = tabularData.getTabularType().getRowType();
+
+            tabularData.put(new CompositeDataSupport(compositeType, ImmutableMap.of("name", "one", "value", 1L)));
+            tabularData.put(new CompositeDataSupport(compositeType, ImmutableMap.of("name", "two", "value", 2L)));
+
+            return tabularData;
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static TabularDataSupport createEmptyTestTabularData()
+    {
+        try {
+            String[] itemNames = {"name", "value"};
+            OpenType<?>[] itemTypes = {SimpleType.STRING, SimpleType.LONG};
+            CompositeType compositeType = new CompositeType("TestData", "Test Data", itemNames, itemNames, itemTypes);
+            return new TabularDataSupport(new TabularType("TestTable", "Test Table", compositeType, new String[] {"name"}));
         }
         catch (Exception e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
- Preserve raw JMX boolean and `TabularData` attributes at the shared metrics collection boundary.
- Route raw JMX `TabularData` through the existing OpenMetrics composite renderer.
- Skip raw JMX collection for final `ObjectName`s already exported through jmxutils, using a single snapshot of managed exports per collection.
