### PR TITLE
Fix/end span on async request failure

### DIFF
--- a/http-client/pom.xml
+++ b/http-client/pom.xml
@@ -182,6 +182,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-trace</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
             <scope>test</scope>

--- a/http-client/src/main/java/io/airlift/http/client/jetty/JettyResponseFuture.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/JettyResponseFuture.java
@@ -189,6 +189,7 @@ class JettyResponseFuture<T, E extends Exception>
 
         span.setStatus(StatusCode.ERROR, throwable.getMessage());
         span.recordException(throwable, Attributes.of(EXCEPTION_ESCAPED, true));
+        span.end();
     }
 
     @Override

--- a/http-client/src/main/java/io/airlift/http/client/jetty/JettyResponseFuture.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/JettyResponseFuture.java
@@ -160,6 +160,10 @@ class JettyResponseFuture<T, E extends Exception>
                 // handler returned a value, store it in the future
                 state.set(JettyAsyncHttpState.DONE);
                 set(value);
+
+                // the request failed, even though the handler recovered
+                span.setStatus(StatusCode.ERROR, throwable.getMessage());
+                span.end();
                 return;
             }
             catch (Throwable newThrowable) {

--- a/http-client/src/test/java/io/airlift/http/client/jetty/TestJettyHttpClientTracing.java
+++ b/http-client/src/test/java/io/airlift/http/client/jetty/TestJettyHttpClientTracing.java
@@ -21,6 +21,7 @@ import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import org.junit.jupiter.api.Test;
 
+import java.net.URI;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -98,6 +99,27 @@ public class TestJettyHttpClientTracing
         }
     }
 
+    @Test
+    public void testSpanEndedWhenExceptionHandlerReturnsValue()
+            throws Exception
+    {
+        InMemorySpanExporter spanExporter = InMemorySpanExporter.create();
+        try (SdkTracerProvider tracerProvider = createTracerProvider(spanExporter)) {
+            try (JettyHttpClient client = createClient(tracerProvider)) {
+                Request request = prepareGet()
+                        .setUri(URI.create("http://airlift.invalid/"))
+                        .build();
+
+                assertThat(client.executeAsync(request, new RecoveringResponseHandler()).get()).isEqualTo("recovered");
+            }
+
+            assertThat(spanExporter.getFinishedSpanItems())
+                    .singleElement()
+                    .extracting(span -> span.getStatus().getStatusCode())
+                    .isEqualTo(StatusCode.ERROR);
+        }
+    }
+
     private static SdkTracerProvider createTracerProvider(InMemorySpanExporter spanExporter)
     {
         return SdkTracerProvider.builder()
@@ -130,6 +152,22 @@ public class TestJettyHttpClientTracing
         public String handle(Request request, Response response)
         {
             throw new RuntimeException("handler failed");
+        }
+    }
+
+    private static final class RecoveringResponseHandler
+            implements ResponseHandler<String, RuntimeException>
+    {
+        @Override
+        public String handleException(Request request, Exception exception)
+        {
+            return "recovered";
+        }
+
+        @Override
+        public String handle(Request request, Response response)
+        {
+            return "handled";
         }
     }
 

--- a/http-client/src/test/java/io/airlift/http/client/jetty/TestJettyHttpClientTracing.java
+++ b/http-client/src/test/java/io/airlift/http/client/jetty/TestJettyHttpClientTracing.java
@@ -5,13 +5,20 @@ import io.airlift.http.client.EchoServlet;
 import io.airlift.http.client.HeaderName;
 import io.airlift.http.client.HttpClientConfig;
 import io.airlift.http.client.Request;
+import io.airlift.http.client.Response;
+import io.airlift.http.client.ResponseHandler;
 import io.airlift.http.client.TestingHttpServer;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.TracerProvider;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.context.propagation.TextMapGetter;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.context.propagation.TextMapSetter;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
@@ -22,6 +29,7 @@ import static io.airlift.http.client.Request.Builder.prepareGet;
 import static io.airlift.http.client.StringResponseHandler.createStringResponseHandler;
 import static io.opentelemetry.api.OpenTelemetry.propagating;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestJettyHttpClientTracing
 {
@@ -63,6 +71,65 @@ public class TestJettyHttpClientTracing
             client.execute(request, createStringResponseHandler());
 
             assertThat(servlet.getRequestHeaders(TRACE_HEADER)).isEmpty();
+        }
+    }
+
+    @Test
+    public void testSpanEndedWhenResponseHandlerThrows()
+            throws Exception
+    {
+        InMemorySpanExporter spanExporter = InMemorySpanExporter.create();
+        try (SdkTracerProvider tracerProvider = createTracerProvider(spanExporter)) {
+            try (TestingHttpServer server = new TestingHttpServer(Optional.empty(), new EchoServlet());
+                    JettyHttpClient client = createClient(tracerProvider)) {
+                Request request = prepareGet()
+                        .setUri(server.baseURI())
+                        .build();
+
+                assertThatThrownBy(() -> client.executeAsync(request, new ThrowingResponseHandler()).get())
+                        .cause()
+                        .hasMessage("handler failed");
+            }
+
+            assertThat(spanExporter.getFinishedSpanItems())
+                    .singleElement()
+                    .extracting(span -> span.getStatus().getStatusCode())
+                    .isEqualTo(StatusCode.ERROR);
+        }
+    }
+
+    private static SdkTracerProvider createTracerProvider(InMemorySpanExporter spanExporter)
+    {
+        return SdkTracerProvider.builder()
+                .addSpanProcessor(SimpleSpanProcessor.create(spanExporter))
+                .build();
+    }
+
+    private static JettyHttpClient createClient(SdkTracerProvider tracerProvider)
+    {
+        return new JettyHttpClient(
+                "tracing-test",
+                new HttpClientConfig(),
+                ImmutableList.of(),
+                OpenTelemetry.noop(),
+                tracerProvider.get("testing"),
+                Optional.empty(),
+                Optional.empty());
+    }
+
+    private static final class ThrowingResponseHandler
+            implements ResponseHandler<String, RuntimeException>
+    {
+        @Override
+        public String handleException(Request request, Exception exception)
+        {
+            throw new RuntimeException("handler failed", exception);
+        }
+
+        @Override
+        public String handle(Request request, Response response)
+        {
+            throw new RuntimeException("handler failed");
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting pull request to Airlift -->

Async HTTP client spans were never ended on either failure path in                                                                                             `JettyResponseFuture`, so they were never exported

# Airlift contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [x] All automated tests are passing.
 - [ ] Pull request was categorized using one of the existing labels.
