### PR TITLE
[MCP] `CacheableResult` requires `resultType`

### DIFF
--- a/mcp/src/main/java/io/airlift/mcp/model/CacheableResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/CacheableResult.java
@@ -32,6 +32,12 @@ public interface CacheableResult<T extends CacheableResult<T>>
     };
 
     @JsonProperty
+    default Optional<ResultType> resultType()
+    {
+        return Optional.empty();
+    }
+
+    @JsonProperty
     default OptionalInt ttlMs()
     {
         return OptionalInt.empty();

--- a/mcp/src/main/java/io/airlift/mcp/model/DiscoverResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/DiscoverResult.java
@@ -13,7 +13,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
 
 public record DiscoverResult(
-        ResultType resultType,
+        Optional<ResultType> resultType,
         List<String> supportedVersions,
         ServerCapabilities capabilities,
         Optional<String> instructions,
@@ -24,7 +24,7 @@ public record DiscoverResult(
 {
     public DiscoverResult
     {
-        requireNonNull(resultType, "resultType is null");
+        resultType = requireNonNullElse(resultType, Optional.empty());
         supportedVersions = ImmutableList.copyOf(supportedVersions);
         requireNonNull(capabilities, "capabilities is null");
         instructions = requireNonNullElse(instructions, Optional.empty());
@@ -42,6 +42,6 @@ public record DiscoverResult(
     @Override
     public DiscoverResult withCacheableResult(int ttlMs, CacheScope cacheScope)
     {
-        return new DiscoverResult(ResultType.COMPLETE, supportedVersions, capabilities, instructions, OptionalInt.of(ttlMs), Optional.of(cacheScope), meta);
+        return new DiscoverResult(Optional.of(ResultType.COMPLETE), supportedVersions, capabilities, instructions, OptionalInt.of(ttlMs), Optional.of(cacheScope), meta);
     }
 }

--- a/mcp/src/main/java/io/airlift/mcp/model/ListPromptsResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ListPromptsResult.java
@@ -10,13 +10,14 @@ import java.util.OptionalInt;
 import static io.airlift.mcp.model.Meta.normalize;
 import static java.util.Objects.requireNonNullElse;
 
-public record ListPromptsResult(List<Prompt> prompts, Optional<String> nextCursor, OptionalInt ttlMs, Optional<CacheScope> cacheScope, Optional<Map<String, Object>> meta)
+public record ListPromptsResult(Optional<ResultType> resultType, List<Prompt> prompts, Optional<String> nextCursor, OptionalInt ttlMs, Optional<CacheScope> cacheScope, Optional<Map<String, Object>> meta)
         implements CacheableResult<ListPromptsResult>,
                    Meta<ListPromptsResult>,
                    PaginatedResult
 {
     public ListPromptsResult
     {
+        resultType = requireNonNullElse(resultType, Optional.empty());
         prompts = ImmutableList.copyOf(prompts);
         nextCursor = requireNonNullElse(nextCursor, Optional.empty());
         ttlMs = requireNonNullElse(ttlMs, OptionalInt.empty());
@@ -26,23 +27,23 @@ public record ListPromptsResult(List<Prompt> prompts, Optional<String> nextCurso
 
     public ListPromptsResult(List<Prompt> prompts)
     {
-        this(prompts, Optional.empty(), OptionalInt.empty(), Optional.empty(), Optional.empty());
+        this(Optional.empty(), prompts, Optional.empty(), OptionalInt.empty(), Optional.empty(), Optional.empty());
     }
 
     public ListPromptsResult(List<Prompt> prompts, Optional<String> nextCursor)
     {
-        this(prompts, nextCursor, OptionalInt.empty(), Optional.empty(), Optional.empty());
+        this(Optional.empty(), prompts, nextCursor, OptionalInt.empty(), Optional.empty(), Optional.empty());
     }
 
     @Override
     public ListPromptsResult withCacheableResult(int ttlMs, CacheScope cacheScope)
     {
-        return new ListPromptsResult(prompts, nextCursor, OptionalInt.of(ttlMs), Optional.of(cacheScope), meta);
+        return new ListPromptsResult(Optional.of(ResultType.COMPLETE), prompts, nextCursor, OptionalInt.of(ttlMs), Optional.of(cacheScope), meta);
     }
 
     @Override
     public ListPromptsResult withMeta(Map<String, Object> meta)
     {
-        return new ListPromptsResult(prompts, nextCursor, ttlMs, cacheScope, Optional.of(meta));
+        return new ListPromptsResult(resultType, prompts, nextCursor, ttlMs, cacheScope, Optional.of(meta));
     }
 }

--- a/mcp/src/main/java/io/airlift/mcp/model/ListResourceTemplatesResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ListResourceTemplatesResult.java
@@ -10,13 +10,14 @@ import java.util.OptionalInt;
 import static io.airlift.mcp.model.Meta.normalize;
 import static java.util.Objects.requireNonNullElse;
 
-public record ListResourceTemplatesResult(List<ResourceTemplate> resourceTemplates, Optional<String> nextCursor, OptionalInt ttlMs, Optional<CacheScope> cacheScope, Optional<Map<String, Object>> meta)
+public record ListResourceTemplatesResult(Optional<ResultType> resultType, List<ResourceTemplate> resourceTemplates, Optional<String> nextCursor, OptionalInt ttlMs, Optional<CacheScope> cacheScope, Optional<Map<String, Object>> meta)
         implements CacheableResult<ListResourceTemplatesResult>,
                    Meta<ListResourceTemplatesResult>,
                    PaginatedResult
 {
     public ListResourceTemplatesResult
     {
+        resultType = requireNonNullElse(resultType, Optional.empty());
         resourceTemplates = ImmutableList.copyOf(resourceTemplates);
         nextCursor = requireNonNullElse(nextCursor, Optional.empty());
         ttlMs = requireNonNullElse(ttlMs, OptionalInt.empty());
@@ -26,23 +27,23 @@ public record ListResourceTemplatesResult(List<ResourceTemplate> resourceTemplat
 
     public ListResourceTemplatesResult(List<ResourceTemplate> resourceTemplates)
     {
-        this(resourceTemplates, Optional.empty(), OptionalInt.empty(), Optional.empty(), Optional.empty());
+        this(Optional.empty(), resourceTemplates, Optional.empty(), OptionalInt.empty(), Optional.empty(), Optional.empty());
     }
 
     public ListResourceTemplatesResult(List<ResourceTemplate> resourceTemplates, Optional<String> nextCursor)
     {
-        this(resourceTemplates, nextCursor, OptionalInt.empty(), Optional.empty(), Optional.empty());
+        this(Optional.empty(), resourceTemplates, nextCursor, OptionalInt.empty(), Optional.empty(), Optional.empty());
     }
 
     @Override
     public ListResourceTemplatesResult withCacheableResult(int ttlMs, CacheScope cacheScope)
     {
-        return new ListResourceTemplatesResult(resourceTemplates, nextCursor, OptionalInt.of(ttlMs), Optional.of(cacheScope), meta);
+        return new ListResourceTemplatesResult(Optional.of(ResultType.COMPLETE), resourceTemplates, nextCursor, OptionalInt.of(ttlMs), Optional.of(cacheScope), meta);
     }
 
     @Override
     public ListResourceTemplatesResult withMeta(Map<String, Object> meta)
     {
-        return new ListResourceTemplatesResult(resourceTemplates, nextCursor, ttlMs, cacheScope, Optional.of(meta));
+        return new ListResourceTemplatesResult(resultType, resourceTemplates, nextCursor, ttlMs, cacheScope, Optional.of(meta));
     }
 }

--- a/mcp/src/main/java/io/airlift/mcp/model/ListResourcesResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ListResourcesResult.java
@@ -10,13 +10,14 @@ import java.util.OptionalInt;
 import static io.airlift.mcp.model.Meta.normalize;
 import static java.util.Objects.requireNonNullElse;
 
-public record ListResourcesResult(List<Resource> resources, Optional<String> nextCursor, OptionalInt ttlMs, Optional<CacheScope> cacheScope, Optional<Map<String, Object>> meta)
+public record ListResourcesResult(Optional<ResultType> resultType, List<Resource> resources, Optional<String> nextCursor, OptionalInt ttlMs, Optional<CacheScope> cacheScope, Optional<Map<String, Object>> meta)
         implements CacheableResult<ListResourcesResult>,
                    Meta<ListResourcesResult>,
                    PaginatedResult
 {
     public ListResourcesResult
     {
+        resultType = requireNonNullElse(resultType, Optional.empty());
         resources = ImmutableList.copyOf(resources);
         nextCursor = requireNonNullElse(nextCursor, Optional.empty());
         ttlMs = requireNonNullElse(ttlMs, OptionalInt.empty());
@@ -26,23 +27,23 @@ public record ListResourcesResult(List<Resource> resources, Optional<String> nex
 
     public ListResourcesResult(List<Resource> resources, Optional<String> nextCursor)
     {
-        this(resources, nextCursor, OptionalInt.empty(), Optional.empty(), Optional.empty());
+        this(Optional.empty(), resources, nextCursor, OptionalInt.empty(), Optional.empty(), Optional.empty());
     }
 
     public ListResourcesResult(List<Resource> resources)
     {
-        this(resources, Optional.empty(), OptionalInt.empty(), Optional.empty(), Optional.empty());
+        this(Optional.empty(), resources, Optional.empty(), OptionalInt.empty(), Optional.empty(), Optional.empty());
     }
 
     @Override
     public ListResourcesResult withCacheableResult(int ttlMs, CacheScope cacheScope)
     {
-        return new ListResourcesResult(resources, nextCursor, OptionalInt.of(ttlMs), Optional.of(cacheScope), meta);
+        return new ListResourcesResult(Optional.of(ResultType.COMPLETE), resources, nextCursor, OptionalInt.of(ttlMs), Optional.of(cacheScope), meta);
     }
 
     @Override
     public ListResourcesResult withMeta(Map<String, Object> meta)
     {
-        return new ListResourcesResult(resources, nextCursor, ttlMs, cacheScope, Optional.of(meta));
+        return new ListResourcesResult(resultType, resources, nextCursor, ttlMs, cacheScope, Optional.of(meta));
     }
 }

--- a/mcp/src/main/java/io/airlift/mcp/model/ListToolsResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ListToolsResult.java
@@ -10,13 +10,14 @@ import java.util.OptionalInt;
 import static io.airlift.mcp.model.Meta.normalize;
 import static java.util.Objects.requireNonNullElse;
 
-public record ListToolsResult(List<Tool> tools, Optional<String> nextCursor, OptionalInt ttlMs, Optional<CacheScope> cacheScope, Optional<Map<String, Object>> meta)
+public record ListToolsResult(Optional<ResultType> resultType, List<Tool> tools, Optional<String> nextCursor, OptionalInt ttlMs, Optional<CacheScope> cacheScope, Optional<Map<String, Object>> meta)
         implements CacheableResult<ListToolsResult>,
                    Meta<ListToolsResult>,
                    PaginatedResult
 {
     public ListToolsResult
     {
+        resultType = requireNonNullElse(resultType, Optional.empty());
         tools = ImmutableList.copyOf(tools);
         nextCursor = requireNonNullElse(nextCursor, Optional.empty());
         ttlMs = requireNonNullElse(ttlMs, OptionalInt.empty());
@@ -26,23 +27,23 @@ public record ListToolsResult(List<Tool> tools, Optional<String> nextCursor, Opt
 
     public ListToolsResult(List<Tool> tools)
     {
-        this(tools, Optional.empty(), OptionalInt.empty(), Optional.empty(), Optional.empty());
+        this(Optional.empty(), tools, Optional.empty(), OptionalInt.empty(), Optional.empty(), Optional.empty());
     }
 
     public ListToolsResult(List<Tool> tools, Optional<String> nextCursor)
     {
-        this(tools, nextCursor, OptionalInt.empty(), Optional.empty(), Optional.empty());
+        this(Optional.empty(), tools, nextCursor, OptionalInt.empty(), Optional.empty(), Optional.empty());
     }
 
     @Override
     public ListToolsResult withCacheableResult(int ttlMs, CacheScope cacheScope)
     {
-        return new ListToolsResult(tools, nextCursor, OptionalInt.of(ttlMs), Optional.of(cacheScope), meta);
+        return new ListToolsResult(Optional.of(ResultType.COMPLETE), tools, nextCursor, OptionalInt.of(ttlMs), Optional.of(cacheScope), meta);
     }
 
     @Override
     public ListToolsResult withMeta(Map<String, Object> meta)
     {
-        return new ListToolsResult(tools, nextCursor, ttlMs, cacheScope, Optional.of(meta));
+        return new ListToolsResult(resultType, tools, nextCursor, ttlMs, cacheScope, Optional.of(meta));
     }
 }

--- a/mcp/src/main/java/io/airlift/mcp/model/ReadResourceResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ReadResourceResult.java
@@ -10,11 +10,12 @@ import java.util.OptionalInt;
 import static io.airlift.mcp.model.Meta.normalize;
 import static java.util.Objects.requireNonNullElse;
 
-public record ReadResourceResult(List<ResourceContents> contents, OptionalInt ttlMs, Optional<CacheScope> cacheScope, Optional<Map<String, Object>> meta)
+public record ReadResourceResult(Optional<ResultType> resultType, List<ResourceContents> contents, OptionalInt ttlMs, Optional<CacheScope> cacheScope, Optional<Map<String, Object>> meta)
         implements CacheableResult<ReadResourceResult>, Meta<ReadResourceResult>
 {
     public ReadResourceResult
     {
+        resultType = requireNonNullElse(resultType, Optional.empty());
         contents = ImmutableList.copyOf(contents);
         ttlMs = requireNonNullElse(ttlMs, OptionalInt.empty());
         cacheScope = requireNonNullElse(cacheScope, Optional.empty());
@@ -23,18 +24,18 @@ public record ReadResourceResult(List<ResourceContents> contents, OptionalInt tt
 
     public ReadResourceResult(List<ResourceContents> contents)
     {
-        this(contents, OptionalInt.empty(), Optional.empty(), Optional.empty());
+        this(Optional.empty(), contents, OptionalInt.empty(), Optional.empty(), Optional.empty());
     }
 
     @Override
     public ReadResourceResult withCacheableResult(int ttlMs, CacheScope cacheScope)
     {
-        return new ReadResourceResult(contents, OptionalInt.of(ttlMs), Optional.of(cacheScope), meta);
+        return new ReadResourceResult(Optional.of(ResultType.COMPLETE), contents, OptionalInt.of(ttlMs), Optional.of(cacheScope), meta);
     }
 
     @Override
     public ReadResourceResult withMeta(Map<String, Object> meta)
     {
-        return new ReadResourceResult(contents, ttlMs, cacheScope, Optional.of(meta));
+        return new ReadResourceResult(resultType, contents, ttlMs, cacheScope, Optional.of(meta));
     }
 }

--- a/mcp/src/main/java/io/airlift/mcp/operations/OperationsImpl.java
+++ b/mcp/src/main/java/io/airlift/mcp/operations/OperationsImpl.java
@@ -305,7 +305,7 @@ public class OperationsImpl
                 tools.isEmpty() ? Optional.empty() : Optional.of(new ListChanged(true)),
                 Optional.empty());
 
-        return withCacheableResult(metadata, DiscoverResult.class, new DiscoverResult(COMPLETE, SUPPORTED_VERSIONS, serverCapabilities, metadata.instructions(), OptionalInt.empty(), Optional.empty(), Optional.empty()));
+        return withCacheableResult(metadata, DiscoverResult.class, new DiscoverResult(Optional.of(COMPLETE), SUPPORTED_VERSIONS, serverCapabilities, metadata.instructions(), OptionalInt.empty(), Optional.empty(), Optional.empty()));
     }
 
     private <T extends CacheableResult<?>> T withCacheableResult(McpMetadata metadata, Class<T> clazz, T result)


### PR DESCRIPTION
Make it Optional for backward compatibility

# Airlift contribution check list

 - [X] Git commit messages follow https://cbea.ms/git-commit/.
 - [X] All automated tests are passing.
 - [X] Pull request was categorized using one of the existing labels.
