### PR TITLE
Add OpenMetrics exponential histogram support

### DIFF
--- a/openmetrics/README.md
+++ b/openmetrics/README.md
@@ -14,6 +14,17 @@ Prometheus can be configured to hit the openmetrics endpoint using:
 
     scrape_configs:
     - job_name: sample_server
+      scrape_native_histograms: true
       static_configs:
       - targets:
         - localhost:8080
+
+The `/metrics` endpoint supports OpenMetrics 1.0 text and the Prometheus protobuf exposition
+format. The response is selected from the request's `Accept` header. For protobuf, use:
+
+    Accept: application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited
+
+When the OpenTelemetry stats backend is active, protobuf responses expose `TimeDistribution`,
+`TimeStat`, `Distribution`, and `DistributionStat` values as Prometheus native exponential
+histograms. OpenMetrics text responses continue to expose summaries for compatibility. Time
+histograms use nanosecond values and include the `ns` unit in the protobuf metric family.

--- a/openmetrics/src/main/java/io/airlift/openmetrics/MetricsResource.java
+++ b/openmetrics/src/main/java/io/airlift/openmetrics/MetricsResource.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Map;
 
 import static io.airlift.openmetrics.MetricsUtils.groupMetricFamilies;
-import static io.airlift.openmetrics.MetricsUtils.writeMetricFamilies;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 
@@ -37,6 +36,8 @@ import static java.util.Objects.requireNonNull;
 public class MetricsResource
 {
     private static final String OPENMETRICS_CONTENT_TYPE = "application/openmetrics-text; version=1.0.0; charset=utf-8";
+    // OpenMetrics text is the default; protobuf is selected only after explicit negotiation.
+    private static final String PROMETHEUS_PROTOBUF_CONTENT_TYPE = "application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited; qs=0.9";
 
     private final OpenMetricsCollector collector;
 
@@ -55,10 +56,18 @@ public class MetricsResource
         // metrics write directly to the response stream, so the exposition is never held in memory
         return output -> {
             Writer writer = new BufferedWriter(new OutputStreamWriter(output, UTF_8));
-            writeMetricFamilies(writer, metricFamilies);
+            MetricsUtils.writeMetricFamilies(writer, metricFamilies);
             writer.write("# EOF\n");
             writer.flush();
         };
+    }
+
+    @GET
+    @Produces(PROMETHEUS_PROTOBUF_CONTENT_TYPE)
+    public StreamingOutput getPrometheusProtobufMetrics(@QueryParam("name[]") List<String> filter)
+    {
+        Map<String, List<Metric>> metricFamilies = groupMetricFamilies(collector.collectPrometheusProtobuf(filter));
+        return output -> PrometheusProtobufWriter.writeMetricFamilies(output, metricFamilies);
     }
 
     @VisibleForTesting

--- a/openmetrics/src/main/java/io/airlift/openmetrics/OpenMetricsCollector.java
+++ b/openmetrics/src/main/java/io/airlift/openmetrics/OpenMetricsCollector.java
@@ -24,12 +24,14 @@ import io.airlift.metrics.MetricSource;
 import io.airlift.metrics.MetricsCollector;
 import io.airlift.openmetrics.types.CompositeMetric;
 import io.airlift.openmetrics.types.Counter;
+import io.airlift.openmetrics.types.ExponentialHistogramMetric;
 import io.airlift.openmetrics.types.Gauge;
 import io.airlift.openmetrics.types.Metric;
 import io.airlift.openmetrics.types.Summary;
 import io.airlift.stats.CounterStat;
 import io.airlift.stats.Distribution;
 import io.airlift.stats.DistributionStat;
+import io.airlift.stats.ExponentialHistogram.ExponentialHistogramSnapshot;
 import io.airlift.stats.TimeDistribution;
 import io.airlift.stats.TimeStat;
 
@@ -41,8 +43,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.openmetrics.types.ExponentialHistogramMetric.MIN_PROMETHEUS_SCALE;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -76,10 +80,20 @@ public class OpenMetricsCollector
 
     public List<Metric> collect(List<String> filters)
     {
+        return collect(filters, false);
+    }
+
+    public List<Metric> collectPrometheusProtobuf(List<String> filters)
+    {
+        return collect(filters, true);
+    }
+
+    private List<Metric> collect(List<String> filters, boolean exponentialHistograms)
+    {
         if (filters == null || filters.isEmpty()) {
-            return collect();
+            return toOpenMetrics(collector.collect(), exponentialHistograms);
         }
-        return filterMetrics(toOpenMetrics(collector.collect()), ImmutableSet.copyOf(filters));
+        return filterMetrics(toOpenMetrics(collector.collect(), exponentialHistograms), ImmutableSet.copyOf(filters));
     }
 
     public Optional<Metric> findMetric(String metricName)
@@ -113,10 +127,15 @@ public class OpenMetricsCollector
     @VisibleForTesting
     static List<Metric> toOpenMetrics(List<CollectedMetricGroup> collectedMetricGroups)
     {
+        return toOpenMetrics(collectedMetricGroups, false);
+    }
+
+    private static List<Metric> toOpenMetrics(List<CollectedMetricGroup> collectedMetricGroups, boolean exponentialHistograms)
+    {
         ImmutableList.Builder<Metric> metrics = ImmutableList.builder();
         collectedMetricGroups.stream()
                 .flatMap(group -> group.attributes().stream()
-                        .map(attribute -> toOpenMetric(openMetricsMetricName(group, attribute), attribute, group.labels())))
+                        .map(attribute -> toOpenMetric(openMetricsMetricName(group, attribute), attribute, group.labels(), exponentialHistograms)))
                 .flatMap(Optional::stream)
                 .forEach(metrics::add);
         return metrics.build();
@@ -149,10 +168,16 @@ public class OpenMetricsCollector
     @VisibleForTesting
     static Optional<Metric> toOpenMetric(Attribute attribute, Map<String, String> labels)
     {
-        return toOpenMetric(openMetricsMetricName(attribute.path()), attribute, labels);
+        return toOpenMetric(openMetricsMetricName(attribute.path()), attribute, labels, false);
     }
 
-    private static Optional<Metric> toOpenMetric(String metricName, Attribute attribute, Map<String, String> labels)
+    @VisibleForTesting
+    static Optional<Metric> toPrometheusProtobufMetric(Attribute attribute, Map<String, String> labels)
+    {
+        return toOpenMetric(openMetricsMetricName(attribute.path()), attribute, labels, true);
+    }
+
+    private static Optional<Metric> toOpenMetric(String metricName, Attribute attribute, Map<String, String> labels, boolean exponentialHistograms)
     {
         Object value = attribute.value();
         return switch (value) {
@@ -161,12 +186,61 @@ public class OpenMetricsCollector
             case CompositeData compositeData -> Optional.of(CompositeMetric.from(metricName, compositeData, labels, attribute.description()));
             case TabularData tabularData -> Optional.of(CompositeMetric.from(metricName, tabularData, labels, attribute.description()));
             case CounterStat counterStat -> Optional.of(Counter.from(metricName, counterStat, labels, attribute.description()));
+            case TimeDistribution timeDistribution when exponentialHistograms -> toPrometheusExponentialHistogram(
+                    metricName,
+                    timeDistribution.exponentialHistogramSnapshot(),
+                    labels,
+                    attribute.description(),
+                    "ns",
+                    () -> Summary.from(metricName, timeDistribution, labels, attribute.description()));
             case TimeDistribution timeDistribution -> Optional.of(Summary.from(metricName, timeDistribution, labels, attribute.description()));
+            case TimeStat timeStat when exponentialHistograms -> toPrometheusExponentialHistogram(
+                    metricName,
+                    timeStat.exponentialHistogramSnapshot(),
+                    labels,
+                    attribute.description(),
+                    "ns",
+                    () -> timeStatToOpenMetrics(metricName, timeStat, attribute, labels));
             case TimeStat timeStat -> Optional.of(timeStatToOpenMetrics(metricName, timeStat, attribute, labels));
+            case Distribution distribution when exponentialHistograms -> toPrometheusExponentialHistogram(
+                    metricName,
+                    distribution.exponentialHistogramSnapshot(),
+                    labels,
+                    attribute.description(),
+                    null,
+                    () -> Summary.from(metricName, distribution, labels, attribute.description()));
             case Distribution distribution -> Optional.of(Summary.from(metricName, distribution, labels, attribute.description()));
+            case DistributionStat distributionStat when exponentialHistograms -> toPrometheusExponentialHistogram(
+                    metricName,
+                    distributionStat.exponentialHistogramSnapshot(),
+                    labels,
+                    attribute.description(),
+                    null,
+                    () -> distributionStatToOpenMetrics(metricName, distributionStat, attribute, labels));
             case DistributionStat distributionStat -> Optional.of(distributionStatToOpenMetrics(metricName, distributionStat, attribute, labels));
             case null, default -> Optional.empty();
         };
+    }
+
+    private static Optional<Metric> toPrometheusExponentialHistogram(
+            String metricName,
+            Optional<ExponentialHistogramSnapshot> snapshot,
+            Map<String, String> labels,
+            String help,
+            String unit,
+            Supplier<Metric> fallback)
+    {
+        if (snapshot.isEmpty()) {
+            return Optional.of(fallback.get());
+        }
+
+        ExponentialHistogramSnapshot exponentialHistogram = snapshot.orElseThrow();
+        // Downscaling can reduce an overly high scale, but raising a scale would require inventing
+        // how each existing bucket's count is distributed between finer buckets.
+        if (exponentialHistogram.scale() < MIN_PROMETHEUS_SCALE) {
+            return Optional.empty();
+        }
+        return Optional.of(new ExponentialHistogramMetric(metricName, exponentialHistogram, labels, help, unit));
     }
 
     private static CompositeMetric timeStatToOpenMetrics(String metricName, TimeStat timeStat, Attribute attribute, Map<String, String> labels)

--- a/openmetrics/src/main/java/io/airlift/openmetrics/PrometheusProtobufWriter.java
+++ b/openmetrics/src/main/java/io/airlift/openmetrics/PrometheusProtobufWriter.java
@@ -1,0 +1,280 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.openmetrics;
+
+import io.airlift.openmetrics.types.BigCounter;
+import io.airlift.openmetrics.types.CompositeMetric;
+import io.airlift.openmetrics.types.Counter;
+import io.airlift.openmetrics.types.ExponentialHistogramMetric;
+import io.airlift.openmetrics.types.Gauge;
+import io.airlift.openmetrics.types.Info;
+import io.airlift.openmetrics.types.Metric;
+import io.airlift.openmetrics.types.Summary;
+import io.airlift.stats.ExponentialHistogram.Buckets;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.List;
+import java.util.Map;
+
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Comparator.comparing;
+
+final class PrometheusProtobufWriter
+{
+    private static final int METRIC_TYPE_COUNTER = 0;
+    private static final int METRIC_TYPE_GAUGE = 1;
+    private static final int METRIC_TYPE_SUMMARY = 2;
+    private static final int METRIC_TYPE_HISTOGRAM = 4;
+
+    private PrometheusProtobufWriter() {}
+
+    public static void writeMetricFamilies(OutputStream output, Map<String, List<Metric>> metricFamilies)
+            throws IOException
+    {
+        for (List<Metric> metricFamily : metricFamilies.values()) {
+            ProtoOutput family = writeMetricFamily(metricFamily);
+            writeVarint(output, family.size());
+            family.writeTo(output);
+        }
+    }
+
+    private static ProtoOutput writeMetricFamily(List<Metric> metrics)
+    {
+        Metric first = metrics.getFirst();
+        ProtoOutput family = new ProtoOutput();
+        family.writeString(1, first.metricName());
+        if (first.help() != null && !first.help().isEmpty()) {
+            family.writeString(2, first.help());
+        }
+        family.writeUInt(3, metricType(first));
+        for (Metric metric : metrics) {
+            family.writeMessage(4, writeMetric(metric));
+        }
+        if (first instanceof ExponentialHistogramMetric histogram && histogram.unit() != null) {
+            family.writeString(5, histogram.unit());
+        }
+        return family;
+    }
+
+    private static ProtoOutput writeMetric(Metric metric)
+    {
+        ProtoOutput output = new ProtoOutput();
+        metric.labels().entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .forEach(entry -> output.writeMessage(1, writeLabel(entry)));
+
+        switch (metric) {
+            case BigCounter counter -> output.writeMessage(3, writeDoubleValue(counter.value().doubleValue()));
+            case Counter counter -> output.writeMessage(3, writeDoubleValue(counter.value()));
+            case ExponentialHistogramMetric histogram -> output.writeMessage(7, writeHistogram(histogram));
+            case Gauge gauge -> output.writeMessage(2, writeDoubleValue(gauge.value()));
+            case Info _ -> output.writeMessage(2, writeDoubleValue(1));
+            case Summary summary -> output.writeMessage(4, writeSummary(summary));
+            case CompositeMetric _ -> throw compositeMetricNotFlattened();
+        }
+        return output;
+    }
+
+    private static ProtoOutput writeLabel(Map.Entry<String, String> entry)
+    {
+        ProtoOutput label = new ProtoOutput();
+        label.writeString(1, entry.getKey());
+        label.writeString(2, entry.getValue());
+        return label;
+    }
+
+    private static ProtoOutput writeDoubleValue(double value)
+    {
+        ProtoOutput output = new ProtoOutput();
+        output.writeDouble(1, value);
+        return output;
+    }
+
+    private static ProtoOutput writeSummary(Summary summary)
+    {
+        ProtoOutput output = new ProtoOutput();
+        if (summary.count() != null) {
+            output.writeUInt(1, summary.count());
+        }
+        if (summary.sum() != null) {
+            output.writeDouble(2, summary.sum());
+        }
+        if (summary.quantiles() != null) {
+            summary.quantiles().entrySet().stream()
+                    .sorted(comparing(Map.Entry::getKey))
+                    .forEach(entry -> {
+                        ProtoOutput quantile = new ProtoOutput();
+                        quantile.writeDouble(1, entry.getKey());
+                        quantile.writeDouble(2, entry.getValue());
+                        output.writeMessage(3, quantile);
+                    });
+        }
+        if (summary.created() != null) {
+            output.writeMessage(4, writeTimestamp(summary.created()));
+        }
+        return output;
+    }
+
+    private static ProtoOutput writeTimestamp(double epochSeconds)
+    {
+        long seconds = (long) Math.floor(epochSeconds);
+        int nanos = (int) Math.round((epochSeconds - seconds) * 1_000_000_000);
+        if (nanos == 1_000_000_000) {
+            seconds++;
+            nanos = 0;
+        }
+
+        ProtoOutput timestamp = new ProtoOutput();
+        timestamp.writeInt(1, seconds);
+        if (nanos != 0) {
+            timestamp.writeInt(2, nanos);
+        }
+        return timestamp;
+    }
+
+    private static ProtoOutput writeHistogram(ExponentialHistogramMetric metric)
+    {
+        ProtoOutput histogram = new ProtoOutput();
+        histogram.writeUInt(1, metric.snapshot().count());
+        histogram.writeDouble(2, metric.snapshot().sum());
+        histogram.writeSInt(5, metric.snapshot().scale());
+        histogram.writeDouble(6, 0);
+        histogram.writeUInt(7, metric.snapshot().zeroCount());
+        writeBuckets(histogram, 9, 10, metric.snapshot().negativeBuckets());
+        writeBuckets(histogram, 12, 13, metric.snapshot().positiveBuckets());
+
+        // An empty histogram needs a no-op span to distinguish it from a classic histogram.
+        if (metric.snapshot().zeroCount() == 0 &&
+                metric.snapshot().negativeBuckets().isEmpty() &&
+                metric.snapshot().positiveBuckets().isEmpty()) {
+            histogram.writeMessage(12, new ProtoOutput());
+        }
+        return histogram;
+    }
+
+    private static void writeBuckets(ProtoOutput histogram, int spanField, int deltaField, Buckets buckets)
+    {
+        long[] counts = buckets.counts();
+        if (counts.length == 0) {
+            return;
+        }
+
+        ProtoOutput span = new ProtoOutput();
+        // OpenTelemetry index 0 is (1, base], while Prometheus index 0 is (base^-1, 1].
+        span.writeSInt(1, (long) buckets.offset() + 1);
+        span.writeUInt(2, counts.length);
+        histogram.writeMessage(spanField, span);
+
+        long previous = 0;
+        for (long count : counts) {
+            histogram.writeSInt(deltaField, count - previous);
+            previous = count;
+        }
+    }
+
+    private static int metricType(Metric metric)
+    {
+        return switch (metric) {
+            case BigCounter _, Counter _ -> METRIC_TYPE_COUNTER;
+            case Gauge _, Info _ -> METRIC_TYPE_GAUGE;
+            case Summary _ -> METRIC_TYPE_SUMMARY;
+            case ExponentialHistogramMetric _ -> METRIC_TYPE_HISTOGRAM;
+            case CompositeMetric _ -> throw compositeMetricNotFlattened();
+        };
+    }
+
+    private static IllegalArgumentException compositeMetricNotFlattened()
+    {
+        return new IllegalArgumentException("CompositeMetric must be flattened before Prometheus protobuf encoding");
+    }
+
+    private static void writeVarint(OutputStream output, long value)
+            throws IOException
+    {
+        while ((value & ~0x7FL) != 0) {
+            output.write(((int) value & 0x7F) | 0x80);
+            value >>>= 7;
+        }
+        output.write((int) value);
+    }
+
+    private static final class ProtoOutput
+            extends ByteArrayOutputStream
+    {
+        private static final VarHandle DOUBLE_HANDLE = MethodHandles.byteArrayViewVarHandle(double[].class, LITTLE_ENDIAN);
+
+        private final byte[] doubleBuffer = new byte[Double.BYTES];
+
+        public void writeString(int field, String value)
+        {
+            writeBytes(field, value.getBytes(UTF_8));
+        }
+
+        public void writeMessage(int field, ProtoOutput value)
+        {
+            writeBytes(field, value.toByteArray());
+        }
+
+        public void writeDouble(int field, double value)
+        {
+            writeTag(field, 1);
+            DOUBLE_HANDLE.set(doubleBuffer, 0, value);
+            writeBytes(doubleBuffer);
+        }
+
+        public void writeInt(int field, long value)
+        {
+            writeTag(field, 0);
+            writeVarint(value);
+        }
+
+        public void writeUInt(int field, long value)
+        {
+            writeTag(field, 0);
+            writeVarint(value);
+        }
+
+        public void writeSInt(int field, long value)
+        {
+            writeTag(field, 0);
+            writeVarint((value << 1) ^ (value >> 63));
+        }
+
+        private void writeBytes(int field, byte[] value)
+        {
+            writeTag(field, 2);
+            writeVarint(value.length);
+            writeBytes(value);
+        }
+
+        private void writeTag(int field, int wireType)
+        {
+            writeVarint(((long) field << 3) | wireType);
+        }
+
+        private void writeVarint(long value)
+        {
+            while ((value & ~0x7FL) != 0) {
+                write(((int) value & 0x7F) | 0x80);
+                value >>>= 7;
+            }
+            write((int) value);
+        }
+    }
+}

--- a/openmetrics/src/main/java/io/airlift/openmetrics/types/ExponentialHistogramMetric.java
+++ b/openmetrics/src/main/java/io/airlift/openmetrics/types/ExponentialHistogramMetric.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.openmetrics.types;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.stats.ExponentialHistogram.ExponentialHistogramSnapshot;
+
+import java.io.Writer;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public record ExponentialHistogramMetric(String metricName, ExponentialHistogramSnapshot snapshot, Map<String, String> labels, String help, String unit)
+        implements Metric
+{
+    public static final int MIN_PROMETHEUS_SCALE = -4;
+    public static final int MAX_PROMETHEUS_SCALE = 8;
+
+    public ExponentialHistogramMetric
+    {
+        requireNonNull(metricName, "metricName is null");
+        requireNonNull(snapshot, "snapshot is null");
+        checkArgument(snapshot.scale() >= MIN_PROMETHEUS_SCALE, "snapshot scale is below the minimum Prometheus scale");
+        snapshot = snapshot.downscaleToAtMost(MAX_PROMETHEUS_SCALE);
+        labels = ImmutableMap.copyOf(labels);
+    }
+
+    @Override
+    public void writeMetricExposition(Writer writer)
+    {
+        throw new UnsupportedOperationException("Exponential histograms require Prometheus protobuf exposition");
+    }
+
+    @Override
+    public void writeMetricDescriptor(Writer writer)
+    {
+        throw new UnsupportedOperationException("Exponential histograms require Prometheus protobuf exposition");
+    }
+}

--- a/openmetrics/src/main/java/io/airlift/openmetrics/types/Metric.java
+++ b/openmetrics/src/main/java/io/airlift/openmetrics/types/Metric.java
@@ -15,6 +15,7 @@ package io.airlift.openmetrics.types;
 
 import java.io.IOException;
 import java.io.Writer;
+import java.util.Map;
 
 public sealed interface Metric
         permits BigCounter,
@@ -25,6 +26,10 @@ public sealed interface Metric
                 Summary
 {
     String metricName();
+
+    Map<String, String> labels();
+
+    String help();
 
     /**
      * Writes this metric's sample lines in the OpenMetrics text exposition format,

--- a/openmetrics/src/main/java/io/airlift/openmetrics/types/Metric.java
+++ b/openmetrics/src/main/java/io/airlift/openmetrics/types/Metric.java
@@ -21,6 +21,7 @@ public sealed interface Metric
         permits BigCounter,
                 CompositeMetric,
                 Counter,
+                ExponentialHistogramMetric,
                 Gauge,
                 Info,
                 Summary

--- a/openmetrics/src/test/java/io/airlift/openmetrics/TestMetricsResource.java
+++ b/openmetrics/src/test/java/io/airlift/openmetrics/TestMetricsResource.java
@@ -5,6 +5,8 @@ import com.google.common.collect.ImmutableMap;
 import io.airlift.openmetrics.types.CompositeMetric;
 import io.airlift.openmetrics.types.Counter;
 import io.airlift.openmetrics.types.Gauge;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 import org.junit.jupiter.api.Test;
 
 import javax.management.openmbean.CompositeData;
@@ -14,6 +16,7 @@ import javax.management.openmbean.OpenType;
 import javax.management.openmbean.SimpleType;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static io.airlift.openmetrics.MetricsResource.sanitizeMetricName;
@@ -29,6 +32,18 @@ public class TestMetricsResource
         String original = "com.zaxxer.hikari:type=Pool (HikariPool-1),ThreadsAwaitingConnection";
         String expected = "com_zaxxer_hikari_type_Pool_HikariPool_1_ThreadsAwaitingConnection";
         assertThat(sanitizeMetricName(original)).isEqualTo(expected);
+    }
+
+    @Test
+    public void testOpenMetricsTextPreferredWhenFormatsAreEquallyAcceptable()
+            throws NoSuchMethodException
+    {
+        MediaType openMetrics = producedMediaType("getMetrics");
+        MediaType prometheusProtobuf = producedMediaType("getPrometheusProtobufMetrics");
+
+        assertThat(openMetrics.isCompatible(MediaType.valueOf("application/openmetrics-text"))).isTrue();
+        assertThat(prometheusProtobuf.isCompatible(MediaType.valueOf("application/vnd.google.protobuf"))).isTrue();
+        assertThat(serverQuality(openMetrics)).isGreaterThan(serverQuality(prometheusProtobuf));
     }
 
     @Test
@@ -113,6 +128,20 @@ public class TestMetricsResource
         assertThatThrownBy(() -> renderMetricsExpositions(ImmutableList.of(counter, gauge)))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Metric family test_metric.abc contains mixed metric types: [class io.airlift.openmetrics.types.Counter, class io.airlift.openmetrics.types.Gauge]");
+    }
+
+    private static MediaType producedMediaType(String methodName)
+            throws NoSuchMethodException
+    {
+        Produces produces = MetricsResource.class.getMethod(methodName, List.class).getAnnotation(Produces.class);
+        assertThat(produces).isNotNull();
+        assertThat(produces.value()).hasSize(1);
+        return MediaType.valueOf(produces.value()[0]);
+    }
+
+    private static double serverQuality(MediaType mediaType)
+    {
+        return Double.parseDouble(mediaType.getParameters().getOrDefault("qs", "1"));
     }
 
     @Test

--- a/openmetrics/src/test/java/io/airlift/openmetrics/TestOpenMetricsCollector.java
+++ b/openmetrics/src/test/java/io/airlift/openmetrics/TestOpenMetricsCollector.java
@@ -7,12 +7,15 @@ import io.airlift.metrics.MetricSource.JmxMetricSource;
 import io.airlift.metrics.MetricSource.ManagedMetricSource;
 import io.airlift.openmetrics.types.CompositeMetric;
 import io.airlift.openmetrics.types.Counter;
+import io.airlift.openmetrics.types.ExponentialHistogramMetric;
 import io.airlift.openmetrics.types.Gauge;
 import io.airlift.openmetrics.types.Metric;
 import io.airlift.openmetrics.types.Summary;
 import io.airlift.stats.CounterStat;
 import io.airlift.stats.Distribution;
 import io.airlift.stats.DistributionStat;
+import io.airlift.stats.ExponentialHistogram.Buckets;
+import io.airlift.stats.ExponentialHistogram.ExponentialHistogramSnapshot;
 import io.airlift.stats.TimeDistribution;
 import io.airlift.stats.TimeStat;
 import io.airlift.testing.TestingTicker;
@@ -201,6 +204,124 @@ public class TestOpenMetricsCollector
             assertThat(summary.quantiles()).containsKeys(0.01, 0.5, 0.99);
             assertThat(summary.labels()).isEqualTo(LABELS);
             assertThat(summary.help()).isEqualTo("metric help");
+        });
+    }
+
+    @Test
+    public void testConvertDistributionToProtobufExponentialHistogram()
+    {
+        ExponentialHistogramSnapshot snapshot = new ExponentialHistogramSnapshot(
+                12,
+                2,
+                300,
+                100,
+                200,
+                0,
+                new Buckets(0, new long[] {1, 1}),
+                new Buckets(0, new long[0]));
+        Distribution distribution = new Distribution()
+        {
+            @Override
+            public Optional<ExponentialHistogramSnapshot> exponentialHistogramSnapshot()
+            {
+                return Optional.of(snapshot);
+            }
+        };
+
+        Optional<Metric> metric = OpenMetricsCollector.toPrometheusProtobufMetric(
+                new Attribute(List.of("metric_name"), distribution, "metric help"),
+                LABELS);
+
+        assertThat(metric).isPresent();
+        assertThat(metric.orElseThrow()).isInstanceOfSatisfying(ExponentialHistogramMetric.class, histogram -> {
+            assertThat(histogram.metricName()).isEqualTo("metric_name");
+            assertThat(histogram.snapshot().scale()).isEqualTo(8);
+            assertThat(histogram.snapshot().count()).isEqualTo(2);
+            assertThat(histogram.labels()).isEqualTo(LABELS);
+            assertThat(histogram.help()).isEqualTo("metric help");
+            assertThat(histogram.unit()).isNull();
+        });
+    }
+
+    @Test
+    public void testConvertDistributionWithoutExponentialHistogramToProtobufSummary()
+    {
+        Distribution distribution = new Distribution()
+        {
+            @Override
+            public Optional<ExponentialHistogramSnapshot> exponentialHistogramSnapshot()
+            {
+                return Optional.empty();
+            }
+        };
+        distribution.add(100);
+        distribution.add(200);
+
+        Optional<Metric> metric = OpenMetricsCollector.toPrometheusProtobufMetric(
+                new Attribute(List.of("metric_name"), distribution, "metric help"),
+                LABELS);
+
+        assertThat(metric.orElseThrow()).isInstanceOf(Summary.class);
+    }
+
+    @Test
+    public void testDropProtobufExponentialHistogramBelowPrometheusMinimumScale()
+    {
+        ExponentialHistogramSnapshot snapshot = new ExponentialHistogramSnapshot(
+                -5,
+                2,
+                300,
+                100,
+                200,
+                0,
+                new Buckets(0, new long[] {1, 1}),
+                new Buckets(0, new long[0]));
+        Distribution distribution = new Distribution()
+        {
+            @Override
+            public Optional<ExponentialHistogramSnapshot> exponentialHistogramSnapshot()
+            {
+                return Optional.of(snapshot);
+            }
+        };
+
+        Optional<Metric> metric = OpenMetricsCollector.toPrometheusProtobufMetric(
+                new Attribute(List.of("metric_name"), distribution, "metric help"),
+                LABELS);
+
+        assertThat(metric).isEmpty();
+    }
+
+    @Test
+    public void testConvertTimeStatToProtobufExponentialHistogram()
+    {
+        ExponentialHistogramSnapshot snapshot = new ExponentialHistogramSnapshot(
+                8,
+                1,
+                100,
+                100,
+                100,
+                0,
+                new Buckets(0, new long[] {1}),
+                new Buckets(0, new long[0]));
+        TimeStat timeStat = new TimeStat()
+        {
+            @Override
+            public Optional<ExponentialHistogramSnapshot> exponentialHistogramSnapshot()
+            {
+                return Optional.of(snapshot);
+            }
+        };
+
+        Optional<Metric> metric = OpenMetricsCollector.toPrometheusProtobufMetric(
+                new Attribute(List.of("metric_name"), timeStat, "metric help"),
+                LABELS);
+
+        assertThat(metric).isPresent();
+        assertThat(metric.orElseThrow()).isInstanceOfSatisfying(ExponentialHistogramMetric.class, histogram -> {
+            assertThat(histogram.metricName()).isEqualTo("metric_name");
+            assertThat(histogram.snapshot()).isEqualTo(snapshot);
+            assertThat(histogram.unit()).isEqualTo("ns");
         });
     }
 

--- a/openmetrics/src/test/java/io/airlift/openmetrics/TestPrometheusProtobufWriter.java
+++ b/openmetrics/src/test/java/io/airlift/openmetrics/TestPrometheusProtobufWriter.java
@@ -1,0 +1,333 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.openmetrics;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.openmetrics.types.CompositeMetric;
+import io.airlift.openmetrics.types.Counter;
+import io.airlift.openmetrics.types.ExponentialHistogramMetric;
+import io.airlift.openmetrics.types.Gauge;
+import io.airlift.openmetrics.types.Metric;
+import io.airlift.openmetrics.types.Summary;
+import io.airlift.stats.ExponentialHistogram.Buckets;
+import io.airlift.stats.ExponentialHistogram.ExponentialHistogramSnapshot;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static io.airlift.openmetrics.MetricsUtils.groupMetricFamilies;
+import static io.airlift.openmetrics.PrometheusProtobufWriter.writeMetricFamilies;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestPrometheusProtobufWriter
+{
+    @Test
+    public void testCompositeMetric()
+            throws Exception
+    {
+        Metric compositeMetric = new CompositeMetric(
+                "memory",
+                ImmutableMap.of(),
+                "Memory",
+                List.of(
+                        new Gauge("memory_used", 7, ImmutableMap.of(), "Memory used"),
+                        new Gauge("memory_max", 9, ImmutableMap.of(), "Memory max")));
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        writeMetricFamilies(output, groupMetricFamilies(List.of(compositeMetric)));
+
+        ProtoReader stream = new ProtoReader(output.toByteArray());
+        ProtoReader usedFamily = stream.readDelimitedMessage();
+        assertThat(usedFamily.readString(1)).isEqualTo("memory_used");
+        assertThat(usedFamily.readString(2)).isEqualTo("Memory used");
+        assertThat(usedFamily.readUInt(3)).isEqualTo(1);
+        assertThat(usedFamily.readMessage(4).readMessage(2).readDouble(1)).isEqualTo(7);
+
+        ProtoReader maxFamily = stream.readDelimitedMessage();
+        assertThat(maxFamily.readString(1)).isEqualTo("memory_max");
+        assertThat(maxFamily.readString(2)).isEqualTo("Memory max");
+        assertThat(maxFamily.readUInt(3)).isEqualTo(1);
+        assertThat(maxFamily.readMessage(4).readMessage(2).readDouble(1)).isEqualTo(9);
+        assertThat(stream.isAtEnd()).isTrue();
+    }
+
+    @Test
+    public void testCompositeMetricMustBeFlattened()
+    {
+        Metric compositeMetric = new CompositeMetric(
+                "memory",
+                ImmutableMap.of(),
+                "Memory",
+                List.of(new Gauge("memory_used", 7, ImmutableMap.of(), "Memory used")));
+
+        assertThatThrownBy(() -> writeMetricFamilies(
+                new ByteArrayOutputStream(),
+                Map.of(compositeMetric.metricName(), List.of(compositeMetric))))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("CompositeMetric must be flattened before Prometheus protobuf encoding");
+    }
+
+    @Test
+    public void testStandardMetricTypes()
+            throws Exception
+    {
+        Metric counter = new Counter("requests", 17, ImmutableMap.of(), "Requests");
+        Metric gauge = new Gauge("threads", 4.5, ImmutableMap.of(), "Threads");
+        Metric summary = new Summary("latency", 3L, 9.0, null, ImmutableMap.of(0.5, 2.5), ImmutableMap.of(), "Latency");
+        Map<String, List<Metric>> metricFamilies = new LinkedHashMap<>();
+        metricFamilies.put(counter.metricName(), List.of(counter));
+        metricFamilies.put(gauge.metricName(), List.of(gauge));
+        metricFamilies.put(summary.metricName(), List.of(summary));
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        writeMetricFamilies(output, metricFamilies);
+        ProtoReader stream = new ProtoReader(output.toByteArray());
+
+        ProtoReader counterFamily = stream.readDelimitedMessage();
+        assertThat(counterFamily.readString(1)).isEqualTo("requests");
+        assertThat(counterFamily.readString(2)).isEqualTo("Requests");
+        assertThat(counterFamily.readUInt(3)).isZero();
+        ProtoReader counterSample = counterFamily.readMessage(4);
+        assertThat(counterSample.readMessage(3).readDouble(1)).isEqualTo(17);
+
+        ProtoReader gaugeFamily = stream.readDelimitedMessage();
+        assertThat(gaugeFamily.readString(1)).isEqualTo("threads");
+        assertThat(gaugeFamily.readString(2)).isEqualTo("Threads");
+        assertThat(gaugeFamily.readUInt(3)).isEqualTo(1);
+        ProtoReader gaugeSample = gaugeFamily.readMessage(4);
+        assertThat(gaugeSample.readMessage(2).readDouble(1)).isEqualTo(4.5);
+
+        ProtoReader summaryFamily = stream.readDelimitedMessage();
+        assertThat(summaryFamily.readString(1)).isEqualTo("latency");
+        assertThat(summaryFamily.readString(2)).isEqualTo("Latency");
+        assertThat(summaryFamily.readUInt(3)).isEqualTo(2);
+        ProtoReader summarySample = summaryFamily.readMessage(4);
+        ProtoReader summaryValue = summarySample.readMessage(4);
+        assertThat(summaryValue.readUInt(1)).isEqualTo(3);
+        assertThat(summaryValue.readDouble(2)).isEqualTo(9);
+        ProtoReader quantile = summaryValue.readMessage(3);
+        assertThat(quantile.readDouble(1)).isEqualTo(0.5);
+        assertThat(quantile.readDouble(2)).isEqualTo(2.5);
+        assertThat(stream.isAtEnd()).isTrue();
+    }
+
+    @Test
+    public void testExponentialHistogram()
+            throws Exception
+    {
+        ExponentialHistogramSnapshot snapshot = new ExponentialHistogramSnapshot(
+                8,
+                7,
+                11,
+                -4,
+                6,
+                1,
+                new Buckets(3, new long[] {2, 0, 1}),
+                new Buckets(-2, new long[] {1, 2}));
+        Metric metric = new ExponentialHistogramMetric(
+                "request_time",
+                snapshot,
+                ImmutableMap.of("node", "test"),
+                "Request time",
+                "ns");
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        writeMetricFamilies(output, Map.of(metric.metricName(), List.of(metric)));
+
+        ProtoReader stream = new ProtoReader(output.toByteArray());
+        ProtoReader family = stream.readDelimitedMessage();
+        assertThat(stream.isAtEnd()).isTrue();
+        assertThat(family.readString(1)).isEqualTo("request_time");
+        assertThat(family.readString(2)).isEqualTo("Request time");
+        assertThat(family.readUInt(3)).isEqualTo(4);
+
+        ProtoReader sample = family.readMessage(4);
+        ProtoReader label = sample.readMessage(1);
+        assertThat(label.readString(1)).isEqualTo("node");
+        assertThat(label.readString(2)).isEqualTo("test");
+        assertThat(label.isAtEnd()).isTrue();
+
+        ProtoReader histogram = sample.readMessage(7);
+        assertThat(sample.isAtEnd()).isTrue();
+        assertThat(histogram.readUInt(1)).isEqualTo(7);
+        assertThat(histogram.readDouble(2)).isEqualTo(11);
+        assertThat(histogram.readSInt(5)).isEqualTo(8);
+        assertThat(histogram.readDouble(6)).isZero();
+        assertThat(histogram.readUInt(7)).isEqualTo(1);
+
+        ProtoReader negativeSpan = histogram.readMessage(9);
+        assertThat(negativeSpan.readSInt(1)).isEqualTo(-1);
+        assertThat(negativeSpan.readUInt(2)).isEqualTo(2);
+        assertThat(negativeSpan.isAtEnd()).isTrue();
+        assertThat(histogram.readSInt(10)).isEqualTo(1);
+        assertThat(histogram.readSInt(10)).isEqualTo(1);
+
+        ProtoReader positiveSpan = histogram.readMessage(12);
+        assertThat(positiveSpan.readSInt(1)).isEqualTo(4);
+        assertThat(positiveSpan.readUInt(2)).isEqualTo(3);
+        assertThat(positiveSpan.isAtEnd()).isTrue();
+        assertThat(histogram.readSInt(13)).isEqualTo(2);
+        assertThat(histogram.readSInt(13)).isEqualTo(-2);
+        assertThat(histogram.readSInt(13)).isEqualTo(1);
+        assertThat(histogram.isAtEnd()).isTrue();
+
+        assertThat(family.readString(5)).isEqualTo("ns");
+        assertThat(family.isAtEnd()).isTrue();
+    }
+
+    @Test
+    public void testHistogramDownscalesToPrometheusMaximum()
+    {
+        ExponentialHistogramMetric metric = new ExponentialHistogramMetric(
+                "distribution",
+                new ExponentialHistogramSnapshot(
+                        10,
+                        7,
+                        14,
+                        1,
+                        4,
+                        1,
+                        new Buckets(8, new long[] {1, 2, 3}),
+                        new Buckets(0, new long[0])),
+                ImmutableMap.of(),
+                "help",
+                null);
+
+        assertThat(metric.snapshot().scale()).isEqualTo(8);
+        assertThat(metric.snapshot().positiveBuckets().offset()).isEqualTo(2);
+        assertThat(metric.snapshot().positiveBuckets().counts()).containsExactly(6);
+        assertThat(metric.snapshot().count()).isEqualTo(7);
+        assertThat(metric.snapshot().sum()).isEqualTo(14);
+    }
+
+    @Test
+    public void testEmptyHistogramHasNativeHistogramMarker()
+            throws Exception
+    {
+        ExponentialHistogramSnapshot snapshot = new ExponentialHistogramSnapshot(
+                8,
+                0,
+                0,
+                Double.NaN,
+                Double.NaN,
+                0,
+                new Buckets(0, new long[0]),
+                new Buckets(0, new long[0]));
+        Metric metric = new ExponentialHistogramMetric("empty", snapshot, ImmutableMap.of(), null, null);
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        writeMetricFamilies(output, Map.of(metric.metricName(), List.of(metric)));
+
+        ProtoReader family = new ProtoReader(output.toByteArray()).readDelimitedMessage();
+        family.readString(1);
+        family.readUInt(3);
+        ProtoReader sample = family.readMessage(4);
+        ProtoReader histogram = sample.readMessage(7);
+        histogram.readUInt(1);
+        histogram.readDouble(2);
+        histogram.readSInt(5);
+        histogram.readDouble(6);
+        histogram.readUInt(7);
+        assertThat(histogram.readMessage(12).isAtEnd()).isTrue();
+        assertThat(histogram.isAtEnd()).isTrue();
+    }
+
+    private static final class ProtoReader
+    {
+        private final byte[] data;
+        private int position;
+
+        private ProtoReader(byte[] data)
+        {
+            this.data = data;
+        }
+
+        public ProtoReader readDelimitedMessage()
+        {
+            return readBytes((int) readVarint());
+        }
+
+        public ProtoReader readMessage(int field)
+        {
+            readTag(field, 2);
+            return readBytes((int) readVarint());
+        }
+
+        public String readString(int field)
+        {
+            ProtoReader value = readMessage(field);
+            value.position = value.data.length;
+            return new String(value.data, StandardCharsets.UTF_8);
+        }
+
+        public long readUInt(int field)
+        {
+            readTag(field, 0);
+            return readVarint();
+        }
+
+        public long readSInt(int field)
+        {
+            long value = readUInt(field);
+            return (value >>> 1) ^ -(value & 1);
+        }
+
+        public double readDouble(int field)
+        {
+            readTag(field, 1);
+            long bits = 0;
+            for (int index = 0; index < Long.BYTES; index++) {
+                bits |= (long) (data[position++] & 0xFF) << (index * Byte.SIZE);
+            }
+            return Double.longBitsToDouble(bits);
+        }
+
+        public boolean isAtEnd()
+        {
+            return position == data.length;
+        }
+
+        private void readTag(int field, int wireType)
+        {
+            assertThat(readVarint()).isEqualTo(((long) field << 3) | wireType);
+        }
+
+        private ProtoReader readBytes(int length)
+        {
+            byte[] value = Arrays.copyOfRange(data, position, position + length);
+            position += length;
+            return new ProtoReader(value);
+        }
+
+        private long readVarint()
+        {
+            long value = 0;
+            int shift = 0;
+            while (true) {
+                int next = data[position++] & 0xFF;
+                value |= (long) (next & 0x7F) << shift;
+                if ((next & 0x80) == 0) {
+                    return value;
+                }
+                shift += 7;
+            }
+        }
+    }
+}

--- a/stats/src/main/java/io/airlift/stats/ExponentialHistogram.java
+++ b/stats/src/main/java/io/airlift/stats/ExponentialHistogram.java
@@ -333,6 +333,25 @@ public final class ExponentialHistogram
             validateBucketRange(scale, negativeBuckets);
         }
 
+        public ExponentialHistogramSnapshot downscaleToAtMost(int targetScale)
+        {
+            checkArgument(targetScale >= MIN_SCALE && targetScale <= MAX_SCALE, "targetScale must be between %s and %s", MIN_SCALE, MAX_SCALE);
+            if (scale <= targetScale) {
+                return this;
+            }
+
+            int scaleReduction = scale - targetScale;
+            return new ExponentialHistogramSnapshot(
+                    targetScale,
+                    count,
+                    sum,
+                    min,
+                    max,
+                    zeroCount,
+                    positiveBuckets.downscale(scaleReduction),
+                    negativeBuckets.downscale(scaleReduction));
+        }
+
         public static ExponentialHistogramSnapshot merge(List<ExponentialHistogramSnapshot> snapshots)
         {
             return merge(snapshots, DEFAULT_MAX_BUCKETS);
@@ -460,6 +479,16 @@ public final class ExponentialHistogram
         return (long) buckets.offset() + buckets.counts.length - 1;
     }
 
+    private static long[] downscaleBucketCounts(int offset, long[] counts, int scaleReduction)
+    {
+        int newOffset = offset >> scaleReduction;
+        long[] newCounts = new long[((offset + counts.length - 1) >> scaleReduction) - newOffset + 1];
+        for (int index = 0; index < counts.length; index++) {
+            newCounts[((offset + index) >> scaleReduction) - newOffset] += counts[index];
+        }
+        return newCounts;
+    }
+
     private interface BucketSelector
     {
         Buckets buckets(ExponentialHistogramSnapshot snapshot);
@@ -480,6 +509,16 @@ public final class ExponentialHistogram
         public boolean isEmpty()
         {
             return counts.length == 0;
+        }
+
+        private Buckets downscale(int scaleReduction)
+        {
+            if (isEmpty()) {
+                return this;
+            }
+
+            int newOffset = offset >> scaleReduction;
+            return new Buckets(newOffset, downscaleBucketCounts(offset, counts, scaleReduction));
         }
 
         @Override
@@ -569,12 +608,8 @@ public final class ExponentialHistogram
             }
 
             int newOffset = offset >> by;
-            long[] newCounts = new long[(lastIndex() >> by) - newOffset + 1];
-            for (int i = 0; i < counts.length; i++) {
-                newCounts[((offset + i) >> by) - newOffset] += counts[i];
-            }
+            counts = downscaleBucketCounts(offset, counts, by);
             offset = newOffset;
-            counts = newCounts;
         }
 
         public Buckets snapshot()

--- a/stats/src/test/java/io/airlift/stats/TestExponentialHistogram.java
+++ b/stats/src/test/java/io/airlift/stats/TestExponentialHistogram.java
@@ -261,6 +261,42 @@ class TestExponentialHistogram
     }
 
     @Test
+    public void testSnapshotDownscaleToAtMost()
+    {
+        ExponentialHistogramSnapshot snapshot = new ExponentialHistogramSnapshot(
+                2,
+                22,
+                4,
+                -4,
+                4,
+                2,
+                new Buckets(4, new long[] {1, 2, 3, 4}),
+                new Buckets(-4, new long[] {4, 3, 2, 1}));
+
+        ExponentialHistogramSnapshot downscaled = snapshot.downscaleToAtMost(0);
+
+        assertThat(downscaled.scale()).isEqualTo(0);
+        assertThat(downscaled.count()).isEqualTo(22);
+        assertThat(downscaled.sum()).isEqualTo(4);
+        assertThat(downscaled.min()).isEqualTo(-4);
+        assertThat(downscaled.max()).isEqualTo(4);
+        assertThat(downscaled.zeroCount()).isEqualTo(2);
+        assertThat(downscaled.positiveBuckets()).isEqualTo(new Buckets(1, new long[] {10}));
+        assertThat(downscaled.negativeBuckets()).isEqualTo(new Buckets(-1, new long[] {10}));
+        assertThat(downscaled.downscaleToAtMost(1)).isSameAs(downscaled);
+    }
+
+    @Test
+    public void testSnapshotDownscaleToAtMostValidatesScale()
+    {
+        ExponentialHistogramSnapshot snapshot = new ExponentialHistogram().snapshot();
+
+        assertThatThrownBy(() -> snapshot.downscaleToAtMost(ExponentialHistogram.MIN_SCALE - 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("targetScale must be between -10 and 20");
+    }
+
+    @Test
     public void testReset()
     {
         ExponentialHistogram histogram = new ExponentialHistogram(1, 3);


### PR DESCRIPTION
Native exponential histograms are only representable in the Prometheus protobuf format. Text responses retain summaries for compatibility, and snapshots are downscaled to Prometheus's supported scale range before encoding.

This also includes a custom/manual protobuf writer for Prometheus.  The format is trivial and stable, so this is simpler then working with the protobuf code generator.

# Airlift contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [x] All automated tests are passing.
 - [x] Pull request was categorized using one of the existing labels.
