### PR TITLE
[MCP] some tech debt

### DIFF
--- a/mcp/src/main/java/io/airlift/mcp/McpMetadata.java
+++ b/mcp/src/main/java/io/airlift/mcp/McpMetadata.java
@@ -9,7 +9,7 @@ import static io.airlift.mcp.model.Constants.SKILL_INDEX_URI;
 import static io.airlift.mcp.model.Constants.SKILL_MD_FILE;
 import static java.util.Objects.requireNonNull;
 
-public record McpMetadata(String uriPath, Implementation implementation, Optional<String> instructions, CacheableResult cacheableResultValues, boolean autoAddSkillInstructions)
+public record McpMetadata(String uriPath, Implementation implementation, Optional<String> instructions, CacheableResult<?> cacheableResultValues, boolean autoAddSkillInstructions)
 {
     public static final McpMetadata DEFAULT = new McpMetadata("/mcp");
 
@@ -58,7 +58,7 @@ public record McpMetadata(String uriPath, Implementation implementation, Optiona
                 .or(() -> Optional.of(SKILLS_INSTRUCTIONS));
     }
 
-    public McpMetadata withCacheableResultValues(CacheableResult cacheableResultValues)
+    public McpMetadata withCacheableResultValues(CacheableResult<?> cacheableResultValues)
     {
         return new McpMetadata(uriPath, implementation, instructions, cacheableResultValues, autoAddSkillInstructions);
     }

--- a/mcp/src/main/java/io/airlift/mcp/McpModule.java
+++ b/mcp/src/main/java/io/airlift/mcp/McpModule.java
@@ -1,6 +1,5 @@
 package io.airlift.mcp;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Binder;
@@ -23,15 +22,6 @@ import io.airlift.mcp.handler.ResourceEntry;
 import io.airlift.mcp.handler.ResourceTemplateEntry;
 import io.airlift.mcp.handler.ToolEntry;
 import io.airlift.mcp.internal.InternalMcpModule;
-import io.airlift.mcp.model.CompleteReference;
-import io.airlift.mcp.model.CompleteReference.PromptReference;
-import io.airlift.mcp.model.CompleteReference.ResourceReference;
-import io.airlift.mcp.model.Content;
-import io.airlift.mcp.model.Content.AudioContent;
-import io.airlift.mcp.model.Content.EmbeddedResource;
-import io.airlift.mcp.model.Content.ImageContent;
-import io.airlift.mcp.model.Content.ResourceLink;
-import io.airlift.mcp.model.Content.TextContent;
 import io.airlift.mcp.model.Icon;
 import io.airlift.mcp.model.JsonRpcMessage;
 import io.airlift.mcp.model.JsonRpcMessageDeserializer;
@@ -74,6 +64,7 @@ import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.jackson.JacksonSubTypeBinder.jacksonSubTypeBinder;
 import static io.airlift.json.JsonBinder.jsonBinder;
+import static io.airlift.mcp.model.McpJacksonSubTypes.buildJacksonSubType;
 import static io.airlift.mcp.reflection.ReflectionHelper.forAllInClass;
 import static io.airlift.mcp.reflection.SkillsHelper.resourceFromSkill;
 import static io.airlift.mcp.reflection.SkillsHelper.resourceTemplateFromSkillTemplate;
@@ -152,22 +143,6 @@ public class McpModule
             requireNonNull(identityType, "identityType is null");
             requireNonNull(identityMapperBinding, "identityMapperBinding is null");
         }
-    }
-
-    @VisibleForTesting
-    public static JacksonSubType buildJacksonSubType()
-    {
-        return JacksonSubType.builder()
-                .forBase(Content.class, "type")
-                .add(TextContent.class, "text")
-                .add(ImageContent.class, "image")
-                .add(AudioContent.class, "audio")
-                .add(EmbeddedResource.class, "resource")
-                .add(ResourceLink.class, "resource_link")
-                .forBase(CompleteReference.class, "type")
-                .add(PromptReference.class, "ref/prompt")
-                .add(ResourceReference.class, "ref/resource")
-                .build();
     }
 
     public interface LegacyBuilder

--- a/mcp/src/main/java/io/airlift/mcp/model/CacheableResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/CacheableResult.java
@@ -7,9 +7,10 @@ import java.util.OptionalInt;
 
 import static io.airlift.mcp.model.CacheScope.PRIVATE;
 
-public interface CacheableResult
+@SuppressWarnings("rawtypes")
+public interface CacheableResult<T extends CacheableResult<T>>
 {
-    CacheableResult DEFAULT = new CacheableResult()
+    CacheableResult<?> DEFAULT = new CacheableResult()
     {
         @Override
         public OptionalInt ttlMs()
@@ -24,7 +25,7 @@ public interface CacheableResult
         }
 
         @Override
-        public Object withCacheableResult(int ttlMs, CacheScope cacheScope)
+        public CacheableResult withCacheableResult(int ttlMs, CacheScope cacheScope)
         {
             throw new UnsupportedOperationException();
         }
@@ -42,5 +43,5 @@ public interface CacheableResult
         return Optional.empty();
     }
 
-    Object withCacheableResult(int ttlMs, CacheScope cacheScope);
+    T withCacheableResult(int ttlMs, CacheScope cacheScope);
 }

--- a/mcp/src/main/java/io/airlift/mcp/model/CallToolRequest.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/CallToolRequest.java
@@ -9,7 +9,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
 
 public record CallToolRequest(String name, Map<String, Object> arguments, Optional<Map<String, Object>> meta)
-        implements Meta
+        implements Meta<CallToolRequest>
 {
     public CallToolRequest
     {

--- a/mcp/src/main/java/io/airlift/mcp/model/CallToolResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/CallToolResult.java
@@ -11,7 +11,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
 
 public record CallToolResult(List<Content> content, Optional<StructuredContent<?>> structuredContent, boolean isError, Optional<Map<String, Object>> meta)
-        implements Meta
+        implements Meta<CallToolResult>
 {
     public CallToolResult
     {

--- a/mcp/src/main/java/io/airlift/mcp/model/CancelledNotification.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/CancelledNotification.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 import static java.util.Objects.requireNonNullElse;
 
 public record CancelledNotification(Object requestId, Optional<String> reason, Optional<Map<String, Object>> meta)
-        implements Meta
+        implements Meta<CancelledNotification>
 {
     public CancelledNotification
     {

--- a/mcp/src/main/java/io/airlift/mcp/model/CompleteRequest.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/CompleteRequest.java
@@ -9,7 +9,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
 
 public record CompleteRequest(CompleteReference ref, CompleteArgument argument, Optional<CompleteContext> context, Optional<Map<String, Object>> meta)
-        implements Meta
+        implements Meta<CompleteRequest>
 {
     public CompleteRequest
     {

--- a/mcp/src/main/java/io/airlift/mcp/model/CompleteResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/CompleteResult.java
@@ -12,7 +12,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
 
 public record CompleteResult(CompleteCompletion completion, Optional<Map<String, Object>> meta)
-        implements Meta
+        implements Meta<CompleteResult>
 {
     // see: https://modelcontextprotocol.io/specification/2025-03-26/server/utilities/completion#completeresult
     public static final int MAX_COMPLETIONS = 100;

--- a/mcp/src/main/java/io/airlift/mcp/model/CreateMessageRequest.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/CreateMessageRequest.java
@@ -22,7 +22,7 @@ public record CreateMessageRequest(
         Optional<List<String>> stopSequences,
         Optional<Map<String, Object>> metadata,
         Optional<Map<String, Object>> meta)
-        implements Meta
+        implements Meta<CreateMessageRequest>
 {
     public CreateMessageRequest
     {

--- a/mcp/src/main/java/io/airlift/mcp/model/DiscoverResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/DiscoverResult.java
@@ -19,7 +19,7 @@ public record DiscoverResult(
         OptionalInt ttlMs,
         Optional<CacheScope> cacheScope,
         Optional<Map<String, Object>> meta)
-        implements Meta<DiscoverResult>, CacheableResult
+        implements Meta<DiscoverResult>, CacheableResult<DiscoverResult>
 {
     public DiscoverResult
     {

--- a/mcp/src/main/java/io/airlift/mcp/model/DiscoverResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/DiscoverResult.java
@@ -6,6 +6,7 @@ import io.airlift.mcp.model.InitializeResult.ServerCapabilities;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
@@ -15,8 +16,10 @@ public record DiscoverResult(
         List<String> supportedVersions,
         ServerCapabilities capabilities,
         Optional<String> instructions,
+        OptionalInt ttlMs,
+        Optional<CacheScope> cacheScope,
         Optional<Map<String, Object>> meta)
-        implements Meta<DiscoverResult>
+        implements Meta<DiscoverResult>, CacheableResult
 {
     public DiscoverResult
     {
@@ -24,12 +27,20 @@ public record DiscoverResult(
         supportedVersions = ImmutableList.copyOf(supportedVersions);
         requireNonNull(capabilities, "capabilities is null");
         instructions = requireNonNullElse(instructions, Optional.empty());
+        ttlMs = requireNonNullElse(ttlMs, OptionalInt.empty());
+        cacheScope = requireNonNullElse(cacheScope, Optional.empty());
         meta = requireNonNullElse(meta, Optional.empty());
     }
 
     @Override
     public DiscoverResult withMeta(Map<String, Object> meta)
     {
-        return new DiscoverResult(resultType, supportedVersions, capabilities, instructions, Optional.of(meta));
+        return new DiscoverResult(resultType, supportedVersions, capabilities, instructions, ttlMs, cacheScope, Optional.of(meta));
+    }
+
+    @Override
+    public DiscoverResult withCacheableResult(int ttlMs, CacheScope cacheScope)
+    {
+        return new DiscoverResult(ResultType.COMPLETE, supportedVersions, capabilities, instructions, OptionalInt.of(ttlMs), Optional.of(cacheScope), meta);
     }
 }

--- a/mcp/src/main/java/io/airlift/mcp/model/DiscoverResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/DiscoverResult.java
@@ -16,7 +16,7 @@ public record DiscoverResult(
         ServerCapabilities capabilities,
         Optional<String> instructions,
         Optional<Map<String, Object>> meta)
-        implements Meta
+        implements Meta<DiscoverResult>
 {
     public DiscoverResult
     {
@@ -28,7 +28,7 @@ public record DiscoverResult(
     }
 
     @Override
-    public Object withMeta(Map<String, Object> meta)
+    public DiscoverResult withMeta(Map<String, Object> meta)
     {
         return new DiscoverResult(resultType, supportedVersions, capabilities, instructions, Optional.of(meta));
     }

--- a/mcp/src/main/java/io/airlift/mcp/model/ElicitRequest.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ElicitRequest.java
@@ -1,0 +1,4 @@
+package io.airlift.mcp.model;
+
+public sealed interface ElicitRequest
+        permits ElicitRequestForm, ElicitRequestUrl {}

--- a/mcp/src/main/java/io/airlift/mcp/model/ElicitRequestForm.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ElicitRequestForm.java
@@ -9,7 +9,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
 
 public record ElicitRequestForm(Optional<String> mode, String message, ObjectNode requestedSchema, Optional<Map<String, Object>> meta)
-        implements Meta<ElicitRequestForm>
+        implements Meta<ElicitRequestForm>, ElicitRequest
 {
     public ElicitRequestForm
     {

--- a/mcp/src/main/java/io/airlift/mcp/model/ElicitRequestForm.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ElicitRequestForm.java
@@ -9,7 +9,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
 
 public record ElicitRequestForm(Optional<String> mode, String message, ObjectNode requestedSchema, Optional<Map<String, Object>> meta)
-        implements Meta
+        implements Meta<ElicitRequestForm>
 {
     public ElicitRequestForm
     {

--- a/mcp/src/main/java/io/airlift/mcp/model/ElicitRequestUrl.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ElicitRequestUrl.java
@@ -7,7 +7,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
 
 public record ElicitRequestUrl(Optional<String> mode, String elicitationId, String message, String url, Optional<Map<String, Object>> meta)
-        implements Meta
+        implements Meta<ElicitRequestUrl>
 {
     public ElicitRequestUrl
     {

--- a/mcp/src/main/java/io/airlift/mcp/model/ElicitRequestUrl.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ElicitRequestUrl.java
@@ -7,7 +7,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
 
 public record ElicitRequestUrl(Optional<String> mode, String elicitationId, String message, String url, Optional<Map<String, Object>> meta)
-        implements Meta<ElicitRequestUrl>
+        implements Meta<ElicitRequestUrl>, ElicitRequest
 {
     public ElicitRequestUrl
     {

--- a/mcp/src/main/java/io/airlift/mcp/model/ElicitResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ElicitResult.java
@@ -10,7 +10,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
 
 public record ElicitResult(Action action, Optional<Map<String, Object>> content, Optional<Map<String, Object>> meta)
-        implements Meta
+        implements Meta<ElicitResult>
 {
     public ElicitResult
     {

--- a/mcp/src/main/java/io/airlift/mcp/model/GetPromptRequest.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/GetPromptRequest.java
@@ -9,7 +9,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
 
 public record GetPromptRequest(String name, Map<String, Object> arguments, Optional<Map<String, Object>> meta)
-        implements Meta
+        implements Meta<GetPromptRequest>
 {
     public GetPromptRequest
     {

--- a/mcp/src/main/java/io/airlift/mcp/model/GetPromptResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/GetPromptResult.java
@@ -10,7 +10,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
 
 public record GetPromptResult(Optional<String> description, List<PromptMessage> messages, Optional<Map<String, Object>> meta)
-        implements Meta
+        implements Meta<GetPromptResult>
 {
     public record PromptMessage(Role role, Content content)
     {

--- a/mcp/src/main/java/io/airlift/mcp/model/InitializeRequest.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/InitializeRequest.java
@@ -11,7 +11,7 @@ public record InitializeRequest(
         ClientCapabilities capabilities,
         Implementation clientInfo,
         Optional<Map<String, Object>> meta)
-        implements Meta
+        implements Meta<InitializeRequest>
 {
     public InitializeRequest
     {

--- a/mcp/src/main/java/io/airlift/mcp/model/ListPromptsResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ListPromptsResult.java
@@ -11,7 +11,7 @@ import static java.util.Objects.requireNonNullElse;
 
 public record ListPromptsResult(List<Prompt> prompts, Optional<String> nextCursor, OptionalInt ttlMs, Optional<CacheScope> cacheScope, Optional<Map<String, Object>> meta)
         implements CacheableResult,
-                   Meta,
+                   Meta<ListPromptsResult>,
                    PaginatedResult
 {
     public ListPromptsResult

--- a/mcp/src/main/java/io/airlift/mcp/model/ListPromptsResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ListPromptsResult.java
@@ -10,7 +10,7 @@ import java.util.OptionalInt;
 import static java.util.Objects.requireNonNullElse;
 
 public record ListPromptsResult(List<Prompt> prompts, Optional<String> nextCursor, OptionalInt ttlMs, Optional<CacheScope> cacheScope, Optional<Map<String, Object>> meta)
-        implements CacheableResult,
+        implements CacheableResult<ListPromptsResult>,
                    Meta<ListPromptsResult>,
                    PaginatedResult
 {

--- a/mcp/src/main/java/io/airlift/mcp/model/ListRequest.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ListRequest.java
@@ -1,14 +1,22 @@
 package io.airlift.mcp.model;
 
+import java.util.Map;
 import java.util.Optional;
 
 import static java.util.Objects.requireNonNullElse;
 
-public record ListRequest(Optional<String> cursor)
-        implements PaginatedRequest
+public record ListRequest(Optional<String> cursor, Optional<Map<String, Object>> meta)
+        implements PaginatedRequest, Meta<ListRequest>
 {
     public ListRequest
     {
         cursor = requireNonNullElse(cursor, Optional.empty());
+        meta = requireNonNullElse(meta, Optional.empty());
+    }
+
+    @Override
+    public ListRequest withMeta(Map<String, Object> meta)
+    {
+        return new ListRequest(cursor, Optional.of(meta));
     }
 }

--- a/mcp/src/main/java/io/airlift/mcp/model/ListResourceTemplatesResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ListResourceTemplatesResult.java
@@ -11,7 +11,7 @@ import static java.util.Objects.requireNonNullElse;
 
 public record ListResourceTemplatesResult(List<ResourceTemplate> resourceTemplates, Optional<String> nextCursor, OptionalInt ttlMs, Optional<CacheScope> cacheScope, Optional<Map<String, Object>> meta)
         implements CacheableResult,
-                   Meta,
+                   Meta<ListResourceTemplatesResult>,
                    PaginatedResult
 {
     public ListResourceTemplatesResult

--- a/mcp/src/main/java/io/airlift/mcp/model/ListResourceTemplatesResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ListResourceTemplatesResult.java
@@ -10,7 +10,7 @@ import java.util.OptionalInt;
 import static java.util.Objects.requireNonNullElse;
 
 public record ListResourceTemplatesResult(List<ResourceTemplate> resourceTemplates, Optional<String> nextCursor, OptionalInt ttlMs, Optional<CacheScope> cacheScope, Optional<Map<String, Object>> meta)
-        implements CacheableResult,
+        implements CacheableResult<ListResourceTemplatesResult>,
                    Meta<ListResourceTemplatesResult>,
                    PaginatedResult
 {

--- a/mcp/src/main/java/io/airlift/mcp/model/ListResourcesResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ListResourcesResult.java
@@ -11,7 +11,7 @@ import static java.util.Objects.requireNonNullElse;
 
 public record ListResourcesResult(List<Resource> resources, Optional<String> nextCursor, OptionalInt ttlMs, Optional<CacheScope> cacheScope, Optional<Map<String, Object>> meta)
         implements CacheableResult,
-                   Meta,
+                   Meta<ListResourcesResult>,
                    PaginatedResult
 {
     public ListResourcesResult

--- a/mcp/src/main/java/io/airlift/mcp/model/ListResourcesResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ListResourcesResult.java
@@ -10,7 +10,7 @@ import java.util.OptionalInt;
 import static java.util.Objects.requireNonNullElse;
 
 public record ListResourcesResult(List<Resource> resources, Optional<String> nextCursor, OptionalInt ttlMs, Optional<CacheScope> cacheScope, Optional<Map<String, Object>> meta)
-        implements CacheableResult,
+        implements CacheableResult<ListResourcesResult>,
                    Meta<ListResourcesResult>,
                    PaginatedResult
 {

--- a/mcp/src/main/java/io/airlift/mcp/model/ListRootsResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ListRootsResult.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 import static java.util.Objects.requireNonNullElse;
 
 public record ListRootsResult(List<Root> roots, Optional<Map<String, Object>> meta)
-        implements Meta
+        implements Meta<ListRootsResult>
 {
     public ListRootsResult
     {

--- a/mcp/src/main/java/io/airlift/mcp/model/ListToolsResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ListToolsResult.java
@@ -11,7 +11,7 @@ import static java.util.Objects.requireNonNullElse;
 
 public record ListToolsResult(List<Tool> tools, Optional<String> nextCursor, OptionalInt ttlMs, Optional<CacheScope> cacheScope, Optional<Map<String, Object>> meta)
         implements CacheableResult,
-                   Meta,
+                   Meta<ListToolsResult>,
                    PaginatedResult
 {
     public ListToolsResult

--- a/mcp/src/main/java/io/airlift/mcp/model/ListToolsResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ListToolsResult.java
@@ -10,7 +10,7 @@ import java.util.OptionalInt;
 import static java.util.Objects.requireNonNullElse;
 
 public record ListToolsResult(List<Tool> tools, Optional<String> nextCursor, OptionalInt ttlMs, Optional<CacheScope> cacheScope, Optional<Map<String, Object>> meta)
-        implements CacheableResult,
+        implements CacheableResult<ListToolsResult>,
                    Meta<ListToolsResult>,
                    PaginatedResult
 {

--- a/mcp/src/main/java/io/airlift/mcp/model/McpJacksonSubTypes.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/McpJacksonSubTypes.java
@@ -1,0 +1,23 @@
+package io.airlift.mcp.model;
+
+import io.airlift.jackson.JacksonSubType;
+
+public final class McpJacksonSubTypes
+{
+    private McpJacksonSubTypes() {}
+
+    public static JacksonSubType buildJacksonSubType()
+    {
+        return JacksonSubType.builder()
+                .forBase(Content.class, "type")
+                .add(Content.TextContent.class, "text")
+                .add(Content.ImageContent.class, "image")
+                .add(Content.AudioContent.class, "audio")
+                .add(Content.EmbeddedResource.class, "resource")
+                .add(Content.ResourceLink.class, "resource_link")
+                .forBase(CompleteReference.class, "type")
+                .add(CompleteReference.PromptReference.class, "ref/prompt")
+                .add(CompleteReference.ResourceReference.class, "ref/resource")
+                .build();
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/Meta.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/Meta.java
@@ -5,10 +5,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Map;
 import java.util.Optional;
 
-public interface Meta
+public interface Meta<T extends Meta<T>>
 {
     @JsonProperty("_meta")
     Optional<Map<String, Object>> meta();
 
-    Object withMeta(Map<String, Object> meta);
+    T withMeta(Map<String, Object> meta);
 }

--- a/mcp/src/main/java/io/airlift/mcp/model/MetaOnly.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/MetaOnly.java
@@ -1,0 +1,23 @@
+package io.airlift.mcp.model;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNullElse;
+
+public record MetaOnly(Optional<Map<String, Object>> meta)
+        implements Meta<MetaOnly>
+{
+    public static final MetaOnly EMPTY_META = new MetaOnly(Optional.empty());
+
+    public MetaOnly
+    {
+        meta = requireNonNullElse(meta, Optional.empty());
+    }
+
+    @Override
+    public MetaOnly withMeta(Map<String, Object> meta)
+    {
+        return new MetaOnly(Optional.of(meta));
+    }
+}

--- a/mcp/src/main/java/io/airlift/mcp/model/Prompt.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/Prompt.java
@@ -15,7 +15,7 @@ public record Prompt(String name, Optional<String> description, Optional<Role> r
         requireNonNull(name, "name is null");
         description = requireNonNullElse(description, Optional.empty());
         role = requireNonNullElse(role, Optional.empty());
-        arguments = ImmutableList.copyOf(arguments);
+        arguments = ImmutableList.copyOf(requireNonNullElse(arguments, ImmutableList.of()));
         icons = requireNonNullElse(icons, Optional.empty());
     }
 

--- a/mcp/src/main/java/io/airlift/mcp/model/ReadResourceRequest.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ReadResourceRequest.java
@@ -7,7 +7,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
 
 public record ReadResourceRequest(String uri, Optional<Map<String, Object>> meta)
-        implements Meta
+        implements Meta<ReadResourceRequest>
 {
     public ReadResourceRequest
     {

--- a/mcp/src/main/java/io/airlift/mcp/model/ReadResourceResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ReadResourceResult.java
@@ -10,7 +10,7 @@ import java.util.OptionalInt;
 import static java.util.Objects.requireNonNullElse;
 
 public record ReadResourceResult(List<ResourceContents> contents, OptionalInt ttlMs, Optional<CacheScope> cacheScope, Optional<Map<String, Object>> meta)
-        implements CacheableResult, Meta
+        implements CacheableResult, Meta<ReadResourceResult>
 {
     public ReadResourceResult
     {

--- a/mcp/src/main/java/io/airlift/mcp/model/ReadResourceResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ReadResourceResult.java
@@ -10,7 +10,7 @@ import java.util.OptionalInt;
 import static java.util.Objects.requireNonNullElse;
 
 public record ReadResourceResult(List<ResourceContents> contents, OptionalInt ttlMs, Optional<CacheScope> cacheScope, Optional<Map<String, Object>> meta)
-        implements CacheableResult, Meta<ReadResourceResult>
+        implements CacheableResult<ReadResourceResult>, Meta<ReadResourceResult>
 {
     public ReadResourceResult
     {

--- a/mcp/src/main/java/io/airlift/mcp/model/ResourceContents.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ResourceContents.java
@@ -8,7 +8,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
 
 public record ResourceContents(Optional<String> name, String uri, String mimeType, Optional<String> text, Optional<String> blob, Optional<Map<String, Object>> meta)
-        implements Meta
+        implements Meta<ResourceContents>
 {
     public ResourceContents
     {

--- a/mcp/src/main/java/io/airlift/mcp/model/Root.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/Root.java
@@ -7,7 +7,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
 
 public record Root(String uri, Optional<String> name, Optional<Map<String, Object>> meta)
-        implements Meta
+        implements Meta<Root>
 {
     public Root
     {

--- a/mcp/src/main/java/io/airlift/mcp/model/SubscribeRequest.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/SubscribeRequest.java
@@ -7,7 +7,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
 
 public record SubscribeRequest(String uri, Optional<Map<String, Object>> meta)
-        implements Meta
+        implements Meta<SubscribeRequest>
 {
     public SubscribeRequest
     {

--- a/mcp/src/main/java/io/airlift/mcp/model/SubscriptionNotifications.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/SubscriptionNotifications.java
@@ -7,7 +7,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
 
 public record SubscriptionNotifications(SubscriptionFilter notifications, Optional<Map<String, Object>> meta)
-        implements Meta
+        implements Meta<SubscriptionNotifications>
 {
     public SubscriptionNotifications
     {

--- a/mcp/src/main/java/io/airlift/mcp/model/Tool.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/Tool.java
@@ -21,7 +21,7 @@ public record Tool(
         ToolAnnotations annotations,
         Optional<List<Icon>> icons,
         Optional<Map<String, Object>> meta)
-        implements Meta
+        implements Meta<Tool>
 {
     private static final Set<Character> ALLOWED_CHARACTERS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_-.".chars().mapToObj(i -> (char) i).collect(toImmutableSet());
 

--- a/mcp/src/main/java/io/airlift/mcp/operations/OperationsImpl.java
+++ b/mcp/src/main/java/io/airlift/mcp/operations/OperationsImpl.java
@@ -124,7 +124,7 @@ public class OperationsImpl
     }
 
     public record MetaOnly(Optional<Map<String, Object>> meta)
-            implements Meta
+            implements Meta<MetaOnly>
     {
         public static final MetaOnly EMPTY_META = new MetaOnly(Optional.empty());
 
@@ -134,7 +134,7 @@ public class OperationsImpl
         }
 
         @Override
-        public Object withMeta(Map<String, Object> meta)
+        public MetaOnly withMeta(Map<String, Object> meta)
         {
             return new MetaOnly(Optional.of(meta));
         }
@@ -151,7 +151,7 @@ public class OperationsImpl
         MessageWriter messageWriter = MessageWriter.newMessageWriter(response);
         request.setAttribute(MESSAGE_WRITER_ATTRIBUTE, messageWriter);
 
-        Meta meta = rpcRequest.params().map(params -> jsonMapper.convertValue(params, MetaOnly.class))
+        Meta<?> meta = rpcRequest.params().map(params -> jsonMapper.convertValue(params, MetaOnly.class))
                 .orElse(MetaOnly.EMPTY_META);
         RequestMetadata requestMetadata = RequestMetadata.fromRequest(jsonMapper, request, meta, method, validationMode);
         RequestContextImpl requestContext = new RequestContextImpl(request, requestMetadata, jsonMapper, messageWriter, authenticated);
@@ -175,7 +175,7 @@ public class OperationsImpl
             default -> throw exception(METHOD_NOT_FOUND, "Unknown method: " + method);
         };
 
-        if (result instanceof Meta resultMeta) {
+        if (result instanceof Meta<?> resultMeta) {
             result = addServerInfo(serverImplementation, resultMeta);
         }
 
@@ -207,7 +207,7 @@ public class OperationsImpl
         response.setStatus(SC_METHOD_NOT_ALLOWED);
     }
 
-    private Meta subscriptionsList(RequestContextImpl requestContext, Object requestId, SubscriptionNotifications subscriptionNotifications)
+    private Meta<?> subscriptionsList(RequestContextImpl requestContext, Object requestId, SubscriptionNotifications subscriptionNotifications)
     {
         SubscriptionLoop subscriptionLoop = new SubscriptionLoop(jsonMapper, requestId, entities, requestContext, subscriptionNotifications.notifications(), streamingTimeout, resourceSubscriptionCachePeriod);
         subscriptionLoop.run();
@@ -329,7 +329,7 @@ public class OperationsImpl
         return clazz.cast(result.withCacheableResult(metadata.cacheableResultValues().ttlMs().orElse(0), metadata.cacheableResultValues().cacheScope().orElse(PRIVATE)));
     }
 
-    private Object addServerInfo(Implementation serverImplementation, Meta resultMeta)
+    private Object addServerInfo(Implementation serverImplementation, Meta<?> resultMeta)
     {
         ImmutableMap.Builder<String, Object> builder = ImmutableMap.builder();
         resultMeta.meta().ifPresent(builder::putAll);

--- a/mcp/src/main/java/io/airlift/mcp/operations/OperationsImpl.java
+++ b/mcp/src/main/java/io/airlift/mcp/operations/OperationsImpl.java
@@ -308,7 +308,7 @@ public class OperationsImpl
         return withCacheableResult(metadata, DiscoverResult.class, new DiscoverResult(COMPLETE, SUPPORTED_VERSIONS, serverCapabilities, metadata.instructions(), OptionalInt.empty(), Optional.empty(), Optional.empty()));
     }
 
-    private <T extends CacheableResult> T withCacheableResult(McpMetadata metadata, Class<T> clazz, T result)
+    private <T extends CacheableResult<?>> T withCacheableResult(McpMetadata metadata, Class<T> clazz, T result)
     {
         return clazz.cast(result.withCacheableResult(metadata.cacheableResultValues().ttlMs().orElse(0), metadata.cacheableResultValues().cacheScope().orElse(PRIVATE)));
     }

--- a/mcp/src/main/java/io/airlift/mcp/operations/OperationsImpl.java
+++ b/mcp/src/main/java/io/airlift/mcp/operations/OperationsImpl.java
@@ -36,6 +36,7 @@ import io.airlift.mcp.model.ListResourceTemplatesResult;
 import io.airlift.mcp.model.ListResourcesResult;
 import io.airlift.mcp.model.ListToolsResult;
 import io.airlift.mcp.model.Meta;
+import io.airlift.mcp.model.MetaOnly;
 import io.airlift.mcp.model.Prompt;
 import io.airlift.mcp.model.ReadResourceRequest;
 import io.airlift.mcp.model.ReadResourceResult;
@@ -86,7 +87,6 @@ import static jakarta.servlet.http.HttpServletResponse.SC_ACCEPTED;
 import static jakarta.servlet.http.HttpServletResponse.SC_METHOD_NOT_ALLOWED;
 import static jakarta.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 import static java.util.Objects.requireNonNull;
-import static java.util.Objects.requireNonNullElse;
 
 public class OperationsImpl
         implements Operations
@@ -121,23 +121,6 @@ public class OperationsImpl
         paginationUtil = new PaginationUtil(mcpConfig);
         resourceSubscriptionCachePeriod = mcpConfig.getResourceSubscriptionCachePeriod().toJavaTime();
         streamingTimeout = mcpConfig.getEventStreamingTimeout().toJavaTime();
-    }
-
-    public record MetaOnly(Optional<Map<String, Object>> meta)
-            implements Meta<MetaOnly>
-    {
-        public static final MetaOnly EMPTY_META = new MetaOnly(Optional.empty());
-
-        public MetaOnly
-        {
-            meta = requireNonNullElse(meta, Optional.empty());
-        }
-
-        @Override
-        public MetaOnly withMeta(Map<String, Object> meta)
-        {
-            return new MetaOnly(Optional.of(meta));
-        }
     }
 
     @Override

--- a/mcp/src/main/java/io/airlift/mcp/operations/OperationsImpl.java
+++ b/mcp/src/main/java/io/airlift/mcp/operations/OperationsImpl.java
@@ -54,6 +54,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Set;
 
 import static io.airlift.http.server.tracing.TracingServletFilter.updateRequestSpan;
@@ -304,7 +305,7 @@ public class OperationsImpl
                 tools.isEmpty() ? Optional.empty() : Optional.of(new ListChanged(true)),
                 Optional.empty());
 
-        return new DiscoverResult(COMPLETE, SUPPORTED_VERSIONS, serverCapabilities, metadata.instructions(), Optional.empty());
+        return withCacheableResult(metadata, DiscoverResult.class, new DiscoverResult(COMPLETE, SUPPORTED_VERSIONS, serverCapabilities, metadata.instructions(), OptionalInt.empty(), Optional.empty(), Optional.empty()));
     }
 
     private <T extends CacheableResult> T withCacheableResult(McpMetadata metadata, Class<T> clazz, T result)

--- a/mcp/src/main/java/io/airlift/mcp/operations/RequestMetadata.java
+++ b/mcp/src/main/java/io/airlift/mcp/operations/RequestMetadata.java
@@ -53,7 +53,7 @@ public record RequestMetadata(
         requireNonNull(mcpName, "mcpName is null");
     }
 
-    public static RequestMetadata fromRequest(JsonMapper jsonMapper, HttpServletRequest request, Meta metadata, String mcpMethod, ValidationMode validationMode)
+    public static RequestMetadata fromRequest(JsonMapper jsonMapper, HttpServletRequest request, Meta<?> metadata, String mcpMethod, ValidationMode validationMode)
     {
         boolean isStrict = validationMode == ValidationMode.STRICT;
 
@@ -102,13 +102,13 @@ public record RequestMetadata(
         return Optional.ofNullable(request.getHeader(name));
     }
 
-    private static <T> T required(JsonMapper jsonMapper, Meta metadata, String name, Class<T> clazz)
+    private static <T> T required(JsonMapper jsonMapper, Meta<?> metadata, String name, Class<T> clazz)
     {
         return optional(jsonMapper, metadata, name, clazz)
                 .orElseThrow(() -> exception(INVALID_PARAMS, "Missing required metadata: " + name));
     }
 
-    private static <T> Optional<T> optional(JsonMapper jsonMapper, Meta metadata, String name, Class<T> clazz)
+    private static <T> Optional<T> optional(JsonMapper jsonMapper, Meta<?> metadata, String name, Class<T> clazz)
     {
         return metadata.meta()
                 .flatMap(values -> {

--- a/mcp/src/main/java/io/airlift/mcp/operations/SubscriptionLoop.java
+++ b/mcp/src/main/java/io/airlift/mcp/operations/SubscriptionLoop.java
@@ -75,7 +75,7 @@ class SubscriptionLoop
     }
 
     public record Acknowledgment(SubscriptionFilter notifications, Optional<Map<String, Object>> meta)
-            implements Meta
+            implements Meta<Acknowledgment>
     {
         public Acknowledgment
         {
@@ -122,7 +122,7 @@ class SubscriptionLoop
     }
 
     public record Notification(Optional<String> uri, Optional<Map<String, Object>> meta)
-            implements Meta
+            implements Meta<Notification>
     {
         public Notification
         {
@@ -162,7 +162,7 @@ class SubscriptionLoop
         requestContext.sendMessage(message, Optional.of(notification));
     }
 
-    private <T extends Meta> T withSubscriptionId(Class<T> clazz, T instance)
+    private <T extends Meta<?>> T withSubscriptionId(Class<T> clazz, T instance)
     {
         Map<String, Object> meta = ImmutableMap.of(Constants.METADATA_SUBSCRIPTION_ID, subscriptionId.toString());
         return clazz.cast(instance.withMeta(meta));

--- a/mcp/src/main/java/io/airlift/mcp/operations/legacy/OperationsCommon.java
+++ b/mcp/src/main/java/io/airlift/mcp/operations/legacy/OperationsCommon.java
@@ -128,7 +128,7 @@ public class OperationsCommon
                 .orElseGet(CompleteResult::empty);
     }
 
-    static Optional<Object> progressToken(Meta meta)
+    static Optional<Object> progressToken(Meta<?> meta)
     {
         return meta.meta().flatMap(m -> Optional.ofNullable(m.get(METADATA_PROGRESS_TOKEN)));
     }

--- a/mcp/src/test/java/io/airlift/mcp/TestSerializationEdgeCases.java
+++ b/mcp/src/test/java/io/airlift/mcp/TestSerializationEdgeCases.java
@@ -37,6 +37,7 @@ import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.stream.Stream;
 
+import static io.airlift.mcp.model.McpJacksonSubTypes.buildJacksonSubType;
 import static java.util.Objects.requireNonNullElse;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -50,7 +51,7 @@ public class TestSerializationEdgeCases
 
     public TestSerializationEdgeCases()
     {
-        JacksonSubType jacksonSubType = McpModule.buildJacksonSubType();
+        JacksonSubType jacksonSubType = buildJacksonSubType();
         JsonMapperProvider jsonMapperProvider = new JsonMapperProvider()
                 .withJacksonSubTypes(ImmutableSet.of(jacksonSubType));
         jsonMapper = jsonMapperProvider.get();

--- a/mcp/src/test/java/io/airlift/mcp/operations/TestRequestMetadata.java
+++ b/mcp/src/test/java/io/airlift/mcp/operations/TestRequestMetadata.java
@@ -38,7 +38,7 @@ public class TestRequestMetadata
     @Test
     public void testClientInfoPresent()
     {
-        Meta metadata = metadata(ImmutableMap.<String, Object>builder()
+        Meta<?> metadata = metadata(ImmutableMap.<String, Object>builder()
                 .putAll(requiredMetadata())
                 .put(METADATA_CLIENT_INFO, ImmutableMap.of("name", "test client", "version", "1"))
                 .buildOrThrow());
@@ -66,7 +66,7 @@ public class TestRequestMetadata
     @Test
     public void testClientCapabilitiesRemainRequired()
     {
-        Meta metadata = metadata(ImmutableMap.of(METADATA_PROTOCOL_VERSION, LATEST_PROTOCOL.value()));
+        Meta<?> metadata = metadata(ImmutableMap.of(METADATA_PROTOCOL_VERSION, LATEST_PROTOCOL.value()));
         HttpServletRequest request = request();
 
         assertThatThrownBy(() -> RequestMetadata.fromRequest(JSON_MAPPER, request, metadata, MCP_METHOD, STRICT))
@@ -80,7 +80,7 @@ public class TestRequestMetadata
     @Test
     public void testClientInfoValidatedWhenPresent()
     {
-        Meta metadata = metadata(ImmutableMap.<String, Object>builder()
+        Meta<?> metadata = metadata(ImmutableMap.<String, Object>builder()
                 .putAll(requiredMetadata())
                 .put(METADATA_CLIENT_INFO, "invalid")
                 .buildOrThrow());
@@ -116,7 +116,7 @@ public class TestRequestMetadata
                 METADATA_CLIENT_CAPABILITIES, ImmutableMap.of());
     }
 
-    private static Meta metadata(Map<String, Object> values)
+    private static Meta<?> metadata(Map<String, Object> values)
     {
         return new TestMeta(Optional.of(values));
     }
@@ -138,7 +138,7 @@ public class TestRequestMetadata
     }
 
     private record TestMeta(Optional<Map<String, Object>> meta)
-            implements Meta
+            implements Meta<TestMeta>
     {
         @Override
         public TestMeta withMeta(Map<String, Object> meta)


### PR DESCRIPTION
- requireNonNullElse for arguments
- Extract McpJsonSubTypes util
- Have ListRequest implement Meta
- Introduce ElicitRequest
- Make `CacheableResult` parameterized
- DiscoverResult is cacheable
- Move MetaOnly to model package
- Make `Meta` parameterized
- This allows `withMeta` to be used properly by generic helper methods

# Airlift contribution check list

 - [X] Git commit messages follow https://cbea.ms/git-commit/.
 - [X] All automated tests are passing.
 - [X] Pull request was categorized using one of the existing labels.
