### PR TITLE
Fix exception on empty TabularData, allow CompositeData in MetricsCollector

### DIFF
--- a/metrics/src/main/java/io/airlift/metrics/MetricsCollector.java
+++ b/metrics/src/main/java/io/airlift/metrics/MetricsCollector.java
@@ -129,7 +129,7 @@ public class MetricsCollector
                 }
                 else {
                     Object attributeValue = managedClass.invokeAttribute(attributeName);
-                    if (attributeValue instanceof Number || attributeValue instanceof Boolean) {
+                    if (attributeValue instanceof Number || attributeValue instanceof Boolean || attributeValue instanceof CompositeData) {
                         metrics.add(new CollectedMetricGroup.Attribute(attributePath, attributeValue, attributeDescription));
                     }
                 }


### PR DESCRIPTION
~~TabularData with no rows fails, but shouldn't (an empty table can be valid at a specific time, for example a table with active user sessions)~~ Fixed in https://github.com/airlift/airlift/commit/54eebaa8aa095e266a4fd9a5af14887154e5c0b6

The CompositeData was not properly handled by the `MetricsCollector`, while the `OpenMetricsCollector` was depending on it.

This PR is related to https://github.com/trinodb/trino/pull/30193

# Airlift contribution check list

 - [ X ] Git commit messages follow https://cbea.ms/git-commit/.
 - [ ] All automated tests are passing.
 - [ ] Pull request was categorized using one of the existing labels.
