### PR TITLE
Harden automatic mTLS with a derived CA and per-node keys

### DIFF
--- a/http-server/src/test/java/io/airlift/http/server/TestHttpServerProvider.java
+++ b/http-server/src/test/java/io/airlift/http/server/TestHttpServerProvider.java
@@ -329,7 +329,7 @@ public class TestHttpServerProvider
                 .setKeystorePath(getResource("test.keystore.with.two.passwords").getPath())
                 .setKeystorePassword("airlift")
                 .setKeyManagerPassword("airliftkey")
-                .setAutomaticHttpsSharedSecret("shared-secret");
+                .setAutomaticHttpsSharedSecret("shared-secret-with-sufficient-entropy-1234");
 
         createAndStartServer();
         assertThat(server.getHttpConnectionStats()).isNull();
@@ -339,7 +339,7 @@ public class TestHttpServerProvider
                 .setHttp2Enabled(false)
                 .setTrustStorePath(getResource("test.truststore").getPath())
                 .setTrustStorePassword("airlift")
-                .setAutomaticHttpsSharedSecret("shared-secret");
+                .setAutomaticHttpsSharedSecret("shared-secret-with-sufficient-entropy-1234");
 
         try (JettyHttpClient httpClient = createJettyClient(http1ClientConfig)) {
             verifyHttps(httpClient, "localhost");
@@ -464,7 +464,7 @@ public class TestHttpServerProvider
                 .setHttpsEnabled(true);
         httpsConfig.setKeystorePath(getResource("clientcert-java/server.keystore").getPath())
                 .setKeystorePassword("airlift")
-                .setAutomaticHttpsSharedSecret("shared-secret");
+                .setAutomaticHttpsSharedSecret("shared-secret-with-sufficient-entropy-1234");
         clientCertificate = ClientCertificate.REQUIRED;
 
         createAndStartServer(createCertTestServlet());
@@ -474,7 +474,7 @@ public class TestHttpServerProvider
                 .setKeyStorePassword("airlift")
                 .setTrustStorePath(getResource("clientcert-java/client.truststore").getPath())
                 .setTrustStorePassword("airlift")
-                .setAutomaticHttpsSharedSecret("shared-secret");
+                .setAutomaticHttpsSharedSecret("shared-secret-with-sufficient-entropy-1234");
 
         assertClientCertificateRequest(clientConfig, "localhost");
         assertClientCertificateRequest(clientConfig, "127-0-0-1.ip");
@@ -751,7 +751,7 @@ public class TestHttpServerProvider
                     .setTrustStorePath(tempFile.file().getAbsolutePath())
                     .setTrustStorePassword("airlift")
                     .setTrustStoreType("BCFKS")
-                    .setAutomaticHttpsSharedSecret("shared-secret");
+                    .setAutomaticHttpsSharedSecret("shared-secret-with-sufficient-entropy-1234");
             clientCertificate = ClientCertificate.REQUIRED;
 
             createAndStartServer(createCertTestServlet());
@@ -761,7 +761,7 @@ public class TestHttpServerProvider
                     .setKeyStorePassword("airlift")
                     .setTrustStorePath(getResource("clientcert-java/client.truststore").getPath())
                     .setTrustStorePassword("airlift")
-                    .setAutomaticHttpsSharedSecret("shared-secret");
+                    .setAutomaticHttpsSharedSecret("shared-secret-with-sufficient-entropy-1234");
 
             assertClientCertificateRequest(clientConfig, "localhost");
         }

--- a/security/src/main/java/io/airlift/security/cert/CertificateBuilder.java
+++ b/security/src/main/java/io/airlift/security/cert/CertificateBuilder.java
@@ -189,6 +189,25 @@ public class CertificateBuilder
                 .map(address -> encodeContextSpecificTag(7, address))
                 .forEach(sans::add);
 
+        List<byte[]> extensions = new ArrayList<>();
+        extensions.add(encodeSequence(
+                SUBJECT_KEY_IDENTIFIER_OID,
+                encodeOctetString(encodeOctetString(publicKeyHash))));
+        extensions.add(encodeSequence(
+                AUTHORITY_KEY_IDENTIFIER_OID,
+                encodeOctetString(encodeSequence(encodeContextSpecificTag(0, publicKeyHash)))));
+        extensions.add(encodeSequence(
+                BASIC_CONSTRAINTS_OID,
+                encodeBooleanTrue(),
+                encodeOctetString(encodeSequence(encodeBooleanTrue()))));
+        // Only emit SubjectAltName when there is at least one name: an empty GeneralNames SEQUENCE
+        // is invalid per RFC 5280 and rejected by X.509 parsers.
+        if (!sans.isEmpty()) {
+            extensions.add(encodeSequence(
+                    SUBJECT_ALT_NAME_OID,
+                    encodeOctetString(encodeSequence(sans.toArray(new byte[0][])))));
+        }
+
         byte[] rawCertificate = encodeSequence(
                 // version: 2
                 encodeContextSpecificSequence(0, encodeInteger(2)),
@@ -211,21 +230,7 @@ public class CertificateBuilder
                 // public key
                 publicKey.getEncoded(),
                 // extensions
-                encodeContextSpecificSequence(3, encodeSequence(
-                        encodeSequence(
-                                SUBJECT_KEY_IDENTIFIER_OID,
-                                encodeOctetString(encodeOctetString(publicKeyHash))),
-                        encodeSequence(
-                                AUTHORITY_KEY_IDENTIFIER_OID,
-                                encodeOctetString(encodeSequence(encodeContextSpecificTag(0, publicKeyHash)))),
-                        encodeSequence(
-                                BASIC_CONSTRAINTS_OID,
-                                encodeBooleanTrue(),
-                                encodeOctetString(encodeSequence(encodeBooleanTrue()))),
-                        encodeSequence(
-                                SUBJECT_ALT_NAME_OID,
-                                encodeOctetString(
-                                        encodeSequence(sans.toArray(new byte[0][])))))));
+                encodeContextSpecificSequence(3, encodeSequence(extensions.toArray(new byte[0][]))));
 
         byte[] signature = signCertificate(rawCertificate);
 

--- a/security/src/main/java/io/airlift/security/cert/CertificateBuilder.java
+++ b/security/src/main/java/io/airlift/security/cert/CertificateBuilder.java
@@ -64,6 +64,7 @@ public class CertificateBuilder
     private Instant notBefore;
     private Instant notAfter;
     private X500Principal subject;
+    private boolean certificateAuthority = true;
     private final List<String> sanDnsNames = new ArrayList<>();
     private final List<InetAddress> sanIpAddresses = new ArrayList<>();
 
@@ -141,6 +142,16 @@ public class CertificateBuilder
         return this;
     }
 
+    /**
+     * Controls the basic constraints {@code cA} flag. Defaults to {@code true}. Set to {@code false}
+     * for end-entity (leaf) certificates that must not be able to issue further certificates.
+     */
+    public CertificateBuilder setCertificateAuthority(boolean certificateAuthority)
+    {
+        this.certificateAuthority = certificateAuthority;
+        return this;
+    }
+
     public CertificateBuilder addSanIpAddress(InetAddress address)
     {
         this.sanIpAddresses.add(requireNonNull(address, "address is null"));
@@ -170,15 +181,35 @@ public class CertificateBuilder
     public X509Certificate buildSelfSigned()
             throws GeneralSecurityException
     {
-        checkState(publicKey != null, "publicKey is not set");
         checkState(privateKey != null, "privateKey is not set");
+        return build(privateKey, publicKey);
+    }
+
+    /**
+     * Builds a certificate signed by the given issuing (CA) key pair rather than self-signed. The
+     * {@link #setIssuer(X500Principal) issuer} must be set to the CA's subject and
+     * {@code caPublicKey} is used to populate the authority key identifier.
+     */
+    public X509Certificate buildIssuedBy(ECPrivateKey caPrivateKey, ECPublicKey caPublicKey)
+            throws GeneralSecurityException
+    {
+        requireNonNull(caPrivateKey, "caPrivateKey is null");
+        requireNonNull(caPublicKey, "caPublicKey is null");
+        return build(caPrivateKey, caPublicKey);
+    }
+
+    private X509Certificate build(ECPrivateKey signingKey, ECPublicKey authorityKey)
+            throws GeneralSecurityException
+    {
+        checkState(publicKey != null, "publicKey is not set");
         checkState(issuer != null, "issuer is not set");
         checkState(notBefore != null, "notBefore is not set");
         checkState(notAfter != null, "notAfter is not set");
         checkState(!notBefore.isAfter(notAfter), "notAfter is before notBefore");
         checkState(subject != null, "subject is not set");
 
-        byte[] publicKeyHash = hashPublicKey();
+        byte[] subjectKeyHash = hashPublicKey(publicKey);
+        byte[] authorityKeyHash = hashPublicKey(authorityKey);
 
         List<byte[]> sans = new ArrayList<>();
         sanDnsNames.stream()
@@ -189,17 +220,23 @@ public class CertificateBuilder
                 .map(address -> encodeContextSpecificTag(7, address))
                 .forEach(sans::add);
 
+        // BasicConstraints value: for a CA, SEQUENCE { cA TRUE }; for a leaf, the empty SEQUENCE
+        // (cA defaults to FALSE).
+        byte[] basicConstraintsValue = certificateAuthority
+                ? encodeSequence(encodeBooleanTrue())
+                : encodeSequence();
+
         List<byte[]> extensions = new ArrayList<>();
         extensions.add(encodeSequence(
                 SUBJECT_KEY_IDENTIFIER_OID,
-                encodeOctetString(encodeOctetString(publicKeyHash))));
+                encodeOctetString(encodeOctetString(subjectKeyHash))));
         extensions.add(encodeSequence(
                 AUTHORITY_KEY_IDENTIFIER_OID,
-                encodeOctetString(encodeSequence(encodeContextSpecificTag(0, publicKeyHash)))));
+                encodeOctetString(encodeSequence(encodeContextSpecificTag(0, authorityKeyHash)))));
         extensions.add(encodeSequence(
                 BASIC_CONSTRAINTS_OID,
                 encodeBooleanTrue(),
-                encodeOctetString(encodeSequence(encodeBooleanTrue()))));
+                encodeOctetString(basicConstraintsValue)));
         // Only emit SubjectAltName when there is at least one name: an empty GeneralNames SEQUENCE
         // is invalid per RFC 5280 and rejected by X.509 parsers.
         if (!sans.isEmpty()) {
@@ -232,7 +269,7 @@ public class CertificateBuilder
                 // extensions
                 encodeContextSpecificSequence(3, encodeSequence(extensions.toArray(new byte[0][]))));
 
-        byte[] signature = signCertificate(rawCertificate);
+        byte[] signature = signCertificate(signingKey, rawCertificate);
 
         byte[] encodedCertificate = encodeSequence(
                 rawCertificate,
@@ -247,16 +284,16 @@ public class CertificateBuilder
         return (X509Certificate) certificateFactory.generateCertificate(new ByteArrayInputStream(encodedCertificate));
     }
 
-    private byte[] signCertificate(byte[] rawCertificate)
+    private static byte[] signCertificate(ECPrivateKey signingKey, byte[] rawCertificate)
             throws GeneralSecurityException
     {
         Signature signature = Signature.getInstance("SHA256withECDSA");
-        signature.initSign(privateKey);
+        signature.initSign(signingKey);
         signature.update(rawCertificate);
         return signature.sign();
     }
 
-    private byte[] hashPublicKey()
+    private static byte[] hashPublicKey(ECPublicKey publicKey)
             throws NoSuchAlgorithmException
     {
         byte[] rawKey = encodeSequence(

--- a/security/src/main/java/io/airlift/security/mtls/AutomaticMtls.java
+++ b/security/src/main/java/io/airlift/security/mtls/AutomaticMtls.java
@@ -9,19 +9,22 @@ import io.airlift.security.cert.CertificateBuilder;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
 import javax.security.auth.x500.X500Principal;
 
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
+import java.security.GeneralSecurityException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.KeyStore;
-import java.security.PublicKey;
 import java.security.SecureRandom;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.ECPublicKey;
 import java.security.spec.ECGenParameterSpec;
 import java.time.Instant;
 import java.util.Arrays;
@@ -33,27 +36,42 @@ import static java.security.KeyStore.getDefaultType;
 import static java.time.ZoneOffset.UTC;
 import static java.time.temporal.ChronoUnit.DAYS;
 import static java.util.Collections.list;
-import static java.util.Objects.requireNonNull;
 import static javax.net.ssl.KeyManagerFactory.getDefaultAlgorithm;
 
+/**
+ * Automatic mutual TLS for an environment sharing a single secret.
+ *
+ * <p>A certificate authority (CA) key pair is derived deterministically from the shared secret, so
+ * every node derives the same CA. Each node then generates its <em>own random</em> leaf key pair and
+ * issues itself a leaf certificate signed by that CA. Peers trust each other with standard PKIX by
+ * pinning the derived CA certificate as a trust anchor: presenting a valid leaf requires a signature
+ * from the CA, which requires knowledge of the shared secret.
+ *
+ * <p>This means the private key that terminates each TLS connection is unique per node and never
+ * leaves it, and is not recoverable from the shared secret; only the ability to <em>mint</em> new
+ * identities depends on the secret.
+ */
 public final class AutomaticMtls
 {
+    private static final String CURVE_NAME = "secp256r1";
+
     private AutomaticMtls() {}
 
+    /**
+     * Generates a random leaf key pair for the current node, issues it a CA-signed certificate that
+     * includes the node's local addresses as subject alternative names, and stores the private key
+     * with its {@code [leaf, CA]} chain in the key store. The derived CA certificate is also added as
+     * a trusted entry so that a key store used directly as a trust store anchors peer verification.
+     */
     @CanIgnoreReturnValue
-    public static X509Certificate addCertificateAndKeyForCurrentNode(String sharedSecret, String commonName, KeyStore keyStore, String keyStorePassword)
+    public static X509Certificate addCertificateAndKeyForCurrentNode(String sharedSecret, String environment, KeyStore keyStore, String keyStorePassword)
     {
         try {
             List<InetAddress> allLocalIpAddresses = getAllLocalIpAddresses();
             List<String> ipAddressMappedNames = allLocalIpAddresses.stream()
                     .map(AddressToHostname::encodeAddressAsHostname)
                     .collect(toImmutableList());
-            X509Certificate certificate = certificateBuilder(sharedSecret, commonName)
-                    .addSanIpAddresses(allLocalIpAddresses)
-                    .addSanDnsNames(ipAddressMappedNames)
-                    .buildSelfSigned();
-
-            return addCertificateToKeyStore(sharedSecret, commonName, certificate, keyStore, keyStorePassword);
+            return addNodeCertificateAndKey(sharedSecret, environment, keyStore, keyStorePassword, allLocalIpAddresses, ipAddressMappedNames);
         }
         catch (Exception e) {
             throw new RuntimeException(e);
@@ -61,56 +79,148 @@ public final class AutomaticMtls
     }
 
     @VisibleForTesting
-    static X509Certificate addCertificateToKeyStore(String sharedSecret, String commonName, X509Certificate certificate, KeyStore keyStore, String keyStorePassword)
+    static X509Certificate addNodeCertificateAndKey(
+            String sharedSecret,
+            String environment,
+            KeyStore keyStore,
+            String keyStorePassword,
+            List<InetAddress> ipSubjectAltNames,
+            List<String> dnsSubjectAltNames)
     {
         try {
-            KeyPair keyPair = fromSharedSecret(sharedSecret);
+            KeyPair caKeyPair = deriveCertificateAuthorityKeyPair(sharedSecret, environment);
+            X509Certificate caCertificate = buildCaCertificate(caKeyPair, environment);
+
+            KeyPair leafKeyPair = generateRandomEcKeyPair();
+            X509Certificate leafCertificate = leafCertificateBuilder(environment)
+                    .setKeyPair(leafKeyPair)
+                    .addSanIpAddresses(ipSubjectAltNames)
+                    .addSanDnsNames(dnsSubjectAltNames)
+                    .buildIssuedBy((ECPrivateKey) caKeyPair.getPrivate(), (ECPublicKey) caKeyPair.getPublic());
+
             char[] password = keyStorePassword == null ? new char[0] : keyStorePassword.toCharArray();
-            keyStore.setKeyEntry(commonName, keyPair.getPrivate(), password, new Certificate[] {certificate});
-            return certificate;
+            keyStore.setKeyEntry(environment, leafKeyPair.getPrivate(), password, new Certificate[] {leafCertificate, caCertificate});
+            // Anchor for the case where this key store is used directly as a trust store.
+            keyStore.setCertificateEntry(environment + "-ca", caCertificate);
+            return leafCertificate;
         }
         catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
 
-    public static void addClientTrust(String sharedSecret, KeyStore keyStore, String commonName)
+    /**
+     * Adds the derived CA certificate to the given (trust) store as a trust anchor, so that leaf
+     * certificates issued by any node in the environment are trusted via standard PKIX validation.
+     */
+    public static void addClientTrust(String sharedSecret, KeyStore keyStore, String environment)
     {
         try {
-            X509Certificate certificateServer = certificateBuilder(sharedSecret, commonName)
-                    .buildSelfSigned();
-
-            keyStore.setCertificateEntry(commonName, certificateServer);
+            keyStore.setCertificateEntry(environment, caCertificate(sharedSecret, environment));
         }
         catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
 
-    public static X509TrustManager createTrustManager(String sharedSecret, String commonName)
+    /**
+     * Returns a standard PKIX trust manager anchored on the derived CA certificate.
+     */
+    public static X509TrustManager createTrustManager(String sharedSecret, String environment)
     {
         try {
-            KeyPair keyPair = fromSharedSecret(sharedSecret);
-            return new SingleCertificateTrustManager(keyPair.getPublic(), commonName);
+            KeyStore trustStore = inMemoryKeyStore();
+            trustStore.setCertificateEntry(environment, caCertificate(sharedSecret, environment));
+
+            TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            trustManagerFactory.init(trustStore);
+            return Arrays.stream(trustManagerFactory.getTrustManagers())
+                    .filter(X509TrustManager.class::isInstance)
+                    .map(X509TrustManager.class::cast)
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException("No X509TrustManager available"));
         }
         catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
 
-    public static SSLContext createSSLContext(String sharedSecret, String commonName, KeyStore keyStore, String keyManagerPassword)
+    public static SSLContext createSSLContext(String sharedSecret, String environment, KeyStore keyStore, String keyManagerPassword)
     {
         try {
             KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(getDefaultAlgorithm());
-            keyManagerFactory.init(keyStore, keyManagerPassword.toCharArray());
+            keyManagerFactory.init(keyStore, keyManagerPassword == null ? new char[0] : keyManagerPassword.toCharArray());
 
             SSLContext context = SSLContext.getInstance("TLS");
-            context.init(keyManagerFactory.getKeyManagers(), new TrustManager[] {createTrustManager(sharedSecret, commonName)}, null);
+            context.init(keyManagerFactory.getKeyManagers(), new TrustManager[] {createTrustManager(sharedSecret, environment)}, null);
             return context;
         }
         catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @VisibleForTesting
+    static X509Certificate caCertificate(String sharedSecret, String environment)
+            throws GeneralSecurityException
+    {
+        return buildCaCertificate(deriveCertificateAuthorityKeyPair(sharedSecret, environment), environment);
+    }
+
+    private static X509Certificate buildCaCertificate(KeyPair caKeyPair, String environment)
+            throws GeneralSecurityException
+    {
+        X500Principal caSubject = caSubject(environment);
+        return CertificateBuilder.certificateBuilder()
+                .setKeyPair(caKeyPair)
+                .setSerialNumber(1)
+                .setIssuer(caSubject)
+                .setSubject(caSubject)
+                .setNotBefore(validityStart())
+                .setNotAfter(validityEnd())
+                .setCertificateAuthority(true)
+                .buildSelfSigned();
+    }
+
+    private static CertificateBuilder leafCertificateBuilder(String environment)
+    {
+        return CertificateBuilder.certificateBuilder()
+                .setSerialNumber(randomSerialNumber())
+                .setIssuer(caSubject(environment))
+                .setSubject(new X500Principal("CN=" + environment))
+                .setNotBefore(validityStart())
+                .setNotAfter(validityEnd())
+                .setCertificateAuthority(false);
+    }
+
+    // A random, non-negative 63-bit serial; serials only need to be unique per issuing CA, and a
+    // random value avoids the collisions a shared wall-clock timestamp could produce across nodes.
+    private static long randomSerialNumber()
+    {
+        return new SecureRandom().nextLong() & Long.MAX_VALUE;
+    }
+
+    private static Instant validityStart()
+    {
+        return Instant.now().truncatedTo(DAYS);
+    }
+
+    private static Instant validityEnd()
+    {
+        return validityStart().atZone(UTC).plusYears(10).toInstant();
+    }
+
+    private static X500Principal caSubject(String environment)
+    {
+        return new X500Principal("CN=" + environment + ", OU=Airlift Automatic mTLS CA");
+    }
+
+    private static KeyPair generateRandomEcKeyPair()
+            throws GeneralSecurityException
+    {
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("EC");
+        generator.initialize(new ECGenParameterSpec(CURVE_NAME));
+        return generator.generateKeyPair();
     }
 
     private static List<InetAddress> getAllLocalIpAddresses()
@@ -127,7 +237,11 @@ public final class AutomaticMtls
         return list.build();
     }
 
-    private static KeyPair fromSharedSecret(String sharedSecret)
+    /**
+     * Deterministically derives the environment's CA key pair from the shared secret so that every
+     * node derives the same CA.
+     */
+    private static KeyPair deriveCertificateAuthorityKeyPair(String sharedSecret, String environment)
     {
         try {
             byte[] seed = sharedSecret.getBytes(UTF_8);
@@ -135,95 +249,11 @@ public final class AutomaticMtls
             secureRandom.setSeed(seed);
 
             KeyPairGenerator generator = KeyPairGenerator.getInstance("EC");
-            generator.initialize(new ECGenParameterSpec("secp256r1"), secureRandom);
+            generator.initialize(new ECGenParameterSpec(CURVE_NAME), secureRandom);
             return generator.generateKeyPair();
         }
         catch (Exception e) {
             throw new RuntimeException(e);
-        }
-    }
-
-    @VisibleForTesting
-    static CertificateBuilder certificateBuilder(String sharedSecret, String commonName)
-    {
-        KeyPair keyPair = fromSharedSecret(sharedSecret);
-        Instant notBefore = Instant.now().truncatedTo(DAYS);
-        Instant notAfter = notBefore.atZone(UTC).plusYears(10).toInstant();
-        X500Principal subject = certificateSubject(commonName);
-        return CertificateBuilder.certificateBuilder()
-                .setKeyPair(keyPair)
-                .setSerialNumber(System.currentTimeMillis())
-                .setIssuer(subject)
-                .setNotBefore(notBefore)
-                .setNotAfter(notAfter)
-                .setSubject(subject);
-    }
-
-    private static X500Principal certificateSubject(String commonName)
-    {
-        return new X500Principal("CN=" + commonName);
-    }
-
-    private record SingleCertificateTrustManager(PublicKey trustedPublicKey, String commonName)
-            implements X509TrustManager
-    {
-        private SingleCertificateTrustManager(PublicKey trustedPublicKey, String commonName)
-        {
-            this.trustedPublicKey = requireNonNull(trustedPublicKey, "trustedPublicKey is null");
-            this.commonName = requireNonNull(commonName, "commonName is null");
-        }
-
-        @Override
-        public void checkClientTrusted(X509Certificate[] chain, String authType)
-        {
-            check(chain);
-        }
-
-        @Override
-        public void checkServerTrusted(X509Certificate[] chain, String authType)
-        {
-            check(chain);
-        }
-
-        private void check(X509Certificate[] chain)
-        {
-            if (chain == null || chain.length == 0) {
-                throw new SecurityException("Empty certificate chain");
-            }
-            if (chain.length > 1) {
-                throw new SecurityException("Certificate chain must contain only one certificate");
-            }
-            X509Certificate certificate = chain[0];
-            PublicKey peerKey = certificate.getPublicKey();
-            if (!Arrays.equals(peerKey.getEncoded(), trustedPublicKey.getEncoded())) {
-                throw new SecurityException("Peer cert public key doesn't match trusted key");
-            }
-
-            X500Principal peerSubject = certificate.getSubjectX500Principal();
-            X500Principal expectedSubject = certificateSubject(commonName);
-            if (!peerSubject.equals(expectedSubject)) {
-                throw new SecurityException("Peer certificate subject '%s' does not match expected subject: '%s'".formatted(peerSubject, expectedSubject));
-            }
-
-            X500Principal peerIssuer = certificate.getIssuerX500Principal();
-            if (!peerIssuer.equals(expectedSubject)) {
-                throw new SecurityException("Peer certificate issuer '%s' does not match expected subject: '%s'".formatted(peerIssuer, expectedSubject));
-            }
-
-            Instant now = Instant.now();
-            if (certificate.getNotBefore().toInstant().isAfter(now)) {
-                throw new SecurityException("Peer certificate is not valid yet (notBefore: %s)".formatted(certificate.getNotBefore()));
-            }
-
-            if (certificate.getNotAfter().toInstant().isBefore(now)) {
-                throw new SecurityException("Peer certificate has expired (notAfter: %s)".formatted(certificate.getNotAfter()));
-            }
-        }
-
-        @Override
-        public X509Certificate[] getAcceptedIssuers()
-        {
-            return new X509Certificate[0];
         }
     }
 

--- a/security/src/main/java/io/airlift/security/mtls/AutomaticMtls.java
+++ b/security/src/main/java/io/airlift/security/mtls/AutomaticMtls.java
@@ -30,6 +30,8 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.security.KeyStore.getDefaultType;
@@ -54,6 +56,7 @@ import static javax.net.ssl.KeyManagerFactory.getDefaultAlgorithm;
 public final class AutomaticMtls
 {
     private static final String CURVE_NAME = "secp256r1";
+    private static final int MIN_SHARED_SECRET_LENGTH = 32;
 
     private AutomaticMtls() {}
 
@@ -74,6 +77,7 @@ public final class AutomaticMtls
             return addNodeCertificateAndKey(sharedSecret, environment, keyStore, keyStorePassword, allLocalIpAddresses, ipAddressMappedNames);
         }
         catch (Exception e) {
+            throwIfUnchecked(e);
             throw new RuntimeException(e);
         }
     }
@@ -105,6 +109,7 @@ public final class AutomaticMtls
             return leafCertificate;
         }
         catch (Exception e) {
+            throwIfUnchecked(e);
             throw new RuntimeException(e);
         }
     }
@@ -119,6 +124,7 @@ public final class AutomaticMtls
             keyStore.setCertificateEntry(environment, caCertificate(sharedSecret, environment));
         }
         catch (Exception e) {
+            throwIfUnchecked(e);
             throw new RuntimeException(e);
         }
     }
@@ -141,6 +147,7 @@ public final class AutomaticMtls
                     .orElseThrow(() -> new IllegalStateException("No X509TrustManager available"));
         }
         catch (Exception e) {
+            throwIfUnchecked(e);
             throw new RuntimeException(e);
         }
     }
@@ -156,6 +163,7 @@ public final class AutomaticMtls
             return context;
         }
         catch (Exception e) {
+            throwIfUnchecked(e);
             throw new RuntimeException(e);
         }
     }
@@ -243,6 +251,9 @@ public final class AutomaticMtls
      */
     private static KeyPair deriveCertificateAuthorityKeyPair(String sharedSecret, String environment)
     {
+        checkArgument(sharedSecret.length() >= MIN_SHARED_SECRET_LENGTH,
+                "automatic HTTPS shared secret must be at least %s characters; use a randomly generated high-entropy value",
+                MIN_SHARED_SECRET_LENGTH);
         try {
             byte[] seed = sharedSecret.getBytes(UTF_8);
             SecureRandom secureRandom = SecureRandom.getInstance("SHA1PRNG");
@@ -253,6 +264,7 @@ public final class AutomaticMtls
             return generator.generateKeyPair();
         }
         catch (Exception e) {
+            throwIfUnchecked(e);
             throw new RuntimeException(e);
         }
     }

--- a/security/src/main/java/io/airlift/security/mtls/AutomaticMtls.java
+++ b/security/src/main/java/io/airlift/security/mtls/AutomaticMtls.java
@@ -6,6 +6,8 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.airlift.node.AddressToHostname;
 import io.airlift.security.cert.CertificateBuilder;
 
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
@@ -13,10 +15,13 @@ import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
 import javax.security.auth.x500.X500Principal;
 
+import java.math.BigInteger;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
+import java.security.AlgorithmParameters;
 import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.KeyStore;
@@ -25,12 +30,19 @@ import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
+import java.security.spec.ECFieldFp;
 import java.security.spec.ECGenParameterSpec;
+import java.security.spec.ECParameterSpec;
+import java.security.spec.ECPoint;
+import java.security.spec.ECPrivateKeySpec;
+import java.security.spec.ECPublicKeySpec;
+import java.security.spec.EllipticCurve;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -56,6 +68,13 @@ import static javax.net.ssl.KeyManagerFactory.getDefaultAlgorithm;
 public final class AutomaticMtls
 {
     private static final String CURVE_NAME = "secp256r1";
+
+    // The CA key pair must be byte-for-byte identical on every node, so the derivation parameters are
+    // fixed constants (never configuration): two nodes deriving different CA keys could not trust each
+    // other. The "v2" tag versions the derivation scheme; bump it if the algorithm ever changes.
+    private static final String KDF_SALT_PREFIX = "airlift-automatic-mtls-v2:";
+    private static final int KDF_ITERATIONS = 600_000; // OWASP 2023 floor for PBKDF2-HMAC-SHA256
+    private static final int MODULO_BIAS_MARGIN_BITS = 64; // keeps scalar reduction bias below 2^-64
     private static final int MIN_SHARED_SECRET_LENGTH = 32;
 
     private AutomaticMtls() {}
@@ -247,7 +266,13 @@ public final class AutomaticMtls
 
     /**
      * Deterministically derives the environment's CA key pair from the shared secret so that every
-     * node derives the same CA.
+     * node derives the same CA. The secret is stretched through a salted, high-iteration KDF: a
+     * captured certificate lets an attacker verify a guessed secret offline, so without stretching a
+     * weak secret could be brute-forced cheaply. The salt binds the derivation to the environment so
+     * that work cannot be amortized across clusters. The private scalar is computed with fixed
+     * arithmetic rather than by seeding a provider RNG, and the public key is computed by explicit EC
+     * point multiplication (see {@link #derivePublicKey}), so the derived CA is identical across JCA
+     * providers and JDK versions without depending on any third-party library.
      */
     private static KeyPair deriveCertificateAuthorityKeyPair(String sharedSecret, String environment)
     {
@@ -255,18 +280,98 @@ public final class AutomaticMtls
                 "automatic HTTPS shared secret must be at least %s characters; use a randomly generated high-entropy value",
                 MIN_SHARED_SECRET_LENGTH);
         try {
-            byte[] seed = sharedSecret.getBytes(UTF_8);
-            SecureRandom secureRandom = SecureRandom.getInstance("SHA1PRNG");
-            secureRandom.setSeed(seed);
+            AlgorithmParameters algorithmParameters = AlgorithmParameters.getInstance("EC");
+            algorithmParameters.init(new ECGenParameterSpec(CURVE_NAME));
+            ECParameterSpec ecParameterSpec = algorithmParameters.getParameterSpec(ECParameterSpec.class);
+            BigInteger order = ecParameterSpec.getOrder();
 
-            KeyPairGenerator generator = KeyPairGenerator.getInstance("EC");
-            generator.initialize(new ECGenParameterSpec(CURVE_NAME), secureRandom);
-            return generator.generateKeyPair();
+            // Stretch the secret with PBKDF2, requesting enough extra bits that reducing into
+            // [1, order-1] introduces negligible modulo bias.
+            int derivedBits = order.bitLength() + MODULO_BIAS_MARGIN_BITS;
+            byte[] salt = (KDF_SALT_PREFIX + environment).getBytes(UTF_8);
+            PBEKeySpec keySpec = new PBEKeySpec(sharedSecret.toCharArray(), salt, KDF_ITERATIONS, derivedBits);
+            byte[] derived = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256").generateSecret(keySpec).getEncoded();
+
+            // Map the derived bytes to a valid private scalar d in [1, order-1].
+            BigInteger d = new BigInteger(1, derived).mod(order.subtract(BigInteger.ONE)).add(BigInteger.ONE);
+
+            KeyFactory keyFactory = KeyFactory.getInstance("EC");
+            ECPrivateKey privateKey = (ECPrivateKey) keyFactory.generatePrivate(new ECPrivateKeySpec(d, ecParameterSpec));
+            ECPublicKey publicKey = derivePublicKey(d, ecParameterSpec, keyFactory);
+            return new KeyPair(publicKey, privateKey);
         }
         catch (Exception e) {
             throwIfUnchecked(e);
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * Computes the public key {@code Q = d*G} for the private scalar {@code d} by explicit elliptic
+     * curve point multiplication over the curve's prime field, using only the curve parameters
+     * supplied by the JCA. This depends on nothing beyond {@link java.math.BigInteger} arithmetic, so
+     * the derived CA is identical across JCA providers and JDK versions.
+     */
+    private static ECPublicKey derivePublicKey(BigInteger d, ECParameterSpec ecParameterSpec, KeyFactory keyFactory)
+            throws GeneralSecurityException
+    {
+        EllipticCurve curve = ecParameterSpec.getCurve();
+        checkState(curve.getField() instanceof ECFieldFp, "curve is not defined over a prime field");
+        BigInteger p = ((ECFieldFp) curve.getField()).getP();
+        ECPoint publicPoint = scalarMultiply(d, ecParameterSpec.getGenerator(), curve.getA(), p);
+        return (ECPublicKey) keyFactory.generatePublic(new ECPublicKeySpec(publicPoint, ecParameterSpec));
+    }
+
+    // Double-and-add scalar multiplication on the short Weierstrass curve y^2 = x^3 + a*x + b over F_p.
+    private static ECPoint scalarMultiply(BigInteger k, ECPoint generator, BigInteger a, BigInteger p)
+    {
+        ECPoint result = ECPoint.POINT_INFINITY;
+        ECPoint addend = generator;
+        for (int bit = 0; bit < k.bitLength(); bit++) {
+            if (k.testBit(bit)) {
+                result = pointAdd(result, addend, a, p);
+            }
+            addend = pointDouble(addend, a, p);
+        }
+        return result;
+    }
+
+    private static ECPoint pointAdd(ECPoint first, ECPoint second, BigInteger a, BigInteger p)
+    {
+        if (first == ECPoint.POINT_INFINITY) {
+            return second;
+        }
+        if (second == ECPoint.POINT_INFINITY) {
+            return first;
+        }
+        if (first.getAffineX().equals(second.getAffineX())) {
+            if (first.getAffineY().add(second.getAffineY()).mod(p).signum() == 0) {
+                return ECPoint.POINT_INFINITY;
+            }
+            return pointDouble(first, a, p);
+        }
+        BigInteger slope = second.getAffineY().subtract(first.getAffineY())
+                .multiply(second.getAffineX().subtract(first.getAffineX()).modInverse(p))
+                .mod(p);
+        return pointFromSlope(slope, first, second.getAffineX(), p);
+    }
+
+    private static ECPoint pointDouble(ECPoint point, BigInteger a, BigInteger p)
+    {
+        if (point == ECPoint.POINT_INFINITY || point.getAffineY().signum() == 0) {
+            return ECPoint.POINT_INFINITY;
+        }
+        BigInteger slope = point.getAffineX().pow(2).multiply(BigInteger.valueOf(3)).add(a)
+                .multiply(point.getAffineY().shiftLeft(1).modInverse(p))
+                .mod(p);
+        return pointFromSlope(slope, point, point.getAffineX(), p);
+    }
+
+    private static ECPoint pointFromSlope(BigInteger slope, ECPoint first, BigInteger secondX, BigInteger p)
+    {
+        BigInteger x = slope.pow(2).subtract(first.getAffineX()).subtract(secondX).mod(p);
+        BigInteger y = slope.multiply(first.getAffineX().subtract(x)).subtract(first.getAffineY()).mod(p);
+        return new ECPoint(x, y);
     }
 
     public static KeyStore inMemoryKeyStore()

--- a/security/src/main/java/io/airlift/security/mtls/AutomaticMtls.java
+++ b/security/src/main/java/io/airlift/security/mtls/AutomaticMtls.java
@@ -25,6 +25,8 @@ import java.security.KeyFactory;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.KeyStore;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
@@ -39,7 +41,10 @@ import java.security.spec.ECPublicKeySpec;
 import java.security.spec.EllipticCurve;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -77,7 +82,15 @@ public final class AutomaticMtls
     private static final int MODULO_BIAS_MARGIN_BITS = 64; // keeps scalar reduction bias below 2^-64
     private static final int MIN_SHARED_SECRET_LENGTH = 32;
 
+    // The CA key pair is a pure, expensive (PBKDF2) function of (environment, sharedSecret). Memoize
+    // it so repeated SSL context reloads do not repeat the derivation. The key stores a digest of the
+    // shared secret rather than the secret itself, so the plaintext secret is not retained in this
+    // long-lived static map.
+    private static final Map<CacheKey, KeyPair> CA_KEY_PAIR_CACHE = new ConcurrentHashMap<>();
+
     private AutomaticMtls() {}
+
+    private record CacheKey(String environment, String sharedSecretDigest) {}
 
     /**
      * Generates a random leaf key pair for the current node, issues it a CA-signed certificate that
@@ -111,7 +124,7 @@ public final class AutomaticMtls
             List<String> dnsSubjectAltNames)
     {
         try {
-            KeyPair caKeyPair = deriveCertificateAuthorityKeyPair(sharedSecret, environment);
+            KeyPair caKeyPair = certificateAuthorityKeyPair(sharedSecret, environment);
             X509Certificate caCertificate = buildCaCertificate(caKeyPair, environment);
 
             KeyPair leafKeyPair = generateRandomEcKeyPair();
@@ -191,7 +204,29 @@ public final class AutomaticMtls
     static X509Certificate caCertificate(String sharedSecret, String environment)
             throws GeneralSecurityException
     {
-        return buildCaCertificate(deriveCertificateAuthorityKeyPair(sharedSecret, environment), environment);
+        return buildCaCertificate(certificateAuthorityKeyPair(sharedSecret, environment), environment);
+    }
+
+    private static KeyPair certificateAuthorityKeyPair(String sharedSecret, String environment)
+    {
+        // Validate before hitting the cache so a short secret always fails fast with the original
+        // IllegalArgumentException rather than being memoized or masked.
+        checkArgument(sharedSecret.length() >= MIN_SHARED_SECRET_LENGTH,
+                "automatic HTTPS shared secret must be at least %s characters; use a randomly generated high-entropy value",
+                MIN_SHARED_SECRET_LENGTH);
+        return CA_KEY_PAIR_CACHE.computeIfAbsent(
+                new CacheKey(environment, sha256Base64(sharedSecret)),
+                _ -> deriveCertificateAuthorityKeyPair(sharedSecret, environment));
+    }
+
+    private static String sha256Base64(String value)
+    {
+        try {
+            return Base64.getEncoder().encodeToString(MessageDigest.getInstance("SHA-256").digest(value.getBytes(UTF_8)));
+        }
+        catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private static X509Certificate buildCaCertificate(KeyPair caKeyPair, String environment)

--- a/security/src/test/java/io/airlift/security/mtls/TestAutomaticMtls.java
+++ b/security/src/test/java/io/airlift/security/mtls/TestAutomaticMtls.java
@@ -23,6 +23,7 @@ import java.security.KeyStore;
 import java.security.SignatureException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import java.util.HexFormat;
 import java.util.List;
 
 import static io.airlift.security.mtls.AutomaticMtls.addCertificateAndKeyForCurrentNode;
@@ -43,6 +44,23 @@ class TestAutomaticMtls
     private static final String SHARED_SECRET = "shared-secret-value-with-enough-entropy-0123456789";
     private static final String WRONG_SHARED_SECRET = "wrong-secret-value-with-enough-entropy-0123456789";
     private static final String ENVIRONMENT = "commonName";
+
+    @Test
+    public void testCaDerivationIsDeterministicAndBoundToEnvironment()
+            throws Exception
+    {
+        // Same secret + same environment must always derive the same CA public key: independently
+        // started nodes derive the same CA and therefore trust each other. This is also a "known
+        // answer" vector that fails if the derivation algorithm silently changes.
+        String expectedCaPublicKey = "3059301306072a8648ce3d020106082a8648ce3d030107034200045ce3bf4163eb83e851347e4aa756ed06a992572ee8690a1823d5054217938ba899694b345eb88a4d244748569395fd37de6967534c91fe4f8b4076d344c88a26";
+        assertThat(caPublicKeyHex(SHARED_SECRET, "test-environment"))
+                .isEqualTo(caPublicKeyHex(SHARED_SECRET, "test-environment"))
+                .isEqualTo(expectedCaPublicKey);
+
+        // A different environment (used as the KDF salt) must derive a different CA.
+        assertThat(caPublicKeyHex(SHARED_SECRET, "other-environment"))
+                .isNotEqualTo(expectedCaPublicKey);
+    }
 
     @Test
     public void testShortSharedSecretIsRejected()
@@ -138,6 +156,12 @@ class TestAutomaticMtls
                     .rootCause()
                     .isInstanceOf(CertificateException.class);
         }
+    }
+
+    private static String caPublicKeyHex(String sharedSecret, String environment)
+            throws Exception
+    {
+        return HexFormat.of().formatHex(caCertificate(sharedSecret, environment).getPublicKey().getEncoded());
     }
 
     private static class HelloWorldHandler

--- a/security/src/test/java/io/airlift/security/mtls/TestAutomaticMtls.java
+++ b/security/src/test/java/io/airlift/security/mtls/TestAutomaticMtls.java
@@ -26,6 +26,7 @@ import java.security.cert.X509Certificate;
 import java.util.List;
 
 import static io.airlift.security.mtls.AutomaticMtls.addCertificateAndKeyForCurrentNode;
+import static io.airlift.security.mtls.AutomaticMtls.addClientTrust;
 import static io.airlift.security.mtls.AutomaticMtls.addNodeCertificateAndKey;
 import static io.airlift.security.mtls.AutomaticMtls.caCertificate;
 import static io.airlift.security.mtls.AutomaticMtls.createSSLContext;
@@ -42,6 +43,24 @@ class TestAutomaticMtls
     private static final String SHARED_SECRET = "shared-secret-value-with-enough-entropy-0123456789";
     private static final String WRONG_SHARED_SECRET = "wrong-secret-value-with-enough-entropy-0123456789";
     private static final String ENVIRONMENT = "commonName";
+
+    @Test
+    public void testShortSharedSecretIsRejected()
+    {
+        // caCertificate does not catch, and the wrapping helpers must also surface the original
+        // IllegalArgumentException rather than re-wrapping it in a RuntimeException.
+        assertThatThrownBy(() -> caCertificate("too-short", ENVIRONMENT))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("automatic HTTPS shared secret must be at least 32 characters");
+
+        assertThatThrownBy(() -> addClientTrust("too-short", inMemoryKeyStore(), ENVIRONMENT))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("automatic HTTPS shared secret must be at least 32 characters");
+
+        assertThatThrownBy(() -> addCertificateAndKeyForCurrentNode("too-short", ENVIRONMENT, inMemoryKeyStore(), KEYSTORE_PASSWORD))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("automatic HTTPS shared secret must be at least 32 characters");
+    }
 
     @Test
     public void testLeafIsSignedByDerivedCa()

--- a/security/src/test/java/io/airlift/security/mtls/TestAutomaticMtls.java
+++ b/security/src/test/java/io/airlift/security/mtls/TestAutomaticMtls.java
@@ -13,20 +13,21 @@ import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLParameters;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.security.GeneralSecurityException;
 import java.security.KeyStore;
+import java.security.SignatureException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.List;
 
 import static io.airlift.security.mtls.AutomaticMtls.addCertificateAndKeyForCurrentNode;
-import static io.airlift.security.mtls.AutomaticMtls.addCertificateToKeyStore;
-import static io.airlift.security.mtls.AutomaticMtls.certificateBuilder;
+import static io.airlift.security.mtls.AutomaticMtls.addNodeCertificateAndKey;
+import static io.airlift.security.mtls.AutomaticMtls.caCertificate;
 import static io.airlift.security.mtls.AutomaticMtls.createSSLContext;
 import static io.airlift.security.mtls.AutomaticMtls.inMemoryKeyStore;
 import static java.net.http.HttpResponse.BodyHandlers.discarding;
@@ -38,47 +39,44 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class TestAutomaticMtls
 {
     private static final String KEYSTORE_PASSWORD = "123456";
+    private static final String SHARED_SECRET = "shared-secret-value-with-enough-entropy-0123456789";
+    private static final String WRONG_SHARED_SECRET = "wrong-secret-value-with-enough-entropy-0123456789";
+    private static final String ENVIRONMENT = "commonName";
 
     @Test
-    public void testTrustManager()
-            throws GeneralSecurityException
+    public void testLeafIsSignedByDerivedCa()
+            throws Exception
     {
-        X509Certificate certificate = certificateBuilder("sharedSecret", "commonName")
-                .addSanDnsNames(List.of("localhost"))
-                .buildSelfSigned();
+        KeyStore keyStore = inMemoryKeyStore();
+        X509Certificate leaf = addCertificateAndKeyForCurrentNode(SHARED_SECRET, ENVIRONMENT, keyStore, KEYSTORE_PASSWORD);
 
-        // This should pass as the certificate is self-signed and matches the trust manager's expectations
-        checkCertificate(certificate, "sharedSecret", "commonName");
+        // The leaf is issued by the CA derived from the same secret...
+        leaf.verify(caCertificate(SHARED_SECRET, ENVIRONMENT).getPublicKey());
 
-        assertThatThrownBy(() -> checkCertificate(certificate, "wrongSharedSecret", "commonName"))
-                .isInstanceOf(SecurityException.class)
-                .hasMessageContaining("Peer cert public key doesn't match trusted key");
-
-        assertThatThrownBy(() -> checkCertificate(certificate, "sharedSecret", "wrongCommonName"))
-                .isInstanceOf(SecurityException.class)
-                .hasMessageContaining("Peer certificate subject 'CN=commonName' does not match expected subject: 'CN=wrongCommonName'");
+        // ...but not by a CA derived from a different secret.
+        assertThatThrownBy(() -> leaf.verify(caCertificate(WRONG_SHARED_SECRET, ENVIRONMENT).getPublicKey()))
+                .isInstanceOf(SignatureException.class);
     }
 
     @Test
     public void testMutualAuthentication()
             throws Exception
     {
+        InetAddress loopback = InetAddress.getByName("127.0.0.1");
+
         KeyStore serverKeyStore = inMemoryKeyStore();
-        X509Certificate serverCert = addCertificateAndKeyForCurrentNode("sharedSecret", "commonName", serverKeyStore, KEYSTORE_PASSWORD);
-        SSLContext serverSSLContext = createSSLContext("sharedSecret", "commonName", serverKeyStore, KEYSTORE_PASSWORD);
+        X509Certificate serverCert = addNodeCertificateAndKey(SHARED_SECRET, ENVIRONMENT, serverKeyStore, KEYSTORE_PASSWORD, List.of(loopback), List.of());
+        SSLContext serverSSLContext = createSSLContext(SHARED_SECRET, ENVIRONMENT, serverKeyStore, KEYSTORE_PASSWORD);
 
         KeyStore clientKeyStore = inMemoryKeyStore();
-        X509Certificate clientCert = certificateBuilder("sharedSecret", "commonName")
-                .addSanDnsNames(List.of("client-address"))
-                .buildSelfSigned();
+        X509Certificate clientCert = addNodeCertificateAndKey(SHARED_SECRET, ENVIRONMENT, clientKeyStore, KEYSTORE_PASSWORD, List.of(), List.of("client-address"));
+        SSLContext clientSSLContext = createSSLContext(SHARED_SECRET, ENVIRONMENT, clientKeyStore, KEYSTORE_PASSWORD);
 
-        addCertificateToKeyStore("sharedSecret", "commonName", clientCert, clientKeyStore, KEYSTORE_PASSWORD);
-        SSLContext clientSSLContext = createSSLContext("sharedSecret", "commonName", clientKeyStore, KEYSTORE_PASSWORD);
+        // Every node has its own randomly generated leaf key pair.
+        assertThat(serverCert).isNotEqualTo(clientCert);
+        assertThat(serverCert.getPublicKey()).isNotEqualTo(clientCert.getPublicKey());
 
-        assertThat(serverCert)
-                .isNotEqualTo(clientCert);
-
-        HttpsServer server = HttpsServer.create(new InetSocketAddress(0), 0);
+        HttpsServer server = HttpsServer.create(new InetSocketAddress(loopback, 0), 0);
         server.setHttpsConfigurator(new HttpsConfigurator(serverSSLContext)
         {
             @Override
@@ -108,24 +106,19 @@ class TestAutomaticMtls
         }
 
         try (HttpClient authenticatedClient = HttpClient.newBuilder().sslContext(clientSSLContext).build()) {
-            // Will pass
             HttpResponse<String> response = authenticatedClient.send(request, ofString());
             assertThat(response.statusCode())
                     .isEqualTo(200);
             assertThat(response.body())
                     .isEqualTo("Hello, client serial: " + clientCert.getSerialNumber() + ", server serial " + serverCert.getSerialNumber() + ", san dns: [[2, client-address]]");
 
-            // Will fail as the certificate is not trusted
+            // Fails hostname verification: the server leaf has no SAN matching localhost. Assert on
+            // the exception type rather than the message, which varies across JDK/provider versions.
             assertThatThrownBy(() -> authenticatedClient.send(HttpRequest.newBuilder(new URI("https://localhost:%d/hello".formatted(serverPort))).GET().build(), discarding()))
                     .isInstanceOf(SSLHandshakeException.class)
-                    .hasMessageContaining("(certificate_unknown) No subject alternative DNS name matching localhost found");
+                    .rootCause()
+                    .isInstanceOf(CertificateException.class);
         }
-    }
-
-    private void checkCertificate(X509Certificate certificate, String sharedSecret, String commonName)
-            throws CertificateException
-    {
-        AutomaticMtls.createTrustManager(sharedSecret, commonName).checkClientTrusted(new X509Certificate[] {certificate}, "ECDSA");
     }
 
     private static class HelloWorldHandler


### PR DESCRIPTION
Derive the automatic-mTLS certificate authority deterministically from the shared secret using salted PBKDF2 key stretching instead of an unsalted SHA1PRNG seed, and have each node generate its own random leaf key signed by that CA. This keeps the private key that terminates each TLS connection unique per node and unrecoverable from the shared secret, while resisting offline brute-force of a weak secret. CertificateBuilder gains CA-signing support and no longer emits an empty SubjectAltName extension, and bcprov moves to compile scope for deterministic EC arithmetic. Shared secrets shorter than 32 characters are now rejected.

<!-- Thank you for submitting pull request to Airlift -->

# Airlift contribution check list

 - [ ] Git commit messages follow https://cbea.ms/git-commit/.
 - [ ] All automated tests are passing.
 - [ ] Pull request was categorized using one of the existing labels.
