### PR TITLE
Reduce CI test logging

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -151,6 +151,12 @@
 
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>log-manager</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>testing</artifactId>
             <scope>test</scope>
         </dependency>

--- a/api/src/test/java/io/airlift/api/servertests/integration/testingserver/TestingApiModule.java
+++ b/api/src/test/java/io/airlift/api/servertests/integration/testingserver/TestingApiModule.java
@@ -37,7 +37,6 @@ public class TestingApiModule
 
         Module apiModule = ApiModule.builder()
                 .addApi(apiBuilder -> apiBuilder.add(PublicWidgetApi.class))
-                .withApiLogging()
                 .withOpenApiMetadata(openApiMetadata)
                 .withOpenApiFilterBinding(binding -> binding.to(TestingOpenApiFilter.class))
                 .withCompatibilityTester(newDefaultInstance(basePathFromClass(ApiCompatibilityUtil.class)))

--- a/api/src/test/java/io/airlift/api/servertests/integration/testingserver/TestingServer.java
+++ b/api/src/test/java/io/airlift/api/servertests/integration/testingserver/TestingServer.java
@@ -10,7 +10,9 @@ import io.airlift.http.server.HttpServerInfo;
 import io.airlift.http.server.testing.TestingHttpServerModule;
 import io.airlift.jaxrs.JaxrsModule;
 import io.airlift.json.JsonModule;
+import io.airlift.log.Level;
 import io.airlift.log.Logger;
+import io.airlift.log.Logging;
 import io.airlift.node.NodeModule;
 import jakarta.ws.rs.core.UriBuilder;
 
@@ -22,6 +24,12 @@ public class TestingServer
         implements Closeable
 {
     private static final Logger log = Logger.get(TestingServer.class);
+
+    static {
+        Logging logging = Logging.initialize();
+        logging.setLevel("io.airlift.http.server", Level.WARN);
+        logging.setLevel("org.eclipse.jetty", Level.ERROR);
+    }
 
     private final Injector injector;
     private final URI baseUri;
@@ -38,8 +46,11 @@ public class TestingServer
         ImmutableMap.Builder<String, String> serverProperties = ImmutableMap.<String, String>builder()
                 .put("node.environment", "testing");
 
-        Bootstrap app = new Bootstrap(modules.build());
-        injector = app.setRequiredConfigurationProperties(serverProperties.build()).initialize();
+        injector = new Bootstrap(modules.build())
+                .doNotInitializeLogging()
+                .setRequiredConfigurationProperties(serverProperties.build())
+                .quiet()
+                .initialize();
 
         HttpServerInfo httpServerInfo = injector.getInstance(HttpServerInfo.class);
         baseUri = UriBuilder.fromUri(httpServerInfo.getHttpsUri() != null ? httpServerInfo.getHttpsUri() : httpServerInfo.getHttpUri())

--- a/http-client/src/test/java/io/airlift/http/client/TestHttpClientBinder.java
+++ b/http-client/src/test/java/io/airlift/http/client/TestHttpClientBinder.java
@@ -48,6 +48,7 @@ public class TestHttpClientBinder
                 binder -> httpClientBinder(binder)
                         .bindHttpClient("foo", FooClient.class)
                         .withConfigDefaults(config -> config.setRequestTimeout(new Duration(33, MINUTES))))
+                .doNotInitializeLogging()
                 .quiet()
                 .initialize();
 
@@ -74,6 +75,7 @@ public class TestHttpClientBinder
                     httpClientBinder(binder).bindHttpClient("bar", BarClient.class)
                             .addStatusListenerBinding().toInstance(listener2);
                 })
+                .doNotInitializeLogging()
                 .quiet()
                 .initialize();
 
@@ -104,6 +106,7 @@ public class TestHttpClientBinder
                     httpClientBinder(binder).bindHttpClient("bar", BarClient.class)
                             .addFilterBinding().toInstance(filter2);
                 })
+                .doNotInitializeLogging()
                 .quiet()
                 .initialize();
 
@@ -128,6 +131,7 @@ public class TestHttpClientBinder
                     httpClientBinder(binder).bindHttpClient("foo", FooClient.class).withStatusListener(TestingStatusListener.class);
                     binder.bind(new TypeLiteral<Multiset<Integer>>() {}).toInstance(HashMultiset.create());
                 })
+                .doNotInitializeLogging()
                 .quiet()
                 .initialize();
 
@@ -148,6 +152,7 @@ public class TestHttpClientBinder
                             .withFilter(TestingRequestFilter.class)
                             .addFilterBinding().to(AnotherHttpRequestFilter.class);
                 })
+                .doNotInitializeLogging()
                 .quiet()
                 .initialize();
 
@@ -162,6 +167,7 @@ public class TestHttpClientBinder
                 binder -> httpClientBinder(binder).bindHttpClient("foo", FooClient.class)
                         .withFilter(TestingRequestFilter.class)
                         .withFilter(AnotherHttpRequestFilter.class))
+                .doNotInitializeLogging()
                 .quiet()
                 .initialize();
 
@@ -174,6 +180,7 @@ public class TestHttpClientBinder
     {
         Injector injector = new Bootstrap(
                 binder -> httpClientBinder(binder).bindHttpClient("foo", FooClient.class))
+                .doNotInitializeLogging()
                 .quiet()
                 .initialize();
 
@@ -187,6 +194,7 @@ public class TestHttpClientBinder
                 binder -> httpClientBinder(binder).bindHttpClient("foo", FooClient.class)
                         .withAlias(FooAlias1.class)
                         .withAliases(ImmutableList.of(FooAlias2.class, FooAlias3.class)))
+                .doNotInitializeLogging()
                 .quiet()
                 .initialize();
 
@@ -203,6 +211,7 @@ public class TestHttpClientBinder
                 binder -> httpClientBinder(binder).bindHttpClient("foo", FooClient.class)
                         .withAlias(FooAlias1.class)
                         .withAlias(FooAlias2.class))
+                .doNotInitializeLogging()
                 .quiet()
                 .initialize();
 
@@ -222,6 +231,7 @@ public class TestHttpClientBinder
                     binder.bind(SslContextFactory.Client.class).toInstance(passingFactory);
                     httpClientBinder(binder).bindHttpClient("foo", FooClient.class);
                 })
+                .doNotInitializeLogging()
                 .quiet()
                 .initialize();
 
@@ -230,6 +240,7 @@ public class TestHttpClientBinder
                     binder.bind(SslContextFactory.Client.class).toInstance(failingFactory);
                     httpClientBinder(binder).bindHttpClient("foo", FooClient.class);
                 })
+                .doNotInitializeLogging()
                 .quiet()
                 .initialize())
                 .hasMessageContaining("RuntimeException: fail");
@@ -248,6 +259,7 @@ public class TestHttpClientBinder
                     binder.bind(SslContextFactory.Client.class).annotatedWith(FooClient.class).toInstance(passingFactory);
                     httpClientBinder(binder).bindHttpClient("foo", FooClient.class);
                 })
+                .doNotInitializeLogging()
                 .quiet()
                 .initialize();
 
@@ -258,6 +270,7 @@ public class TestHttpClientBinder
                     binder.bind(SslContextFactory.Client.class).annotatedWith(FooClient.class).toInstance(failingFactory);
                     httpClientBinder(binder).bindHttpClient("foo", FooClient.class);
                 })
+                .doNotInitializeLogging()
                 .quiet()
                 .initialize())
                 .hasMessageContaining("RuntimeException: fail");
@@ -271,6 +284,7 @@ public class TestHttpClientBinder
                     httpClientBinder(binder).bindHttpClient("foo", FooClient.class);
                     httpClientBinder(binder).bindHttpClient("bar", BarClient.class);
                 })
+                .doNotInitializeLogging()
                 .quiet()
                 .initialize();
 
@@ -287,6 +301,7 @@ public class TestHttpClientBinder
                     httpClientBinder(binder).bindHttpClient("foo", FooClient.class);
                     httpClientBinder(binder).bindHttpClient("bar", BarClient.class);
                 })
+                .doNotInitializeLogging()
                 .quiet()
                 .initialize();
 

--- a/http-client/src/test/java/io/airlift/http/client/TestingHttpServer.java
+++ b/http-client/src/test/java/io/airlift/http/client/TestingHttpServer.java
@@ -14,6 +14,8 @@
 package io.airlift.http.client;
 
 import com.google.common.net.HostAndPort;
+import io.airlift.log.Level;
+import io.airlift.log.Logging;
 import jakarta.servlet.Servlet;
 import org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory;
 import org.eclipse.jetty.compression.gzip.GzipCompression;
@@ -43,6 +45,11 @@ import static java.util.Objects.requireNonNull;
 public class TestingHttpServer
         implements AutoCloseable
 {
+    static {
+        Logging logging = Logging.initialize();
+        logging.setLevel("org.eclipse.jetty", Level.ERROR);
+    }
+
     private final String scheme;
     private final Server server;
     private final HostAndPort hostAndPort;

--- a/http-server/src/test/java/io/airlift/http/server/TestHttpServerCipher.java
+++ b/http-server/src/test/java/io/airlift/http/server/TestHttpServerCipher.java
@@ -15,6 +15,8 @@ package io.airlift.http.server;
 
 import com.google.common.collect.ImmutableSet;
 import io.airlift.http.server.HttpServer.ClientCertificate;
+import io.airlift.log.Level;
+import io.airlift.log.Logging;
 import io.airlift.node.NodeInfo;
 import jakarta.servlet.http.HttpServlet;
 import org.eclipse.jetty.client.HttpClient;
@@ -47,6 +49,12 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 @Execution(SAME_THREAD)
 public class TestHttpServerCipher
 {
+    static {
+        Logging logging = Logging.initialize();
+        logging.setLevel("io.airlift.http.server", Level.WARN);
+        logging.setLevel("org.eclipse.jetty", Level.ERROR);
+    }
+
     private static final String KEY_STORE_PATH = constructKeyStorePath();
     private static final String KEY_STORE_PASSWORD = "airlift";
     public static final String CIPHER_1 = "TLS_DHE_RSA_WITH_AES_128_CBC_SHA256";

--- a/http-server/src/test/java/io/airlift/http/server/TestHttpServerModule.java
+++ b/http-server/src/test/java/io/airlift/http/server/TestHttpServerModule.java
@@ -29,6 +29,7 @@ import io.airlift.http.client.HttpUriBuilder;
 import io.airlift.http.client.StatusResponseHandler.StatusResponse;
 import io.airlift.http.client.StringResponseHandler.StringResponse;
 import io.airlift.http.client.jetty.JettyHttpClient;
+import io.airlift.log.Level;
 import io.airlift.log.Logging;
 import io.airlift.node.NodeInfo;
 import io.airlift.node.testing.TestingNodeModule;
@@ -84,7 +85,9 @@ public class TestHttpServerModule
     @BeforeAll
     public void setupSuite()
     {
-        Logging.initialize();
+        Logging logging = Logging.initialize();
+        logging.setLevel("io.airlift.http.server", Level.WARN);
+        logging.setLevel("org.eclipse.jetty", Level.ERROR);
     }
 
     @BeforeEach
@@ -118,6 +121,7 @@ public class TestHttpServerModule
         Injector injector = app
                 .setRequiredConfigurationProperties(properties)
                 .doNotInitializeLogging()
+                .quiet()
                 .initialize();
 
         HttpServer server = injector.getInstance(HttpServer.class);
@@ -149,6 +153,7 @@ public class TestHttpServerModule
         Injector injector = app
                 .setRequiredConfigurationProperties(properties)
                 .doNotInitializeLogging()
+                .quiet()
                 .initialize();
 
         HttpServer primaryServer = injector.getInstance(HttpServer.class);
@@ -182,6 +187,7 @@ public class TestHttpServerModule
         Injector injector = app
                 .setRequiredConfigurationProperties(properties)
                 .doNotInitializeLogging()
+                .quiet()
                 .initialize();
 
         NodeInfo nodeInfo = injector.getInstance(NodeInfo.class);
@@ -222,6 +228,7 @@ public class TestHttpServerModule
         assertThatThrownBy(() -> app
                 .setRequiredConfigurationProperties(properties)
                 .doNotInitializeLogging()
+                .quiet()
                 .initialize())
                 .isInstanceOfSatisfying(ApplicationConfigurationException.class, e -> assertThat(e.getErrors())
                         .anySatisfy(error -> assertThat(error.getMessage()).contains("Configuration property 'http-server.http.port' was not used"))
@@ -263,6 +270,7 @@ public class TestHttpServerModule
         Injector injector = app
                 .setRequiredConfigurationProperties(properties)
                 .doNotInitializeLogging()
+                .quiet()
                 .initialize();
 
         HttpServerInfo httpServerInfo = injector.getInstance(HttpServerInfo.class);

--- a/http-server/src/test/java/io/airlift/http/server/TestHttpServerProvider.java
+++ b/http-server/src/test/java/io/airlift/http/server/TestHttpServerProvider.java
@@ -29,6 +29,7 @@ import io.airlift.http.client.StatusResponseHandler.StatusResponse;
 import io.airlift.http.client.StringResponseHandler.StringResponse;
 import io.airlift.http.client.jetty.JettyHttpClient;
 import io.airlift.http.server.HttpServer.ClientCertificate;
+import io.airlift.log.Level;
 import io.airlift.log.Logging;
 import io.airlift.node.NodeConfig;
 import io.airlift.node.NodeInfo;
@@ -122,7 +123,9 @@ public class TestHttpServerProvider
     @BeforeAll
     public void setupSuite()
     {
-        Logging.initialize();
+        Logging logging = Logging.initialize();
+        logging.setLevel("io.airlift.http.server", Level.WARN);
+        logging.setLevel("org.eclipse.jetty", Level.ERROR);
     }
 
     @BeforeEach

--- a/http-server/src/test/java/io/airlift/http/server/TestJettyMultipleCerts.java
+++ b/http-server/src/test/java/io/airlift/http/server/TestJettyMultipleCerts.java
@@ -22,6 +22,8 @@ import io.airlift.http.client.HttpClientConfig;
 import io.airlift.http.client.StatusResponseHandler.StatusResponse;
 import io.airlift.http.client.jetty.JettyHttpClient;
 import io.airlift.http.server.HttpServer.ClientCertificate;
+import io.airlift.log.Level;
+import io.airlift.log.Logging;
 import io.airlift.node.NodeConfig;
 import io.airlift.node.NodeInfo;
 import jakarta.servlet.http.HttpServlet;
@@ -46,6 +48,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestJettyMultipleCerts
 {
+    static {
+        Logging logging = Logging.initialize();
+        logging.setLevel("io.airlift.http.server", Level.WARN);
+        logging.setLevel("org.eclipse.jetty", Level.ERROR);
+    }
+
     @Test
     public void test()
             throws Exception

--- a/http-server/src/test/java/io/airlift/http/server/testing/AbstractTestTestingHttpServer.java
+++ b/http-server/src/test/java/io/airlift/http/server/testing/AbstractTestTestingHttpServer.java
@@ -37,6 +37,7 @@ import io.airlift.http.server.HttpServer.ClientCertificate;
 import io.airlift.http.server.HttpServerConfig;
 import io.airlift.http.server.HttpServerInfo;
 import io.airlift.http.server.ServerFeature;
+import io.airlift.log.Level;
 import io.airlift.log.Logging;
 import io.airlift.node.NodeInfo;
 import io.airlift.node.testing.TestingNodeModule;
@@ -98,7 +99,9 @@ public abstract class AbstractTestTestingHttpServer
     @BeforeAll
     public void setupSuite()
     {
-        Logging.initialize();
+        Logging logging = Logging.initialize();
+        logging.setLevel("io.airlift.http.server", Level.WARN);
+        logging.setLevel("org.eclipse.jetty", Level.ERROR);
     }
 
     @Test
@@ -181,6 +184,7 @@ public abstract class AbstractTestTestingHttpServer
 
         Injector injector = app
                 .doNotInitializeLogging()
+                .quiet()
                 .initialize();
 
         LifeCycleManager lifeCycleManager = injector.getInstance(LifeCycleManager.class);
@@ -214,6 +218,7 @@ public abstract class AbstractTestTestingHttpServer
 
         Injector injector = app
                 .doNotInitializeLogging()
+                .quiet()
                 .initialize();
 
         LifeCycleManager lifeCycleManager = injector.getInstance(LifeCycleManager.class);
@@ -252,6 +257,7 @@ public abstract class AbstractTestTestingHttpServer
 
         Injector injector = app
                 .doNotInitializeLogging()
+                .quiet()
                 .initialize();
 
         LifeCycleManager lifeCycleManager = injector.getInstance(LifeCycleManager.class);
@@ -296,6 +302,7 @@ public abstract class AbstractTestTestingHttpServer
 
         Injector injector = app
                 .doNotInitializeLogging()
+                .quiet()
                 .initialize();
 
         assertThat(injector.getExistingBinding(Key.get(new TypeLiteral<Set<Filter>>() {}))).isNull();

--- a/http-server/src/test/java/io/airlift/http/server/tracing/TestBaggagePropagation.java
+++ b/http-server/src/test/java/io/airlift/http/server/tracing/TestBaggagePropagation.java
@@ -11,6 +11,8 @@ import io.airlift.http.client.StringResponseHandler.StringResponse;
 import io.airlift.http.server.HttpServer;
 import io.airlift.http.server.HttpServerInfo;
 import io.airlift.http.server.HttpServerModule;
+import io.airlift.log.Level;
+import io.airlift.log.Logging;
 import io.airlift.node.testing.TestingNodeModule;
 import io.airlift.opentelemetry.OpenTelemetryModule;
 import io.opentelemetry.api.baggage.Baggage;
@@ -54,6 +56,12 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class TestBaggagePropagation
 {
+    static {
+        Logging logging = Logging.initialize();
+        logging.setLevel("io.airlift.http.server", Level.WARN);
+        logging.setLevel("org.eclipse.jetty", Level.ERROR);
+    }
+
     @Test
     public void testBaggagePropagatesBetweenBootstrappedServices(@TempDir Path tempDir)
             throws Exception

--- a/http-server/src/test/java/io/airlift/http/server/tracing/TestTracingServletFilter.java
+++ b/http-server/src/test/java/io/airlift/http/server/tracing/TestTracingServletFilter.java
@@ -12,6 +12,8 @@ import io.airlift.http.server.HttpServerConfig;
 import io.airlift.http.server.HttpServerInfo;
 import io.airlift.http.server.ServerFeature;
 import io.airlift.http.server.testing.TestingHttpServer;
+import io.airlift.log.Level;
+import io.airlift.log.Logging;
 import io.airlift.node.NodeInfo;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
@@ -35,6 +37,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestTracingServletFilter
 {
+    static {
+        Logging logging = Logging.initialize();
+        logging.setLevel("io.airlift.http.server", Level.WARN);
+        logging.setLevel("org.eclipse.jetty", Level.ERROR);
+    }
+
     private static final String TRACE_ID = "0123456789abcdef0123456789abcdef";
     public static final HeaderName TRACEPARENT_HEADER = HeaderName.of("traceparent");
 

--- a/mcp/pom.xml
+++ b/mcp/pom.xml
@@ -167,6 +167,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log-manager</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.modelcontextprotocol.sdk</groupId>
             <artifactId>mcp-core</artifactId>
             <scope>test</scope>

--- a/mcp/src/test/java/io/airlift/mcp/TestingServer.java
+++ b/mcp/src/test/java/io/airlift/mcp/TestingServer.java
@@ -11,6 +11,8 @@ import io.airlift.http.client.HttpClient;
 import io.airlift.http.server.testing.TestingHttpServerModule;
 import io.airlift.jaxrs.JaxrsModule;
 import io.airlift.json.JsonModule;
+import io.airlift.log.Level;
+import io.airlift.log.Logging;
 import io.airlift.node.NodeModule;
 
 import java.io.Closeable;
@@ -23,6 +25,13 @@ import static io.airlift.http.client.HttpClientBinder.httpClientBinder;
 public class TestingServer
         implements Closeable
 {
+    static {
+        Logging logging = Logging.initialize();
+        logging.setLevel("io.airlift.http.server", Level.WARN);
+        logging.setLevel("io.modelcontextprotocol.spec.McpSchema", Level.ERROR);
+        logging.setLevel("org.eclipse.jetty", Level.ERROR);
+    }
+
     private final Injector injector;
 
     public TestingServer(Map<String, String> properties, Optional<Module> additionalModule, Function<McpModule.Builder, Module> mcpModuleApplicator)
@@ -45,8 +54,11 @@ public class TestingServer
                 .put("mcp.resource-subscription.cache-period", "1ms")
                 .putAll(properties);
 
-        Bootstrap app = new Bootstrap(modules.build());
-        injector = app.setRequiredConfigurationProperties(serverProperties.buildKeepingLast()).initialize();
+        injector = new Bootstrap(modules.build())
+                .doNotInitializeLogging()
+                .setRequiredConfigurationProperties(serverProperties.buildKeepingLast())
+                .quiet()
+                .initialize();
     }
 
     public Injector injector()


### PR DESCRIPTION
Reduce noise in CI so API and MCP test failures are easier to find. Repetitive test-server lifecycle, request, configuration, and protocol messages no longer overwhelm build output.

## CI impact

Measured across the Java 25 and 26 jobs in the [last successful run before this change](https://github.com/airlift/airlift/actions/runs/30452498738) and the [successful run for the final PR commit](https://github.com/airlift/airlift/actions/runs/30568858262).

Complete workflow output fell from **75,916 lines / 21,126,687 bytes** to **25,920 lines / 3,598,948 bytes**: **49,996 fewer lines (65.9%)** and **83.0% fewer bytes**. Within the directly comparable Maven output from `./mvnw install -B -P ci` through the end of the MCP module, output fell from **63,661 lines / 19,423,544 bytes** to **12,900 lines / 1,801,999 bytes**: **50,761 fewer lines (79.7%)** and **90.7% fewer bytes**.

| Module | Before | After | Removed |
| --- | ---: | ---: | ---: |
| HTTP client | 11,256 lines / 2,260,954 bytes | 416 lines / 52,136 bytes | 10,840 lines (96.3%) / 97.7% of bytes |
| HTTP server | 3,768 lines / 755,489 bytes | 366 lines / 43,787 bytes | 3,402 lines (90.3%) / 94.2% of bytes |
| API | 31,547 lines / 13,367,537 bytes | 1,473 lines / 229,288 bytes | 30,074 lines (95.3%) / 98.3% of bytes |
| MCP | 8,035 lines / 1,895,216 bytes | 1,590 lines / 329,498 bytes | 6,445 lines (80.2%) / 82.6% of bytes |

### Log records by source

| Module | Log source | Before | After | Removed |
| --- | --- | ---: | ---: | ---: |
| HTTP client | Bootstrap configuration | 30 | 30 | 0 |
| HTTP client | Jetty lifecycle, version, and certificate records | 10,812 | 0 | 10,812 |
| HTTP client | Logging reinitialization warnings | 28 | 0 | 28 |
| HTTP server | Bootstrap configuration | 1,700 | 40 | 1,660 |
| HTTP server | Airlift HTTP server lifecycle | 186 | 0 | 186 |
| HTTP server | Jetty lifecycle | 1,364 | 0 | 1,364 |
| API | API usage requests and responses | 29,384 | 0 | 29,384 |
| API | Bootstrap configuration | 94 | 6 | 88 |
| API | Airlift HTTP server lifecycle | 34 | 16 | 18 |
| API | Jetty lifecycle | 282 | 134 | 148 |
| API | Logging reinitialization warnings | 6 | 4 | 2 |
| MCP | Bootstrap configuration | 4,554 | 0 | 4,554 |
| MCP | Airlift HTTP server lifecycle | 36 | 0 | 36 |
| MCP | MCP schema missing-field warnings | 1,212 | 0 | 1,212 |
| MCP | Jetty lifecycle | 296 | 0 | 296 |
| MCP | Logging reinitialization warnings | 44 | 0 | 44 |

Complete workflow totals cover the entire downloaded Actions logs. The comparable Maven span starts at each Java job's `./mvnw install -B -P ci` command and ends immediately before the module following MCP; module totals use the Maven `Building` boundaries. Source counts include structured logger records from those module sections. The HTTP client Jetty row additionally includes direct stderr-format INFO startup, shutdown, version, and certificate lines (4,927 structured and 5,885 direct records before the change). Java stack frames containing logger package names are excluded.
