### PR TITLE
Add HTTP client interceptors and exchange recording

### DIFF
--- a/http-client-generator/src/test/java/io/airlift/http/client/generator/AirliftHttpClientCodegenIntegrationTest.java
+++ b/http-client-generator/src/test/java/io/airlift/http/client/generator/AirliftHttpClientCodegenIntegrationTest.java
@@ -13,6 +13,13 @@
  */
 package io.airlift.http.client.generator;
 
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import io.airlift.http.client.HttpClientConfig;
+import io.airlift.http.client.RecordedExchange;
+import io.airlift.http.client.RecordedExchangeSanitizer;
+import io.airlift.http.client.RecordingHttpClientInterceptor;
+import io.airlift.http.client.jetty.JettyHttpClient;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.openapitools.codegen.ClientOptInput;
@@ -27,17 +34,99 @@ import javax.tools.ToolProvider;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Method;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 
+import static io.airlift.http.client.RecordedExchangeSanitizer.REDACTED;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.stream.Collectors.joining;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 class AirliftHttpClientCodegenIntegrationTest
 {
+    @Test
+    void testGeneratedClientRecordsEachPhysicalExchange(@TempDir Path outputPath)
+            throws Exception
+    {
+        String inputSpec = getClass().getClassLoader().getResource("petstore.yaml").getFile();
+
+        CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("airlift-http-client")
+                .setInputSpec(inputSpec)
+                .setOutputDir(outputPath.toString())
+                .addAdditionalProperty("projectName", "petstore")
+                .addAdditionalProperty("apiPackage", "com.example.api")
+                .addAdditionalProperty("modelPackage", "com.example.model")
+                .addAdditionalProperty("invokerPackage", "com.example");
+
+        new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
+        Path classesDir = verifyGeneratedCodeCompiles(outputPath);
+
+        ConcurrentLinkedQueue<RecordedExchange> recordings = new ConcurrentLinkedQueue<>();
+        RecordingHttpClientInterceptor recorder = newRecorder(recordings);
+        AtomicInteger requests = new AtomicInteger();
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/", exchange -> respond(exchange, requests.incrementAndGet()));
+        server.start();
+
+        URI baseUri = URI.create("http://127.0.0.1:" + server.getAddress().getPort());
+        try (URLClassLoader generatedClasses = new URLClassLoader(
+                new java.net.URL[] {classesDir.toUri().toURL()},
+                getClass().getClassLoader());
+                JettyHttpClient httpClient = new JettyHttpClient(new HttpClientConfig(), List.of(recorder))) {
+            Class<?> retryPolicyClass = generatedClasses.loadClass("com.example.RetryPolicy");
+            Class<?> clientClass = generatedClasses.loadClass("com.example.api.PetsClient");
+            Method listPets = Arrays.stream(clientClass.getMethods())
+                    .filter(method -> method.getName().equals("listPets"))
+                    .findFirst()
+                    .orElseThrow();
+
+            Object disabledRetry = retryPolicyClass.getMethod("disabled").invoke(null);
+            Object ordinaryClient = clientClass
+                    .getConstructor(io.airlift.http.client.HttpClient.class, URI.class, retryPolicyClass)
+                    .newInstance(httpClient, baseUri, disabledRetry);
+            assertDecodedPet(listPets.invoke(ordinaryClient, new Object[listPets.getParameterCount()]));
+            assertThat(recordings).hasSize(1);
+
+            Object oneRetry = retryPolicyClass.getMethod("withDefaults").invoke(null);
+            Object retryingClient = clientClass
+                    .getConstructor(io.airlift.http.client.HttpClient.class, URI.class, retryPolicyClass)
+                    .newInstance(httpClient, baseUri, oneRetry);
+            assertDecodedPet(listPets.invoke(retryingClient, new Object[listPets.getParameterCount()]));
+        }
+        finally {
+            server.stop(0);
+        }
+
+        assertThat(requests).hasValue(3);
+        List<RecordedExchange> exchanges = recordings.stream()
+                .sorted(java.util.Comparator.comparingLong(RecordedExchange::sequence))
+                .toList();
+        assertThat(exchanges)
+                .extracting(RecordedExchange::sequence)
+                .containsExactly(1L, 2L, 3L);
+        assertThat(exchanges)
+                .extracting(exchange -> exchange.response().orElseThrow().statusCode())
+                .containsExactly(200, 429, 200);
+        assertThat(exchanges).allSatisfy(exchange -> {
+            assertThat(exchange.request().method()).isEqualTo("GET");
+            assertThat(exchange.request().uri()).endsWith("/pets");
+            assertThat(exchange.response().orElseThrow().headers().get("set-cookie")).containsExactly(REDACTED);
+            assertThat(exchange.failure()).isEmpty();
+        });
+    }
+
     @Test
     void testGeneratePetstoreClient(@TempDir Path outputPath)
             throws Exception
@@ -352,7 +441,7 @@ class AirliftHttpClientCodegenIntegrationTest
         }
     }
 
-    private void verifyGeneratedCodeCompiles(Path outputDir)
+    private Path verifyGeneratedCodeCompiles(Path outputDir)
             throws IOException
     {
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
@@ -404,5 +493,45 @@ class AirliftHttpClientCodegenIntegrationTest
                 fail("Generated code failed to compile:\n%s".formatted(errors));
             }
         }
+        return classesDir;
+    }
+
+    private static void respond(HttpExchange exchange, int requestNumber)
+            throws IOException
+    {
+        int statusCode = requestNumber == 2 ? 429 : 200;
+        byte[] body = (statusCode == 429 ? "{\"error\":\"slow down\"}" : "[{\"id\":1,\"name\":\"Milo\"}]").getBytes(UTF_8);
+        try {
+            exchange.getResponseHeaders().add("Content-Type", "application/json; charset=utf-8");
+            exchange.getResponseHeaders().add("Set-Cookie", "session=server-secret");
+            exchange.getResponseHeaders().add("Retry-After", "0");
+            exchange.sendResponseHeaders(statusCode, body.length);
+            exchange.getResponseBody().write(body);
+        }
+        finally {
+            exchange.close();
+        }
+    }
+
+    private static void assertDecodedPet(Object result)
+            throws ReflectiveOperationException
+    {
+        assertThat(result).isInstanceOf(List.class);
+        List<?> pets = (List<?>) result;
+        assertThat(pets).hasSize(1);
+        Object pet = pets.getFirst();
+        assertThat(pet.getClass().getMethod("name").invoke(pet)).isEqualTo("Milo");
+    }
+
+    private static RecordingHttpClientInterceptor newRecorder(ConcurrentLinkedQueue<RecordedExchange> recordings)
+            throws ReflectiveOperationException
+    {
+        Class<?> dataSizeClass = Class.forName("io.airlift.units.DataSize");
+        Object maxBodySize = dataSizeClass.getMethod("ofBytes", long.class).invoke(null, 64 * 1024L);
+        RecordedExchangeSanitizer sanitizer = exchange -> exchange;
+        Consumer<RecordedExchange> sink = recordings::add;
+        return (RecordingHttpClientInterceptor) RecordingHttpClientInterceptor.class
+                .getConstructor(dataSizeClass, RecordedExchangeSanitizer.class, Consumer.class)
+                .newInstance(maxBodySize, sanitizer, sink);
     }
 }

--- a/http-client/pom.xml
+++ b/http-client/pom.xml
@@ -182,6 +182,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-trace</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
             <scope>test</scope>

--- a/http-client/src/main/java/io/airlift/http/client/HttpClientBinder.java
+++ b/http-client/src/main/java/io/airlift/http/client/HttpClientBinder.java
@@ -26,6 +26,7 @@ import org.eclipse.jetty.io.ByteBufferPool;
 
 import java.lang.annotation.Annotation;
 import java.util.Collection;
+import java.util.Optional;
 
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
@@ -35,6 +36,7 @@ public class HttpClientBinder
 {
     private final Binder binder;
     private final Multibinder<HttpRequestFilter> globalFilterBinder;
+    private final Multibinder<HttpClientInterceptor> globalInterceptorBinder;
     private final Multibinder<HttpStatusListener> globalStatusListenerBinder;
     private final OptionalBinder<ByteBufferPool> byteBufferPool;
 
@@ -42,6 +44,7 @@ public class HttpClientBinder
     {
         this.binder = binder.skipSources(getClass());
         this.globalFilterBinder = newSetBinder(binder, HttpRequestFilter.class, GlobalFilter.class);
+        this.globalInterceptorBinder = newSetBinder(binder, HttpClientInterceptor.class, GlobalFilter.class);
         this.globalStatusListenerBinder = newSetBinder(binder, HttpStatusListener.class, GlobalFilter.class);
         this.byteBufferPool = newOptionalBinder(binder, ByteBufferPool.class);
     }
@@ -58,6 +61,7 @@ public class HttpClientBinder
         return new HttpClientBindingBuilder(
                 module,
                 newSetBinder(binder, Key.get(HttpRequestFilter.class, annotation)),
+                newSetBinder(binder, Key.get(HttpClientInterceptor.class, annotation)),
                 newSetBinder(binder, Key.get(HttpStatusListener.class, annotation)),
                 newOptionalBinder(binder, Key.get(ByteBufferPool.class, annotation)));
     }
@@ -70,6 +74,11 @@ public class HttpClientBinder
     public LinkedBindingBuilder<HttpStatusListener> addGlobalStatusListenerBinding()
     {
         return globalStatusListenerBinder.addBinding();
+    }
+
+    public LinkedBindingBuilder<HttpClientInterceptor> addGlobalInterceptorBinding()
+    {
+        return globalInterceptorBinder.addBinding();
     }
 
     public HttpClientBinder bindGlobalFilter(Class<? extends HttpRequestFilter> filterClass)
@@ -90,17 +99,55 @@ public class HttpClientBinder
         return this;
     }
 
+    public HttpClientBinder bindGlobalInterceptor(Class<? extends HttpClientInterceptor> interceptorClass)
+    {
+        globalInterceptorBinder.addBinding().to(interceptorClass).in(Scopes.SINGLETON);
+        return this;
+    }
+
+    public HttpClientBinder bindGlobalInterceptor(HttpClientInterceptor interceptor)
+    {
+        globalInterceptorBinder.addBinding().toInstance(interceptor);
+        return this;
+    }
+
     public static class HttpClientBindingBuilder
     {
         private final HttpClientModule module;
         private final Multibinder<HttpRequestFilter> filterBinder;
+        private final Optional<Multibinder<HttpClientInterceptor>> interceptorBinder;
         private final Multibinder<HttpStatusListener> statusListenerBinder;
         private final OptionalBinder<ByteBufferPool> byteBufferPoolBinder;
 
-        public HttpClientBindingBuilder(HttpClientModule module, Multibinder<HttpRequestFilter> filterBinder, Multibinder<HttpStatusListener> statusListenerBinder, OptionalBinder<ByteBufferPool> byteBufferPoolBinder)
+        public HttpClientBindingBuilder(
+                HttpClientModule module,
+                Multibinder<HttpRequestFilter> filterBinder,
+                Multibinder<HttpStatusListener> statusListenerBinder,
+                OptionalBinder<ByteBufferPool> byteBufferPoolBinder)
+        {
+            this(module, filterBinder, Optional.empty(), statusListenerBinder, byteBufferPoolBinder);
+        }
+
+        public HttpClientBindingBuilder(
+                HttpClientModule module,
+                Multibinder<HttpRequestFilter> filterBinder,
+                Multibinder<HttpClientInterceptor> interceptorBinder,
+                Multibinder<HttpStatusListener> statusListenerBinder,
+                OptionalBinder<ByteBufferPool> byteBufferPoolBinder)
+        {
+            this(module, filterBinder, Optional.of(requireNonNull(interceptorBinder, "interceptorBinder is null")), statusListenerBinder, byteBufferPoolBinder);
+        }
+
+        private HttpClientBindingBuilder(
+                HttpClientModule module,
+                Multibinder<HttpRequestFilter> filterBinder,
+                Optional<Multibinder<HttpClientInterceptor>> interceptorBinder,
+                Multibinder<HttpStatusListener> statusListenerBinder,
+                OptionalBinder<ByteBufferPool> byteBufferPoolBinder)
         {
             this.module = requireNonNull(module, "module is null");
             this.filterBinder = requireNonNull(filterBinder, "multibinder is null");
+            this.interceptorBinder = requireNonNull(interceptorBinder, "interceptorBinder is null");
             this.statusListenerBinder = requireNonNull(statusListenerBinder, "statusListenerBinder is null");
             this.byteBufferPoolBinder = requireNonNull(byteBufferPoolBinder, "byteBufferPoolBinder is null");
         }
@@ -133,6 +180,17 @@ public class HttpClientBinder
         public HttpClientBindingBuilder withFilter(Class<? extends HttpRequestFilter> filterClass)
         {
             filterBinder.addBinding().to(filterClass);
+            return this;
+        }
+
+        public LinkedBindingBuilder<HttpClientInterceptor> addInterceptorBinding()
+        {
+            return interceptorBinder.orElseThrow(() -> new IllegalStateException("interceptor binder is not configured")).addBinding();
+        }
+
+        public HttpClientBindingBuilder withInterceptor(Class<? extends HttpClientInterceptor> interceptorClass)
+        {
+            addInterceptorBinding().to(interceptorClass);
             return this;
         }
 

--- a/http-client/src/main/java/io/airlift/http/client/HttpClientInterceptor.java
+++ b/http-client/src/main/java/io/airlift/http/client/HttpClientInterceptor.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.http.client;
+
+/**
+ * Intercepts a synchronous HTTP exchange.
+ * <p>
+ * An interceptor can rewrite a request, short-circuit an exchange, or wrap the
+ * response returned by {@link Chain#proceed(Request)}. Interceptors that wrap a
+ * response must preserve its close behavior. Registered interceptor instances
+ * can be invoked concurrently by independent client calls.
+ */
+@FunctionalInterface
+public interface HttpClientInterceptor
+{
+    StreamingResponse intercept(Chain chain);
+
+    interface Chain
+    {
+        /**
+         * Returns the request presented to this interceptor.
+         */
+        Request request();
+
+        /**
+         * Continues the exchange with the supplied request.
+         * <p>
+         * An interceptor can call this method zero or more times. Every
+         * returned response that is not returned to the caller must be closed
+         * by the interceptor.
+         */
+        StreamingResponse proceed(Request request);
+    }
+}

--- a/http-client/src/main/java/io/airlift/http/client/HttpClientModule.java
+++ b/http-client/src/main/java/io/airlift/http/client/HttpClientModule.java
@@ -83,6 +83,10 @@ public class HttpClientModule
         // kick off the binding for the filter set
         newSetBinder(binder, HttpRequestFilter.class, annotation);
 
+        // kick off the bindings for interceptors
+        newSetBinder(binder, HttpClientInterceptor.class, GlobalFilter.class);
+        newSetBinder(binder, HttpClientInterceptor.class, annotation);
+
         // export stats
         newExporter(binder).export(HttpClient.class).annotatedWith(annotation).withGeneratedName();
     }
@@ -146,12 +150,26 @@ public class HttpClientModule
                     .addAll(injector.getInstance(Key.get(new TypeLiteral<Set<HttpRequestFilter>>() {}, annotation)))
                     .build();
 
+            Set<HttpClientInterceptor> interceptors = ImmutableSet.<HttpClientInterceptor>builder()
+                    .addAll(injector.getInstance(Key.get(new TypeLiteral<Set<HttpClientInterceptor>>() {}, GlobalFilter.class)))
+                    .addAll(injector.getInstance(Key.get(new TypeLiteral<Set<HttpClientInterceptor>>() {}, annotation)))
+                    .build();
+
             Set<HttpStatusListener> httpStatusListeners = ImmutableSet.<HttpStatusListener>builder()
                     .addAll(injector.getInstance(Key.get(new TypeLiteral<Set<HttpStatusListener>>() {}, GlobalFilter.class)))
                     .addAll(injector.getInstance(Key.get(new TypeLiteral<Set<HttpStatusListener>>() {}, annotation)))
                     .build();
 
-            return new JettyHttpClient(name, config, ImmutableList.copyOf(filters), openTelemetry, tracer, environment, sslContextFactory, httpStatusListeners);
+            return new JettyHttpClient(
+                    name,
+                    config,
+                    ImmutableList.copyOf(filters),
+                    openTelemetry,
+                    tracer,
+                    environment,
+                    sslContextFactory,
+                    httpStatusListeners,
+                    ImmutableList.copyOf(interceptors));
         }
     }
 }

--- a/http-client/src/main/java/io/airlift/http/client/RecordedExchange.java
+++ b/http-client/src/main/java/io/airlift/http/client/RecordedExchange.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.http.client;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public record RecordedExchange(
+        int version,
+        long sequence,
+        RecordedRequest request,
+        Optional<RecordedResponse> response,
+        Optional<RecordedFailure> failure)
+{
+    public static final int CURRENT_VERSION = 1;
+
+    public RecordedExchange
+    {
+        checkArgument(version == CURRENT_VERSION, "unsupported recorded exchange version: %s", version);
+        checkArgument(sequence > 0, "sequence must be positive");
+        requireNonNull(request, "request is null");
+        requireNonNull(response, "response is null");
+        requireNonNull(failure, "failure is null");
+        checkArgument(response.isPresent() || failure.isPresent(), "response and failure are both empty");
+    }
+
+    public RecordedExchange withRequest(RecordedRequest request)
+    {
+        return new RecordedExchange(version, sequence, request, response, failure);
+    }
+
+    public RecordedExchange withResponse(Optional<RecordedResponse> response)
+    {
+        return new RecordedExchange(version, sequence, request, response, failure);
+    }
+
+    public RecordedExchange withFailure(Optional<RecordedFailure> failure)
+    {
+        return new RecordedExchange(version, sequence, request, response, failure);
+    }
+
+    public record RecordedRequest(String method, String uri, Map<String, List<String>> headers, CapturedBody body)
+    {
+        public RecordedRequest
+        {
+            requireNonNull(method, "method is null");
+            requireNonNull(uri, "uri is null");
+            headers = copyHeaders(headers);
+            requireNonNull(body, "body is null");
+        }
+
+        public RecordedRequest withHeaders(Map<String, List<String>> headers)
+        {
+            return new RecordedRequest(method, uri, headers, body);
+        }
+
+        public RecordedRequest withUri(String uri)
+        {
+            return new RecordedRequest(method, uri, headers, body);
+        }
+
+        public RecordedRequest withBody(CapturedBody body)
+        {
+            return new RecordedRequest(method, uri, headers, body);
+        }
+    }
+
+    public record RecordedResponse(int statusCode, Map<String, List<String>> headers, CapturedBody body)
+    {
+        public RecordedResponse
+        {
+            checkArgument(statusCode >= 100 && statusCode <= 999, "invalid status code: %s", statusCode);
+            headers = copyHeaders(headers);
+            requireNonNull(body, "body is null");
+        }
+
+        public RecordedResponse withHeaders(Map<String, List<String>> headers)
+        {
+            return new RecordedResponse(statusCode, headers, body);
+        }
+
+        public RecordedResponse withBody(CapturedBody body)
+        {
+            return new RecordedResponse(statusCode, headers, body);
+        }
+    }
+
+    public record RecordedFailure(String type, String message)
+    {
+        public RecordedFailure
+        {
+            requireNonNull(type, "type is null");
+            requireNonNull(message, "message is null");
+        }
+    }
+
+    public record CapturedBody(byte[] bytes, CaptureState state, boolean truncated)
+    {
+        public CapturedBody
+        {
+            bytes = requireNonNull(bytes, "bytes is null").clone();
+            requireNonNull(state, "state is null");
+            checkArgument(state != CaptureState.UNSUPPORTED || (bytes.length == 0 && !truncated), "unsupported body cannot contain captured bytes");
+        }
+
+        @Override
+        public byte[] bytes()
+        {
+            return bytes.clone();
+        }
+    }
+
+    public enum CaptureState
+    {
+        COMPLETE,
+        INCOMPLETE,
+        UNSUPPORTED,
+    }
+
+    private static Map<String, List<String>> copyHeaders(Map<String, List<String>> headers)
+    {
+        requireNonNull(headers, "headers is null");
+        ImmutableMap.Builder<String, List<String>> copy = ImmutableMap.builder();
+        headers.forEach((name, values) -> copy.put(requireNonNull(name, "header name is null"), ImmutableList.copyOf(values)));
+        return copy.buildOrThrow();
+    }
+}

--- a/http-client/src/main/java/io/airlift/http/client/RecordedExchangeSanitizer.java
+++ b/http-client/src/main/java/io/airlift/http/client/RecordedExchangeSanitizer.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.http.client;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
+
+@FunctionalInterface
+public interface RecordedExchangeSanitizer
+{
+    String REDACTED = "[REDACTED]";
+
+    RecordedExchange sanitize(RecordedExchange exchange);
+
+    default RecordedExchangeSanitizer andThen(RecordedExchangeSanitizer after)
+    {
+        requireNonNull(after, "after is null");
+        return exchange -> after.sanitize(sanitize(exchange));
+    }
+
+    static RecordedExchangeSanitizer redactSensitiveHeaders()
+    {
+        return exchange -> exchange
+                .withRequest(exchange.request().withHeaders(redactHeaders(exchange.request().headers())))
+                .withResponse(exchange.response().map(response -> response.withHeaders(redactHeaders(response.headers()))));
+    }
+
+    private static Map<String, List<String>> redactHeaders(Map<String, List<String>> headers)
+    {
+        ImmutableMap.Builder<String, List<String>> sanitized = ImmutableMap.builder();
+        headers.forEach((name, values) -> sanitized.put(
+                name,
+                isSensitive(name) ? ImmutableList.copyOf(values.stream().map(_ -> REDACTED).toList()) : values));
+        return sanitized.buildOrThrow();
+    }
+
+    private static boolean isSensitive(String name)
+    {
+        String lowerCase = name.toLowerCase(ENGLISH);
+        return lowerCase.equals("authorization") ||
+                lowerCase.equals("proxy-authorization") ||
+                lowerCase.equals("cookie") ||
+                lowerCase.equals("set-cookie") ||
+                lowerCase.equals("api-key") ||
+                lowerCase.equals("x-api-key") ||
+                lowerCase.equals("token") ||
+                lowerCase.endsWith("-token");
+    }
+}

--- a/http-client/src/main/java/io/airlift/http/client/RecordingHttpClientInterceptor.java
+++ b/http-client/src/main/java/io/airlift/http/client/RecordingHttpClientInterceptor.java
@@ -1,0 +1,412 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.http.client;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ListMultimap;
+import io.airlift.http.client.RecordedExchange.CaptureState;
+import io.airlift.http.client.RecordedExchange.CapturedBody;
+import io.airlift.http.client.RecordedExchange.RecordedFailure;
+import io.airlift.http.client.RecordedExchange.RecordedRequest;
+import io.airlift.http.client.RecordedExchange.RecordedResponse;
+import io.airlift.units.DataSize;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.http.client.RecordedExchange.CURRENT_VERSION;
+import static java.lang.Math.min;
+import static java.util.Objects.requireNonNull;
+
+public final class RecordingHttpClientInterceptor
+        implements HttpClientInterceptor
+{
+    private final int maxBodyBytes;
+    private final RecordedExchangeSanitizer sanitizer;
+    private final Consumer<RecordedExchange> sink;
+    private final AtomicLong nextSequence = new AtomicLong();
+
+    public RecordingHttpClientInterceptor(DataSize maxBodySize, RecordedExchangeSanitizer sanitizer, Consumer<RecordedExchange> sink)
+    {
+        long maxBodyBytes = requireNonNull(maxBodySize, "maxBodySize is null").toBytes();
+        checkArgument(maxBodyBytes >= 0 && maxBodyBytes <= Integer.MAX_VALUE, "maxBodySize must be between 0 and %s bytes", Integer.MAX_VALUE);
+        this.maxBodyBytes = (int) maxBodyBytes;
+        this.sanitizer = RecordedExchangeSanitizer.redactSensitiveHeaders()
+                .andThen(requireNonNull(sanitizer, "sanitizer is null"));
+        this.sink = requireNonNull(sink, "sink is null");
+    }
+
+    @Override
+    public StreamingResponse intercept(Chain chain)
+    {
+        requireNonNull(chain, "chain is null");
+        long sequence = nextSequence.incrementAndGet();
+        RecordedRequest request = captureRequest(chain.request());
+        CaptureContext context = new CaptureContext(sequence, request);
+
+        StreamingResponse response;
+        try {
+            response = requireNonNull(chain.proceed(chain.request()), "chain returned null response");
+        }
+        catch (Throwable failure) {
+            context.publish(Optional.empty(), Optional.of(captureFailure(failure)));
+            throw failure;
+        }
+
+        try {
+            return new RecordingStreamingResponse(response, context);
+        }
+        catch (Throwable failure) {
+            response.close();
+            throw failure;
+        }
+    }
+
+    private RecordedRequest captureRequest(Request request)
+    {
+        return new RecordedRequest(
+                request.getMethod(),
+                request.getUri().toASCIIString(),
+                copyHeaders(request.getHeaders()),
+                captureRequestBody(request.getBodyGenerator()));
+    }
+
+    private CapturedBody captureRequestBody(BodyGenerator bodyGenerator)
+    {
+        return switch (bodyGenerator) {
+            case null -> new CapturedBody(new byte[0], CaptureState.COMPLETE, false);
+            case StaticBodyGenerator generator -> captureBytes(generator.getBody(), CaptureState.COMPLETE);
+            case ByteBufferBodyGenerator generator -> captureByteBuffers(generator.getByteBuffers());
+            case FileBodyGenerator _, StreamingBodyGenerator _ -> new CapturedBody(new byte[0], CaptureState.UNSUPPORTED, false);
+        };
+    }
+
+    private CapturedBody captureByteBuffers(ByteBuffer[] byteBuffers)
+    {
+        BodyCapture capture = new BodyCapture(maxBodyBytes);
+        for (ByteBuffer byteBuffer : byteBuffers) {
+            capture.append(requireNonNull(byteBuffer, "byteBuffer is null").duplicate());
+        }
+        return capture.snapshot(CaptureState.COMPLETE);
+    }
+
+    private CapturedBody captureBytes(byte[] bytes, CaptureState state)
+    {
+        int capturedLength = min(bytes.length, maxBodyBytes);
+        byte[] captured = new byte[capturedLength];
+        System.arraycopy(bytes, 0, captured, 0, capturedLength);
+        return new CapturedBody(captured, state, bytes.length > maxBodyBytes);
+    }
+
+    private static Map<String, List<String>> copyHeaders(ListMultimap<HeaderName, String> headers)
+    {
+        ImmutableMap.Builder<String, List<String>> copy = ImmutableMap.builder();
+        headers.asMap().forEach((name, values) -> copy.put(name.toString(), ImmutableList.copyOf(values)));
+        return copy.buildOrThrow();
+    }
+
+    private static RecordedFailure captureFailure(Throwable throwable)
+    {
+        Throwable cause = requireNonNull(throwable, "throwable is null");
+        while (cause.getCause() != null && cause.getCause() != cause) {
+            cause = cause.getCause();
+        }
+        return new RecordedFailure(cause.getClass().getName(), Optional.ofNullable(cause.getMessage()).orElse(""));
+    }
+
+    private final class CaptureContext
+    {
+        private final long sequence;
+        private final RecordedRequest request;
+        private final AtomicBoolean published = new AtomicBoolean();
+
+        private CaptureContext(long sequence, RecordedRequest request)
+        {
+            this.sequence = sequence;
+            this.request = requireNonNull(request, "request is null");
+        }
+
+        private void publish(Optional<RecordedResponse> response, Optional<RecordedFailure> failure)
+        {
+            if (published.compareAndSet(false, true)) {
+                RecordedExchange rawExchange = new RecordedExchange(CURRENT_VERSION, sequence, request, response, failure);
+                sink.accept(requireNonNull(sanitizer.sanitize(rawExchange), "sanitizer returned null"));
+            }
+        }
+    }
+
+    private final class RecordingStreamingResponse
+            implements StreamingResponse
+    {
+        private final StreamingResponse delegate;
+        private final CaptureContext context;
+        private final int statusCode;
+        private final Map<String, List<String>> headers;
+        private final Response.Content content;
+        private final AtomicBoolean closed = new AtomicBoolean();
+        private final BodyCapture capture;
+
+        private RecordingStreamingResponse(StreamingResponse delegate, CaptureContext context)
+        {
+            this.delegate = requireNonNull(delegate, "delegate is null");
+            this.context = requireNonNull(context, "context is null");
+            this.statusCode = delegate.getStatusCode();
+            this.headers = copyHeaders(delegate.getHeaders());
+
+            this.content = switch (delegate.getContent()) {
+                case Response.BytesContent(byte[] bytes) -> {
+                    CapturedBody body = captureBytes(bytes, CaptureState.COMPLETE);
+                    context.publish(Optional.of(recordedResponse(body)), Optional.empty());
+                    this.capture = null;
+                    yield new Response.BytesContent(bytes);
+                }
+                case Response.InputStreamContent(InputStream inputStream) -> {
+                    this.capture = new BodyCapture(maxBodyBytes);
+                    yield new Response.InputStreamContent(new RecordingInputStream(inputStream, this));
+                }
+            };
+        }
+
+        @Override
+        public HttpVersion getHttpVersion()
+        {
+            return delegate.getHttpVersion();
+        }
+
+        @Override
+        public int getStatusCode()
+        {
+            return statusCode;
+        }
+
+        @Override
+        public ListMultimap<HeaderName, String> getHeaders()
+        {
+            return delegate.getHeaders();
+        }
+
+        @Override
+        public Response.Content getContent()
+        {
+            return content;
+        }
+
+        @Override
+        public InputStream getInputStream()
+        {
+            return switch (content) {
+                case Response.BytesContent(byte[] bytes) -> new ByteArrayInputStream(bytes);
+                case Response.InputStreamContent(InputStream inputStream) -> inputStream;
+            };
+        }
+
+        @Override
+        public long getBytesRead()
+        {
+            return delegate.getBytesRead();
+        }
+
+        @Override
+        public void close()
+        {
+            if (!closed.compareAndSet(false, true)) {
+                return;
+            }
+
+            try {
+                delegate.close();
+            }
+            catch (Throwable failure) {
+                publish(CaptureState.INCOMPLETE, Optional.of(captureFailure(failure)));
+                throw failure;
+            }
+            publish(CaptureState.INCOMPLETE, Optional.empty());
+        }
+
+        private void streamComplete()
+        {
+            publish(CaptureState.COMPLETE, Optional.empty());
+        }
+
+        private void streamClosed()
+        {
+            publish(CaptureState.INCOMPLETE, Optional.empty());
+        }
+
+        private void streamFailed(IOException failure)
+        {
+            publish(CaptureState.INCOMPLETE, Optional.of(captureFailure(failure)));
+        }
+
+        private void publish(CaptureState state, Optional<RecordedFailure> failure)
+        {
+            if (capture != null) {
+                context.publish(Optional.of(recordedResponse(capture.snapshot(state))), failure);
+            }
+        }
+
+        private RecordedResponse recordedResponse(CapturedBody body)
+        {
+            return new RecordedResponse(statusCode, headers, body);
+        }
+    }
+
+    private static final class RecordingInputStream
+            extends FilterInputStream
+    {
+        private final RecordingStreamingResponse response;
+        private final AtomicBoolean closed = new AtomicBoolean();
+
+        private RecordingInputStream(InputStream delegate, RecordingStreamingResponse response)
+        {
+            super(requireNonNull(delegate, "delegate is null"));
+            this.response = requireNonNull(response, "response is null");
+        }
+
+        @Override
+        public int read()
+                throws IOException
+        {
+            try {
+                int value = super.read();
+                if (value < 0) {
+                    response.streamComplete();
+                }
+                else {
+                    response.capture.append((byte) value);
+                }
+                return value;
+            }
+            catch (IOException failure) {
+                response.streamFailed(failure);
+                throw failure;
+            }
+        }
+
+        @Override
+        public int read(byte[] bytes, int offset, int length)
+                throws IOException
+        {
+            try {
+                int read = super.read(bytes, offset, length);
+                if (read < 0) {
+                    response.streamComplete();
+                }
+                else {
+                    response.capture.append(bytes, offset, read);
+                }
+                return read;
+            }
+            catch (IOException failure) {
+                response.streamFailed(failure);
+                throw failure;
+            }
+        }
+
+        @Override
+        public long skip(long bytes)
+                throws IOException
+        {
+            if (bytes <= 0) {
+                return 0;
+            }
+
+            byte[] buffer = new byte[(int) min(bytes, 8_192)];
+            long skipped = 0;
+            while (skipped < bytes) {
+                int read = read(buffer, 0, (int) min(buffer.length, bytes - skipped));
+                if (read < 0) {
+                    break;
+                }
+                skipped += read;
+            }
+            return skipped;
+        }
+
+        @Override
+        public void close()
+                throws IOException
+        {
+            if (!closed.compareAndSet(false, true)) {
+                return;
+            }
+            try {
+                super.close();
+            }
+            catch (IOException failure) {
+                response.streamFailed(failure);
+                throw failure;
+            }
+            response.streamClosed();
+        }
+    }
+
+    private static final class BodyCapture
+    {
+        private final int limit;
+        private final ByteArrayOutputStream output;
+        private boolean truncated;
+
+        private BodyCapture(int limit)
+        {
+            this.limit = limit;
+            this.output = new ByteArrayOutputStream(min(limit, 1024));
+        }
+
+        private void append(byte value)
+        {
+            if (output.size() < limit) {
+                output.write(value);
+            }
+            else {
+                truncated = true;
+            }
+        }
+
+        private void append(byte[] bytes, int offset, int length)
+        {
+            int captured = min(length, limit - output.size());
+            output.write(bytes, offset, captured);
+            truncated |= captured < length;
+        }
+
+        private void append(ByteBuffer buffer)
+        {
+            int captured = min(buffer.remaining(), limit - output.size());
+            if (captured > 0) {
+                byte[] bytes = new byte[captured];
+                buffer.get(bytes);
+                output.writeBytes(bytes);
+            }
+            truncated |= buffer.hasRemaining();
+        }
+
+        private CapturedBody snapshot(CaptureState state)
+        {
+            return new CapturedBody(output.toByteArray(), state, truncated);
+        }
+    }
+}

--- a/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/JettyHttpClient.java
@@ -10,6 +10,7 @@ import io.airlift.http.client.ByteBufferBodyGenerator;
 import io.airlift.http.client.FileBodyGenerator;
 import io.airlift.http.client.HeaderName;
 import io.airlift.http.client.HttpClientConfig;
+import io.airlift.http.client.HttpClientInterceptor;
 import io.airlift.http.client.HttpRequestFilter;
 import io.airlift.http.client.HttpStatusListener;
 import io.airlift.http.client.Request;
@@ -106,6 +107,7 @@ import java.util.Queue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
@@ -164,6 +166,7 @@ public class JettyHttpClient
     private final CachedDistribution currentResponseProcessTime;
 
     private final List<HttpRequestFilter> requestFilters;
+    private final List<HttpClientInterceptor> interceptorChain;
     private final HttpStatusListeners httpStatusListeners;
     private final String name;
     private final TextMapPropagator propagator;
@@ -181,6 +184,11 @@ public class JettyHttpClient
     public JettyHttpClient(HttpClientConfig config)
     {
         this(uniqueName(), config);
+    }
+
+    public JettyHttpClient(HttpClientConfig config, Iterable<? extends HttpClientInterceptor> interceptors)
+    {
+        this(uniqueName(), config, ImmutableList.of(), NOOP_OPEN_TELEMETRY, NOOP_TRACER, Optional.empty(), Optional.empty(), ImmutableList.of(), interceptors);
     }
 
     public JettyHttpClient(String name, HttpClientConfig config)
@@ -237,6 +245,20 @@ public class JettyHttpClient
             Optional<SslContextFactory.Client> maybeSslContextFactory,
             Iterable<? extends HttpStatusListener> httpStatusListeners)
     {
+        this(name, config, requestFilters, openTelemetry, tracer, environment, maybeSslContextFactory, httpStatusListeners, ImmutableList.of());
+    }
+
+    public JettyHttpClient(
+            String name,
+            HttpClientConfig config,
+            Iterable<? extends HttpRequestFilter> requestFilters,
+            OpenTelemetry openTelemetry,
+            Tracer tracer,
+            Optional<String> environment,
+            Optional<SslContextFactory.Client> maybeSslContextFactory,
+            Iterable<? extends HttpStatusListener> httpStatusListeners,
+            Iterable<? extends HttpClientInterceptor> interceptors)
+    {
         this.name = requireNonNull(name, "name is null");
         this.propagator = openTelemetry.getPropagators().getTextMapPropagator();
         this.tracer = requireNonNull(tracer, "tracer is null");
@@ -244,6 +266,7 @@ public class JettyHttpClient
         requireNonNull(config, "config is null");
         requireNonNull(requestFilters, "requestFilters is null");
         requireNonNull(httpStatusListeners, "httpStatusListeners is null");
+        requireNonNull(interceptors, "interceptors is null");
 
         maxResponseContentLength = config.getMaxResponseContentLength();
         requestTimeout = config.getRequestTimeout();
@@ -372,6 +395,13 @@ public class JettyHttpClient
         this.clientDiagnostics = new JettyClientDiagnostics();
 
         this.requestFilters = ImmutableList.copyOf(requestFilters);
+        this.interceptorChain = ImmutableList.<HttpClientInterceptor>builder()
+                .addAll(this.requestFilters.stream()
+                        .map(filter -> (HttpClientInterceptor) chain -> chain.proceed(filter.filterRequest(chain.request())))
+                        .toList())
+                .add(this::interceptTracing)
+                .addAll(interceptors)
+                .build();
         this.httpStatusListeners = new HttpStatusListeners(ImmutableList.copyOf(httpStatusListeners));
 
         this.monitoredQueuedThreadPoolMBean = new MonitoredQueuedThreadPoolMBean((MonitoredQueuedThreadPool) httpClient.getExecutor());
@@ -663,106 +693,109 @@ public class JettyHttpClient
     public <T, E extends Exception> T execute(Request request, ResponseHandler<T, E> responseHandler)
             throws E
     {
-        request = applyRequestFilters(request);
+        requireNonNull(request, "request is null");
+        requireNonNull(responseHandler, "responseHandler is null");
 
-        Span span = startSpan(request);
-        request = injectTracing(request, span);
-
+        ExecutionState state = new ExecutionState(request, true);
         try {
-            InternalResponse<T> internalResponse = internalExecute(request, OptionalLong.of(getMaxResponseContentLength(request).toBytes()), responseHandler::handleException, span);
-            return switch (internalResponse) {
-                case InternalExceptionResponse(T exceptionResponse) -> exceptionResponse;
-                case InternalStandardResponse(JettyResponse jettyResponse, Runnable completionHandler) -> {
-                    try {
-                        yield responseHandler.handle(request, jettyResponse);
-                    }
-                    finally {
-                        completionHandler.run();
-                    }
+            try (StreamingResponse response = executeIntercepted(state)) {
+                try {
+                    return responseHandler.handle(state.request(), response);
                 }
-            };
+                catch (Throwable t) {
+                    recordSpanFailure(state.span(), t);
+                    throw t;
+                }
+            }
         }
-        catch (Throwable t) {
-            span.setStatus(StatusCode.ERROR, t.getMessage());
-            span.recordException(t, Attributes.of(EXCEPTION_ESCAPED, true));
-            throw t;
-        }
-        finally {
-            span.end();
+        catch (TransportException e) {
+            try {
+                return responseHandler.handleException(e.request(), e.exception());
+            }
+            catch (Throwable t) {
+                recordSpanFailure(state.span(), t);
+                throw t;
+            }
+            finally {
+                state.span().end();
+            }
         }
     }
 
     @Override
     public StreamingResponse executeStreaming(Request request)
     {
-        request = applyRequestFilters(request);
+        requireNonNull(request, "request is null");
 
-        Span span = startSpan(request);
-        request = injectTracing(request, span);
+        try {
+            return executeIntercepted(new ExecutionState(request, false));
+        }
+        catch (TransportException e) {
+            throw propagate(e.request(), e.exception());
+        }
+    }
 
-        ExceptionHandler<StreamingResponse, RuntimeException> exceptionHandler = (r, exception) -> {
-            try {
-                span.setStatus(StatusCode.ERROR, exception.getMessage());
-                span.recordException(exception, Attributes.of(EXCEPTION_ESCAPED, true));
+    private StreamingResponse executeIntercepted(ExecutionState state)
+    {
+        return new RealChain(0, state.request(), state).proceed(state.request());
+    }
 
-                throw propagate(r, exception);
-            }
-            finally {
+    private StreamingResponse interceptTracing(HttpClientInterceptor.Chain chain)
+    {
+        RealChain realChain = (RealChain) chain;
+        ExecutionState state = realChain.state();
+
+        Span span = startSpan(chain.request());
+        state.setSpan(span);
+        Request tracedRequest = injectTracing(chain.request(), span);
+
+        try {
+            StreamingResponse response = requireNonNull(chain.proceed(tracedRequest), "interceptor returned null response");
+            return new ForwardingStreamingResponse(response, () -> {
+                try {
+                    response.close();
+                }
+                catch (Throwable t) {
+                    if (state.limitResponseSize()) {
+                        recordSpanFailure(span, t);
+                    }
+                    throw t;
+                }
+                finally {
+                    span.end();
+                }
+            });
+        }
+        catch (Throwable t) {
+            if (!(t instanceof TransportException) || !state.limitResponseSize()) {
+                Throwable failure = t instanceof TransportException transportException ? transportException.exception() : t;
+                recordSpanFailure(span, failure);
                 span.end();
             }
+            throwIfUnchecked(t);
+            throw new RuntimeException(t);
+        }
+    }
+
+    private static void recordSpanFailure(Span span, Throwable failure)
+    {
+        span.setStatus(StatusCode.ERROR, failure.getMessage());
+        span.recordException(failure, Attributes.of(EXCEPTION_ESCAPED, true));
+    }
+
+    private StreamingResponse executeTerminal(Request request, ExecutionState state)
+    {
+        OptionalLong maxResponseLength = state.limitResponseSize()
+                ? OptionalLong.of(getMaxResponseContentLength(request).toBytes())
+                : OptionalLong.empty();
+
+        ExceptionHandler<StreamingResponse, RuntimeException> exceptionHandler = (failedRequest, exception) -> {
+            throw new TransportException(failedRequest, exception);
         };
 
-        return switch (internalExecute(request, OptionalLong.empty(), exceptionHandler, span)) {
+        return switch (internalExecute(request, maxResponseLength, exceptionHandler, state.span())) {
             case InternalExceptionResponse(StreamingResponse exceptionResponse) -> exceptionResponse;
-            case InternalStandardResponse(JettyResponse jettyResponse, Runnable completionHandler) -> new StreamingResponse()
-            {
-                @Override
-                public io.airlift.http.client.HttpVersion getHttpVersion()
-                {
-                    return jettyResponse.getHttpVersion();
-                }
-
-                @Override
-                public int getStatusCode()
-                {
-                    return jettyResponse.getStatusCode();
-                }
-
-                @Override
-                public ListMultimap<HeaderName, String> getHeaders()
-                {
-                    return jettyResponse.getHeaders();
-                }
-
-                @Override
-                public Content getContent()
-                {
-                    return jettyResponse.getContent();
-                }
-
-                @Override
-                public InputStream getInputStream()
-                {
-                    return jettyResponse.getInputStream();
-                }
-
-                @Override
-                public long getBytesRead()
-                {
-                    return jettyResponse.getBytesRead();
-                }
-
-                @Override
-                public void close()
-                {
-                    try {
-                        completionHandler.run();
-                    }
-                    finally {
-                        span.end();
-                    }
-                }
-            };
+            case InternalStandardResponse(JettyResponse jettyResponse, Runnable completionHandler) -> new ForwardingStreamingResponse(jettyResponse, completionHandler);
         };
     }
 
@@ -771,6 +804,166 @@ public class JettyHttpClient
     {
         T handleException(Request request, Exception exception)
                 throws E;
+    }
+
+    private final class RealChain
+            implements HttpClientInterceptor.Chain
+    {
+        private final int index;
+        private final Request request;
+        private final ExecutionState state;
+
+        private RealChain(int index, Request request, ExecutionState state)
+        {
+            this.index = index;
+            this.request = requireNonNull(request, "request is null");
+            this.state = requireNonNull(state, "state is null");
+        }
+
+        @Override
+        public Request request()
+        {
+            return request;
+        }
+
+        @Override
+        public StreamingResponse proceed(Request request)
+        {
+            requireNonNull(request, "request is null");
+            state.setRequest(request);
+            if (index == interceptorChain.size()) {
+                return executeTerminal(request, state);
+            }
+            return requireNonNull(
+                    interceptorChain.get(index).intercept(new RealChain(index + 1, request, state)),
+                    "interceptor returned null response");
+        }
+
+        private ExecutionState state()
+        {
+            return state;
+        }
+    }
+
+    private static final class ExecutionState
+    {
+        private Request request;
+        private final boolean limitResponseSize;
+        private Span span;
+
+        private ExecutionState(Request request, boolean limitResponseSize)
+        {
+            this.request = requireNonNull(request, "request is null");
+            this.limitResponseSize = limitResponseSize;
+        }
+
+        private Request request()
+        {
+            return request;
+        }
+
+        private void setRequest(Request request)
+        {
+            this.request = requireNonNull(request, "request is null");
+        }
+
+        private boolean limitResponseSize()
+        {
+            return limitResponseSize;
+        }
+
+        private Span span()
+        {
+            return requireNonNull(span, "span is null");
+        }
+
+        private void setSpan(Span span)
+        {
+            this.span = requireNonNull(span, "span is null");
+        }
+    }
+
+    private static final class TransportException
+            extends RuntimeException
+    {
+        private final Request request;
+        private final Exception exception;
+
+        private TransportException(Request request, Exception exception)
+        {
+            super(exception);
+            this.request = requireNonNull(request, "request is null");
+            this.exception = requireNonNull(exception, "exception is null");
+        }
+
+        private Request request()
+        {
+            return request;
+        }
+
+        private Exception exception()
+        {
+            return exception;
+        }
+    }
+
+    private static final class ForwardingStreamingResponse
+            implements StreamingResponse
+    {
+        private final io.airlift.http.client.Response delegate;
+        private final Runnable closeHandler;
+        private final AtomicBoolean closed = new AtomicBoolean();
+
+        private ForwardingStreamingResponse(io.airlift.http.client.Response delegate, Runnable closeHandler)
+        {
+            this.delegate = requireNonNull(delegate, "delegate is null");
+            this.closeHandler = requireNonNull(closeHandler, "closeHandler is null");
+        }
+
+        @Override
+        public io.airlift.http.client.HttpVersion getHttpVersion()
+        {
+            return delegate.getHttpVersion();
+        }
+
+        @Override
+        public int getStatusCode()
+        {
+            return delegate.getStatusCode();
+        }
+
+        @Override
+        public ListMultimap<HeaderName, String> getHeaders()
+        {
+            return delegate.getHeaders();
+        }
+
+        @Override
+        public Content getContent()
+        {
+            return delegate.getContent();
+        }
+
+        @Override
+        public InputStream getInputStream()
+                throws IOException
+        {
+            return delegate.getInputStream();
+        }
+
+        @Override
+        public long getBytesRead()
+        {
+            return delegate.getBytesRead();
+        }
+
+        @Override
+        public void close()
+        {
+            if (closed.compareAndSet(false, true)) {
+                closeHandler.run();
+            }
+        }
     }
 
     @SuppressWarnings("unused")

--- a/http-client/src/test/java/io/airlift/http/client/TestHttpClientBinder.java
+++ b/http-client/src/test/java/io/airlift/http/client/TestHttpClientBinder.java
@@ -17,6 +17,8 @@ package io.airlift.http.client;
 
 import com.google.common.collect.HashMultiset;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multiset;
 import com.google.inject.BindingAnnotation;
 import com.google.inject.Injector;
@@ -29,11 +31,19 @@ import io.airlift.units.Duration;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import static io.airlift.http.client.HttpClientBinder.httpClientBinder;
+import static io.airlift.http.client.Request.Builder.prepareGet;
+import static io.airlift.http.client.StringResponseHandler.createStringResponseHandler;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -118,6 +128,51 @@ public class TestHttpClientBinder
         assertThat(barClient.getRequestFilters().get(0)).isEqualTo(globalFilter1);
         assertThat(barClient.getRequestFilters().get(1)).isEqualTo(globalFilter2);
         assertThat(barClient.getRequestFilters().get(2)).isEqualTo(filter2);
+    }
+
+    @Test
+    public void testGlobalAndNamedInterceptorBindingOrder()
+    {
+        List<String> events = new CopyOnWriteArrayList<>();
+        HttpClientInterceptor globalInterceptor1 = orderedInterceptor("global-1", events, false);
+        HttpClientInterceptor globalInterceptor2 = orderedInterceptor("global-2", events, false);
+        HttpClientInterceptor fooInterceptor = orderedInterceptor("foo", events, true);
+        HttpClientInterceptor barInterceptor = orderedInterceptor("bar", events, true);
+
+        Injector injector = new Bootstrap(
+                binder -> {
+                    httpClientBinder(binder)
+                            .addGlobalInterceptorBinding().toInstance(globalInterceptor1);
+                    httpClientBinder(binder)
+                            .bindGlobalInterceptor(globalInterceptor2);
+                    httpClientBinder(binder).bindHttpClient("foo", FooClient.class)
+                            .addInterceptorBinding().toInstance(fooInterceptor);
+                    httpClientBinder(binder).bindHttpClient("bar", BarClient.class)
+                            .addInterceptorBinding().toInstance(barInterceptor);
+                })
+                .quiet()
+                .initialize();
+
+        HttpClient fooClient = injector.getInstance(Key.get(HttpClient.class, FooClient.class));
+        fooClient.execute(prepareGet().setUri(URI.create("http://unused.invalid")).build(), createStringResponseHandler());
+        assertThat(events).containsExactly(
+                "global-1-before",
+                "global-2-before",
+                "foo-before",
+                "foo-after",
+                "global-2-after",
+                "global-1-after");
+
+        events.clear();
+        HttpClient barClient = injector.getInstance(Key.get(HttpClient.class, BarClient.class));
+        barClient.execute(prepareGet().setUri(URI.create("http://unused.invalid")).build(), createStringResponseHandler());
+        assertThat(events).containsExactly(
+                "global-1-before",
+                "global-2-before",
+                "bar-before",
+                "bar-after",
+                "global-2-after",
+                "global-1-after");
     }
 
     @Test
@@ -313,6 +368,68 @@ public class TestHttpClientBinder
     {
         assertThat(httpClient).isInstanceOfSatisfying(JettyHttpClient.class, jettyClient ->
                 assertThat(jettyClient.getStatusListeners().size()).isEqualTo(statusListenerCount));
+    }
+
+    private static HttpClientInterceptor orderedInterceptor(String name, List<String> events, boolean shortCircuit)
+    {
+        return chain -> {
+            events.add(name + "-before");
+            StreamingResponse response = shortCircuit
+                    ? new StaticStreamingResponse("body")
+                    : chain.proceed(chain.request());
+            events.add(name + "-after");
+            return response;
+        };
+    }
+
+    private static final class StaticStreamingResponse
+            implements StreamingResponse
+    {
+        private final byte[] body;
+
+        private StaticStreamingResponse(String body)
+        {
+            this.body = body.getBytes(StandardCharsets.UTF_8);
+        }
+
+        @Override
+        public HttpVersion getHttpVersion()
+        {
+            return HttpVersion.HTTP_1;
+        }
+
+        @Override
+        public int getStatusCode()
+        {
+            return HttpStatus.OK.code();
+        }
+
+        @Override
+        public ListMultimap<HeaderName, String> getHeaders()
+        {
+            return ImmutableListMultimap.of();
+        }
+
+        @Override
+        public Content getContent()
+        {
+            return new BytesContent(body);
+        }
+
+        @Override
+        public InputStream getInputStream()
+        {
+            return new ByteArrayInputStream(body);
+        }
+
+        @Override
+        public long getBytesRead()
+        {
+            return body.length;
+        }
+
+        @Override
+        public void close() {}
     }
 
     @Retention(RUNTIME)

--- a/http-client/src/test/java/io/airlift/http/client/TestRecordingHttpClientInterceptor.java
+++ b/http-client/src/test/java/io/airlift/http/client/TestRecordingHttpClientInterceptor.java
@@ -1,0 +1,458 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.http.client;
+
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ListMultimap;
+import io.airlift.http.client.RecordedExchange.CaptureState;
+import io.airlift.http.client.RecordedExchange.CapturedBody;
+import io.airlift.http.client.jetty.JettyHttpClient;
+import io.airlift.units.DataSize;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+
+import static io.airlift.http.client.RecordedExchangeSanitizer.REDACTED;
+import static io.airlift.http.client.Request.Builder.prepareGet;
+import static io.airlift.http.client.Request.Builder.preparePost;
+import static io.airlift.http.client.StaticBodyGenerator.createStaticBodyGenerator;
+import static io.airlift.http.client.StreamingBodyGenerator.streamingBodyGenerator;
+import static io.airlift.http.client.StringResponseHandler.createStringResponseHandler;
+import static io.airlift.units.DataSize.Unit.BYTE;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TestRecordingHttpClientInterceptor
+{
+    @Test
+    void testRecordsSanitizedRealExchangeWithoutConsumingDecoder()
+            throws Exception
+    {
+        EchoServlet servlet = new EchoServlet();
+        servlet.setResponseStatusCode(HttpStatus.CREATED.code());
+        servlet.addResponseHeader("Set-Cookie", "session=response-secret");
+        servlet.setResponseBody("response-secret");
+        ConcurrentLinkedQueue<RecordedExchange> recordings = new ConcurrentLinkedQueue<>();
+        AtomicBoolean callerSanitizerInvoked = new AtomicBoolean();
+        RecordedExchangeSanitizer callerSanitizer = exchange -> {
+            callerSanitizerInvoked.set(true);
+            return exchange
+                    .withRequest(exchange.request()
+                            .withUri("http://recorded.invalid/resource?access_token=" + REDACTED)
+                            .withBody(redactedBody()))
+                    .withResponse(exchange.response().map(response -> response.withBody(redactedBody())));
+        };
+        RecordingHttpClientInterceptor recorder = new RecordingHttpClientInterceptor(
+                DataSize.of(1_024, BYTE),
+                callerSanitizer,
+                recordings::add);
+
+        try (TestingHttpServer server = new TestingHttpServer(Optional.empty(), servlet);
+                JettyHttpClient client = new JettyHttpClient(new HttpClientConfig(), List.of(recorder))) {
+            Request request = preparePost()
+                    .setUri(server.baseURI().resolve("/resource?access_token=request-secret"))
+                    .setHeader(HeaderName.of("Authorization"), "Bearer request-secret")
+                    .setHeader(HeaderName.of("Cookie"), "session=request-secret")
+                    .setHeader(HeaderName.of("X-GitHub-Token"), "request-secret")
+                    .setBodyGenerator(createStaticBodyGenerator("request-secret", UTF_8))
+                    .build();
+
+            StringResponseHandler.StringResponse response = client.execute(request, createStringResponseHandler());
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED.code());
+            assertThat(response.getBody()).isEqualTo("response-secret");
+        }
+
+        assertThat(callerSanitizerInvoked).isTrue();
+        assertThat(recordings).hasSize(1);
+        RecordedExchange exchange = recordings.element();
+        assertThat(exchange.version()).isEqualTo(RecordedExchange.CURRENT_VERSION);
+        assertThat(exchange.sequence()).isEqualTo(1);
+        assertThat(exchange.request().method()).isEqualTo("POST");
+        assertThat(exchange.request().uri()).isEqualTo("http://recorded.invalid/resource?access_token=" + REDACTED);
+        assertThat(exchange.request().headers().get("authorization")).containsExactly(REDACTED);
+        assertThat(exchange.request().headers().get("cookie")).containsExactly(REDACTED);
+        assertThat(exchange.request().headers().get("x-github-token")).containsExactly(REDACTED);
+        assertThat(new String(exchange.request().body().bytes(), UTF_8)).isEqualTo(REDACTED);
+        assertThat(exchange.response()).get().satisfies(recordedResponse -> {
+            assertThat(recordedResponse.statusCode()).isEqualTo(HttpStatus.CREATED.code());
+            assertThat(recordedResponse.headers().get("set-cookie")).containsExactly(REDACTED);
+            assertThat(new String(recordedResponse.body().bytes(), UTF_8)).isEqualTo(REDACTED);
+        });
+        assertThat(exchange.failure()).isEmpty();
+    }
+
+    @Test
+    void testStreamingResponseUsesOneTeeAndCompletesAtEof()
+            throws Exception
+    {
+        EchoServlet servlet = new EchoServlet();
+        servlet.setResponseBody("streamed-body");
+        ConcurrentLinkedQueue<RecordedExchange> recordings = new ConcurrentLinkedQueue<>();
+        RecordingHttpClientInterceptor recorder = recorder(1_024, recordings);
+
+        try (TestingHttpServer server = new TestingHttpServer(Optional.empty(), servlet);
+                JettyHttpClient client = new JettyHttpClient(new HttpClientConfig(), List.of(recorder));
+                StreamingResponse response = client.executeStreaming(prepareGet().setUri(server.baseURI()).build())) {
+            Response.InputStreamContent content = (Response.InputStreamContent) response.getContent();
+            assertThat(response.getInputStream()).isSameAs(content.inputStream());
+            assertThat(new String(content.inputStream().readAllBytes(), UTF_8)).isEqualTo("streamed-body");
+        }
+
+        assertThat(recordings).hasSize(1);
+        CapturedBody body = recordings.element().response().orElseThrow().body();
+        assertThat(new String(body.bytes(), UTF_8)).isEqualTo("streamed-body");
+        assertThat(body.state()).isEqualTo(CaptureState.COMPLETE);
+        assertThat(body.truncated()).isFalse();
+    }
+
+    @Test
+    void testEarlyCloseRecordsIncompleteBody()
+            throws Exception
+    {
+        EchoServlet servlet = new EchoServlet();
+        servlet.setResponseBody("streamed-body");
+        ConcurrentLinkedQueue<RecordedExchange> recordings = new ConcurrentLinkedQueue<>();
+        RecordingHttpClientInterceptor recorder = recorder(1_024, recordings);
+
+        try (TestingHttpServer server = new TestingHttpServer(Optional.empty(), servlet);
+                JettyHttpClient client = new JettyHttpClient(new HttpClientConfig(), List.of(recorder));
+                StreamingResponse response = client.executeStreaming(prepareGet().setUri(server.baseURI()).build())) {
+            assertThat(response.getInputStream().readNBytes(3)).containsExactly("str".getBytes(UTF_8));
+        }
+
+        assertThat(recordings).hasSize(1);
+        CapturedBody body = recordings.element().response().orElseThrow().body();
+        assertThat(new String(body.bytes(), UTF_8)).isEqualTo("str");
+        assertThat(body.state()).isEqualTo(CaptureState.INCOMPLETE);
+        assertThat(body.truncated()).isFalse();
+    }
+
+    @Test
+    void testRequestAndResponseCaptureAreBoundedWithoutTruncatingDecoder()
+            throws Exception
+    {
+        EchoServlet servlet = new EchoServlet();
+        servlet.setResponseBody("response-body");
+        ConcurrentLinkedQueue<RecordedExchange> recordings = new ConcurrentLinkedQueue<>();
+        RecordingHttpClientInterceptor recorder = recorder(4, recordings);
+
+        try (TestingHttpServer server = new TestingHttpServer(Optional.empty(), servlet);
+                JettyHttpClient client = new JettyHttpClient(new HttpClientConfig(), List.of(recorder))) {
+            Request request = preparePost()
+                    .setUri(server.baseURI())
+                    .setBodyGenerator(createStaticBodyGenerator("request-body", UTF_8))
+                    .build();
+            assertThat(client.execute(request, createStringResponseHandler()).getBody()).isEqualTo("response-body");
+        }
+
+        RecordedExchange exchange = recordings.element();
+        assertThat(new String(exchange.request().body().bytes(), UTF_8)).isEqualTo("requ");
+        assertThat(exchange.request().body().state()).isEqualTo(CaptureState.COMPLETE);
+        assertThat(exchange.request().body().truncated()).isTrue();
+        assertThat(new String(exchange.response().orElseThrow().body().bytes(), UTF_8)).isEqualTo("resp");
+        assertThat(exchange.response().orElseThrow().body().state()).isEqualTo(CaptureState.COMPLETE);
+        assertThat(exchange.response().orElseThrow().body().truncated()).isTrue();
+    }
+
+    @Test
+    void testByteBufferRequestSnapshotDoesNotConsumeBuffers()
+    {
+        ByteBuffer first = ByteBuffer.wrap("first".getBytes(UTF_8));
+        first.position(1);
+        ByteBuffer second = ByteBuffer.wrap("-second".getBytes(UTF_8));
+        ConcurrentLinkedQueue<RecordedExchange> recordings = new ConcurrentLinkedQueue<>();
+        RecordingHttpClientInterceptor recorder = recorder(1_024, recordings);
+        Request request = preparePost()
+                .setUri(URI.create("http://unused.invalid"))
+                .setBodyGenerator(new ByteBufferBodyGenerator(first, second))
+                .build();
+
+        try (StreamingResponse ignored = recorder.intercept(chain(request, _ -> new StaticStreamingResponse("response")))) {
+            assertThat(first.position()).isEqualTo(1);
+            assertThat(second.position()).isZero();
+        }
+
+        assertThat(new String(recordings.element().request().body().bytes(), UTF_8)).isEqualTo("irst-second");
+        assertThat(recordings.element().request().body().state()).isEqualTo(CaptureState.COMPLETE);
+    }
+
+    @Test
+    void testFileAndStreamingRequestCaptureIsUnsupported()
+    {
+        ConcurrentLinkedQueue<RecordedExchange> recordings = new ConcurrentLinkedQueue<>();
+        RecordingHttpClientInterceptor recorder = recorder(1_024, recordings);
+        List<Request> requests = List.of(
+                preparePost()
+                        .setUri(URI.create("http://unused.invalid/stream"))
+                        .setBodyGenerator(streamingBodyGenerator(new ByteArrayInputStream("request".getBytes(UTF_8))))
+                        .build(),
+                preparePost()
+                        .setUri(URI.create("http://unused.invalid/file"))
+                        .setBodyGenerator(new FileBodyGenerator(Path.of("must-not-be-read")))
+                        .build());
+
+        for (Request request : requests) {
+            try (StreamingResponse response = recorder.intercept(chain(request, _ -> new StaticStreamingResponse("response")))) {
+                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK.code());
+            }
+        }
+
+        assertThat(recordings).allSatisfy(exchange -> {
+            assertThat(exchange.request().body().state()).isEqualTo(CaptureState.UNSUPPORTED);
+            assertThat(exchange.request().body().bytes()).isEmpty();
+        });
+    }
+
+    @Test
+    void testSkippedResponseBytesAreStillCaptured()
+            throws Exception
+    {
+        ConcurrentLinkedQueue<RecordedExchange> recordings = new ConcurrentLinkedQueue<>();
+        RecordingHttpClientInterceptor recorder = recorder(1_024, recordings);
+        Request request = prepareGet().setUri(URI.create("http://unused.invalid")).build();
+
+        try (StreamingResponse response = recorder.intercept(chain(
+                request,
+                _ -> new StreamStreamingResponse(new ByteArrayInputStream("abcdef".getBytes(UTF_8)))))) {
+            assertThat(response.getInputStream().skip(2)).isEqualTo(2);
+            assertThat(new String(response.getInputStream().readAllBytes(), UTF_8)).isEqualTo("cdef");
+        }
+
+        CapturedBody body = recordings.element().response().orElseThrow().body();
+        assertThat(new String(body.bytes(), UTF_8)).isEqualTo("abcdef");
+        assertThat(body.state()).isEqualTo(CaptureState.COMPLETE);
+    }
+
+    @Test
+    void testShortCircuitResponseIsRecorded()
+    {
+        ConcurrentLinkedQueue<RecordedExchange> recordings = new ConcurrentLinkedQueue<>();
+        RecordingHttpClientInterceptor recorder = recorder(1_024, recordings);
+        Request request = prepareGet().setUri(URI.create("http://unused.invalid")).build();
+
+        try (JettyHttpClient client = new JettyHttpClient(
+                new HttpClientConfig(),
+                List.<HttpClientInterceptor>of(recorder, _ -> new StaticStreamingResponse("short-circuit")))) {
+            assertThat(client.execute(request, createStringResponseHandler()).getBody()).isEqualTo("short-circuit");
+        }
+
+        assertThat(new String(recordings.element().response().orElseThrow().body().bytes(), UTF_8)).isEqualTo("short-circuit");
+    }
+
+    @Test
+    void testFailureRecordsRootCauseInsteadOfTransportWrapper()
+    {
+        ConcurrentLinkedQueue<RecordedExchange> recordings = new ConcurrentLinkedQueue<>();
+        RecordingHttpClientInterceptor recorder = recorder(1_024, recordings);
+        Request request = prepareGet().setUri(URI.create("http://unused.invalid")).build();
+        IOException transportFailure = new IOException("connection failed");
+
+        assertThatThrownBy(() -> recorder.intercept(chain(request, _ -> {
+            throw new UncheckedIOException("transport wrapper", transportFailure);
+        })))
+                .isInstanceOf(UncheckedIOException.class)
+                .hasCause(transportFailure);
+
+        assertThat(recordings).hasSize(1);
+        assertThat(recordings.element().response()).isEmpty();
+        assertThat(recordings.element().failure()).get().satisfies(failure -> {
+            assertThat(failure.type()).isEqualTo(IOException.class.getName());
+            assertThat(failure.message()).isEqualTo("connection failed");
+        });
+    }
+
+    @Test
+    void testResponseReadFailureIsRecordedWithIncompleteBody()
+            throws Exception
+    {
+        ConcurrentLinkedQueue<RecordedExchange> recordings = new ConcurrentLinkedQueue<>();
+        RecordingHttpClientInterceptor recorder = recorder(1_024, recordings);
+        Request request = prepareGet().setUri(URI.create("http://unused.invalid")).build();
+        InputStream failingInput = new InputStream()
+        {
+            @Override
+            public int read()
+                    throws IOException
+            {
+                throw new IOException("read failed");
+            }
+        };
+
+        try (StreamingResponse response = recorder.intercept(chain(request, _ -> new StreamStreamingResponse(failingInput)))) {
+            assertThatThrownBy(() -> response.getInputStream().read())
+                    .isInstanceOf(IOException.class)
+                    .hasMessage("read failed");
+        }
+
+        RecordedExchange exchange = recordings.element();
+        assertThat(exchange.response()).get().satisfies(response -> assertThat(response.body().state()).isEqualTo(CaptureState.INCOMPLETE));
+        assertThat(exchange.failure()).get().satisfies(failure -> assertThat(failure.type()).isEqualTo(IOException.class.getName()));
+    }
+
+    @Test
+    void testConcurrentSequencesAreUniqueAndCorrelateRequests()
+            throws Exception
+    {
+        int requestCount = 100;
+        ConcurrentLinkedQueue<RecordedExchange> recordings = new ConcurrentLinkedQueue<>();
+        RecordingHttpClientInterceptor recorder = recorder(1_024, recordings);
+        List<Future<?>> futures = new ArrayList<>();
+
+        try (ExecutorService executor = Executors.newFixedThreadPool(16)) {
+            for (int index = 0; index < requestCount; index++) {
+                int requestIndex = index;
+                futures.add(executor.submit(() -> {
+                    Request request = prepareGet()
+                            .setUri(URI.create("http://unused.invalid/request-" + requestIndex))
+                            .build();
+                    try (StreamingResponse ignored = recorder.intercept(chain(request, _ -> new StaticStreamingResponse("response-" + requestIndex)))) {
+                        return null;
+                    }
+                }));
+            }
+            for (Future<?> future : futures) {
+                future.get(10, SECONDS);
+            }
+        }
+
+        assertThat(recordings).hasSize(requestCount);
+        assertThat(recordings.stream().map(RecordedExchange::sequence).sorted()).containsExactlyElementsOf(
+                java.util.stream.LongStream.rangeClosed(1, requestCount).boxed().toList());
+        assertThat(recordings.stream()
+                .sorted(Comparator.comparingLong(RecordedExchange::sequence))
+                .map(exchange -> exchange.request().uri()))
+                .doesNotHaveDuplicates();
+    }
+
+    private static RecordingHttpClientInterceptor recorder(int maxBodyBytes, ConcurrentLinkedQueue<RecordedExchange> recordings)
+    {
+        return new RecordingHttpClientInterceptor(DataSize.of(maxBodyBytes, BYTE), exchange -> exchange, recordings::add);
+    }
+
+    private static CapturedBody redactedBody()
+    {
+        return new CapturedBody(REDACTED.getBytes(UTF_8), CaptureState.COMPLETE, false);
+    }
+
+    private static HttpClientInterceptor.Chain chain(Request request, Function<Request, StreamingResponse> proceed)
+    {
+        return new HttpClientInterceptor.Chain()
+        {
+            @Override
+            public Request request()
+            {
+                return request;
+            }
+
+            @Override
+            public StreamingResponse proceed(Request request)
+            {
+                return proceed.apply(request);
+            }
+        };
+    }
+
+    private static class StaticStreamingResponse
+            implements StreamingResponse
+    {
+        private final byte[] body;
+
+        private StaticStreamingResponse(String body)
+        {
+            this.body = body.getBytes(StandardCharsets.UTF_8);
+        }
+
+        @Override
+        public HttpVersion getHttpVersion()
+        {
+            return HttpVersion.HTTP_1;
+        }
+
+        @Override
+        public int getStatusCode()
+        {
+            return HttpStatus.OK.code();
+        }
+
+        @Override
+        public ListMultimap<HeaderName, String> getHeaders()
+        {
+            return ImmutableListMultimap.of();
+        }
+
+        @Override
+        public Content getContent()
+        {
+            return new BytesContent(body);
+        }
+
+        @Override
+        public InputStream getInputStream()
+        {
+            return new ByteArrayInputStream(body);
+        }
+
+        @Override
+        public long getBytesRead()
+        {
+            return body.length;
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    private static final class StreamStreamingResponse
+            extends StaticStreamingResponse
+    {
+        private final InputStream inputStream;
+
+        private StreamStreamingResponse(InputStream inputStream)
+        {
+            super("");
+            this.inputStream = inputStream;
+        }
+
+        @Override
+        public Content getContent()
+        {
+            return new InputStreamContent(inputStream);
+        }
+
+        @Override
+        public InputStream getInputStream()
+        {
+            return inputStream;
+        }
+    }
+}

--- a/http-client/src/test/java/io/airlift/http/client/jetty/TestJettyHttpClientInterceptor.java
+++ b/http-client/src/test/java/io/airlift/http/client/jetty/TestJettyHttpClientInterceptor.java
@@ -1,0 +1,672 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.http.client.jetty;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ListMultimap;
+import io.airlift.http.client.EchoServlet;
+import io.airlift.http.client.HeaderName;
+import io.airlift.http.client.HttpClientConfig;
+import io.airlift.http.client.HttpClientInterceptor;
+import io.airlift.http.client.HttpRequestFilter;
+import io.airlift.http.client.HttpStatus;
+import io.airlift.http.client.HttpVersion;
+import io.airlift.http.client.Request;
+import io.airlift.http.client.Response;
+import io.airlift.http.client.ResponseHandler;
+import io.airlift.http.client.StreamingResponse;
+import io.airlift.http.client.TestingHttpServer;
+import io.opentelemetry.api.trace.TracerProvider;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.context.propagation.TextMapSetter;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.google.common.collect.MoreCollectors.onlyElement;
+import static io.airlift.http.client.Request.Builder.fromRequest;
+import static io.airlift.http.client.Request.Builder.prepareGet;
+import static io.airlift.http.client.StatusResponseHandler.createStatusResponseHandler;
+import static io.airlift.http.client.StringResponseHandler.createStringResponseHandler;
+import static io.opentelemetry.api.OpenTelemetry.propagating;
+import static io.opentelemetry.api.trace.StatusCode.ERROR;
+import static io.opentelemetry.api.trace.StatusCode.UNSET;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TestJettyHttpClientInterceptor
+{
+    private static final HeaderName FILTER_HEADER = HeaderName.of("x-test-filter");
+    private static final HeaderName INTERCEPTOR_HEADER = HeaderName.of("x-test-interceptor");
+    private static final HeaderName REQUEST_ID_HEADER = HeaderName.of("x-test-request-id");
+    private static final HeaderName TRACE_HEADER = HeaderName.of("x-test-trace");
+
+    @Test
+    void testRequestRewriteReachesTransport()
+            throws Exception
+    {
+        EchoServlet servlet = new EchoServlet();
+        try (TestingHttpServer server = new TestingHttpServer(Optional.empty(), servlet);
+                JettyHttpClient client = new JettyHttpClient(new HttpClientConfig(), List.of(chain -> {
+                    Request rewritten = fromRequest(chain.request())
+                            .setUri(server.baseURI().resolve("/rewritten?value=expected"))
+                            .setHeader(INTERCEPTOR_HEADER, "present")
+                            .build();
+                    return chain.proceed(rewritten);
+                }))) {
+            client.execute(prepareGet().setUri(server.baseURI()).build(), createStatusResponseHandler());
+
+            assertThat(servlet.getRequestUri().getPath()).isEqualTo("/rewritten");
+            assertThat(servlet.getRequestUri().getQuery()).isEqualTo("value=expected");
+            assertThat(servlet.getRequestHeaders(INTERCEPTOR_HEADER)).containsExactly("present");
+        }
+    }
+
+    @Test
+    void testLegacyFiltersAndTracingRunBeforeUserInterceptors()
+    {
+        AtomicReference<Request> interceptedRequest = new AtomicReference<>();
+        HttpRequestFilter filter = request -> fromRequest(request)
+                .setHeader(FILTER_HEADER, "filtered")
+                .build();
+        HttpClientInterceptor interceptor = chain -> {
+            interceptedRequest.set(chain.request());
+            return new StaticStreamingResponse(HttpStatus.OK, "short-circuit");
+        };
+
+        try (JettyHttpClient client = new JettyHttpClient(
+                "interceptor-order-test",
+                new HttpClientConfig(),
+                List.of(filter),
+                propagating(ContextPropagators.create(new TestingPropagator())),
+                TracerProvider.noop().get("testing"),
+                Optional.empty(),
+                Optional.empty(),
+                List.of(),
+                List.of(interceptor))) {
+            client.execute(prepareGet().setUri(URI.create("http://unused.invalid")).build(), createStringResponseHandler());
+        }
+
+        assertThat(interceptedRequest.get().getHeaders().get(FILTER_HEADER)).containsExactly("filtered");
+        assertThat(interceptedRequest.get().getHeaders().get(TRACE_HEADER)).containsExactly("injected");
+    }
+
+    @Test
+    void testFirstRegisteredInterceptorIsOutermost()
+    {
+        List<String> events = new CopyOnWriteArrayList<>();
+        List<HttpClientInterceptor> interceptors = List.of(
+                orderedInterceptor("first", events, false),
+                orderedInterceptor("second", events, false),
+                orderedInterceptor("third", events, true));
+
+        try (JettyHttpClient client = new JettyHttpClient(new HttpClientConfig(), interceptors)) {
+            client.execute(prepareGet().setUri(URI.create("http://unused.invalid")).build(), createStringResponseHandler());
+        }
+
+        assertThat(events).containsExactly(
+                "first-before",
+                "second-before",
+                "third-before",
+                "third-after",
+                "second-after",
+                "first-after");
+    }
+
+    @Test
+    void testResponseWrappingIsVisibleToSynchronousHandler()
+    {
+        HttpClientInterceptor wrappingInterceptor = chain -> new ForwardingStreamingResponse(chain.proceed(chain.request()))
+        {
+            @Override
+            public int getStatusCode()
+            {
+                return HttpStatus.CREATED.code();
+            }
+        };
+        HttpClientInterceptor shortCircuit = _ -> new StaticStreamingResponse(HttpStatus.OK, "body");
+
+        try (JettyHttpClient client = new JettyHttpClient(new HttpClientConfig(), List.of(wrappingInterceptor, shortCircuit))) {
+            assertThat(client.execute(prepareGet().setUri(URI.create("http://unused.invalid")).build(), createStatusResponseHandler()).getStatusCode())
+                    .isEqualTo(HttpStatus.CREATED.code());
+        }
+    }
+
+    @Test
+    void testShortCircuitIsVisibleToStreamingCaller()
+            throws IOException
+    {
+        HttpClientInterceptor shortCircuit = _ -> new StaticStreamingResponse(HttpStatus.ACCEPTED, "short-circuit");
+
+        try (JettyHttpClient client = new JettyHttpClient(new HttpClientConfig(), List.of(shortCircuit));
+                StreamingResponse response = client.executeStreaming(prepareGet().setUri(URI.create("http://unused.invalid")).build())) {
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.ACCEPTED.code());
+            assertThat(new String(response.getInputStream().readAllBytes(), StandardCharsets.UTF_8)).isEqualTo("short-circuit");
+        }
+    }
+
+    @Test
+    void testTransportFailureIsObservedByInterceptorAndHandledByResponseHandler()
+            throws Exception
+    {
+        AtomicReference<RuntimeException> observedFailure = new AtomicReference<>();
+        AtomicReference<Exception> handledFailure = new AtomicReference<>();
+        HttpClientInterceptor interceptor = chain -> {
+            try {
+                return chain.proceed(chain.request());
+            }
+            catch (RuntimeException e) {
+                observedFailure.set(e);
+                throw e;
+            }
+        };
+
+        try (ResettingServer server = new ResettingServer();
+                JettyHttpClient client = new JettyHttpClient(new HttpClientConfig(), List.of(interceptor))) {
+            String result = client.execute(prepareGet().setUri(server.uri()).build(), new ResponseHandler<>()
+            {
+                @Override
+                public String handleException(Request request, Exception exception)
+                {
+                    handledFailure.set(exception);
+                    return "handled";
+                }
+
+                @Override
+                public String handle(Request request, Response response)
+                {
+                    throw new AssertionError("transport failure unexpectedly produced a response");
+                }
+            });
+
+            assertThat(result).isEqualTo("handled");
+            assertThat(observedFailure.get()).hasCause(handledFailure.get());
+        }
+    }
+
+    @Test
+    void testInterceptorFailureBypassesResponseHandler()
+    {
+        IllegalStateException failure = new IllegalStateException("interceptor failed");
+        AtomicBoolean exceptionHandlerCalled = new AtomicBoolean();
+        HttpClientInterceptor interceptor = _ -> {
+            throw failure;
+        };
+
+        try (JettyHttpClient client = new JettyHttpClient(new HttpClientConfig(), List.of(interceptor))) {
+            assertThatThrownBy(() -> client.execute(prepareGet().setUri(URI.create("http://unused.invalid")).build(), new ResponseHandler<>()
+            {
+                @Override
+                public Object handleException(Request request, Exception exception)
+                {
+                    exceptionHandlerCalled.set(true);
+                    return null;
+                }
+
+                @Override
+                public Object handle(Request request, Response response)
+                {
+                    throw new AssertionError("interceptor failure unexpectedly produced a response");
+                }
+            }))
+                    .isSameAs(failure);
+        }
+
+        assertThat(exceptionHandlerCalled).isFalse();
+    }
+
+    @Test
+    void testSynchronousExecutionClosesResponseExactlyOnce()
+    {
+        AtomicInteger closeCount = new AtomicInteger();
+        HttpClientInterceptor shortCircuit = _ -> new StaticStreamingResponse(HttpStatus.OK, "body", closeCount);
+
+        try (JettyHttpClient client = new JettyHttpClient(new HttpClientConfig(), List.of(shortCircuit))) {
+            client.execute(prepareGet().setUri(URI.create("http://unused.invalid")).build(), createStringResponseHandler());
+        }
+
+        assertThat(closeCount).hasValue(1);
+    }
+
+    @Test
+    void testSynchronousHandlerFailureIsRecordedBeforeSpanEnds()
+    {
+        RuntimeException failure = new RuntimeException("handler failed");
+        InMemorySpanExporter exporter = InMemorySpanExporter.create();
+        try (SdkTracerProvider tracerProvider = SdkTracerProvider.builder()
+                .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+                .build();
+                JettyHttpClient client = tracingClient(tracerProvider, _ -> new StaticStreamingResponse(HttpStatus.OK, "body"))) {
+            assertThatThrownBy(() -> client.execute(
+                    prepareGet().setUri(URI.create("http://unused.invalid")).build(),
+                    new ResponseHandler<>()
+                    {
+                        @Override
+                        public Object handleException(Request request, Exception exception)
+                        {
+                            throw new AssertionError("short circuit unexpectedly produced a transport failure");
+                        }
+
+                        @Override
+                        public Object handle(Request request, Response response)
+                        {
+                            throw failure;
+                        }
+                    }))
+                    .isSameAs(failure);
+            assertSpanFailure(exporter, failure);
+        }
+    }
+
+    @Test
+    void testSynchronousCloseFailureIsRecordedBeforeSpanEnds()
+    {
+        RuntimeException failure = new RuntimeException("close failed");
+        InMemorySpanExporter exporter = InMemorySpanExporter.create();
+        try (SdkTracerProvider tracerProvider = SdkTracerProvider.builder()
+                .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+                .build();
+                JettyHttpClient client = tracingClient(tracerProvider, _ -> new StaticStreamingResponse(HttpStatus.OK, "body")
+                {
+                    @Override
+                    public void close()
+                    {
+                        throw failure;
+                    }
+                })) {
+            assertThatThrownBy(() -> client.execute(
+                    prepareGet().setUri(URI.create("http://unused.invalid")).build(),
+                    createStringResponseHandler()))
+                    .isSameAs(failure);
+            assertSpanFailure(exporter, failure);
+        }
+    }
+
+    @Test
+    void testHandledSynchronousTransportFailurePreservesSpanStatus()
+            throws Exception
+    {
+        InMemorySpanExporter exporter = InMemorySpanExporter.create();
+        try (ResettingServer server = new ResettingServer();
+                SdkTracerProvider tracerProvider = SdkTracerProvider.builder()
+                        .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+                        .build();
+                JettyHttpClient client = tracingClient(tracerProvider, chain -> chain.proceed(chain.request()))) {
+            String result = client.execute(prepareGet().setUri(server.uri()).build(), new ResponseHandler<String, RuntimeException>()
+            {
+                @Override
+                public String handleException(Request request, Exception exception)
+                {
+                    return "handled";
+                }
+
+                @Override
+                public String handle(Request request, Response response)
+                {
+                    throw new AssertionError("transport failure unexpectedly produced a response");
+                }
+            });
+            assertThat(result).isEqualTo("handled");
+
+            SpanData span = exporter.getFinishedSpanItems().stream().collect(onlyElement());
+            assertThat(span.getStatus().getStatusCode()).isEqualTo(UNSET);
+            assertThat(span.getEvents()).isEmpty();
+        }
+    }
+
+    @Test
+    void testSynchronousTransportExceptionHandlerFailureIsRecordedBeforeSpanEnds()
+            throws Exception
+    {
+        RuntimeException failure = new RuntimeException("exception handler failed");
+        InMemorySpanExporter exporter = InMemorySpanExporter.create();
+        try (ResettingServer server = new ResettingServer();
+                SdkTracerProvider tracerProvider = SdkTracerProvider.builder()
+                        .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+                        .build();
+                JettyHttpClient client = tracingClient(tracerProvider, chain -> chain.proceed(chain.request()))) {
+            assertThatThrownBy(() -> client.execute(prepareGet().setUri(server.uri()).build(), new ResponseHandler<>()
+            {
+                @Override
+                public Object handleException(Request request, Exception exception)
+                {
+                    throw failure;
+                }
+
+                @Override
+                public Object handle(Request request, Response response)
+                {
+                    throw new AssertionError("transport failure unexpectedly produced a response");
+                }
+            }))
+                    .isSameAs(failure);
+            assertSpanFailure(exporter, failure);
+        }
+    }
+
+    @Test
+    void testStreamingExecutionClosesResponseExactlyOnce()
+    {
+        AtomicInteger closeCount = new AtomicInteger();
+        HttpClientInterceptor shortCircuit = _ -> new StaticStreamingResponse(HttpStatus.OK, "body", closeCount);
+
+        try (JettyHttpClient client = new JettyHttpClient(new HttpClientConfig(), List.of(shortCircuit))) {
+            StreamingResponse response = client.executeStreaming(prepareGet().setUri(URI.create("http://unused.invalid")).build());
+            response.close();
+            response.close();
+        }
+
+        assertThat(closeCount).hasValue(1);
+    }
+
+    @Test
+    void testConcurrentChainsKeepRequestStateLocal()
+            throws Exception
+    {
+        int requestCount = 16;
+        CyclicBarrier barrier = new CyclicBarrier(requestCount);
+        HttpClientInterceptor synchronize = chain -> {
+            await(barrier);
+            return chain.proceed(chain.request());
+        };
+        HttpClientInterceptor respondWithRequestId = chain -> new StaticStreamingResponse(
+                HttpStatus.OK,
+                requireNonNull(chain.request().getHeader(REQUEST_ID_HEADER), "request id is null"));
+
+        try (JettyHttpClient client = new JettyHttpClient(new HttpClientConfig(), List.of(synchronize, respondWithRequestId));
+                ExecutorService executor = Executors.newFixedThreadPool(requestCount)) {
+            List<Future<String>> futures = java.util.stream.IntStream.range(0, requestCount)
+                    .mapToObj(index -> executor.submit(() -> client.execute(
+                            prepareGet()
+                                    .setUri(URI.create("http://unused.invalid"))
+                                    .setHeader(REQUEST_ID_HEADER, "request-" + index)
+                                    .build(),
+                            createStringResponseHandler()).getBody()))
+                    .toList();
+
+            for (int index = 0; index < requestCount; index++) {
+                assertThat(futures.get(index).get(10, SECONDS)).isEqualTo("request-" + index);
+            }
+        }
+    }
+
+    @Test
+    void testAsyncExecutionDoesNotInvokeSynchronousInterceptors()
+            throws Exception
+    {
+        AtomicInteger invocationCount = new AtomicInteger();
+        HttpClientInterceptor interceptor = chain -> {
+            invocationCount.incrementAndGet();
+            return chain.proceed(chain.request());
+        };
+
+        try (TestingHttpServer server = new TestingHttpServer(Optional.empty(), new EchoServlet());
+                JettyHttpClient client = new JettyHttpClient(new HttpClientConfig(), List.of(interceptor))) {
+            assertThat(client.executeAsync(prepareGet().setUri(server.baseURI()).build(), createStatusResponseHandler()).get().getStatusCode())
+                    .isEqualTo(HttpStatus.OK.code());
+        }
+
+        assertThat(invocationCount).hasValue(0);
+    }
+
+    private static HttpClientInterceptor orderedInterceptor(String name, List<String> events, boolean shortCircuit)
+    {
+        return chain -> {
+            events.add(name + "-before");
+            StreamingResponse response = shortCircuit
+                    ? new StaticStreamingResponse(HttpStatus.OK, "body")
+                    : chain.proceed(chain.request());
+            events.add(name + "-after");
+            return response;
+        };
+    }
+
+    private static JettyHttpClient tracingClient(SdkTracerProvider tracerProvider, HttpClientInterceptor interceptor)
+    {
+        return new JettyHttpClient(
+                "interceptor-tracing-test",
+                new HttpClientConfig(),
+                List.of(),
+                propagating(ContextPropagators.noop()),
+                tracerProvider.get("testing"),
+                Optional.empty(),
+                Optional.empty(),
+                List.of(),
+                List.of(interceptor));
+    }
+
+    private static void assertSpanFailure(InMemorySpanExporter exporter, RuntimeException failure)
+    {
+        SpanData span = exporter.getFinishedSpanItems().stream().collect(onlyElement());
+        assertThat(span.getStatus().getStatusCode()).isEqualTo(ERROR);
+        assertThat(span.getStatus().getDescription()).isEqualTo(failure.getMessage());
+        assertThat(span.getEvents())
+                .singleElement()
+                .satisfies(event -> assertThat(event.getAttributes().get(JettyHttpClient.EXCEPTION_ESCAPED)).isTrue());
+    }
+
+    private static void await(CyclicBarrier barrier)
+    {
+        try {
+            barrier.await(10, SECONDS);
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static class StaticStreamingResponse
+            implements StreamingResponse
+    {
+        private final HttpStatus status;
+        private final byte[] body;
+        private final AtomicInteger closeCount;
+
+        private StaticStreamingResponse(HttpStatus status, String body)
+        {
+            this(status, body, new AtomicInteger());
+        }
+
+        private StaticStreamingResponse(HttpStatus status, String body, AtomicInteger closeCount)
+        {
+            this.status = status;
+            this.body = body.getBytes(StandardCharsets.UTF_8);
+            this.closeCount = closeCount;
+        }
+
+        @Override
+        public HttpVersion getHttpVersion()
+        {
+            return HttpVersion.HTTP_1;
+        }
+
+        @Override
+        public int getStatusCode()
+        {
+            return status.code();
+        }
+
+        @Override
+        public ListMultimap<HeaderName, String> getHeaders()
+        {
+            return ImmutableListMultimap.of();
+        }
+
+        @Override
+        public Content getContent()
+        {
+            return new BytesContent(body);
+        }
+
+        @Override
+        public InputStream getInputStream()
+        {
+            return new ByteArrayInputStream(body);
+        }
+
+        @Override
+        public long getBytesRead()
+        {
+            return body.length;
+        }
+
+        @Override
+        public void close()
+        {
+            closeCount.incrementAndGet();
+        }
+    }
+
+    private static class ForwardingStreamingResponse
+            implements StreamingResponse
+    {
+        private final StreamingResponse delegate;
+
+        private ForwardingStreamingResponse(StreamingResponse delegate)
+        {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public HttpVersion getHttpVersion()
+        {
+            return delegate.getHttpVersion();
+        }
+
+        @Override
+        public int getStatusCode()
+        {
+            return delegate.getStatusCode();
+        }
+
+        @Override
+        public ListMultimap<HeaderName, String> getHeaders()
+        {
+            return delegate.getHeaders();
+        }
+
+        @Override
+        public Content getContent()
+        {
+            return delegate.getContent();
+        }
+
+        @Override
+        public InputStream getInputStream()
+                throws IOException
+        {
+            return delegate.getInputStream();
+        }
+
+        @Override
+        public long getBytesRead()
+        {
+            return delegate.getBytesRead();
+        }
+
+        @Override
+        public void close()
+        {
+            delegate.close();
+        }
+    }
+
+    private static final class ResettingServer
+            implements AutoCloseable
+    {
+        private final ServerSocket serverSocket;
+        private final ExecutorService executor = Executors.newSingleThreadExecutor();
+        private final Future<?> serverTask;
+
+        private ResettingServer()
+                throws IOException
+        {
+            serverSocket = new ServerSocket(0, 1, InetAddress.getLoopbackAddress());
+            serverTask = executor.submit(() -> {
+                try (Socket socket = serverSocket.accept()) {
+                    socket.setSoLinger(true, 0);
+                }
+                catch (IOException e) {
+                    if (!serverSocket.isClosed()) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            });
+        }
+
+        private URI uri()
+        {
+            return URI.create("http://" + InetAddress.getLoopbackAddress().getHostAddress() + ":" + serverSocket.getLocalPort());
+        }
+
+        @Override
+        public void close()
+                throws Exception
+        {
+            serverSocket.close();
+            executor.shutdownNow();
+            serverTask.get(10, SECONDS);
+        }
+    }
+
+    private static final class TestingPropagator
+            implements TextMapPropagator
+    {
+        @Override
+        public Collection<String> fields()
+        {
+            return ImmutableList.of(TRACE_HEADER.toString());
+        }
+
+        @Override
+        public <C> void inject(Context context, C carrier, TextMapSetter<C> setter)
+        {
+            setter.set(carrier, TRACE_HEADER.toString(), "injected");
+        }
+
+        @Override
+        public <C> Context extract(Context context, C carrier, TextMapGetter<C> getter)
+        {
+            return context;
+        }
+    }
+}


### PR DESCRIPTION
## Why
- Airlift HTTP clients can transform requests or observe status codes, but cannot surround a complete synchronous transport exchange.
- Applications need an OkHttp-style extension point for request rewriting, short circuits, response wrapping, and observability without replacing the Jetty transport.
- Bounded, sanitized recordings make real exchanges reusable as fixtures for tests and mock-server implementations.

## Approach
- Add a minimal `Request`/`StreamingResponse` interceptor chain with deterministic global and named-client registration.
- Adapt existing request filters into the chain while preserving their public API, ordering, tracing, and synchronous failure lifecycle.
- Add a versioned recorder that tees caller-consumed response bytes, reports incomplete or truncated capture, and sanitizes every exchange before it reaches a sink.
- Keep retry policy outside the SPI so generated clients record each physical attempt independently.
- Treat this as the useful first part of the OkHttp model: async interception, separate application/network registries, transport-internal follow-ups, and response-to-request association are not added.

# Airlift contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [x] All automated tests are passing.
 - [x] Pull request was categorized using one of the existing labels.