### PR TITLE
Enable colored console output on non-TTY consoles

### DIFF
--- a/log-manager/src/main/java/io/airlift/log/TerminalColors.java
+++ b/log-manager/src/main/java/io/airlift/log/TerminalColors.java
@@ -1,6 +1,5 @@
 package io.airlift.log;
 
-import java.io.Console;
 import java.io.PrintWriter;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
@@ -137,33 +136,22 @@ public class TerminalColors
 
     private static boolean isColorSupported()
     {
-        Console console = System.console();
-        // Console.isTerminal() reports whether the console is attached to a terminal, which
-        // holds regardless of whether System.console() returns a Console for redirected output.
-        // https://github.com/openjdk/jdk/pull/26273 changed that, so the Console itself must not
-        // be used as the signal.
-        boolean terminal = console != null && console.isTerminal();
-        return isColorSupported(terminal, System.getenv("TERM"), System.getenv("NO_COLOR"));
+        return isColorSupported(System.getenv("TERM"), System.getenv("NO_COLOR"));
     }
 
-    static boolean isColorSupported(boolean terminal, String term, String noColor)
+    static boolean isColorSupported(String term, String noColor)
     {
-        // Output is redirected to a file or a pipe
-        if (!terminal) {
-            return false;
-        }
-
-        // No terminal at all
-        if (term == null) {
-            return false;
-        }
-
-        // Dumb terminal
-        if (term.equalsIgnoreCase("dumb")) {
-            return false;
-        }
+        // Color is only ever emitted on the interactive console handler (see the interactive flag),
+        // whose output is routinely consumed by sinks that render ANSI but are not TTYs and do not
+        // set TERM - Docker log pipes, IDE run consoles, CI. So color is enabled by default and only
+        // the standard opt-outs disable it, rather than requiring an attached terminal.
 
         // https://no-color.org/ - honored when present and not an empty string
-        return isNullOrEmpty(noColor);
+        if (!isNullOrEmpty(noColor)) {
+            return false;
+        }
+
+        // Dumb terminal explicitly declares no capabilities
+        return !"dumb".equalsIgnoreCase(term);
     }
 }

--- a/log-manager/src/test/java/io/airlift/log/TestTerminalColors.java
+++ b/log-manager/src/test/java/io/airlift/log/TestTerminalColors.java
@@ -15,27 +15,27 @@ public class TestTerminalColors
     private static final TerminalColors NOT_SUPPORTED = new TerminalColors(true, false);
 
     @Test
-    public void testColorSupportRequiresTerminal()
+    public void testColorEnabledByDefault()
     {
-        assertThat(TerminalColors.isColorSupported(true, "xterm-256color", null)).isTrue();
-        assertThat(TerminalColors.isColorSupported(false, "xterm-256color", null)).isFalse();
+        assertThat(TerminalColors.isColorSupported("xterm-256color", null)).isTrue();
+        // no TERM, as under an IDE run console or a Docker log pipe, still supports color
+        assertThat(TerminalColors.isColorSupported(null, null)).isTrue();
     }
 
     @Test
-    public void testColorSupportRequiresCapableTerm()
+    public void testDumbTerminalDisablesColor()
     {
-        assertThat(TerminalColors.isColorSupported(true, null, null)).isFalse();
-        assertThat(TerminalColors.isColorSupported(true, "dumb", null)).isFalse();
-        assertThat(TerminalColors.isColorSupported(true, "DUMB", null)).isFalse();
+        assertThat(TerminalColors.isColorSupported("dumb", null)).isFalse();
+        assertThat(TerminalColors.isColorSupported("DUMB", null)).isFalse();
     }
 
     @Test
     public void testNoColor()
     {
-        assertThat(TerminalColors.isColorSupported(true, "xterm-256color", "1")).isFalse();
-        assertThat(TerminalColors.isColorSupported(true, "xterm-256color", "0")).isFalse();
+        assertThat(TerminalColors.isColorSupported("xterm-256color", "1")).isFalse();
+        assertThat(TerminalColors.isColorSupported("xterm-256color", "0")).isFalse();
         // https://no-color.org/ - only honored when not an empty string
-        assertThat(TerminalColors.isColorSupported(true, "xterm-256color", "")).isTrue();
+        assertThat(TerminalColors.isColorSupported("xterm-256color", "")).isTrue();
     }
 
     @Test


### PR DESCRIPTION
Follow-up to #2068.

That PR gated colored console output on an attached terminal
(`Console.isTerminal()` plus a required `TERM`). In practice the color is
lost in exactly the environments where colored console logs are most wanted,
because none of them reliably present the JVM with a TTY or set `TERM`:

- Docker, with or without `-t`
- IDE run consoles (IntelliJ)
- CI

Color is only ever emitted on the interactive console handler (`interactive`
flag), whose output is meant to be read by a human and is routinely rendered
by these non-TTY sinks. So this enables color by default and disables it only
through the standard opt-outs — `NO_COLOR` and `TERM=dumb` — instead of
requiring an attached terminal. File and socket handlers are unaffected: they
use `interactive=false` and never emit color.

## Contribution checklist
- [x] Git commit messages follow https://cbea.ms/git-commit/.
- [x] All automated tests are passing.
- [x] Pull request was categorized using one of the existing labels.