### PR TITLE
Update CI to Java 26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         java-version:
           - 25
-          - 26-ea
+          - 26
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5


### PR DESCRIPTION
Updates the CI build matrix to use the released Java 26 runtime while retaining Java 25 coverage.

This replaces the retired Java 26 early-access runtime so CI continues to validate against the current release.

Checks: YAML parsing and Git whitespace validation.