### PR TITLE
Don't color the log message to ensure visibility against all backgrounds

### DIFF
--- a/log-manager/src/main/java/io/airlift/log/StaticFormatter.java
+++ b/log-manager/src/main/java/io/airlift/log/StaticFormatter.java
@@ -23,7 +23,6 @@ import static io.airlift.log.TerminalColors.Color.BRIGHT_BLACK;
 import static io.airlift.log.TerminalColors.Color.CYAN;
 import static io.airlift.log.TerminalColors.Color.GREEN;
 import static io.airlift.log.TerminalColors.Color.PURPLE;
-import static io.airlift.log.TerminalColors.Color.WHITE;
 import static io.airlift.log.TerminalColors.coloredWriter;
 import static java.time.temporal.ChronoField.DAY_OF_MONTH;
 import static java.time.temporal.ChronoField.HOUR_OF_DAY;
@@ -108,7 +107,7 @@ class StaticFormatter
         }
 
         builder.append('\t')
-                .append(colors.colored(record.getMessage(), WHITE));
+                .append(record.getMessage());
 
         if (record.getParameters() != null && record.getParameters().length != 0) {
             builder.append(" parameters=").append(deepToString(record.getParameters()));


### PR DESCRIPTION
# Summary

Sometimes Airlift log messages are not visible with a white terminal background.

# Detail

Presently the Airlift log stdout format always specifically colours the message part of the log in white.

In most cases this is ok, since terminals with a white background usually remap white to an alternative colour, such as light grey (e.g macOS).

However this is not guaranteed. Recent versions of OpenShift default to a light theme and don't do this remap. As a consequence the message part of Trino log lines is invisible without selecting the text or viewing the log via another means (e.g k8s CLI).

# Solution

The solution is simple, the message part of the log line should not have an explicit colour set. Instead this should use the terminal default which will guarantee that it is always visible.

# Airlift contribution check list

 - [ ] Git commit messages follow https://cbea.ms/git-commit/.
 - [ ] All automated tests are passing.
 - [ ] Pull request was categorized using one of the existing labels.
