### PR TITLE
Introduce @McpSchema

### DIFF
--- a/mcp/src/main/java/io/airlift/mcp/McpSchema.java
+++ b/mcp/src/main/java/io/airlift/mcp/McpSchema.java
@@ -1,0 +1,30 @@
+package io.airlift.mcp;
+
+import io.airlift.mcp.model.JsonSchemaBuilder;
+
+/**
+ * IMPORTANT: all attributes of this annotation are mutually
+ * exclusive. Only one attribute can be specified at a time.
+ * It is an error to specify more than one, and an exception
+ * will be thrown if it is.
+ */
+public @interface McpSchema
+{
+    /**
+     * The class to use to generate the schema. The class will
+     * be passed to the bound {@link JsonSchemaBuilder.SchemaBuilder}.
+     */
+    Class<?> schemaClass() default void.class;
+
+    /**
+     * The raw schema to use to generate the schema. The schema will
+     * be parsed by a {@code JsonMapper} but is otherwise unchanged.
+     */
+    String rawSchema() default "";
+
+    /**
+     * The fully qualified name of the class to use to generate the schema.
+     * The class will be passed to the bound {@link JsonSchemaBuilder.SchemaBuilder}.
+     */
+    String schemaClassName() default "";
+}

--- a/mcp/src/main/java/io/airlift/mcp/McpTool.java
+++ b/mcp/src/main/java/io/airlift/mcp/McpTool.java
@@ -35,4 +35,18 @@ public @interface McpTool
     OptionalBoolean openWorldHint() default UNDEFINED;
 
     McpApp app() default @McpApp(resourceUri = "", sourcePath = "");
+
+    /**
+     * If specified, overrides the input schema for the tool. Normally, the arguments
+     * to the tool method are used to generate the input schema. When this annotation is
+     * specified, the input schema is taken from the {@link McpSchema} annotation.
+     */
+    McpSchema inputSchema() default @McpSchema;
+
+    /**
+     * If specified, overrides the output schema for the tool. Normally, the return type
+     * of the tool method is used to generate the output schema. When this annotation is
+     * specified, the output schema is taken from the {@link McpSchema} annotation.
+     */
+    McpSchema outputSchema() default @McpSchema;
 }

--- a/mcp/src/main/java/io/airlift/mcp/reflection/ToolHandlerProvider.java
+++ b/mcp/src/main/java/io/airlift/mcp/reflection/ToolHandlerProvider.java
@@ -1,5 +1,6 @@
 package io.airlift.mcp.reflection;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableList;
@@ -10,6 +11,7 @@ import com.google.inject.Injector;
 import com.google.inject.Provider;
 import io.airlift.mcp.McpApp;
 import io.airlift.mcp.McpException;
+import io.airlift.mcp.McpSchema;
 import io.airlift.mcp.McpTool;
 import io.airlift.mcp.handler.ResourceEntry;
 import io.airlift.mcp.handler.ToolEntry;
@@ -22,6 +24,7 @@ import io.airlift.mcp.model.StructuredContentResult;
 import io.airlift.mcp.model.Tool;
 import io.airlift.mcp.model.UiToolVisibility;
 
+import java.io.UncheckedIOException;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
@@ -30,6 +33,7 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.airlift.mcp.McpException.exception;
 import static io.airlift.mcp.model.JsonRpcErrorCode.INTERNAL_ERROR;
@@ -161,23 +165,64 @@ public class ToolHandlerProvider
                 tool.idempotentHint().toJsonValue(),
                 tool.openWorldHint().toJsonValue());
 
-        Optional<ObjectNode> outputSchema;
-        if (CallToolResult.class.isAssignableFrom(method.getReturnType())) {
-            outputSchema = Optional.empty();
+        ObjectNode inputSchema = checkMcpSchema(tool.name(), tool.inputSchema(), jsonSchemaBuilder)
+                .orElseGet(() -> jsonSchemaBuilder.build(description, parameters));
+
+        Optional<ObjectNode> outputSchema = checkMcpSchema(tool.name(), tool.outputSchema(), jsonSchemaBuilder)
+                .or(() -> {
+                    if (CallToolResult.class.isAssignableFrom(method.getReturnType())) {
+                        return Optional.empty();
+                    }
+                    else if (StructuredContentResult.class.isAssignableFrom(method.getReturnType())) {
+                        return Optional.of(jsonSchemaBuilder.build(description, requiredArgument(method.getGenericReturnType())));
+                    }
+                    else if (method.getReturnType().isRecord()) {
+                        return Optional.of(jsonSchemaBuilder.build(description, method.getReturnType()));
+                    }
+                    return Optional.empty();
+                });
+
+        return applyApp(new Tool(tool.name(), description, title, inputSchema, outputSchema, toolAnnotations), tool);
+    }
+
+    private Optional<ObjectNode> checkMcpSchema(String toolName, McpSchema mcpSchema, JsonSchemaBuilder jsonSchemaBuilder)
+    {
+        boolean hasRawSchema = !mcpSchema.rawSchema().isEmpty();
+        boolean hasSchemaClass = mcpSchema.schemaClass() != void.class;
+        boolean hasSchemaClassName = !mcpSchema.schemaClassName().isEmpty();
+
+        if (hasRawSchema) {
+            checkState(!hasSchemaClass, "Tool %s has both rawSchema and schemaClass defined".formatted(toolName));
+            checkState(!hasSchemaClassName, "Tool %s has both rawSchema and schemaClassName defined".formatted(toolName));
+            try {
+                return Optional.of(jsonMapper.readTree(mcpSchema.rawSchema()))
+                        .filter(jsonNode -> {
+                            if (!jsonNode.isObject()) {
+                                throw new IllegalArgumentException("rawSchema must be an object for Tool: %s, Schema: %s".formatted(toolName, mcpSchema.rawSchema()));
+                            }
+                            return true;
+                        })
+                        .map(jsonNode -> (ObjectNode) jsonNode);
+            }
+            catch (JsonProcessingException e) {
+                throw new UncheckedIOException("Could not parse rawSchema for Tool: %s, Schema: %s".formatted(toolName, mcpSchema.rawSchema()), e);
+            }
         }
-        else if (StructuredContentResult.class.isAssignableFrom(method.getReturnType())) {
-            outputSchema = Optional.of(jsonSchemaBuilder.build(description, requiredArgument(method.getGenericReturnType())));
+        else if (hasSchemaClass) {
+            checkState(!hasSchemaClassName, "Tool %s has both schemaClass and schemaClassName defined".formatted(toolName));
+            return Optional.of(jsonSchemaBuilder.build(Optional.of("Tool %s".formatted(toolName)), mcpSchema.schemaClass()));
         }
-        else if (method.getReturnType().isRecord()) {
-            outputSchema = Optional.of(jsonSchemaBuilder.build(description, method.getReturnType()));
-        }
-        else {
-            outputSchema = Optional.empty();
+        else if (hasSchemaClassName) {
+            try {
+                Class<?> clazz = Class.forName(mcpSchema.schemaClassName(), false, Thread.currentThread().getContextClassLoader());
+                return Optional.of(jsonSchemaBuilder.build(Optional.of("Tool %s".formatted(toolName)), clazz));
+            }
+            catch (ClassNotFoundException e) {
+                throw new RuntimeException("Could not load schema class for Tool: %s, Class: %s".formatted(toolName, mcpSchema.schemaClassName()), e);
+            }
         }
 
-        ObjectNode jsonSchema = jsonSchemaBuilder.build(description, parameters);
-
-        return applyApp(new Tool(tool.name(), description, title, jsonSchema, outputSchema, toolAnnotations), tool);
+        return Optional.empty();
     }
 
     private Tool applyApp(Tool tool, McpTool mcpTool)

--- a/mcp/src/test/java/io/airlift/mcp/TestMcpSchema.java
+++ b/mcp/src/test/java/io/airlift/mcp/TestMcpSchema.java
@@ -1,0 +1,290 @@
+package io.airlift.mcp;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Closer;
+import com.google.inject.Module;
+import io.airlift.http.server.testing.TestingHttpServer;
+import io.airlift.mcp.operations.legacy.sessions.StandardSessionController;
+import io.airlift.mcp.storage.MemoryStorageController;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.inject.Scopes.SINGLETON;
+import static io.airlift.mcp.TestingClient.buildClient;
+import static java.util.function.Function.identity;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests the {@link McpSchema} override feature: {@code @McpTool(inputSchema = ...)} and
+ * {@code @McpTool(outputSchema = ...)} let a tool replace the reflection-derived input/output
+ * schema with one built from a raw JSON string, a class, or a fully-qualified class name.
+ */
+@SuppressWarnings("SameParameterValue")
+public class TestMcpSchema
+{
+    // A raw schema whose distinctive "custom" property proves it was used verbatim rather than
+    // being derived from the tool method's parameters/return type.
+    private static final String RAW_SCHEMA = "{\"type\":\"object\",\"properties\":{\"custom\":{\"type\":\"string\"}},\"required\":[\"custom\"]}";
+
+    private static final String CUSTOM_INPUT_CLASS_NAME = "io.airlift.mcp.TestMcpSchema$CustomInput";
+
+    public record CustomInput(String alpha, int beta) {}
+
+    public record CustomOutput(boolean ok) {}
+
+    private final Closer closer = Closer.create();
+
+    private Map<String, Tool> goodTools;
+
+    @AfterEach
+    public void teardown()
+            throws IOException
+    {
+        closer.close();
+    }
+
+    @Test
+    public void testDefaultSchemasWhenNoOverride()
+    {
+        Tool tool = tool("no-override");
+
+        // input schema is derived from the method parameters
+        assertThat(tool.inputSchema().get("type")).isEqualTo("object");
+        assertThat(propertyNames(tool.inputSchema())).containsExactlyInAnyOrder("a", "b");
+
+        // a plain (non-record) return type produces no output schema
+        assertThat(tool.outputSchema()).isNull();
+    }
+
+    @Test
+    public void testRawInputSchemaOverride()
+    {
+        Tool tool = tool("raw-input");
+
+        Map<String, Object> inputSchema = tool.inputSchema();
+        assertThat(inputSchema.get("type")).isEqualTo("object");
+        // the raw schema is used verbatim - the method's "ignored" parameter does not appear
+        assertThat(propertyNames(inputSchema)).containsExactly("custom");
+        assertThat(property(inputSchema, "custom").get("type")).isEqualTo("string");
+    }
+
+    @Test
+    public void testClassInputSchemaOverride()
+    {
+        Tool tool = tool("class-input");
+
+        assertThat(tool.inputSchema().get("type")).isEqualTo("object");
+        assertThat(propertyNames(tool.inputSchema())).containsExactlyInAnyOrder("alpha", "beta");
+    }
+
+    @Test
+    public void testClassNameInputSchemaOverride()
+    {
+        Tool byName = tool("classname-input");
+        Tool byClass = tool("class-input");
+
+        // resolving the schema by class name yields the same schema as resolving it by class
+        // (ignoring the description, which is derived from the differing tool names)
+        assertThat(schemaWithoutDescription(byName.inputSchema())).isEqualTo(schemaWithoutDescription(byClass.inputSchema()));
+        assertThat(propertyNames(byName.inputSchema())).containsExactlyInAnyOrder("alpha", "beta");
+    }
+
+    @Test
+    public void testRawOutputSchemaOverride()
+    {
+        Tool tool = tool("raw-output");
+
+        assertThat(tool.outputSchema()).isNotNull();
+        assertThat(tool.outputSchema().get("type")).isEqualTo("object");
+        assertThat(propertyNames(tool.outputSchema())).containsExactly("custom");
+    }
+
+    @Test
+    public void testClassOutputSchemaOverride()
+    {
+        Tool tool = tool("class-output");
+
+        assertThat(tool.outputSchema()).isNotNull();
+        assertThat(propertyNames(tool.outputSchema())).containsExactly("ok");
+    }
+
+    @Test
+    public void testRawSchemaAndSchemaClassAreMutuallyExclusive()
+    {
+        assertThatThrownBy(() -> buildServer(RawAndClassEndpoint.class).close())
+                .hasStackTraceContaining("has both rawSchema and schemaClass defined");
+    }
+
+    @Test
+    public void testSchemaClassAndSchemaClassNameAreMutuallyExclusive()
+    {
+        assertThatThrownBy(() -> buildServer(ClassAndClassNameEndpoint.class).close())
+                .hasStackTraceContaining("has both schemaClass and");
+    }
+
+    @Test
+    public void testRawSchemaMustBeAnObject()
+    {
+        assertThatThrownBy(() -> buildServer(NonObjectRawSchemaEndpoint.class).close())
+                .hasStackTraceContaining("rawSchema must be an object");
+    }
+
+    @Test
+    public void testMalformedRawSchemaIsRejected()
+    {
+        assertThatThrownBy(() -> buildServer(MalformedRawSchemaEndpoint.class).close())
+                .hasStackTraceContaining("Could not parse rawSchema");
+    }
+
+    @Test
+    public void testUnknownSchemaClassNameIsRejected()
+    {
+        assertThatThrownBy(() -> buildServer(UnknownClassNameEndpoint.class).close())
+                .hasStackTraceContaining("Could not load schema class");
+    }
+
+    private Tool tool(String name)
+    {
+        Tool tool = goodTools().get(name);
+        assertThat(tool).as("tool %s should exist", name).isNotNull();
+        return tool;
+    }
+
+    private Map<String, Tool> goodTools()
+    {
+        if (goodTools == null) {
+            TestingServer server = closer.register(buildServer(SchemaEndpoints.class));
+            String baseUri = server.injector().getInstance(TestingHttpServer.class).getBaseUrl().toString();
+            TestingClient client = buildClient(closer, baseUri, "tester");
+            goodTools = client.mcpClient().listTools().tools().stream()
+                    .collect(toImmutableMap(Tool::name, identity()));
+        }
+        return goodTools;
+    }
+
+    private static TestingServer buildServer(Class<?> endpointsClass)
+    {
+        Function<McpModule.Builder, Module> applicator = builder -> builder
+                .withIdentityMapper(TestingIdentity.class, binding -> binding.to(TestingIdentityMapper.class).in(SINGLETON))
+                .withStorage(binding -> binding.to(MemoryStorageController.class).in(SINGLETON))
+                .withLegacyBindings().withSessions(binding -> binding.to(StandardSessionController.class).in(SINGLETON))
+                .withAllInClass(endpointsClass)
+                .build();
+        return new TestingServer(ImmutableMap.of(), Optional.empty(), applicator);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> property(Map<String, Object> schema, String name)
+    {
+        Map<String, Object> properties = (Map<String, Object>) schema.get("properties");
+        return (Map<String, Object>) properties.get(name);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Set<String> propertyNames(Map<String, Object> schema)
+    {
+        return ((Map<String, Object>) schema.get("properties")).keySet();
+    }
+
+    private static Map<String, Object> schemaWithoutDescription(Map<String, Object> schema)
+    {
+        Map<String, Object> copy = new HashMap<>(schema);
+        copy.remove("description");
+        return copy;
+    }
+
+    @SuppressWarnings("unused")
+    public static class SchemaEndpoints
+    {
+        @McpTool(name = "no-override", description = "default schemas")
+        public String noOverride(int a, int b)
+        {
+            return "ok";
+        }
+
+        @McpTool(name = "raw-input", description = "raw input schema", inputSchema = @McpSchema(rawSchema = RAW_SCHEMA))
+        public String rawInput(int ignored)
+        {
+            return "ok";
+        }
+
+        @McpTool(name = "class-input", description = "class input schema", inputSchema = @McpSchema(schemaClass = CustomInput.class))
+        public String classInput(int ignored)
+        {
+            return "ok";
+        }
+
+        @McpTool(name = "classname-input", description = "class-name input schema", inputSchema = @McpSchema(schemaClassName = CUSTOM_INPUT_CLASS_NAME))
+        public String classNameInput(int ignored)
+        {
+            return "ok";
+        }
+
+        @McpTool(name = "raw-output", description = "raw output schema", outputSchema = @McpSchema(rawSchema = RAW_SCHEMA))
+        public String rawOutput()
+        {
+            return "ok";
+        }
+
+        @McpTool(name = "class-output", description = "class output schema", outputSchema = @McpSchema(schemaClass = CustomOutput.class))
+        public String classOutput()
+        {
+            return "ok";
+        }
+    }
+
+    public static class RawAndClassEndpoint
+    {
+        @McpTool(name = "raw-and-class", description = "invalid", inputSchema = @McpSchema(rawSchema = RAW_SCHEMA, schemaClass = CustomInput.class))
+        public String rawAndClass()
+        {
+            return "ok";
+        }
+    }
+
+    public static class ClassAndClassNameEndpoint
+    {
+        @McpTool(name = "class-and-classname", description = "invalid", inputSchema = @McpSchema(schemaClass = CustomInput.class, schemaClassName = CUSTOM_INPUT_CLASS_NAME))
+        public String classAndClassName()
+        {
+            return "ok";
+        }
+    }
+
+    public static class NonObjectRawSchemaEndpoint
+    {
+        @McpTool(name = "non-object-raw", description = "invalid", inputSchema = @McpSchema(rawSchema = "123"))
+        public String nonObjectRaw()
+        {
+            return "ok";
+        }
+    }
+
+    public static class MalformedRawSchemaEndpoint
+    {
+        @McpTool(name = "malformed-raw", description = "invalid", inputSchema = @McpSchema(rawSchema = "{not valid json"))
+        public String malformedRaw()
+        {
+            return "ok";
+        }
+    }
+
+    public static class UnknownClassNameEndpoint
+    {
+        @McpTool(name = "unknown-classname", description = "invalid", inputSchema = @McpSchema(schemaClassName = "io.airlift.mcp.DoesNotExist"))
+        public String unknownClassName()
+        {
+            return "ok";
+        }
+    }
+}


### PR DESCRIPTION
Relying only on method arguments and return type for input/output schema is limiting. Introduce @McpSchema to allow different, more feature-rich ways of specifying the input/output schema for a tool.

# Airlift contribution check list

 - [X] Git commit messages follow https://cbea.ms/git-commit/.
 - [X] All automated tests are passing.
 - [X] Pull request was categorized using one of the existing labels.
