### PR TITLE
Support SecretKeySpec keystore entries in KeystoreSecretProvider

### DIFF
--- a/secrets-keystore-plugin/src/main/java/io/airlift/secrets/keystore/KeystoreSecretProvider.java
+++ b/secrets-keystore-plugin/src/main/java/io/airlift/secrets/keystore/KeystoreSecretProvider.java
@@ -16,26 +16,35 @@ package io.airlift.secrets.keystore;
 import com.google.inject.Inject;
 import io.airlift.spi.secrets.SecretProvider;
 
-import javax.crypto.SecretKeyFactory;
-import javax.crypto.spec.PBEKeySpec;
-
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
+import java.util.Locale;
+
+import static io.airlift.secrets.keystore.KeystoreSecretUtils.readSecretValue;
+import static java.util.Objects.requireNonNull;
 
 public class KeystoreSecretProvider
         implements SecretProvider
 {
     private final KeyStore keyStore;
     private final char[] keystorePassword;
+    private final char[] entryPassword;
 
     @Inject
     public KeystoreSecretProvider(KeystoreSecretProviderConfig config)
             throws GeneralSecurityException, IOException
     {
-        keystorePassword = config.getKeyStorePassword().toCharArray();
+        requireNonNull(config, "config is null");
+        String configuredKeystorePassword = config.getKeyStorePassword();
+        keystorePassword = configuredKeystorePassword.toCharArray();
+        String configuredEntryPassword = config.getKeyStoreEntryPassword() != null
+                ? config.getKeyStoreEntryPassword()
+                : configuredKeystorePassword;
+        entryPassword = configuredEntryPassword.toCharArray();
+
         keyStore = KeyStore.getInstance(config.getKeyStoreType());
         try (InputStream stream = new FileInputStream(config.getKeyStoreFilePath())) {
             keyStore.load(stream, keystorePassword);
@@ -46,14 +55,11 @@ public class KeystoreSecretProvider
     public String resolveSecretValue(String key)
     {
         try {
-            KeyStore.SecretKeyEntry secretKeyEntry = (KeyStore.SecretKeyEntry) keyStore.getEntry(key, new KeyStore.PasswordProtection(keystorePassword));
-
-            if (secretKeyEntry == null) {
+            String alias = key.toLowerCase(Locale.US);
+            if (!keyStore.containsAlias(alias)) {
                 throw new RuntimeException("Key not found in keystore: " + key);
             }
-            SecretKeyFactory factory = SecretKeyFactory.getInstance("PBE");
-            PBEKeySpec keySpec = (PBEKeySpec) factory.getKeySpec(secretKeyEntry.getSecretKey(), PBEKeySpec.class);
-            return new String(keySpec.getPassword());
+            return readSecretValue(keyStore, alias, entryPassword);
         }
         catch (GeneralSecurityException e) {
             throw new RuntimeException(e);

--- a/secrets-keystore-plugin/src/main/java/io/airlift/secrets/keystore/KeystoreSecretProviderConfig.java
+++ b/secrets-keystore-plugin/src/main/java/io/airlift/secrets/keystore/KeystoreSecretProviderConfig.java
@@ -23,6 +23,7 @@ public class KeystoreSecretProviderConfig
     private String keyStoreFilePath;
     private String keyStoreType;
     private String keyStorePassword;
+    private String keyStoreEntryPassword;
 
     @Config("keystore-file-path")
     public KeystoreSecretProviderConfig setKeyStoreFilePath(String keyStoreFilePath)
@@ -62,5 +63,18 @@ public class KeystoreSecretProviderConfig
     public String getKeyStorePassword()
     {
         return keyStorePassword;
+    }
+
+    @Config("keystore-entry-password")
+    @ConfigSecuritySensitive
+    public KeystoreSecretProviderConfig setKeyStoreEntryPassword(String keyStoreEntryPassword)
+    {
+        this.keyStoreEntryPassword = keyStoreEntryPassword;
+        return this;
+    }
+
+    public String getKeyStoreEntryPassword()
+    {
+        return keyStoreEntryPassword;
     }
 }

--- a/secrets-keystore-plugin/src/main/java/io/airlift/secrets/keystore/KeystoreSecretUtils.java
+++ b/secrets-keystore-plugin/src/main/java/io/airlift/secrets/keystore/KeystoreSecretUtils.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.airlift.secrets.keystore;
+
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.spec.SecretKeySpec;
+
+import java.security.GeneralSecurityException;
+import java.security.Key;
+import java.security.KeyStore;
+import java.security.KeyStore.PasswordProtection;
+import java.security.KeyStore.SecretKeyEntry;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+final class KeystoreSecretUtils
+{
+    private KeystoreSecretUtils() {}
+
+    static String readSecretValue(KeyStore keyStore, String alias, char[] entryPassword)
+            throws GeneralSecurityException
+    {
+        try {
+            // KeyStore setKeyEntry format: UTF-8 credential bytes in a SecretKeySpec
+            if (keyStore.isKeyEntry(alias)) {
+                Key key = keyStore.getKey(alias, entryPassword);
+                if (key instanceof SecretKeySpec secretKeySpec) {
+                    return new String(secretKeySpec.getEncoded(), UTF_8);
+                }
+            }
+
+            // PBE-protected SecretKeyEntry format (setEntry + getEntry)
+            KeyStore.Entry entry = keyStore.getEntry(alias, new PasswordProtection(entryPassword));
+            if (!(entry instanceof SecretKeyEntry secretKeyEntry)) {
+                throw new RuntimeException("Unsupported keystore entry format for alias: " + alias);
+            }
+            SecretKeyFactory factory = SecretKeyFactory.getInstance(secretKeyEntry.getSecretKey().getAlgorithm());
+            PBEKeySpec keySpec = (PBEKeySpec) factory.getKeySpec(secretKeyEntry.getSecretKey(), PBEKeySpec.class);
+            return new String(keySpec.getPassword());
+        }
+        catch (ClassCastException e) {
+            throw new RuntimeException("Unsupported keystore entry format for alias: " + alias, e);
+        }
+    }
+}

--- a/secrets-keystore-plugin/src/test/java/io/airlift/secrets/keystore/TestKeystoreSecretProvider.java
+++ b/secrets-keystore-plugin/src/test/java/io/airlift/secrets/keystore/TestKeystoreSecretProvider.java
@@ -21,10 +21,17 @@ import org.junit.jupiter.api.TestInstance;
 
 import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.spec.SecretKeySpec;
 
 import java.io.FileOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.GeneralSecurityException;
 import java.security.KeyStore;
+import java.util.Locale;
+import java.util.Map;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
@@ -72,7 +79,7 @@ final class TestKeystoreSecretProvider
     }
 
     @Test
-    public void testConfigurationResolver()
+    public void testPbeSecretKeyEntryFormat()
     {
         assertThat(secretProvider.resolveSecretValue("key")).isEqualTo("value");
     }
@@ -94,5 +101,252 @@ final class TestKeystoreSecretProvider
                         .setKeyStorePassword("invalid_password"))
                         .resolveSecretValue("key"))
                 .hasMessageContaining("Failed PKCS12 integrity checking");
+    }
+
+    @Test
+    public void testSecretKeySpecKeyEntryFormat()
+            throws Exception
+    {
+        Path keystorePath = createSecretKeySpecKeyStore(
+                Map.of("my-service.access.key", "AKIATEST"),
+                "none");
+
+        KeystoreSecretProvider provider = new KeystoreSecretProvider(new KeystoreSecretProviderConfig()
+                .setKeyStoreType("JCEKS")
+                .setKeyStoreFilePath(keystorePath.toString())
+                .setKeyStorePassword("none"));
+
+        assertThat(provider.resolveSecretValue("my-service.access.key")).isEqualTo("AKIATEST");
+    }
+
+    @Test
+    public void testSecretKeySpecKeyEntryFormatWithDifferentStoreAndEntryPasswords()
+            throws Exception
+    {
+        String storePassword = "store_password";
+        String entryPassword = "entry_password";
+        Path keystorePath = createSecretKeySpecKeyStore(
+                Map.of("my-service.access.key", "AKIATEST"),
+                storePassword,
+                entryPassword);
+
+        KeystoreSecretProvider provider = new KeystoreSecretProvider(new KeystoreSecretProviderConfig()
+                .setKeyStoreType("JCEKS")
+                .setKeyStoreFilePath(keystorePath.toString())
+                .setKeyStorePassword(storePassword)
+                .setKeyStoreEntryPassword(entryPassword));
+
+        assertThat(provider.resolveSecretValue("my-service.access.key")).isEqualTo("AKIATEST");
+    }
+
+    @Test
+    public void testPbeKeyEntryFormatWithDifferentStoreAndEntryPasswords()
+            throws Exception
+    {
+        String storePassword = "store_password";
+        String entryPassword = "entry_password";
+        Path keystorePath = createPbeKeyStore("key", "value", storePassword, entryPassword);
+
+        KeystoreSecretProvider provider = new KeystoreSecretProvider(new KeystoreSecretProviderConfig()
+                .setKeyStoreType("pkcs12")
+                .setKeyStoreFilePath(keystorePath.toString())
+                .setKeyStorePassword(storePassword)
+                .setKeyStoreEntryPassword(entryPassword));
+
+        assertThat(provider.resolveSecretValue("key")).isEqualTo("value");
+    }
+
+    @Test
+    public void testResolveSecretValueNormalizesAliasToLowerCase()
+            throws Exception
+    {
+        Path keystorePath = createSecretKeySpecKeyStore(
+                Map.of("my-service.access.key", "AKIATEST"),
+                "none");
+
+        KeystoreSecretProvider provider = new KeystoreSecretProvider(new KeystoreSecretProviderConfig()
+                .setKeyStoreType("JCEKS")
+                .setKeyStoreFilePath(keystorePath.toString())
+                .setKeyStorePassword("none"));
+
+        assertThat(provider.resolveSecretValue("My-Service.Access.Key")).isEqualTo("AKIATEST");
+    }
+
+    @Test
+    public void testMixedFormatKeystore()
+            throws Exception
+    {
+        String password = "password";
+        Path keystorePath = createMixedFormatKeyStore(
+                Map.of("hadoop.alias", "hadoop-secret"),
+                Map.of("pbe.alias", "pbe-secret"),
+                password);
+
+        KeystoreSecretProvider provider = new KeystoreSecretProvider(new KeystoreSecretProviderConfig()
+                .setKeyStoreType("JCEKS")
+                .setKeyStoreFilePath(keystorePath.toString())
+                .setKeyStorePassword(password));
+
+        assertThat(provider.resolveSecretValue("hadoop.alias")).isEqualTo("hadoop-secret");
+        assertThat(provider.resolveSecretValue("pbe.alias")).isEqualTo("pbe-secret");
+    }
+
+    @Test
+    public void testWrongEntryPasswordForSecretKeySpecEntry()
+            throws Exception
+    {
+        String storePassword = "store_password";
+        String entryPassword = "entry_password";
+        Path keystorePath = createSecretKeySpecKeyStore(
+                Map.of("my-service.access.key", "AKIATEST"),
+                storePassword,
+                entryPassword);
+
+        KeystoreSecretProvider provider = new KeystoreSecretProvider(new KeystoreSecretProviderConfig()
+                .setKeyStoreType("JCEKS")
+                .setKeyStoreFilePath(keystorePath.toString())
+                .setKeyStorePassword(storePassword)
+                .setKeyStoreEntryPassword("wrong_entry_password"));
+
+        assertThatThrownBy(() -> provider.resolveSecretValue("my-service.access.key"))
+                .isInstanceOf(RuntimeException.class)
+                .hasCauseInstanceOf(GeneralSecurityException.class);
+    }
+
+    @Test
+    public void testWrongEntryPasswordForPbeEntry()
+            throws Exception
+    {
+        String storePassword = "store_password";
+        String entryPassword = "entry_password";
+        Path keystorePath = createPbeKeyStore("key", "value", storePassword, entryPassword);
+
+        KeystoreSecretProvider provider = new KeystoreSecretProvider(new KeystoreSecretProviderConfig()
+                .setKeyStoreType("pkcs12")
+                .setKeyStoreFilePath(keystorePath.toString())
+                .setKeyStorePassword(storePassword)
+                .setKeyStoreEntryPassword("wrong_entry_password"));
+
+        assertThatThrownBy(() -> provider.resolveSecretValue("key"))
+                .isInstanceOf(RuntimeException.class)
+                .hasCauseInstanceOf(GeneralSecurityException.class);
+    }
+
+    @Test
+    public void testResolveMultipleS3StyleAliases()
+            throws Exception
+    {
+        Path keystorePath = createSecretKeySpecKeyStore(
+                Map.of(
+                        "fs.s3a.bucket.bucket-a.access.key", "AKIATEST",
+                        "fs.s3a.bucket.bucket-a.secret.key", "SECRETTEST"),
+                "none");
+
+        KeystoreSecretProvider provider = new KeystoreSecretProvider(new KeystoreSecretProviderConfig()
+                .setKeyStoreType("JCEKS")
+                .setKeyStoreFilePath(keystorePath.toString())
+                .setKeyStorePassword("none"));
+
+        assertThat(provider.resolveSecretValue("fs.s3a.bucket.bucket-a.access.key")).isEqualTo("AKIATEST");
+        assertThat(provider.resolveSecretValue("fs.s3a.bucket.bucket-a.secret.key")).isEqualTo("SECRETTEST");
+    }
+
+    @Test
+    public void testEntryPasswordDefaultsToStorePasswordWhenUnset()
+            throws Exception
+    {
+        String password = "same_password";
+        Path keystorePath = createSecretKeySpecKeyStore(
+                Map.of("my-service.access.key", "AKIATEST"),
+                password);
+
+        KeystoreSecretProvider provider = new KeystoreSecretProvider(new KeystoreSecretProviderConfig()
+                .setKeyStoreType("JCEKS")
+                .setKeyStoreFilePath(keystorePath.toString())
+                .setKeyStorePassword(password));
+
+        assertThat(provider.resolveSecretValue("my-service.access.key")).isEqualTo("AKIATEST");
+    }
+
+    private static Path createSecretKeySpecKeyStore(Map<String, String> aliases, String password)
+            throws Exception
+    {
+        return createSecretKeySpecKeyStore(aliases, password, password);
+    }
+
+    private static Path createSecretKeySpecKeyStore(Map<String, String> aliases, String storePassword, String entryPassword)
+            throws Exception
+    {
+        KeyStore keyStore = KeyStore.getInstance("JCEKS");
+        keyStore.load(null, storePassword.toCharArray());
+        for (Map.Entry<String, String> entry : aliases.entrySet()) {
+            String alias = entry.getKey().toLowerCase(Locale.US);
+            keyStore.setKeyEntry(
+                    alias,
+                    new SecretKeySpec(entry.getValue().getBytes(UTF_8), "AES"),
+                    entryPassword.toCharArray(),
+                    null);
+        }
+
+        Path keystorePath = Files.createTempFile("secret-key-spec-keystore", ".jceks");
+        keystorePath.toFile().deleteOnExit();
+        try (FileOutputStream outputStream = new FileOutputStream(keystorePath.toFile())) {
+            keyStore.store(outputStream, storePassword.toCharArray());
+        }
+        return keystorePath;
+    }
+
+    private static Path createPbeKeyStore(String alias, String secretValue, String storePassword, String entryPassword)
+            throws Exception
+    {
+        KeyStore keyStore = KeyStore.getInstance("pkcs12");
+        keyStore.load(null, storePassword.toCharArray());
+
+        SecretKeyFactory factory = SecretKeyFactory.getInstance("PBE");
+        keyStore.setEntry(
+                alias,
+                new KeyStore.SecretKeyEntry(factory.generateSecret(new PBEKeySpec(secretValue.toCharArray()))),
+                new KeyStore.PasswordProtection(entryPassword.toCharArray()));
+
+        Path keystorePath = Files.createTempFile("pbe-keystore", ".p12");
+        keystorePath.toFile().deleteOnExit();
+        try (FileOutputStream outputStream = new FileOutputStream(keystorePath.toFile())) {
+            keyStore.store(outputStream, storePassword.toCharArray());
+        }
+        return keystorePath;
+    }
+
+    private static Path createMixedFormatKeyStore(
+            Map<String, String> secretKeySpecAliases,
+            Map<String, String> pbeAliases,
+            String password)
+            throws Exception
+    {
+        KeyStore keyStore = KeyStore.getInstance("JCEKS");
+        keyStore.load(null, password.toCharArray());
+
+        for (Map.Entry<String, String> entry : secretKeySpecAliases.entrySet()) {
+            String alias = entry.getKey().toLowerCase(Locale.US);
+            keyStore.setKeyEntry(
+                    alias,
+                    new SecretKeySpec(entry.getValue().getBytes(UTF_8), "AES"),
+                    password.toCharArray(),
+                    null);
+        }
+
+        SecretKeyFactory factory = SecretKeyFactory.getInstance("PBE");
+        for (Map.Entry<String, String> entry : pbeAliases.entrySet()) {
+            keyStore.setEntry(
+                    entry.getKey(),
+                    new KeyStore.SecretKeyEntry(factory.generateSecret(new PBEKeySpec(entry.getValue().toCharArray()))),
+                    new KeyStore.PasswordProtection(password.toCharArray()));
+        }
+
+        Path keystorePath = Files.createTempFile("mixed-format-keystore", ".jceks");
+        keystorePath.toFile().deleteOnExit();
+        try (FileOutputStream outputStream = new FileOutputStream(keystorePath.toFile())) {
+            keyStore.store(outputStream, password.toCharArray());
+        }
+        return keystorePath;
     }
 }

--- a/secrets-keystore-plugin/src/test/java/io/airlift/secrets/keystore/TestKeystoreSecretProviderConfig.java
+++ b/secrets-keystore-plugin/src/test/java/io/airlift/secrets/keystore/TestKeystoreSecretProviderConfig.java
@@ -33,7 +33,8 @@ final class TestKeystoreSecretProviderConfig
         assertRecordedDefaults(recordDefaults(KeystoreSecretProviderConfig.class)
                 .setKeyStoreFilePath(null)
                 .setKeyStoreType(null)
-                .setKeyStorePassword(null));
+                .setKeyStorePassword(null)
+                .setKeyStoreEntryPassword(null));
     }
 
     @Test
@@ -46,12 +47,14 @@ final class TestKeystoreSecretProviderConfig
                 .put("keystore-file-path", keystoreFile.toString())
                 .put("keystore-type", "JCEKS")
                 .put("keystore-password", "keystore_password")
+                .put("keystore-entry-password", "entry_password")
                 .buildOrThrow();
 
         KeystoreSecretProviderConfig expected = new KeystoreSecretProviderConfig()
                 .setKeyStoreFilePath(keystoreFile.toString())
                 .setKeyStoreType("JCEKS")
-                .setKeyStorePassword("keystore_password");
+                .setKeyStorePassword("keystore_password")
+                .setKeyStoreEntryPassword("entry_password");
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
KeystoreSecretProvider previously read only PBE-protected SecretKeyEntry values via getEntry. Some credential tooling writes secrets as UTF-8 bytes in a SecretKeySpec using setKeyEntry; read those via getKey before falling back to the existing PBE path.

Also add keystore-entry-password config, normalize aliases to lowercase, and extract shared read logic into KeystoreSecretUtils.

Trino (and other Airlift consumers) can use this to resolve credentials from JCEKS files produced by legacy Java KeyStore credential stores.

<!-- Thank you for submitting pull request to Airlift -->

# Airlift contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [x] All automated tests are passing.
 - [x] Pull request was categorized using one of the existing labels.
