### PR TITLE
Support reload-safe application lifecycles

### DIFF
--- a/bootstrap/src/main/java/io/airlift/bootstrap/Bootstrap.java
+++ b/bootstrap/src/main/java/io/airlift/bootstrap/Bootstrap.java
@@ -48,6 +48,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
@@ -72,6 +73,8 @@ import static java.util.Objects.requireNonNull;
  */
 public class Bootstrap
 {
+    private static final CopyOnWriteArrayList<BootstrapListener> listeners = new CopyOnWriteArrayList<>();
+
     private final String name;
     private final Logger log;
 
@@ -115,6 +118,23 @@ public class Bootstrap
         this.name = requireNonNull(name, "name is null");
         this.modules = ImmutableList.copyOf(modules);
         this.log = Logger.get(name);
+    }
+
+    /**
+     * Adds a class-loader-wide listener for bootstrap attempts that begin after registration.
+     */
+    public static void addListener(BootstrapListener listener)
+    {
+        listeners.add(requireNonNull(listener, "listener is null"));
+    }
+
+    /**
+     * Removes a class-loader-wide listener from bootstrap attempts that begin after removal.
+     * An attempt already in progress continues using its initial listener snapshot.
+     */
+    public static void removeListener(BootstrapListener listener)
+    {
+        listeners.remove(requireNonNull(listener, "listener is null"));
     }
 
     public Bootstrap setRequiredConfigurationProperty(String key, String value)
@@ -343,33 +363,66 @@ public class Bootstrap
 
     public Injector initialize()
     {
-        checkState(state != State.INITIALIZED, "Already initialized");
-        if (state == State.UNINITIALIZED) {
-            configure();
+        List<BootstrapListener> listeners = List.copyOf(Bootstrap.listeners);
+        try {
+            checkState(state != State.INITIALIZED, "Already initialized");
+            if (state == State.UNINITIALIZED) {
+                configure();
+            }
+            state = State.INITIALIZED;
+
+            // system modules
+            Builder<Module> moduleList = ImmutableList.builder();
+            moduleList.add(new LifeCycleModule(name));
+            moduleList.add(new ConfigurationModule(configurationFactory));
+            moduleList.add(binder -> closingBinder(binder).registerCloseable(configurationFactory));
+            moduleList.add(binder -> binder.bind(WarningsMonitor.class).toInstance(log::warn));
+
+            // disable broken Guice "features"
+            moduleList.add(Binder::disableCircularProxies);
+            moduleList.add(Binder::requireExplicitBindings);
+            moduleList.add(Binder::requireExactBindingAnnotations);
+
+            moduleList.add(binder -> binder.bind(SecretsResolver.class).toInstance(secretsResolver));
+            moduleList.addAll(modules);
+
+            // create the injector
+            Injector injector = Guice.createInjector(Stage.PRODUCTION, moduleList.build());
+
+            injector.getInstance(LifeCycleManager.class).start();
+            notifyInitialized(listeners, injector);
+            return injector;
         }
-        state = State.INITIALIZED;
+        catch (RuntimeException failure) {
+            notifyFailed(listeners, failure);
+            throw failure;
+        }
+    }
 
-        // system modules
-        Builder<Module> moduleList = ImmutableList.builder();
-        moduleList.add(new LifeCycleModule(name));
-        moduleList.add(new ConfigurationModule(configurationFactory));
-        moduleList.add(binder -> closingBinder(binder).registerCloseable(configurationFactory));
-        moduleList.add(binder -> binder.bind(WarningsMonitor.class).toInstance(log::warn));
+    private void notifyInitialized(List<BootstrapListener> listeners, Injector injector)
+    {
+        for (BootstrapListener listener : listeners) {
+            try {
+                listener.bootstrapInitialized(this, injector);
+            }
+            catch (RuntimeException listenerFailure) {
+                log.warn(listenerFailure, "Bootstrap listener failed after initialization");
+            }
+        }
+    }
 
-        // disable broken Guice "features"
-        moduleList.add(Binder::disableCircularProxies);
-        moduleList.add(Binder::requireExplicitBindings);
-        moduleList.add(Binder::requireExactBindingAnnotations);
-
-        moduleList.add(binder -> binder.bind(SecretsResolver.class).toInstance(secretsResolver));
-        moduleList.addAll(modules);
-
-        // create the injector
-        Injector injector = Guice.createInjector(Stage.PRODUCTION, moduleList.build());
-
-        injector.getInstance(LifeCycleManager.class).start();
-
-        return injector;
+    private void notifyFailed(List<BootstrapListener> listeners, Throwable failure)
+    {
+        for (BootstrapListener listener : listeners) {
+            try {
+                listener.bootstrapFailed(this, failure);
+            }
+            catch (RuntimeException listenerFailure) {
+                if (failure != listenerFailure) {
+                    failure.addSuppressed(listenerFailure);
+                }
+            }
+        }
     }
 
     private void logConfiguration(ConfigurationFactory configurationFactory)

--- a/bootstrap/src/main/java/io/airlift/bootstrap/Bootstrap.java
+++ b/bootstrap/src/main/java/io/airlift/bootstrap/Bootstrap.java
@@ -364,6 +364,7 @@ public class Bootstrap
     public Injector initialize()
     {
         List<BootstrapListener> listeners = List.copyOf(Bootstrap.listeners);
+        LifeCycleModule lifeCycleModule = new LifeCycleModule(name);
         try {
             checkState(state != State.INITIALIZED, "Already initialized");
             if (state == State.UNINITIALIZED) {
@@ -373,7 +374,7 @@ public class Bootstrap
 
             // system modules
             Builder<Module> moduleList = ImmutableList.builder();
-            moduleList.add(new LifeCycleModule(name));
+            moduleList.add(lifeCycleModule);
             moduleList.add(new ConfigurationModule(configurationFactory));
             moduleList.add(binder -> closingBinder(binder).registerCloseable(configurationFactory));
             moduleList.add(binder -> binder.bind(WarningsMonitor.class).toInstance(log::warn));
@@ -394,6 +395,12 @@ public class Bootstrap
             return injector;
         }
         catch (RuntimeException failure) {
+            try {
+                lifeCycleModule.stopAfterInitializationFailure();
+            }
+            catch (RuntimeException cleanupFailure) {
+                failure.addSuppressed(cleanupFailure);
+            }
             notifyFailed(listeners, failure);
             throw failure;
         }

--- a/bootstrap/src/main/java/io/airlift/bootstrap/BootstrapListener.java
+++ b/bootstrap/src/main/java/io/airlift/bootstrap/BootstrapListener.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.bootstrap;
+
+import com.google.inject.Injector;
+
+/**
+ * Observes application bootstrap without changing application assembly. Listeners are registered
+ * for all {@link Bootstrap} instances in the class loader, and each initialization attempt uses
+ * the listeners registered when it begins.
+ * <p>
+ * A listener observes whether bootstrap completed; it does not own application resources or
+ * participate in shutdown. Application components should use lifecycle annotations and
+ * {@link LifeCycleManager} for startup and cleanup.
+ */
+public interface BootstrapListener
+{
+    default void bootstrapInitialized(Bootstrap bootstrap, Injector injector) {}
+
+    default void bootstrapFailed(Bootstrap bootstrap, Throwable failure) {}
+}

--- a/bootstrap/src/main/java/io/airlift/bootstrap/LifeCycleManager.java
+++ b/bootstrap/src/main/java/io/airlift/bootstrap/LifeCycleManager.java
@@ -138,8 +138,20 @@ public final class LifeCycleManager
     public void stopWithoutFailureLogging()
             throws LifeCycleStopException
     {
+        stopWithoutFailureLogging(false);
+    }
+
+    void stopAfterInitializationFailure()
+            throws LifeCycleStopException
+    {
+        stopWithoutFailureLogging(true);
+    }
+
+    private void stopWithoutFailureLogging(boolean stopBeforeStarted)
+            throws LifeCycleStopException
+    {
         List<Exception> failures = new ArrayList<>();
-        stop((_, _, exception) -> failures.add(exception));
+        stop((_, _, exception) -> failures.add(exception), stopBeforeStarted);
         if (!failures.isEmpty()) {
             LifeCycleStopException stopException = new LifeCycleStopException();
             for (Exception e : failures) {
@@ -178,7 +190,24 @@ public final class LifeCycleManager
      */
     private void stop(LifeCycleStopFailureHandler handler)
     {
-        if (!state.compareAndSet(State.STARTED, State.STOPPING)) {
+        stop(handler, false);
+    }
+
+    private void stop(LifeCycleStopFailureHandler handler, boolean stopBeforeStarted)
+    {
+        if (stopBeforeStarted) {
+            State currentState;
+            // Failed initialization can leave the manager in any nonterminal state. Claim cleanup
+            // atomically while allowing another cleanup attempt to win the race.
+            do {
+                currentState = state.get();
+                if ((currentState == State.STOPPING) || (currentState == State.STOPPED)) {
+                    return;
+                }
+            }
+            while (!state.compareAndSet(currentState, State.STOPPING));
+        }
+        else if (!state.compareAndSet(State.STARTED, State.STOPPING)) {
             return;
         }
 

--- a/bootstrap/src/main/java/io/airlift/bootstrap/LifeCycleModule.java
+++ b/bootstrap/src/main/java/io/airlift/bootstrap/LifeCycleModule.java
@@ -50,6 +50,13 @@ public class LifeCycleModule
         this("LifeCycleManager");
     }
 
+    @VisibleForTesting
+    LifeCycleModule(List<Object> injectedInstances)
+    {
+        this();
+        this.injectedInstances.addAll(requireNonNull(injectedInstances, "injectedInstances is null"));
+    }
+
     public LifeCycleModule(String name)
     {
         this.name = requireNonNull(name, "name is null");
@@ -89,9 +96,21 @@ public class LifeCycleModule
     @Singleton
     public LifeCycleManager getLifeCycleManager()
     {
-        LifeCycleManager lifeCycleManager = new LifeCycleManager(name, injectedInstances, lifeCycleMethodsMap);
+        LifeCycleManager lifeCycleManager = new LifeCycleManager(name, List.of(), lifeCycleMethodsMap);
+        // Publish the manager before adding instances so cleanup can reach instances added before a later failure.
         this.lifeCycleManager.set(lifeCycleManager);
+        for (Object instance : injectedInstances) {
+            lifeCycleManager.addInstance(instance);
+        }
         return lifeCycleManager;
+    }
+
+    void stopAfterInitializationFailure()
+    {
+        LifeCycleManager manager = lifeCycleManager.get();
+        if (manager != null) {
+            manager.stopAfterInitializationFailure();
+        }
     }
 
     private boolean isLifeCycleClass(Class<?> clazz)

--- a/bootstrap/src/test/java/io/airlift/bootstrap/TestBootstrap.java
+++ b/bootstrap/src/test/java/io/airlift/bootstrap/TestBootstrap.java
@@ -19,6 +19,7 @@ import com.google.inject.Binder;
 import com.google.inject.ConfigurationException;
 import com.google.inject.CreationException;
 import com.google.inject.Inject;
+import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.google.inject.ProvisionException;
 import com.google.inject.Scopes;
@@ -29,8 +30,12 @@ import io.airlift.configuration.ConfigPropertyMetadata;
 import io.airlift.configuration.ConfigSecuritySensitive;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.configuration.ConfigBinder.configBinder;
@@ -41,6 +46,146 @@ import static org.assertj.core.api.Assertions.fail;
 public class TestBootstrap
 {
     private static boolean fooInstanceCreated;
+
+    @Test
+    public void testBootstrapListener()
+    {
+        AtomicReference<Bootstrap> initializedBootstrap = new AtomicReference<>();
+        AtomicReference<Injector> initializedInjector = new AtomicReference<>();
+        AtomicReference<Bootstrap> failedBootstrap = new AtomicReference<>();
+        AtomicReference<Throwable> initializationFailure = new AtomicReference<>();
+        BootstrapListener listener = new BootstrapListener()
+        {
+            @Override
+            public void bootstrapInitialized(Bootstrap bootstrap, Injector injector)
+            {
+                initializedBootstrap.set(bootstrap);
+                initializedInjector.set(injector);
+            }
+
+            @Override
+            public void bootstrapFailed(Bootstrap bootstrap, Throwable failure)
+            {
+                failedBootstrap.set(bootstrap);
+                initializationFailure.set(failure);
+            }
+        };
+
+        Bootstrap.addListener(listener);
+        try {
+            Bootstrap successful = new Bootstrap();
+            Injector injector = successful.initialize();
+            assertThat(initializedBootstrap).hasValue(successful);
+            assertThat(initializedInjector).hasValue(injector);
+            injector.getInstance(LifeCycleManager.class).stop();
+
+            Bootstrap failing = new Bootstrap(_ -> {
+                throw new IllegalStateException("expected failure");
+            });
+            assertThatThrownBy(failing::initialize)
+                    .isInstanceOf(ApplicationConfigurationException.class);
+            assertThat(failedBootstrap).hasValue(failing);
+            assertThat(initializationFailure.get())
+                    .isInstanceOf(ApplicationConfigurationException.class);
+        }
+        finally {
+            Bootstrap.removeListener(listener);
+        }
+    }
+
+    @Test
+    public void testBootstrapListenerSnapshotIsStableDuringInitialization()
+    {
+        List<String> notifications = new ArrayList<>();
+        AtomicBoolean mutateListeners = new AtomicBoolean(true);
+        BootstrapListener addedListener = new BootstrapListener()
+        {
+            @Override
+            public void bootstrapInitialized(Bootstrap bootstrap, Injector injector)
+            {
+                notifications.add("added");
+            }
+        };
+        BootstrapListener removedListener = new BootstrapListener()
+        {
+            @Override
+            public void bootstrapInitialized(Bootstrap bootstrap, Injector injector)
+            {
+                notifications.add("removed");
+            }
+        };
+
+        Bootstrap.addListener(removedListener);
+        try {
+            Injector firstInjector = new Bootstrap(_ -> {
+                if (mutateListeners.compareAndSet(true, false)) {
+                    Bootstrap.removeListener(removedListener);
+                    Bootstrap.addListener(addedListener);
+                }
+            }).initialize();
+            firstInjector.getInstance(LifeCycleManager.class).stop();
+            assertThat(notifications).containsExactly("removed");
+
+            notifications.clear();
+            Injector secondInjector = new Bootstrap().initialize();
+            secondInjector.getInstance(LifeCycleManager.class).stop();
+            assertThat(notifications).containsExactly("added");
+        }
+        finally {
+            Bootstrap.removeListener(addedListener);
+            Bootstrap.removeListener(removedListener);
+        }
+    }
+
+    @Test
+    public void testBootstrapListenerFailuresAreIsolated()
+            throws Exception
+    {
+        IllegalStateException initializedListenerFailure = new IllegalStateException("expected initialized listener failure");
+        IllegalStateException failedListenerFailure = new IllegalStateException("expected failed listener failure");
+        AtomicReference<Throwable> observedFailure = new AtomicReference<>();
+        BootstrapListener failingListener = new BootstrapListener()
+        {
+            @Override
+            public void bootstrapInitialized(Bootstrap bootstrap, Injector injector)
+            {
+                throw initializedListenerFailure;
+            }
+
+            @Override
+            public void bootstrapFailed(Bootstrap bootstrap, Throwable failure)
+            {
+                observedFailure.set(failure);
+                throw failedListenerFailure;
+            }
+        };
+        BootstrapListener selfSuppressingListener = new BootstrapListener()
+        {
+            @Override
+            public void bootstrapFailed(Bootstrap bootstrap, Throwable failure)
+            {
+                throw (RuntimeException) failure;
+            }
+        };
+
+        Bootstrap.addListener(failingListener);
+        Bootstrap.addListener(selfSuppressingListener);
+        try {
+            Injector injector = new Bootstrap().initialize();
+            injector.getInstance(LifeCycleManager.class).stop();
+
+            Bootstrap failing = new Bootstrap(_ -> {
+                throw new IllegalStateException("expected bootstrap failure");
+            });
+            assertThatThrownBy(failing::initialize)
+                    .isSameAs(observedFailure.get())
+                    .hasSuppressedException(failedListenerFailure);
+        }
+        finally {
+            Bootstrap.removeListener(selfSuppressingListener);
+            Bootstrap.removeListener(failingListener);
+        }
+    }
 
     @Test
     public void testRequiresExplicitBindings()

--- a/bootstrap/src/test/java/io/airlift/bootstrap/TestBootstrap.java
+++ b/bootstrap/src/test/java/io/airlift/bootstrap/TestBootstrap.java
@@ -23,11 +23,14 @@ import com.google.inject.Injector;
 import com.google.inject.Module;
 import com.google.inject.ProvisionException;
 import com.google.inject.Scopes;
+import com.google.inject.TypeLiteral;
 import com.google.inject.spi.Message;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigPropertyMetadata;
 import io.airlift.configuration.ConfigSecuritySensitive;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -185,6 +188,42 @@ public class TestBootstrap
             Bootstrap.removeListener(selfSuppressingListener);
             Bootstrap.removeListener(failingListener);
         }
+    }
+
+    @Test
+    public void testInitializationFailureStopsStartedInstances()
+    {
+        AtomicReference<String> state = new AtomicReference<>("new");
+        Bootstrap bootstrap = new Bootstrap(binder -> {
+            binder.bind(new TypeLiteral<AtomicReference<String>>() {}).toInstance(state);
+            binder.bind(StartedInstance.class).asEagerSingleton();
+            binder.bind(FailingInstance.class).asEagerSingleton();
+        });
+
+        assertThatThrownBy(bootstrap::initialize)
+                .isInstanceOf(CreationException.class)
+                .hasMessageContaining("expected failure");
+        assertThat(state).hasValue("stopped");
+    }
+
+    @Test
+    public void testInitializationFailureRetainsCleanupFailureAsSuppressed()
+    {
+        Bootstrap bootstrap = new Bootstrap(binder -> {
+            binder.bind(FailingStopInstance.class).asEagerSingleton();
+            binder.bind(FailingAfterStopInstance.class).asEagerSingleton();
+        });
+
+        assertThatThrownBy(bootstrap::initialize)
+                .isInstanceOfSatisfying(CreationException.class, failure -> {
+                    assertThat(failure).hasMessageContaining("expected bootstrap failure");
+                    assertThat(failure.getSuppressed())
+                            .singleElement()
+                            .isInstanceOfSatisfying(LifeCycleStopException.class, cleanupFailure -> assertThat(cleanupFailure.getSuppressed())
+                                    .singleElement()
+                                    .isInstanceOfSatisfying(IllegalStateException.class, suppressed -> assertThat(suppressed)
+                                            .hasMessage("expected cleanup failure")));
+                });
     }
 
     @Test
@@ -497,6 +536,60 @@ public class TestBootstrap
     }
 
     public static class Instance {}
+
+    public static class StartedInstance
+    {
+        private final AtomicReference<String> state;
+
+        @Inject
+        public StartedInstance(AtomicReference<String> state)
+        {
+            this.state = state;
+        }
+
+        @PostConstruct
+        public void start()
+        {
+            state.set("started");
+        }
+
+        @PreDestroy
+        public void stop()
+        {
+            if (!state.compareAndSet("started", "stopped")) {
+                throw new IllegalStateException("instance was not started");
+            }
+        }
+    }
+
+    public static class FailingInstance
+    {
+        @Inject
+        public FailingInstance(@SuppressWarnings("UnusedVariable") StartedInstance startedInstance)
+        {
+            throw new IllegalStateException("expected failure");
+        }
+    }
+
+    public static class FailingStopInstance
+    {
+        @PreDestroy
+        public void stop()
+        {
+            throw new IllegalStateException("expected cleanup failure");
+        }
+    }
+
+    public static class FailingAfterStopInstance
+    {
+        @Inject
+        public FailingAfterStopInstance(
+                @SuppressWarnings("UnusedVariable") FailingStopInstance instance,
+                @SuppressWarnings("UnusedVariable") LifeCycleManager lifeCycleManager)
+        {
+            throw new IllegalStateException("expected bootstrap failure");
+        }
+    }
 
     public static class InstanceA
     {

--- a/bootstrap/src/test/java/io/airlift/bootstrap/TestLifeCycleManager.java
+++ b/bootstrap/src/test/java/io/airlift/bootstrap/TestLifeCycleManager.java
@@ -28,6 +28,8 @@ import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.Singleton;
 import com.google.inject.Stage;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -41,6 +43,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
@@ -311,6 +314,26 @@ public class TestLifeCycleManager
     }
 
     @Test
+    public void testInitializationFailureStopsEarlierAccumulatedInstances()
+    {
+        DependentInstance dependentInstance = new DependentInstance();
+        LifeCycleModule lifeCycleModule = new LifeCycleModule(List.of(
+                dependentInstance,
+                new FailingDependentInstance(dependentInstance)));
+
+        assertThatThrownBy(lifeCycleModule::getLifeCycleManager)
+                .isInstanceOf(LifeCycleStartException.class)
+                .hasRootCauseMessage("expected failure");
+        lifeCycleModule.stopAfterInitializationFailure();
+
+        assertThat(stateLog).containsExactly(
+                "postDependentInstance",
+                "postFailingDependentInstance",
+                "preFailingDependentInstance",
+                "preDependentInstance");
+    }
+
+    @Test
     public void testNoPreDestroy()
     {
         Injector injector = Guice.createInjector(
@@ -433,5 +456,23 @@ public class TestLifeCycleManager
         lifeCycleManager.stop();
 
         assertThat(injector.getInstance(BarInstance.class)).isNull();
+    }
+
+    public static class FailingDependentInstance
+    {
+        public FailingDependentInstance(DependentInstance dependentInstance) {}
+
+        @PostConstruct
+        public void start()
+        {
+            note("postFailingDependentInstance");
+            throw new IllegalStateException("expected failure");
+        }
+
+        @PreDestroy
+        public void stop()
+        {
+            note("preFailingDependentInstance");
+        }
     }
 }

--- a/http-server/src/main/java/io/airlift/http/server/HttpServer.java
+++ b/http-server/src/main/java/io/airlift/http/server/HttpServer.java
@@ -85,6 +85,8 @@ import java.util.concurrent.ScheduledExecutorService;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Throwables.throwIfInstanceOf;
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.http.server.ServerFeature.CASE_SENSITIVE_HEADER_CACHE;
@@ -556,13 +558,53 @@ public class HttpServer
 
         log.debug("Server %s stopping in %s, %d active requests to complete", server.getName(), Duration.succinctDuration(server.getStopTimeout(), MILLISECONDS), activeRequests);
 
-        server.stop();
-
-        if (scheduledExecutorService != null) {
-            scheduledExecutorService.shutdown();
-        }
+        stopServer(server, scheduledExecutorService);
 
         log.info("Server %s shutdown complete", server.getName());
+    }
+
+    @VisibleForTesting
+    static void stopServer(Server server, ScheduledExecutorService scheduledExecutorService)
+            throws Exception
+    {
+        Throwable failure = null;
+        try {
+            server.stop();
+        }
+        catch (Throwable stopFailure) {
+            failure = stopFailure;
+        }
+        try {
+            server.destroy();
+        }
+        catch (Throwable destroyFailure) {
+            failure = addFailure(failure, destroyFailure);
+        }
+        try {
+            if (scheduledExecutorService != null) {
+                scheduledExecutorService.shutdown();
+            }
+        }
+        catch (Throwable shutdownFailure) {
+            failure = addFailure(failure, shutdownFailure);
+        }
+
+        if (failure != null) {
+            throwIfInstanceOf(failure, Exception.class);
+            throwIfUnchecked(failure);
+            throw new RuntimeException(failure);
+        }
+    }
+
+    private static Throwable addFailure(Throwable failure, Throwable newFailure)
+    {
+        if (failure == null) {
+            return newFailure;
+        }
+        if (failure != newFailure) {
+            failure.addSuppressed(newFailure);
+        }
+        return failure;
     }
 
     @VisibleForTesting

--- a/http-server/src/test/java/io/airlift/http/server/TestHttpServerModule.java
+++ b/http-server/src/test/java/io/airlift/http/server/TestHttpServerModule.java
@@ -23,6 +23,7 @@ import com.google.inject.Key;
 import com.google.inject.Scopes;
 import io.airlift.bootstrap.ApplicationConfigurationException;
 import io.airlift.bootstrap.Bootstrap;
+import io.airlift.bootstrap.LifeCycleManager;
 import io.airlift.http.client.HttpClient;
 import io.airlift.http.client.HttpStatus;
 import io.airlift.http.client.HttpUriBuilder;
@@ -37,14 +38,18 @@ import io.airlift.tracing.TracingModule;
 import jakarta.servlet.Filter;
 import jakarta.servlet.Servlet;
 import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.server.Server;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
+import org.mockito.InOrder;
 
 import javax.management.MBeanServer;
+import javax.management.MBeanServerFactory;
+import javax.management.ObjectName;
 
 import java.io.File;
 import java.io.IOException;
@@ -53,6 +58,8 @@ import java.lang.annotation.Target;
 import java.lang.management.ManagementFactory;
 import java.net.URI;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
@@ -75,6 +82,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
 
 @TestInstance(PER_CLASS)
 @Execution(SAME_THREAD)
@@ -167,6 +177,77 @@ public class TestHttpServerModule
 
         assertThat(primaryServer).isNotEqualTo(secondaryServer);
         assertThat(primaryInfo.getHttpUri()).isNotEqualTo(secondaryInfo.getHttpUri());
+    }
+
+    @Test
+    public void testStopUnregistersJettyMBeans()
+    {
+        MBeanServer mBeanServer = MBeanServerFactory.createMBeanServer();
+        try {
+            Set<ObjectName> initialMBeans = mBeanServer.queryNames(null, null);
+            Bootstrap app = new Bootstrap(
+                    new HttpServerModule(),
+                    new TestingNodeModule(),
+                    new TracingModule("airlift.http-server", "1.0"),
+                    binder -> {
+                        binder.bind(Servlet.class).to(DummyServlet.class);
+                        binder.bind(MBeanServer.class).toInstance(mBeanServer);
+                    });
+
+            Injector injector = app
+                    .setRequiredConfigurationProperties(Map.of(
+                            "http-server.http.port", "0",
+                            "http-server.log.path", new File(tempDir, "http-request.log").getAbsolutePath()))
+                    .doNotInitializeLogging()
+                    .quiet()
+                    .initialize();
+
+            LifeCycleManager lifeCycleManager = injector.getInstance(LifeCycleManager.class);
+            try {
+                assertThat(mBeanServer.queryNames(null, null)).hasSizeGreaterThan(initialMBeans.size());
+            }
+            finally {
+                lifeCycleManager.stop();
+            }
+
+            assertThat(mBeanServer.queryNames(null, null)).containsExactlyInAnyOrderElementsOf(initialMBeans);
+        }
+        finally {
+            MBeanServerFactory.releaseMBeanServer(mBeanServer);
+        }
+    }
+
+    @Test
+    public void testStopCompletesCleanupAndPreservesFailureOrder()
+            throws Exception
+    {
+        Server server = mock(Server.class);
+        ScheduledExecutorService scheduledExecutor = mock(ScheduledExecutorService.class);
+        RuntimeException stopFailure = new RuntimeException("stop failure");
+        RuntimeException destroyFailure = new RuntimeException("destroy failure");
+        RuntimeException shutdownFailure = new RuntimeException("shutdown failure");
+        doThrow(stopFailure).when(server).stop();
+        doThrow(destroyFailure).when(server).destroy();
+        doThrow(shutdownFailure).when(scheduledExecutor).shutdown();
+
+        assertThatThrownBy(() -> HttpServer.stopServer(server, scheduledExecutor))
+                .isSameAs(stopFailure)
+                .hasSuppressedException(destroyFailure)
+                .hasSuppressedException(shutdownFailure);
+
+        InOrder cleanupOrder = inOrder(server, scheduledExecutor);
+        cleanupOrder.verify(server).stop();
+        cleanupOrder.verify(server).destroy();
+        cleanupOrder.verify(scheduledExecutor).shutdown();
+
+        Server selfSuppressingServer = mock(Server.class);
+        RuntimeException repeatedFailure = new RuntimeException("repeated failure");
+        doThrow(repeatedFailure).when(selfSuppressingServer).stop();
+        doThrow(repeatedFailure).when(selfSuppressingServer).destroy();
+
+        assertThatThrownBy(() -> HttpServer.stopServer(selfSuppressingServer, null))
+                .isSameAs(repeatedFailure)
+                .hasNoSuppressedExceptions();
     }
 
     @Test


### PR DESCRIPTION
## Summary

- add process-wide observation of successful and failed bootstrap attempts
- clean up lifecycle-managed resources when injector creation fails partway through startup
- fully destroy retired Jetty servers so exported MBeans do not survive shutdown

## Motivation

Development tools can start and retire multiple application generations in the same JVM. They need to observe bootstrap completion without changing application assembly, and every retired or rejected generation must release the resources it created.

Previously, a failure during eager singleton construction could leave lifecycle-managed instances running because bootstrap returned no injector to the caller. Jetty shutdown also stopped the server without destroying it, leaving stale MBean registrations behind for later generations.

This change makes those lifecycle boundaries explicit while preserving ordinary application startup behavior. Bootstrap success is reported only after lifecycle startup completes, cleanup failures are suppressed onto the original startup failure, and Jetty destruction remains paired with scheduled-executor cleanup.

## Validation

- bootstrap success and failure observation coverage
- reverse-order cleanup after partial startup failure
- listener failure isolation coverage
- Jetty MBean removal after shutdown
- repeated in-process application generation exercise
