### PR TITLE
Add support for OpenTelemetry baggage propagation

### DIFF
--- a/http-server/pom.xml
+++ b/http-server/pom.xml
@@ -248,6 +248,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>opentelemetry</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>io.airlift</groupId>
@@ -258,6 +264,18 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>tracing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-trace</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/http-server/src/main/java/io/airlift/http/server/tracing/TracingServletFilter.java
+++ b/http-server/src/main/java/io/airlift/http/server/tracing/TracingServletFilter.java
@@ -2,6 +2,7 @@ package io.airlift.http.server.tracing;
 
 import com.google.inject.Inject;
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
@@ -47,6 +48,7 @@ public final class TracingServletFilter
     // This attribute will be deprecated in OTEL soon
     static final AttributeKey<Boolean> EXCEPTION_ESCAPED = AttributeKey.booleanKey("exception.escaped");
     static final String REQUEST_SPAN = "airlift.trace-span";
+    private static final String BAGGAGE_ATTRIBUTE_PREFIX = "baggage.";
 
     private final TextMapPropagator propagator;
     private final Tracer tracer;
@@ -83,6 +85,7 @@ public final class TracingServletFilter
 
         Context parent = propagator.extract(Context.root(), request, ServletTextMapGetter.INSTANCE);
         String method = request.getMethod().toUpperCase(ENGLISH);
+        Baggage baggage = Baggage.fromContext(parent);
 
         SpanBuilder spanBuilder = tracer.spanBuilder(method + " " + request.getRequestURI())
                 .setParent(parent)
@@ -93,6 +96,7 @@ public final class TracingServletFilter
                 .setAttribute(ServerAttributes.SERVER_PORT, getPort(request))
                 .setAttribute(ClientAttributes.CLIENT_ADDRESS, request.getRemoteAddr())
                 .setAttribute(NetworkAttributes.NETWORK_PROTOCOL_NAME, "http");
+        baggage.forEach((key, entry) -> spanBuilder.setAttribute(BAGGAGE_ATTRIBUTE_PREFIX + key, entry.getValue()));
 
         String sessionId = (String) request.getAttribute(SSL_SESSION_ID);
         if (sessionId != null) {
@@ -125,7 +129,12 @@ public final class TracingServletFilter
         // Add to request attributes for TracingFilter to be able to update Span attributes
         request.setAttribute(REQUEST_SPAN, span);
 
-        try (Scope ignored = span.makeCurrent()) {
+        // Make the extracted parent context current (not just the span) so that baggage propagated
+        // from the caller stays in scope for the request and is visible to handlers and logging.
+        try (Scope ignored = Context.current()
+                .with(baggage)
+                .with(span)
+                .makeCurrent()) {
             // a non-recording span drops all attributes, so the response wrapper that exists
             // only to record response attributes is not needed
             chain.doFilter(request, span.isRecording() ? new TracingHttpServletResponse(response, span) : response);

--- a/http-server/src/test/java/io/airlift/http/server/tracing/TestBaggagePropagation.java
+++ b/http-server/src/test/java/io/airlift/http/server/tracing/TestBaggagePropagation.java
@@ -1,0 +1,149 @@
+package io.airlift.http.server.tracing;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.BindingAnnotation;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import io.airlift.bootstrap.Bootstrap;
+import io.airlift.http.client.HeaderName;
+import io.airlift.http.client.HttpClient;
+import io.airlift.http.client.StringResponseHandler.StringResponse;
+import io.airlift.http.server.HttpServer;
+import io.airlift.http.server.HttpServerInfo;
+import io.airlift.http.server.HttpServerModule;
+import io.airlift.node.testing.TestingNodeModule;
+import io.airlift.opentelemetry.OpenTelemetryModule;
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.SpanProcessor;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import jakarta.servlet.Servlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.net.URI;
+import java.nio.file.Path;
+
+import static com.google.common.collect.MoreCollectors.onlyElement;
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
+import static io.airlift.http.client.HttpClientBinder.httpClientBinder;
+import static io.airlift.http.client.Request.Builder.prepareGet;
+import static io.airlift.http.client.StringResponseHandler.createStringResponseHandler;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end test that boots two independent services and verifies that
+ * OpenTelemetry baggage set on the calling (client) service is propagated over HTTP and is
+ * visible in the active context of the receiving (server) service.
+ * The client and server each only allowlist the {@code orderId} baggage key.
+ */
+public class TestBaggagePropagation
+{
+    @Test
+    public void testBaggagePropagatesBetweenBootstrappedServices(@TempDir Path tempDir)
+            throws Exception
+    {
+        @SuppressWarnings("resource")
+        InMemorySpanExporter serverSpanExporter = InMemorySpanExporter.create();
+
+        // Service A: an HTTP server that echoes back the "orderId" baggage entry it observes.
+        Injector serverInjector = new Bootstrap(
+                new TestingNodeModule(),
+                new HttpServerModule(),
+                new OpenTelemetryModule("server-service", "1.0"),
+                binder -> newSetBinder(binder, SpanProcessor.class).addBinding()
+                        .toInstance(SimpleSpanProcessor.create(serverSpanExporter)),
+                binder -> binder.bind(Servlet.class).to(BaggageEchoServlet.class))
+                .setRequiredConfigurationProperties(ImmutableMap.<String, String>builder()
+                        .put("http-server.http.port", "0")
+                        .put("http-server.log.path", tempDir.resolve("http-request.log").toString())
+                        .put("otel.tracing.baggage.allowed-keys", "orderId")
+                        .buildOrThrow())
+                .doNotInitializeLogging()
+                .quiet()
+                .initialize();
+
+        HttpServer server = serverInjector.getInstance(HttpServer.class);
+        server.start();
+        try {
+            URI serverUri = serverInjector.getInstance(HttpServerInfo.class).getHttpUri();
+
+            // Service B: an HTTP client wired through Bootstrap with the same telemetry stack, so the
+            // injected client uses the propagators provided by OpenTelemetryModule.
+            Injector clientInjector = new Bootstrap(
+                    new TestingNodeModule(),
+                    new OpenTelemetryModule("client-service", "1.0"),
+                    binder -> newSetBinder(binder, SpanProcessor.class).addBinding()
+                            .toInstance(SpanProcessor.composite()),
+                    binder -> httpClientBinder(binder).bindHttpClient("test", TestClient.class))
+                    .setRequiredConfigurationProperties(ImmutableMap.of("otel.tracing.baggage.allowed-keys", "orderId"))
+                    .doNotInitializeLogging()
+                    .quiet()
+                    .initialize();
+
+            HttpClient client = clientInjector.getInstance(Key.get(HttpClient.class, TestClient.class));
+
+            // Set request-scoped baggage on the client side, including a key ("secret") that neither
+            // side allowlists; the client injects the allowlisted baggage as the "baggage" header when
+            // the context is current at execution time.
+            Baggage baggage = Baggage.builder()
+                    .put("orderId", "42")
+                    .put("secret", "leaked")
+                    .build();
+            try (Scope ignored = baggage.makeCurrent()) {
+                StringResponse response = client.execute(
+                        prepareGet().setUri(serverUri).build(),
+                        createStringResponseHandler());
+
+                assertThat(response.getStatusCode()).isEqualTo(SC_OK);
+                assertThat(response.getBody()).isEqualTo("42");
+                assertThat(response.getHeader(HeaderName.of("X-Secret"))).contains("<none>");
+            }
+
+            // Baggage is also surfaced as span attributes, not only in logs, and only for allowlisted keys.
+            assertThat(serverSpanExporter.getFinishedSpanItems()).hasSize(1);
+            SpanData serverSpan = serverSpanExporter.getFinishedSpanItems().stream().collect(onlyElement());
+            assertThat(serverSpan.getAttributes().get(AttributeKey.stringKey("baggage.orderId"))).isEqualTo("42");
+            assertThat(serverSpan.getAttributes().get(AttributeKey.stringKey("baggage.secret"))).isNull();
+        }
+        finally {
+            server.stop();
+        }
+    }
+
+    private static class BaggageEchoServlet
+            extends HttpServlet
+    {
+        @Override
+        protected void doGet(HttpServletRequest request, HttpServletResponse response)
+                throws IOException
+        {
+            Baggage baggage = Baggage.fromContext(Context.current());
+            String orderId = baggage.getEntryValue("orderId");
+            String secret = baggage.getEntryValue("secret");
+            response.setHeader("X-Secret", secret == null ? "<none>" : secret);
+            response.setStatus(SC_OK);
+            response.getWriter().write(orderId == null ? "<none>" : orderId);
+        }
+    }
+
+    @Retention(RUNTIME)
+    @Target({FIELD, PARAMETER, METHOD})
+    @BindingAnnotation
+    public @interface TestClient {}
+}

--- a/log-manager/src/main/java/io/airlift/log/JsonRecord.java
+++ b/log-manager/src/main/java/io/airlift/log/JsonRecord.java
@@ -3,6 +3,8 @@ package io.airlift.log;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
+import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.TraceFlags;
@@ -19,6 +21,7 @@ import java.util.stream.Stream;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
+import static java.util.function.Predicate.not;
 
 public class JsonRecord
 {
@@ -33,6 +36,7 @@ public class JsonRecord
     private final Throwable throwable;
     private final Optional<SpanContext> spanContext;
     private final Map<String, String> logAnnotations;
+    private final Map<String, String> baggage;
 
     public JsonRecord(
             Instant timestamp,
@@ -86,6 +90,16 @@ public class JsonRecord
                 .map(Span::getSpanContext)
                 .filter(SpanContext::isValid);
         this.logAnnotations = (logAnnotations == null || logAnnotations.isEmpty()) ? null : logAnnotations;
+        this.baggage = extractBaggage(context);
+    }
+
+    private static Map<String, String> extractBaggage(Context context)
+    {
+        return Optional.ofNullable(context)
+                .map(Baggage::fromContext)
+                .filter(not(Baggage::isEmpty))
+                .map(JsonRecord::convertBaggageToMap)
+                .orElse(null);
     }
 
     @JsonProperty
@@ -176,6 +190,12 @@ public class JsonRecord
         return logAnnotations;
     }
 
+    @JsonProperty("baggage")
+    public Map<String, String> getBaggage()
+    {
+        return baggage;
+    }
+
     @Override
     public String toString()
     {
@@ -211,5 +231,12 @@ public class JsonRecord
     public int hashCode()
     {
         return Objects.hash(timestamp, level, thread, loggerName, message, throwable);
+    }
+
+    private static Map<String, String> convertBaggageToMap(Baggage baggage)
+    {
+        ImmutableMap.Builder<String, String> builder = ImmutableMap.builderWithExpectedSize(baggage.size());
+        baggage.forEach((key, entry) -> builder.put(key, entry.getValue()));
+        return builder.buildOrThrow();
     }
 }

--- a/log-manager/src/main/java/io/airlift/log/StaticFormatter.java
+++ b/log-manager/src/main/java/io/airlift/log/StaticFormatter.java
@@ -1,7 +1,10 @@
 package io.airlift.log;
 
 import com.google.common.base.Joiner;
+import com.google.common.base.Joiner.MapJoiner;
 import com.google.common.collect.ImmutableMap;
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.context.Context;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -36,6 +39,7 @@ class StaticFormatter
         extends Formatter
 {
     private static final ZoneId SYSTEM_ZONE = ZoneId.systemDefault().normalized();
+    private static final MapJoiner BAGGAGE_JOINER = Joiner.on(",").withKeyValueSeparator("=");
     private final String annotations;
     private final TerminalColors colors;
 
@@ -97,6 +101,12 @@ class StaticFormatter
                     .append(colors.colored(annotations, level));
         }
 
+        Baggage baggage = Baggage.fromContext(Context.current());
+        if (!baggage.isEmpty()) {
+            builder.append('\t')
+                    .append(colors.colored(formatBaggage(baggage), level));
+        }
+
         builder.append('\t')
                 .append(colors.colored(record.getMessage(), WHITE));
 
@@ -114,5 +124,12 @@ class StaticFormatter
 
         builder.append('\n');
         return builder.toString();
+    }
+
+    private static String formatBaggage(Baggage baggage)
+    {
+        ImmutableMap.Builder<String, String> builder = ImmutableMap.builderWithExpectedSize(baggage.size());
+        baggage.forEach((key, entry) -> builder.put(key, entry.getValue()));
+        return "baggage=" + BAGGAGE_JOINER.join(builder.buildOrThrow());
     }
 }

--- a/log-manager/src/test/java/io/airlift/log/TestJsonFormatter.java
+++ b/log-manager/src/test/java/io/airlift/log/TestJsonFormatter.java
@@ -9,7 +9,6 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
-import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
@@ -172,6 +171,17 @@ public class TestJsonFormatter
         JsonRecord jsonRecord = jsonCodec(JsonRecord.class).fromJson(logMessage);
 
         assertThat(jsonRecord.getMessage()).isEqualTo(record.getMessage());
-        assertThat(jsonMap.get("annotations")).asInstanceOf(InstanceOfAssertFactories.map(String.class, String.class)).containsExactlyEntriesOf(logAnnotations);
+        assertThat(jsonMap.get("annotations")).isEqualTo(logAnnotations);
+    }
+
+    @Test
+    public void testEmptyAnnotationsOmittedFromJson()
+    {
+        LogRecord record = new LogRecord(Level.DEBUG.toJulLevel(), "Test Log Message");
+
+        String logMessage = (new JsonFormatter(ImmutableMap.of())).format(record);
+
+        Map<String, Object> jsonMap = mapJsonCodec(String.class, Object.class).fromJson(logMessage);
+        assertThat(jsonMap).doesNotContainKey("annotations");
     }
 }

--- a/log-manager/src/test/java/io/airlift/log/TestJsonFormatter.java
+++ b/log-manager/src/test/java/io/airlift/log/TestJsonFormatter.java
@@ -1,6 +1,7 @@
 package io.airlift.log;
 
 import com.google.common.collect.ImmutableMap;
+import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanId;
 import io.opentelemetry.api.trace.TraceFlags;
@@ -14,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.LogRecord;
 
 import static com.google.common.base.Throwables.getStackTraceAsString;
@@ -183,5 +185,57 @@ public class TestJsonFormatter
 
         Map<String, Object> jsonMap = mapJsonCodec(String.class, Object.class).fromJson(logMessage);
         assertThat(jsonMap).doesNotContainKey("annotations");
+    }
+
+    @Test
+    public void testLogBaggage()
+    {
+        LogRecord record = new LogRecord(Level.DEBUG.toJulLevel(), "Test Log Message");
+        Baggage baggage = Baggage.builder()
+                .put("orderId", "42")
+                .put("tenant", "acme")
+                .build();
+
+        String logMessage;
+        try (var ignored = baggage.makeCurrent()) {
+            logMessage = (new JsonFormatter(ImmutableMap.of())).format(record);
+        }
+
+        Map<String, Object> jsonMap = mapJsonCodec(String.class, Object.class).fromJson(logMessage);
+        assertThat(jsonMap.get("baggage")).isEqualTo(ImmutableMap.of("orderId", "42", "tenant", "acme"));
+    }
+
+    @Test
+    public void testLogBaggageInChildThread()
+            throws InterruptedException
+    {
+        LogRecord record = new LogRecord(Level.DEBUG.toJulLevel(), "Test Log Message");
+        Baggage baggage = Baggage.builder()
+                .put("orderId", "42")
+                .build();
+
+        AtomicReference<String> childLogMessage = new AtomicReference<>();
+        try (var ignored = baggage.makeCurrent()) {
+            // The OpenTelemetry Context (and thus baggage) is not inherited by child threads
+            // automatically; wrapping the task makes the child thread run with the current context.
+            Runnable child = Context.current().wrap(() -> childLogMessage.set((new JsonFormatter(ImmutableMap.of())).format(record)));
+            Thread thread = new Thread(child);
+            thread.start();
+            thread.join();
+        }
+
+        Map<String, Object> jsonMap = mapJsonCodec(String.class, Object.class).fromJson(childLogMessage.get());
+        assertThat(jsonMap.get("baggage")).isEqualTo(ImmutableMap.of("orderId", "42"));
+    }
+
+    @Test
+    public void testEmptyBaggageOmittedFromJson()
+    {
+        LogRecord record = new LogRecord(Level.DEBUG.toJulLevel(), "Test Log Message");
+
+        String logMessage = (new JsonFormatter(ImmutableMap.of())).format(record);
+
+        Map<String, Object> jsonMap = mapJsonCodec(String.class, Object.class).fromJson(logMessage);
+        assertThat(jsonMap).doesNotContainKey("baggage");
     }
 }

--- a/log-manager/src/test/java/io/airlift/log/TestStaticFormatter.java
+++ b/log-manager/src/test/java/io/airlift/log/TestStaticFormatter.java
@@ -1,0 +1,40 @@
+package io.airlift.log;
+
+import io.opentelemetry.api.baggage.Baggage;
+import org.junit.jupiter.api.Test;
+
+import java.util.logging.LogRecord;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestStaticFormatter
+{
+    @Test
+    public void testFormatBaggage()
+    {
+        LogRecord record = new LogRecord(Level.DEBUG.toJulLevel(), "Test Log Message");
+        Baggage baggage = Baggage.builder()
+                .put("orderId", "42")
+                .put("tenant", "acme")
+                .build();
+
+        String logMessage;
+        try (var ignored = baggage.makeCurrent()) {
+            logMessage = new StaticFormatter().format(record);
+        }
+
+        assertThat(logMessage).contains("\tbaggage=");
+        assertThat(logMessage).contains("orderId=42");
+        assertThat(logMessage).contains("tenant=acme");
+    }
+
+    @Test
+    public void testNoBaggageOmitsSegment()
+    {
+        LogRecord record = new LogRecord(Level.DEBUG.toJulLevel(), "Test Log Message");
+
+        String logMessage = new StaticFormatter().format(record);
+
+        assertThat(logMessage).doesNotContain("baggage=");
+    }
+}

--- a/opentelemetry/src/main/java/io/airlift/opentelemetry/AllowlistBaggagePropagator.java
+++ b/opentelemetry/src/main/java/io/airlift/opentelemetry/AllowlistBaggagePropagator.java
@@ -1,0 +1,73 @@
+package io.airlift.opentelemetry;
+
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.baggage.BaggageBuilder;
+import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.context.propagation.TextMapSetter;
+
+import java.util.Collection;
+import java.util.Set;
+
+/**
+ * Wraps {@link W3CBaggagePropagator} to enforce a fail-closed allowlist on baggage keys, both when
+ * baggage is injected into an outgoing carrier (e.g. HTTP headers) and when it is extracted from an
+ * incoming one.
+ */
+final class AllowlistBaggagePropagator
+        implements TextMapPropagator
+{
+    private final TextMapPropagator delegate = W3CBaggagePropagator.getInstance();
+    private final Set<String> allowedKeys;
+    private final int maxValueLength;
+
+    public AllowlistBaggagePropagator(BaggageConfig config)
+    {
+        this.allowedKeys = config.getAllowedKeys();
+        this.maxValueLength = config.getMaxValueLength();
+    }
+
+    @Override
+    public Collection<String> fields()
+    {
+        return delegate.fields();
+    }
+
+    @Override
+    public <C> void inject(Context context, C carrier, TextMapSetter<C> setter)
+    {
+        Baggage sanitized = sanitize(Baggage.fromContext(context));
+        delegate.inject(sanitized.storeInContext(context), carrier, setter);
+    }
+
+    @Override
+    public <C> Context extract(Context context, C carrier, TextMapGetter<C> getter)
+    {
+        Context extracted = delegate.extract(context, carrier, getter);
+        Baggage sanitized = sanitize(Baggage.fromContext(extracted));
+        return sanitized.storeInContext(extracted);
+    }
+
+    private Baggage sanitize(Baggage baggage)
+    {
+        BaggageBuilder builder = Baggage.builder();
+        baggage.forEach((key, entry) -> {
+            if (allowedKeys.contains(key) && isSafeValue(entry.getValue())) {
+                builder.put(key, truncate(entry.getValue()));
+            }
+        });
+        return builder.build();
+    }
+
+    private static boolean isSafeValue(String value)
+    {
+        return value.chars().noneMatch(Character::isISOControl);
+    }
+
+    private String truncate(String value)
+    {
+        return value.length() > maxValueLength ? value.substring(0, maxValueLength) : value;
+    }
+}

--- a/opentelemetry/src/main/java/io/airlift/opentelemetry/BaggageConfig.java
+++ b/opentelemetry/src/main/java/io/airlift/opentelemetry/BaggageConfig.java
@@ -1,0 +1,41 @@
+package io.airlift.opentelemetry;
+
+import com.google.common.collect.ImmutableSet;
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import jakarta.validation.constraints.Min;
+
+import java.util.Set;
+
+public class BaggageConfig
+{
+    private Set<String> allowedKeys = ImmutableSet.of();
+    private int maxValueLength = 2048;
+
+    public Set<String> getAllowedKeys()
+    {
+        return allowedKeys;
+    }
+
+    @Config("otel.tracing.baggage.allowed-keys")
+    @ConfigDescription("Comma-separated list of baggage keys allowed to propagate; all other keys are dropped")
+    public BaggageConfig setAllowedKeys(Set<String> allowedKeys)
+    {
+        this.allowedKeys = ImmutableSet.copyOf(allowedKeys);
+        return this;
+    }
+
+    @Min(0)
+    public int getMaxValueLength()
+    {
+        return maxValueLength;
+    }
+
+    @Config("otel.tracing.baggage.max-value-length")
+    @ConfigDescription("Maximum length of an allowed baggage value; longer values are truncated")
+    public BaggageConfig setMaxValueLength(int maxValueLength)
+    {
+        this.maxValueLength = maxValueLength;
+        return this;
+    }
+}

--- a/opentelemetry/src/main/java/io/airlift/opentelemetry/OpenTelemetryModule.java
+++ b/opentelemetry/src/main/java/io/airlift/opentelemetry/OpenTelemetryModule.java
@@ -14,6 +14,7 @@ import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.logs.LogRecordProcessor;
 import io.opentelemetry.sdk.logs.SdkLoggerProvider;
@@ -70,6 +71,7 @@ public class OpenTelemetryModule
         newSetBinder(binder, MetricProducer.class);
         newSetBinder(binder, LogRecordProcessor.class);
         configBinder(binder).bindConfig(OpenTelemetryConfig.class);
+        configBinder(binder).bindConfig(BaggageConfig.class);
     }
 
     @Provides
@@ -81,7 +83,8 @@ public class OpenTelemetryModule
             Set<LogRecordProcessor> logRecordProcessors,
             SdkTracerProvider tracerProvider,
             SdkMeterProvider meterProvider,
-            SdkLoggerProvider loggerProvider)
+            SdkLoggerProvider loggerProvider,
+            BaggageConfig baggageConfig)
     {
         if (spanProcessors.isEmpty() && metricReaders.isEmpty() && metricProducers.isEmpty() && logRecordProcessors.isEmpty()) {
             return OpenTelemetry.noop();
@@ -91,7 +94,9 @@ public class OpenTelemetryModule
                 .setTracerProvider(tracerProvider)
                 .setMeterProvider(meterProvider)
                 .setLoggerProvider(loggerProvider)
-                .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
+                .setPropagators(ContextPropagators.create(TextMapPropagator.composite(
+                        W3CTraceContextPropagator.getInstance(),
+                        new AllowlistBaggagePropagator(baggageConfig))))
                 .build();
     }
 

--- a/opentelemetry/src/test/java/io/airlift/opentelemetry/TestBaggageConfig.java
+++ b/opentelemetry/src/test/java/io/airlift/opentelemetry/TestBaggageConfig.java
@@ -1,0 +1,40 @@
+package io.airlift.opentelemetry;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestBaggageConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(BaggageConfig.class)
+                .setAllowedKeys(ImmutableSet.of())
+                .setMaxValueLength(2048));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("otel.tracing.baggage.allowed-keys", "orderId,tenant")
+                .put("otel.tracing.baggage.max-value-length", "512")
+                .buildOrThrow();
+
+        BaggageConfig expected = new BaggageConfig()
+                .setAllowedKeys(ImmutableSet.of("orderId", "tenant"))
+                .setMaxValueLength(512);
+
+        assertFullMapping(properties, expected);
+
+        assertThat(expected.getAllowedKeys()).isEqualTo(ImmutableSet.of("orderId", "tenant"));
+    }
+}

--- a/opentelemetry/src/test/java/io/airlift/opentelemetry/TestOpenTelemetryModule.java
+++ b/opentelemetry/src/test/java/io/airlift/opentelemetry/TestOpenTelemetryModule.java
@@ -1,14 +1,19 @@
 package io.airlift.opentelemetry;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Injector;
 import io.airlift.bootstrap.Bootstrap;
 import io.airlift.node.NodeInfo;
 import io.airlift.node.testing.TestingNodeModule;
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.logs.Severity;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.sdk.logs.LogRecordProcessor;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.logs.export.SimpleLogRecordProcessor;
@@ -28,7 +33,9 @@ import io.opentelemetry.semconv.DeploymentAttributes;
 import io.opentelemetry.semconv.ServiceAttributes;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.google.common.collect.MoreCollectors.onlyElement;
@@ -39,6 +46,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestOpenTelemetryModule
 {
+    private static final TextMapGetter<Map<String, String>> MAP_GETTER = new TextMapGetter<>()
+    {
+        @Override
+        public Iterable<String> keys(Map<String, String> carrier)
+        {
+            return carrier.keySet();
+        }
+
+        @Override
+        public String get(Map<String, String> carrier, String key)
+        {
+            return (carrier == null) ? null : carrier.get(key);
+        }
+    };
+
     @Test
     void testNoopProviders()
     {
@@ -214,5 +236,109 @@ public class TestOpenTelemetryModule
         reader.collectAllMetrics();
 
         assertThat(produced).isTrue();
+    }
+
+    @Test
+    void testBaggagePropagation()
+    {
+        @SuppressWarnings("resource")
+        InMemorySpanExporter exporter = InMemorySpanExporter.create();
+
+        Injector injector = new Bootstrap(
+                new TestingNodeModule(),
+                new OpenTelemetryModule("testService", "testVersion"),
+                binder -> newSetBinder(binder, SpanProcessor.class).addBinding()
+                        .toInstance(SimpleSpanProcessor.create(exporter)))
+                .setRequiredConfigurationProperties(ImmutableMap.of("otel.tracing.baggage.allowed-keys", "orderId"))
+                .quiet()
+                .initialize();
+
+        OpenTelemetry openTelemetry = injector.getInstance(OpenTelemetry.class);
+        TextMapPropagator propagator = openTelemetry.getPropagators().getTextMapPropagator();
+
+        // Baggage must take part in cross-service context propagation
+        assertThat(propagator.fields()).contains("baggage");
+
+        // Inject baggage from the current context into outgoing carrier (e.g. HTTP headers)
+        Map<String, String> carrier = new HashMap<>();
+        Context context = Baggage.builder().put("orderId", "42").build().storeInContext(Context.root());
+        propagator.inject(context, carrier, Map::put);
+        assertThat(carrier).containsKey("baggage");
+
+        // Extract baggage on the receiving side from the incoming carrier
+        Context extracted = propagator.extract(Context.root(), carrier, MAP_GETTER);
+
+        assertThat(Baggage.fromContext(extracted).getEntryValue("orderId")).isEqualTo("42");
+    }
+
+    @Test
+    void testBaggageAllowlistDropsNonAllowlistedKeysOnInjectAndExtract()
+    {
+        Injector injector = new Bootstrap(
+                new TestingNodeModule(),
+                new OpenTelemetryModule("testService", "testVersion"),
+                binder -> newSetBinder(binder, SpanProcessor.class).addBinding()
+                        .toInstance(SpanProcessor.composite()))
+                .setRequiredConfigurationProperties(ImmutableMap.of("otel.tracing.baggage.allowed-keys", "orderId"))
+                .quiet()
+                .initialize();
+
+        TextMapPropagator propagator = injector.getInstance(OpenTelemetry.class).getPropagators().getTextMapPropagator();
+
+        // A non-allowlisted key can end up in the current baggage at runtime (e.g. added by application
+        // code), not only via an inbound request, so it must be stripped on the way out as well - the
+        // wire payload itself must never contain it, not just the value observed after a subsequent extract.
+        Map<String, String> outboundCarrier = new HashMap<>();
+        Context context = Baggage.builder()
+                .put("orderId", "42")
+                .put("secret", "leaked")
+                .build()
+                .storeInContext(Context.root());
+        propagator.inject(context, outboundCarrier, Map::put);
+
+        assertThat(outboundCarrier.get("baggage"))
+                .contains("orderId")
+                .doesNotContain("secret", "leaked");
+
+        // A non-allowlisted key arriving from a caller must also be dropped on extract.
+        Map<String, String> inboundCarrier = new HashMap<>();
+        inboundCarrier.put("baggage", "orderId=99,secret=leaked");
+        Baggage extracted = Baggage.fromContext(propagator.extract(Context.root(), inboundCarrier, MAP_GETTER));
+
+        assertThat(extracted.getEntryValue("orderId")).isEqualTo("99");
+        assertThat(extracted.getEntryValue("secret")).isNull();
+    }
+
+    @Test
+    void testBaggageAllowlistSanitizesValues()
+    {
+        Injector injector = new Bootstrap(
+                new TestingNodeModule(),
+                new OpenTelemetryModule("testService", "testVersion"),
+                binder -> newSetBinder(binder, SpanProcessor.class).addBinding()
+                        .toInstance(SpanProcessor.composite()))
+                .setRequiredConfigurationProperties(ImmutableMap.of(
+                        "otel.tracing.baggage.allowed-keys", "orderId,note",
+                        "otel.tracing.baggage.max-value-length", "5"))
+                .quiet()
+                .initialize();
+
+        TextMapPropagator propagator = injector.getInstance(OpenTelemetry.class).getPropagators().getTextMapPropagator();
+
+        Context context = Baggage.builder()
+                .put("orderId", "1234567890")
+                .put("note", "line1\nline2")
+                .build()
+                .storeInContext(Context.root());
+
+        Map<String, String> carrier = new HashMap<>();
+        propagator.inject(context, carrier, Map::put);
+        Baggage extracted = Baggage.fromContext(propagator.extract(Context.root(), carrier, MAP_GETTER));
+
+        // value truncated to the configured maximum length
+        assertThat(extracted.getEntryValue("orderId")).isEqualTo("12345");
+        // a value containing control characters is dropped entirely, not merely truncated, since it
+        // could otherwise be used to forge extra log lines or header entries
+        assertThat(extracted.getEntryValue("note")).isNull();
     }
 }


### PR DESCRIPTION
Adds support for https://www.w3.org/TR/baggage/ `baggage` header and its propagation through OTEL (https://opentelemetry.io/docs/concepts/signals/baggage/).

It gets attached to spans under `baggage.` prefix and to the logs, where in JSON logs its under `baggage` key.

# Airlift contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [x] All automated tests are passing.
 - [x] Pull request was categorized using one of the existing labels.
