### PR TITLE
Allow MCP requests without client info

### DIFF
--- a/http-server/pom.xml
+++ b/http-server/pom.xml
@@ -307,7 +307,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.23.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/mcp/pom.xml
+++ b/mcp/pom.xml
@@ -203,6 +203,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>42.7.13</version>

--- a/mcp/src/main/java/io/airlift/mcp/model/Constants.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/Constants.java
@@ -44,6 +44,7 @@ public interface Constants
     String METADATA_PROTOCOL_VERSION = "io.modelcontextprotocol/protocolVersion";
     String METADATA_CLIENT_INFO = "io.modelcontextprotocol/clientInfo";
     String METADATA_CLIENT_CAPABILITIES = "io.modelcontextprotocol/clientCapabilities";
+    String METADATA_SERVER_INFO = "io.modelcontextprotocol/serverInfo";
     String METADATA_CLIENT_LOG_LEVEL = "io.modelcontextprotocol/logLevel";
     String METADATA_PROGRESS_TOKEN = "progressToken";
     String METADATA_SUBSCRIPTION_ID = "io.modelcontextprotocol/subscriptionId";

--- a/mcp/src/main/java/io/airlift/mcp/model/DiscoverResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/DiscoverResult.java
@@ -14,7 +14,6 @@ public record DiscoverResult(
         ResultType resultType,
         List<String> supportedVersions,
         ServerCapabilities capabilities,
-        Implementation serverInfo,
         Optional<String> instructions,
         Optional<Map<String, Object>> meta)
         implements Meta
@@ -24,7 +23,6 @@ public record DiscoverResult(
         requireNonNull(resultType, "resultType is null");
         supportedVersions = ImmutableList.copyOf(supportedVersions);
         requireNonNull(capabilities, "capabilities is null");
-        requireNonNull(serverInfo, "serverInfo is null");
         instructions = requireNonNullElse(instructions, Optional.empty());
         meta = requireNonNullElse(meta, Optional.empty());
     }
@@ -32,6 +30,6 @@ public record DiscoverResult(
     @Override
     public Object withMeta(Map<String, Object> meta)
     {
-        return new DiscoverResult(resultType, supportedVersions, capabilities, serverInfo, instructions, Optional.of(meta));
+        return new DiscoverResult(resultType, supportedVersions, capabilities, instructions, Optional.of(meta));
     }
 }

--- a/mcp/src/main/java/io/airlift/mcp/operations/Operations.java
+++ b/mcp/src/main/java/io/airlift/mcp/operations/Operations.java
@@ -1,7 +1,9 @@
 package io.airlift.mcp.operations;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.mcp.McpIdentity.Authenticated;
 import io.airlift.mcp.messages.MessageWriter;
@@ -11,6 +13,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import java.io.UncheckedIOException;
+import java.util.Map;
 import java.util.Optional;
 
 import static jakarta.servlet.http.HttpServletResponse.SC_OK;
@@ -33,12 +36,23 @@ public interface Operations
         return jsonMapper.convertValue(value, clazz);
     }
 
-    static void writeResult(JsonMapper jsonMapper, MessageWriter messageWriter, HttpServletResponse response, Object requestId, Object result)
+    static void writeResult(JsonMapper jsonMapper, MessageWriter messageWriter, HttpServletResponse response, Object requestId, Object result, Map<String, Object> resultMetadata)
     {
         response.setStatus(SC_OK);
 
         try {
-            JsonRpcResponse<?> rpcResponse = new JsonRpcResponse<>(requestId, Optional.empty(), Optional.of(result));
+            Object responseResult = result;
+            if (!resultMetadata.isEmpty()) {
+                JsonNode resultNode = jsonMapper.valueToTree(result);
+                if (!(resultNode instanceof ObjectNode resultObject)) {
+                    throw new IllegalArgumentException("Result must serialize to a JSON object");
+                }
+                ObjectNode resultMeta = resultObject.withObjectProperty("_meta");
+                resultMetadata.forEach((name, value) -> resultMeta.set(name, jsonMapper.valueToTree(value)));
+                responseResult = resultObject;
+            }
+
+            JsonRpcResponse<?> rpcResponse = new JsonRpcResponse<>(requestId, Optional.empty(), Optional.of(responseResult));
             messageWriter.write(jsonMapper.writeValueAsString(rpcResponse));
             messageWriter.flush();
         }

--- a/mcp/src/main/java/io/airlift/mcp/operations/OperationsImpl.java
+++ b/mcp/src/main/java/io/airlift/mcp/operations/OperationsImpl.java
@@ -61,6 +61,7 @@ import static io.airlift.mcp.McpModule.MCP_SERVER_ICONS;
 import static io.airlift.mcp.model.CacheScope.PRIVATE;
 import static io.airlift.mcp.model.Constants.HEADER_MCP_NAME;
 import static io.airlift.mcp.model.Constants.MESSAGE_WRITER_ATTRIBUTE;
+import static io.airlift.mcp.model.Constants.METADATA_SERVER_INFO;
 import static io.airlift.mcp.model.Constants.METHOD_COMPLETION_COMPLETE;
 import static io.airlift.mcp.model.Constants.METHOD_PROMPT_GET;
 import static io.airlift.mcp.model.Constants.METHOD_PROMPT_LIST;
@@ -156,6 +157,8 @@ public class OperationsImpl
         RequestContextImpl requestContext = new RequestContextImpl(request, requestMetadata, jsonMapper, messageWriter, authenticated);
 
         McpMetadata metadata = metadataMapper.map(requestContext.request());
+        Implementation serverImplementation = iconHelper.mapIcons(serverIcons).map(icons -> metadata.implementation().withAdditionalIcons(icons))
+                .orElse(metadata.implementation());
 
         Object result = switch (method) {
             case METHOD_TOOLS_LIST -> listTools(requestContext, metadata, convertParams(jsonMapper, rpcRequest, ListRequest.class));
@@ -171,7 +174,7 @@ public class OperationsImpl
             default -> throw exception(METHOD_NOT_FOUND, "Unknown method: " + method);
         };
 
-        writeResult(jsonMapper, messageWriter, response, requestId, result);
+        writeResult(jsonMapper, messageWriter, response, requestId, result, ImmutableMap.of(METADATA_SERVER_INFO, serverImplementation));
     }
 
     @Override
@@ -313,9 +316,7 @@ public class OperationsImpl
                 tools.isEmpty() ? Optional.empty() : Optional.of(new ListChanged(true)),
                 Optional.empty());
 
-        Implementation serverImplementation = iconHelper.mapIcons(serverIcons).map(icons -> metadata.implementation().withAdditionalIcons(icons))
-                .orElse(metadata.implementation());
-        return new DiscoverResult(COMPLETE, SUPPORTED_VERSIONS, serverCapabilities, serverImplementation, metadata.instructions(), Optional.empty());
+        return new DiscoverResult(COMPLETE, SUPPORTED_VERSIONS, serverCapabilities, metadata.instructions(), Optional.empty());
     }
 
     private <T extends CacheableResult> T withCacheableResult(McpMetadata metadata, Class<T> clazz, T result)

--- a/mcp/src/main/java/io/airlift/mcp/operations/RequestMetadata.java
+++ b/mcp/src/main/java/io/airlift/mcp/operations/RequestMetadata.java
@@ -33,7 +33,7 @@ import static java.util.Objects.requireNonNull;
 
 public record RequestMetadata(
         Protocol protocol,
-        Implementation implementation,
+        Optional<Implementation> clientInfo,
         ClientCapabilities clientCapabilities,
         Optional<LoggingLevel> loggingLevel,
         Optional<Object> progressToken,
@@ -46,7 +46,7 @@ public record RequestMetadata(
     public RequestMetadata
     {
         requireNonNull(protocol, "protocol is null");
-        requireNonNull(implementation, "implementation is null");
+        requireNonNull(clientInfo, "clientInfo is null");
         requireNonNull(clientCapabilities, "clientCapabilities is null");
         requireNonNull(loggingLevel, "loggingLevel is null");
         requireNonNull(progressToken, "progressToken is null");
@@ -75,12 +75,12 @@ public record RequestMetadata(
         }
         Optional<String> mcpNameHeader = optional(request, HEADER_MCP_NAME);
 
-        Implementation implementation = required(jsonMapper, metadata, METADATA_CLIENT_INFO, Implementation.class);
+        Optional<Implementation> clientInfo = optional(jsonMapper, metadata, METADATA_CLIENT_INFO, Implementation.class);
         ClientCapabilities clientCapabilities = required(jsonMapper, metadata, METADATA_CLIENT_CAPABILITIES, ClientCapabilities.class);
         Optional<LoggingLevel> loggingLevel = optional(jsonMapper, metadata, METADATA_CLIENT_LOG_LEVEL, LoggingLevel.class);
         Optional<Object> progressToken = optional(jsonMapper, metadata, METADATA_PROGRESS_TOKEN, Object.class);
 
-        return new RequestMetadata(protocol, implementation, clientCapabilities, loggingLevel, progressToken, mcpNameHeader);
+        return new RequestMetadata(protocol, clientInfo, clientCapabilities, loggingLevel, progressToken, mcpNameHeader);
     }
 
     private static McpException unsupportedProtocol(String protocolVersionHeader)
@@ -111,14 +111,22 @@ public record RequestMetadata(
     private static <T> Optional<T> optional(JsonMapper jsonMapper, Meta metadata, String name, Class<T> clazz)
     {
         return metadata.meta()
-                .flatMap(m -> Optional.ofNullable(m.get(name)))
-                .map(value -> {
+                .flatMap(values -> {
+                    if (!values.containsKey(name)) {
+                        return Optional.empty();
+                    }
+
+                    Object value = values.get(name);
+                    if (value == null) {
+                        throw exception(INVALID_PARAMS, "Metadata value is not the correct type: null");
+                    }
+
                     try {
                         if (clazz.equals(Object.class)) {
-                            return clazz.cast(value);
+                            return Optional.of(clazz.cast(value));
                         }
 
-                        return jsonMapper.convertValue(value, clazz);
+                        return Optional.of(jsonMapper.convertValue(value, clazz));
                     }
                     catch (Exception e) {
                         throw exception(INVALID_PARAMS, "Metadata value is not the correct type: " + value.getClass().getSimpleName());

--- a/mcp/src/main/java/io/airlift/mcp/operations/legacy/LegacySessionOperations.java
+++ b/mcp/src/main/java/io/airlift/mcp/operations/legacy/LegacySessionOperations.java
@@ -183,7 +183,7 @@ public class LegacySessionOperations
             default -> throw exception(METHOD_NOT_FOUND, "Unknown method: " + method);
         };
 
-        writeResult(jsonMapper, messageWriter, response, requestId, result);
+        writeResult(jsonMapper, messageWriter, response, requestId, result, ImmutableMap.of());
 
         sessionController.ifPresent(controller -> optionalSessionId(request)
                 .ifPresent(sessionId -> checkSaveSentMessages(controller, sessionId, messageWriter)));

--- a/mcp/src/main/java/io/airlift/mcp/operations/legacy/SessionlessOperations.java
+++ b/mcp/src/main/java/io/airlift/mcp/operations/legacy/SessionlessOperations.java
@@ -125,7 +125,7 @@ public class SessionlessOperations
             default -> throw exception(METHOD_NOT_FOUND, "Unknown method: " + method);
         };
 
-        writeResult(jsonMapper, messageWriter, response, requestId, result);
+        writeResult(jsonMapper, messageWriter, response, requestId, result, ImmutableMap.of());
     }
 
     private InitializeResult handleInitialize(LegacyRequestContextImpl requestContext, InitializeRequest initializeRequest)

--- a/mcp/src/test/java/io/airlift/mcp/TestConformance.java
+++ b/mcp/src/test/java/io/airlift/mcp/TestConformance.java
@@ -93,7 +93,7 @@ public class TestConformance
     public void testConformance(String scenario)
     {
         // see: https://github.com/modelcontextprotocol/conformance?tab=readme-ov-file#testing-servers
-        String result = nodeContainer.execute("npx", "--yes", "@modelcontextprotocol/conformance@alpha", "server", "--url", mcpUri, "--scenario", scenario, "--verbose");
+        String result = nodeContainer.execute("npx", "--yes", "@modelcontextprotocol/conformance@0.2.0-alpha.10", "server", "--url", mcpUri, "--scenario", scenario, "--verbose");
         assertThat(result).contains("0 failed, 0 warnings");
     }
 

--- a/mcp/src/test/java/io/airlift/mcp/operations/TestOperations.java
+++ b/mcp/src/test/java/io/airlift/mcp/operations/TestOperations.java
@@ -1,0 +1,101 @@
+package io.airlift.mcp.operations;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.json.JsonMapperProvider;
+import io.airlift.mcp.messages.MessageWriter;
+import io.airlift.mcp.model.DiscoverResult;
+import io.airlift.mcp.model.Implementation;
+import io.airlift.mcp.model.InitializeResult.ServerCapabilities;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static io.airlift.mcp.model.Constants.METADATA_SERVER_INFO;
+import static io.airlift.mcp.model.ResultType.COMPLETE;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+public class TestOperations
+{
+    private static final JsonMapper JSON_MAPPER = new JsonMapperProvider().get();
+
+    @Test
+    public void testWriteResultAddsServerInfoMetadata()
+            throws Exception
+    {
+        JsonNode responseJson = writeResult(Optional.of(ImmutableMap.of("existing", "value")));
+        JsonNode responseMetadata = responseJson.at("/result/_meta");
+        JsonNode responseServerInfo = responseMetadata.get(METADATA_SERVER_INFO);
+        assertThat(responseJson.at("/result/serverInfo").isMissingNode()).isTrue();
+        assertThat(responseMetadata.get("existing").textValue()).isEqualTo("value");
+        assertThat(responseServerInfo.get("name").textValue()).isEqualTo("test server");
+        assertThat(responseServerInfo.get("version").textValue()).isEqualTo("1");
+    }
+
+    @Test
+    public void testWriteResultCreatesMetadata()
+            throws Exception
+    {
+        JsonNode responseJson = writeResult(Optional.empty());
+
+        JsonNode responseMetadata = responseJson.at("/result/_meta");
+        assertThat(responseMetadata.isObject()).isTrue();
+        assertThat(responseMetadata.get(METADATA_SERVER_INFO).get("name").textValue()).isEqualTo("test server");
+    }
+
+    @Test
+    public void testWriteResultRejectsNonObject()
+    {
+        MessageWriter messageWriter = mock(MessageWriter.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        assertThatThrownBy(() -> Operations.writeResult(
+                JSON_MAPPER,
+                messageWriter,
+                response,
+                123,
+                "invalid",
+                ImmutableMap.of(METADATA_SERVER_INFO, new Implementation("test server", "1"))))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Result must serialize to a JSON object");
+
+        verify(response).setStatus(SC_OK);
+        verifyNoMoreInteractions(response);
+        verifyNoInteractions(messageWriter);
+    }
+
+    private static JsonNode writeResult(Optional<Map<String, Object>> metadata)
+            throws Exception
+    {
+        MessageWriter messageWriter = mock(MessageWriter.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        DiscoverResult result = new DiscoverResult(COMPLETE, ImmutableList.of(), new ServerCapabilities(), Optional.empty(), metadata);
+
+        Operations.writeResult(
+                JSON_MAPPER,
+                messageWriter,
+                response,
+                123,
+                result,
+                ImmutableMap.of(METADATA_SERVER_INFO, new Implementation("test server", "1")));
+
+        ArgumentCaptor<String> responseBody = ArgumentCaptor.captor();
+        verify(response).setStatus(SC_OK);
+        verify(messageWriter).write(responseBody.capture());
+        verify(messageWriter).flush();
+        verifyNoMoreInteractions(response, messageWriter);
+
+        return JSON_MAPPER.readTree(responseBody.getValue());
+    }
+}

--- a/mcp/src/test/java/io/airlift/mcp/operations/TestRequestMetadata.java
+++ b/mcp/src/test/java/io/airlift/mcp/operations/TestRequestMetadata.java
@@ -1,0 +1,149 @@
+package io.airlift.mcp.operations;
+
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.json.JsonMapperProvider;
+import io.airlift.mcp.McpException;
+import io.airlift.mcp.model.Implementation;
+import io.airlift.mcp.model.InitializeRequest.ClientCapabilities;
+import io.airlift.mcp.model.Meta;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.airlift.mcp.model.Constants.HEADER_MCP_METHOD;
+import static io.airlift.mcp.model.Constants.HEADER_MCP_NAME;
+import static io.airlift.mcp.model.Constants.HEADER_PROTOCOL_VERSION;
+import static io.airlift.mcp.model.Constants.METADATA_CLIENT_CAPABILITIES;
+import static io.airlift.mcp.model.Constants.METADATA_CLIENT_INFO;
+import static io.airlift.mcp.model.Constants.METADATA_PROTOCOL_VERSION;
+import static io.airlift.mcp.model.JsonRpcErrorCode.INVALID_PARAMS;
+import static io.airlift.mcp.model.Protocol.LATEST_PROTOCOL;
+import static io.airlift.mcp.operations.ValidationMode.STRICT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+public class TestRequestMetadata
+{
+    private static final String MCP_METHOD = "tools/list";
+    private static final JsonMapper JSON_MAPPER = new JsonMapperProvider().get();
+
+    @Test
+    public void testClientInfoPresent()
+    {
+        Meta metadata = metadata(ImmutableMap.<String, Object>builder()
+                .putAll(requiredMetadata())
+                .put(METADATA_CLIENT_INFO, ImmutableMap.of("name", "test client", "version", "1"))
+                .buildOrThrow());
+        HttpServletRequest request = request();
+
+        RequestMetadata requestMetadata = RequestMetadata.fromRequest(JSON_MAPPER, request, metadata, MCP_METHOD, STRICT);
+
+        assertThat(requestMetadata.clientInfo()).contains(new Implementation("test client", "1"));
+        assertThat(requestMetadata.clientCapabilities()).isEqualTo(ClientCapabilities.EMPTY);
+        verifyRequestInteractions(request);
+    }
+
+    @Test
+    public void testClientInfoAbsent()
+    {
+        HttpServletRequest request = request();
+
+        RequestMetadata requestMetadata = RequestMetadata.fromRequest(JSON_MAPPER, request, metadata(requiredMetadata()), MCP_METHOD, STRICT);
+
+        assertThat(requestMetadata.clientInfo()).isEmpty();
+        assertThat(requestMetadata.clientCapabilities()).isEqualTo(ClientCapabilities.EMPTY);
+        verifyRequestInteractions(request);
+    }
+
+    @Test
+    public void testClientCapabilitiesRemainRequired()
+    {
+        Meta metadata = metadata(ImmutableMap.of(METADATA_PROTOCOL_VERSION, LATEST_PROTOCOL.value()));
+        HttpServletRequest request = request();
+
+        assertThatThrownBy(() -> RequestMetadata.fromRequest(JSON_MAPPER, request, metadata, MCP_METHOD, STRICT))
+                .isInstanceOfSatisfying(McpException.class, exception -> {
+                    assertThat(exception.errorDetail().code()).isEqualTo(INVALID_PARAMS.code());
+                    assertThat(exception.errorDetail().message()).isEqualTo("Missing required metadata: " + METADATA_CLIENT_CAPABILITIES);
+                });
+        verifyRequestInteractions(request);
+    }
+
+    @Test
+    public void testClientInfoValidatedWhenPresent()
+    {
+        Meta metadata = metadata(ImmutableMap.<String, Object>builder()
+                .putAll(requiredMetadata())
+                .put(METADATA_CLIENT_INFO, "invalid")
+                .buildOrThrow());
+        HttpServletRequest request = request();
+
+        assertThatThrownBy(() -> RequestMetadata.fromRequest(JSON_MAPPER, request, metadata, MCP_METHOD, STRICT))
+                .isInstanceOfSatisfying(McpException.class, exception -> {
+                    assertThat(exception.errorDetail().code()).isEqualTo(INVALID_PARAMS.code());
+                    assertThat(exception.errorDetail().message()).isEqualTo("Metadata value is not the correct type: String");
+                });
+        verifyRequestInteractions(request);
+    }
+
+    @Test
+    public void testClientInfoNullRejected()
+    {
+        Map<String, Object> values = new HashMap<>(requiredMetadata());
+        values.put(METADATA_CLIENT_INFO, null);
+        HttpServletRequest request = request();
+
+        assertThatThrownBy(() -> RequestMetadata.fromRequest(JSON_MAPPER, request, metadata(values), MCP_METHOD, STRICT))
+                .isInstanceOfSatisfying(McpException.class, exception -> {
+                    assertThat(exception.errorDetail().code()).isEqualTo(INVALID_PARAMS.code());
+                    assertThat(exception.errorDetail().message()).isEqualTo("Metadata value is not the correct type: null");
+                });
+        verifyRequestInteractions(request);
+    }
+
+    private static Map<String, Object> requiredMetadata()
+    {
+        return ImmutableMap.of(
+                METADATA_PROTOCOL_VERSION, LATEST_PROTOCOL.value(),
+                METADATA_CLIENT_CAPABILITIES, ImmutableMap.of());
+    }
+
+    private static Meta metadata(Map<String, Object> values)
+    {
+        return new TestMeta(Optional.of(values));
+    }
+
+    private static HttpServletRequest request()
+    {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getHeader(HEADER_PROTOCOL_VERSION)).thenReturn(LATEST_PROTOCOL.value());
+        when(request.getHeader(HEADER_MCP_METHOD)).thenReturn(MCP_METHOD);
+        return request;
+    }
+
+    private static void verifyRequestInteractions(HttpServletRequest request)
+    {
+        verify(request).getHeader(HEADER_PROTOCOL_VERSION);
+        verify(request).getHeader(HEADER_MCP_METHOD);
+        verify(request).getHeader(HEADER_MCP_NAME);
+        verifyNoMoreInteractions(request);
+    }
+
+    private record TestMeta(Optional<Map<String, Object>> meta)
+            implements Meta
+    {
+        @Override
+        public TestMeta withMeta(Map<String, Object> meta)
+        {
+            return new TestMeta(Optional.of(meta));
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -406,6 +406,12 @@
             </dependency>
 
             <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>5.23.0</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.openapitools</groupId>
                 <artifactId>jackson-databind-nullable</artifactId>
                 <version>0.2.11</version>


### PR DESCRIPTION
Allow stateless MCP servers to accept conforming clients that omit client info and report server identity through response metadata.