### PR TITLE
Clean up Maven dependency versions

### DIFF
--- a/api-maven-plugin/pom.xml
+++ b/api-maven-plugin/pom.xml
@@ -17,12 +17,9 @@
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <dep.maven-plugin-api.version>3.9.16</dep.maven-plugin-api.version>
         <dep.maven-plugin-annotations.version>3.15.2</dep.maven-plugin-annotations.version>
-        <dep.classgraph.version>4.8.184</dep.classgraph.version>
-        <dep.swagger-models.version>2.2.52</dep.swagger-models.version>
     </properties>
 
     <dependencies>
-
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
@@ -48,7 +45,7 @@
         <dependency>
             <groupId>io.github.classgraph</groupId>
             <artifactId>classgraph</artifactId>
-            <version>${dep.classgraph.version}</version>
+            <version>4.8.184</version>
         </dependency>
 
         <dependency>
@@ -82,7 +79,7 @@
         <dependency>
             <groupId>io.swagger.core.v3</groupId>
             <artifactId>swagger-models</artifactId>
-            <version>${dep.swagger-models.version}</version>
+            <version>2.2.52</version>
             <scope>test</scope>
         </dependency>
 

--- a/api-maven-plugin/pom.xml
+++ b/api-maven-plugin/pom.xml
@@ -18,8 +18,6 @@
         <dep.maven-plugin-api.version>3.9.16</dep.maven-plugin-api.version>
         <dep.maven-plugin-annotations.version>3.15.2</dep.maven-plugin-annotations.version>
         <dep.classgraph.version>4.8.184</dep.classgraph.version>
-        <dep.takari-plugin-testing.version>3.1.1</dep.takari-plugin-testing.version>
-        <dep.swagger-parser.version>2.1.45</dep.swagger-parser.version>
         <dep.swagger-models.version>2.2.52</dep.swagger-models.version>
     </properties>
 
@@ -91,21 +89,18 @@
         <dependency>
             <groupId>io.swagger.parser.v3</groupId>
             <artifactId>swagger-parser-core</artifactId>
-            <version>${dep.swagger-parser.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>io.swagger.parser.v3</groupId>
             <artifactId>swagger-parser-v3</artifactId>
-            <version>${dep.swagger-parser.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>io.takari.maven.plugins</groupId>
             <artifactId>takari-plugin-integration-testing</artifactId>
-            <version>${dep.takari-plugin-testing.version}</version>
             <type>pom</type>
             <scope>test</scope>
         </dependency>
@@ -113,7 +108,6 @@
         <dependency>
             <groupId>io.takari.maven.plugins</groupId>
             <artifactId>takari-plugin-testing</artifactId>
-            <version>${dep.takari-plugin-testing.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -153,7 +147,6 @@
             <plugin>
                 <groupId>io.takari.maven.plugins</groupId>
                 <artifactId>takari-lifecycle-plugin</artifactId>
-                <version>2.3.4</version>
                 <extensions>true</extensions>
                 <executions>
                     <execution>

--- a/api-maven-plugin/pom.xml
+++ b/api-maven-plugin/pom.xml
@@ -19,7 +19,7 @@
         <dep.maven-plugin-annotations.version>3.15.2</dep.maven-plugin-annotations.version>
         <dep.classgraph.version>4.8.184</dep.classgraph.version>
         <dep.takari-plugin-testing.version>3.1.1</dep.takari-plugin-testing.version>
-        <dep.swagger-parser.version>2.1.39</dep.swagger-parser.version>
+        <dep.swagger-parser.version>2.1.45</dep.swagger-parser.version>
         <dep.swagger-models.version>2.2.52</dep.swagger-models.version>
     </properties>
 

--- a/api-testing/pom.xml
+++ b/api-testing/pom.xml
@@ -18,9 +18,7 @@
         <!-- skip modernizer as generated code isn't modern enough -->
         <air.check.skip-modernizer>true</air.check.skip-modernizer>
 
-        <dep.openapi-generator-maven-plugin.version>7.24.0</dep.openapi-generator-maven-plugin.version>
         <openapitools.jackson.version>2.22.1</openapitools.jackson.version>
-        <openapitools.jackson-databind-nullable.version>0.2.10</openapitools.jackson-databind-nullable.version>
         <openapitools.jakarta-annotation.version>3.0.0</openapitools.jakarta-annotation.version>
     </properties>
 
@@ -58,7 +56,6 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>${openapitools.jackson-databind-nullable.version}</version>
         </dependency>
     </dependencies>
 
@@ -67,7 +64,6 @@
             <plugin>
                 <groupId>org.openapitools</groupId>
                 <artifactId>openapi-generator-maven-plugin</artifactId>
-                <version>${dep.openapi-generator-maven-plugin.version}</version>
                 <configuration>
                     <generatorName>java</generatorName>
                     <configOptions>

--- a/api-testing/pom.xml
+++ b/api-testing/pom.xml
@@ -17,40 +17,32 @@
         <air.compiler.fail-warnings>false</air.compiler.fail-warnings>
         <!-- skip modernizer as generated code isn't modern enough -->
         <air.check.skip-modernizer>true</air.check.skip-modernizer>
-
-        <openapitools.jackson.version>2.22.1</openapitools.jackson.version>
-        <openapitools.jakarta-annotation.version>3.0.0</openapitools.jakarta-annotation.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.22</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>${openapitools.jackson.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${openapitools.jackson.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>${openapitools.jackson.version}</version>
         </dependency>
 
         <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
-            <version>${openapitools.jakarta-annotation.version}</version>
         </dependency>
 
         <dependency>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -21,26 +21,12 @@
         <dep.commons-fileupload2.version>2.0.0-M5</dep.commons-fileupload2.version>
         <dep.apache.httpcore.version>4.4.16</dep.apache.httpcore.version>
         <dep.apache.httpmime.version>4.5.14</dep.apache.httpmime.version>
-        <dep.swagger.version>2.1.45</dep.swagger.version>
-        <dep.jackson-databind-nullable.version>0.2.10</dep.jackson-databind-nullable.version>
         <dep.exec-maven-plugin.version>3.6.3</dep.exec-maven-plugin.version>
     </properties>
 
     <!-- TODO move these to airbase -->
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>io.swagger.parser.v3</groupId>
-                <artifactId>swagger-parser-core</artifactId>
-                <version>${dep.swagger.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.swagger.parser.v3</groupId>
-                <artifactId>swagger-parser-v3</artifactId>
-                <version>${dep.swagger.version}</version>
-            </dependency>
-
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-fileupload2-core</artifactId>
@@ -77,11 +63,6 @@
                 </exclusions>
             </dependency>
 
-            <dependency>
-                <groupId>org.openapitools</groupId>
-                <artifactId>jackson-databind-nullable</artifactId>
-                <version>${dep.jackson-databind-nullable.version}</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -14,13 +14,10 @@
     <description>Airlift - API building</description>
 
     <properties>
-
         <air.compiler.fail-warnings>false</air.compiler.fail-warnings>
 
         <!-- TODO move these to airbase -->
         <dep.commons-fileupload2.version>2.0.0-M5</dep.commons-fileupload2.version>
-        <dep.apache.httpcore.version>4.4.16</dep.apache.httpcore.version>
-        <dep.apache.httpmime.version>4.5.14</dep.apache.httpmime.version>
         <dep.exec-maven-plugin.version>3.6.3</dep.exec-maven-plugin.version>
     </properties>
 
@@ -42,7 +39,7 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpcore</artifactId>
-                <version>${dep.apache.httpcore.version}</version>
+                <version>4.4.16</version>
                 <exclusions>
                     <exclusion>
                         <groupId>commons-logging</groupId>
@@ -54,7 +51,7 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpmime</artifactId>
-                <version>${dep.apache.httpmime.version}</version>
+                <version>4.5.14</version>
                 <exclusions>
                     <exclusion>
                         <groupId>commons-logging</groupId>
@@ -62,7 +59,6 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-
         </dependencies>
     </dependencyManagement>
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -20,47 +20,6 @@
         <dep.commons-fileupload2.version>2.0.0-M5</dep.commons-fileupload2.version>
     </properties>
 
-    <!-- TODO move these to airbase -->
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-fileupload2-core</artifactId>
-                <version>${dep.commons-fileupload2.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-fileupload2-jakarta-servlet6</artifactId>
-                <version>${dep.commons-fileupload2.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.apache.httpcomponents</groupId>
-                <artifactId>httpcore</artifactId>
-                <version>4.4.16</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>commons-logging</groupId>
-                        <artifactId>commons-logging</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
-            <dependency>
-                <groupId>org.apache.httpcomponents</groupId>
-                <artifactId>httpmime</artifactId>
-                <version>4.5.14</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>commons-logging</groupId>
-                        <artifactId>commons-logging</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -126,11 +85,13 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-fileupload2-core</artifactId>
+            <version>${dep.commons-fileupload2.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-fileupload2-jakarta-servlet6</artifactId>
+            <version>${dep.commons-fileupload2.version}</version>
         </dependency>
 
         <dependency>
@@ -209,13 +170,27 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
+            <version>4.4.16</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpmime</artifactId>
+            <version>4.5.14</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -18,7 +18,6 @@
 
         <!-- TODO move these to airbase -->
         <dep.commons-fileupload2.version>2.0.0-M5</dep.commons-fileupload2.version>
-        <dep.exec-maven-plugin.version>3.6.3</dep.exec-maven-plugin.version>
     </properties>
 
     <!-- TODO move these to airbase -->

--- a/http-client-generator/pom.xml
+++ b/http-client-generator/pom.xml
@@ -15,8 +15,6 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <dep.openapi-generator.version>7.24.0</dep.openapi-generator.version>
-        <dep.takari-plugin-testing.version>3.1.1</dep.takari-plugin-testing.version>
     </properties>
 
     <dependencies>
@@ -29,7 +27,6 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>openapi-generator</artifactId>
-            <version>${dep.openapi-generator.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -61,7 +58,6 @@
         <dependency>
             <groupId>io.takari.maven.plugins</groupId>
             <artifactId>takari-plugin-integration-testing</artifactId>
-            <version>${dep.takari-plugin-testing.version}</version>
             <type>pom</type>
             <scope>test</scope>
         </dependency>
@@ -69,7 +65,6 @@
         <dependency>
             <groupId>io.takari.maven.plugins</groupId>
             <artifactId>takari-plugin-testing</artifactId>
-            <version>${dep.takari-plugin-testing.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -140,7 +135,6 @@
             <plugin>
                 <groupId>io.takari.maven.plugins</groupId>
                 <artifactId>takari-lifecycle-plugin</artifactId>
-                <version>2.3.4</version>
                 <extensions>true</extensions>
                 <executions>
                     <execution>

--- a/mcp/pom.xml
+++ b/mcp/pom.xml
@@ -15,10 +15,6 @@
 
     <properties>
         <dep.testcontainers.version>2.0.5</dep.testcontainers.version>
-        <dep.docker-java.version>3.7.1</dep.docker-java.version>
-        <dep.hikari.version>7.1.0</dep.hikari.version>
-        <dep.postgresql.version>42.7.13</dep.postgresql.version>
-        <dep.jsonschema-generator.version>4.38.0</dep.jsonschema-generator.version>
     </properties>
 
     <dependencies>
@@ -40,7 +36,7 @@
         <dependency>
             <groupId>com.github.victools</groupId>
             <artifactId>jsonschema-generator</artifactId>
-            <version>${dep.jsonschema-generator.version}</version>
+            <version>4.38.0</version>
         </dependency>
 
         <dependency>
@@ -135,14 +131,14 @@
         <dependency>
             <groupId>com.github.docker-java</groupId>
             <artifactId>docker-java-api</artifactId>
-            <version>${dep.docker-java.version}</version>
+            <version>3.7.1</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
-            <version>${dep.hikari.version}</version>
+            <version>7.1.0</version>
             <scope>test</scope>
         </dependency>
 
@@ -209,7 +205,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>${dep.postgresql.version}</version>
+            <version>42.7.13</version>
             <scope>test</scope>
         </dependency>
 

--- a/opentelemetry/pom.xml
+++ b/opentelemetry/pom.xml
@@ -117,7 +117,6 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp-jvm</artifactId>
-            <version>5.4.0</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -106,8 +106,6 @@
         <dep.openapi-generator.version>7.24.0</dep.openapi-generator.version>
         <dep.jersey.version>4.0.2</dep.jersey.version>
         <dep.jjwt.version>0.13.0</dep.jjwt.version>
-        <dep.jmxutils.version>1.29</dep.jmxutils.version>
-        <dep.classmate.version>1.7.3</dep.classmate.version>
         <dep.takari-plugin-testing.version>3.1.1</dep.takari-plugin-testing.version>
         <dep.swagger-parser.version>2.1.45</dep.swagger-parser.version>
     </properties>
@@ -120,12 +118,6 @@
                 <version>${dep.jersey.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>com.fasterxml</groupId>
-                <artifactId>classmate</artifactId>
-                <version>${dep.classmate.version}</version>
             </dependency>
 
             <dependency>
@@ -364,19 +356,6 @@
                 <groupId>io.modelcontextprotocol.sdk</groupId>
                 <artifactId>mcp-json-jackson2</artifactId>
                 <version>${dep.mcp.sdk.version}</version>
-            </dependency>
-
-            <!-- TODO: move to airbase -->
-            <dependency>
-                <groupId>io.opentelemetry</groupId>
-                <artifactId>opentelemetry-api-incubator</artifactId>
-                <version>${dep.opentelemetry.version}-alpha</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.opentelemetry.semconv</groupId>
-                <artifactId>opentelemetry-semconv</artifactId>
-                <version>${dep.opentelemetry-semconv.version}</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
         <dep.brotli4j.version>1.23.0</dep.brotli4j.version>
         <dep.bouncycastle.version>1.85</dep.bouncycastle.version>
         <dep.mcp.sdk.version>2.0.0</dep.mcp.sdk.version>
-        <dep.openapi-generator-maven-plugin.version>7.21.0</dep.openapi-generator-maven-plugin.version>
+        <dep.openapi-generator-maven-plugin.version>7.24.0</dep.openapi-generator-maven-plugin.version>
         <dep.jersey.version>4.0.2</dep.jersey.version>
         <dep.jjwt.version>0.13.0</dep.jjwt.version>
         <dep.jmxutils.version>1.29</dep.jmxutils.version>

--- a/pom.xml
+++ b/pom.xml
@@ -86,8 +86,6 @@
     </scm>
 
     <properties>
-        <!-- TODO: remove when dependency-scope is removed from airbase -->
-        <air.check.skip-dependency-scope>true</air.check.skip-dependency-scope>
         <air.check.skip-spotbugs>true</air.check.skip-spotbugs>
         <air.check.skip-pmd>true</air.check.skip-pmd>
         <air.check.skip-jacoco>true</air.check.skip-jacoco>

--- a/pom.xml
+++ b/pom.xml
@@ -103,11 +103,13 @@
         <dep.brotli4j.version>1.23.0</dep.brotli4j.version>
         <dep.bouncycastle.version>1.85</dep.bouncycastle.version>
         <dep.mcp.sdk.version>2.0.0</dep.mcp.sdk.version>
-        <dep.openapi-generator-maven-plugin.version>7.24.0</dep.openapi-generator-maven-plugin.version>
+        <dep.openapi-generator.version>7.24.0</dep.openapi-generator.version>
         <dep.jersey.version>4.0.2</dep.jersey.version>
         <dep.jjwt.version>0.13.0</dep.jjwt.version>
         <dep.jmxutils.version>1.29</dep.jmxutils.version>
         <dep.classmate.version>1.7.3</dep.classmate.version>
+        <dep.takari-plugin-testing.version>3.1.1</dep.takari-plugin-testing.version>
+        <dep.swagger-parser.version>2.1.45</dep.swagger-parser.version>
     </properties>
 
     <dependencyManagement>
@@ -124,6 +126,12 @@
                 <groupId>com.fasterxml</groupId>
                 <artifactId>classmate</artifactId>
                 <version>${dep.classmate.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>okhttp-jvm</artifactId>
+                <version>5.4.0</version>
             </dependency>
 
             <dependency>
@@ -372,6 +380,31 @@
             </dependency>
 
             <dependency>
+                <groupId>io.swagger.parser.v3</groupId>
+                <artifactId>swagger-parser-core</artifactId>
+                <version>${dep.swagger-parser.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.swagger.parser.v3</groupId>
+                <artifactId>swagger-parser-v3</artifactId>
+                <version>${dep.swagger-parser.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.takari.maven.plugins</groupId>
+                <artifactId>takari-plugin-integration-testing</artifactId>
+                <version>${dep.takari-plugin-testing.version}</version>
+                <type>pom</type>
+            </dependency>
+
+            <dependency>
+                <groupId>io.takari.maven.plugins</groupId>
+                <artifactId>takari-plugin-testing</artifactId>
+                <version>${dep.takari-plugin-testing.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcpkix-jdk18on</artifactId>
                 <version>${dep.bouncycastle.version}</version>
@@ -395,12 +428,34 @@
                 </exclusions>
             </dependency>
 
+            <dependency>
+                <groupId>org.openapitools</groupId>
+                <artifactId>jackson-databind-nullable</artifactId>
+                <version>0.2.10</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.openapitools</groupId>
+                <artifactId>openapi-generator</artifactId>
+                <version>${dep.openapi-generator.version}</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 
     <build>
         <pluginManagement>
             <plugins>
+                <plugin>
+                    <groupId>io.takari.maven.plugins</groupId>
+                    <artifactId>takari-lifecycle-plugin</artifactId>
+                    <version>2.3.4</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.openapitools</groupId>
+                    <artifactId>openapi-generator-maven-plugin</artifactId>
+                    <version>${dep.openapi-generator.version}</version>
+                </plugin>
                 <plugin>
                     <groupId>org.gaul</groupId>
                     <artifactId>modernizer-maven-plugin</artifactId>

--- a/secrets-keystore-plugin/pom.xml
+++ b/secrets-keystore-plugin/pom.xml
@@ -87,11 +87,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>ca.vanzyl.provisio.maven.plugins</groupId>
-                <artifactId>provisio-maven-plugin</artifactId>
-                <version>1.1.3</version>
-            </plugin>
-            <plugin>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-maven-plugin</artifactId>
                 <version>23</version>

--- a/tracing/pom.xml
+++ b/tracing/pom.xml
@@ -69,7 +69,6 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp-jvm</artifactId>
-            <version>5.4.0</version>
             <scope>runtime</scope>
         </dependency>
 


### PR DESCRIPTION
Consolidates shared dependency management in the root POM and inlines module-only versions. Removes obsolete Provisio configuration.