### PR TITLE
Return empty for malformed IP-encoded hostnames

### DIFF
--- a/node/src/main/java/io/airlift/node/AddressToHostname.java
+++ b/node/src/main/java/io/airlift/node/AddressToHostname.java
@@ -69,7 +69,14 @@ public final class AddressToHostname
             ipString = ipString.replace('-', '.');
         }
 
-        byte[] address = InetAddress.ofLiteral(ipString).getAddress();
+        byte[] address;
+        try {
+            address = InetAddress.ofLiteral(ipString).getAddress();
+        }
+        catch (IllegalArgumentException _) {
+            // the suffix matched, but the remainder is not an encoded address, so this is an ordinary hostname
+            return Optional.empty();
+        }
 
         try {
             return Optional.of(InetAddress.getByAddress(hostname, address));

--- a/node/src/test/java/io/airlift/node/TestAddressSource.java
+++ b/node/src/test/java/io/airlift/node/TestAddressSource.java
@@ -34,6 +34,25 @@ public class TestAddressSource
         verifyEncoding("::1", "x--1.ip");
     }
 
+    @Test
+    public void testDecodingNonEncodedHostname()
+    {
+        assertThat(tryDecodeHostnameToAddress("example.com")).isEmpty();
+        assertThat(tryDecodeHostnameToAddress("")).isEmpty();
+    }
+
+    @Test
+    public void testDecodingMalformedEncodedHostname()
+    {
+        // the suffix matches, but the remainder does not decode to an address
+        assertThat(tryDecodeHostnameToAddress("not-an-address.ip")).isEmpty();
+        assertThat(tryDecodeHostnameToAddress("1-2-3-4-5.ip")).isEmpty();
+        assertThat(tryDecodeHostnameToAddress("999-0-0-1.ip")).isEmpty();
+        assertThat(tryDecodeHostnameToAddress("xnot-a-v6-address.ip")).isEmpty();
+        assertThat(tryDecodeHostnameToAddress(".ip")).isEmpty();
+        assertThat(tryDecodeHostnameToAddress("x.ip")).isEmpty();
+    }
+
     private static void verifyEncoding(String addressString, String encodedHostname)
     {
         assertThat(encodeAddressAsHostname(InetAddress.ofLiteral(addressString))).isEqualTo(encodedHostname);


### PR DESCRIPTION
InetAddress.ofLiteral throws IllegalArgumentException on malformed input, and the call sat outside the try block, so tryDecodeHostnameToAddress threw instead of returning an empty Optional.

JettyHttpClient calls this from its SocketAddressResolver for every outbound request. A host ending in the .ip suffix that was not a valid encoded address propagated the exception out of the resolver rather than falling back to normal name resolution.

<!-- Thank you for submitting pull request to Airlift -->

# Airlift contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [x] All automated tests are passing.
 - [x] Pull request was categorized using one of the existing labels.
