### PR TITLE
Prefer delta metric temporality

### DIFF
--- a/opentelemetry/src/main/java/io/airlift/opentelemetry/OpenTelemetryExporterModule.java
+++ b/opentelemetry/src/main/java/io/airlift/opentelemetry/OpenTelemetryExporterModule.java
@@ -39,6 +39,7 @@ import java.util.Optional;
 import java.util.function.BiConsumer;
 
 import static io.airlift.configuration.ConfigBinder.configBinder;
+import static io.opentelemetry.sdk.metrics.export.AggregationTemporalitySelector.deltaPreferred;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.nio.file.Files.readAllBytes;
 
@@ -97,6 +98,7 @@ public class OpenTelemetryExporterModule
             case GRPC -> configureTls(
                     config,
                     OtlpGrpcMetricExporter.builder()
+                            .setAggregationTemporalitySelector(deltaPreferred())
                             .setEndpoint(config.getEndpoint()),
                     OtlpGrpcMetricExporterBuilder::setTrustedCertificates,
                     OtlpGrpcMetricExporterBuilder::setClientTls)
@@ -104,6 +106,7 @@ public class OpenTelemetryExporterModule
             case HTTP_PROTOBUF -> configureTls(
                     config,
                     OtlpHttpMetricExporter.builder()
+                            .setAggregationTemporalitySelector(deltaPreferred())
                             .setEndpoint(config.getEndpoint()),
                     OtlpHttpMetricExporterBuilder::setTrustedCertificates,
                     OtlpHttpMetricExporterBuilder::setClientTls)

--- a/opentelemetry/src/test/java/io/airlift/opentelemetry/TestOpenTelemetryExporterModule.java
+++ b/opentelemetry/src/test/java/io/airlift/opentelemetry/TestOpenTelemetryExporterModule.java
@@ -9,6 +9,8 @@ import io.opentelemetry.exporter.otlp.logs.OtlpGrpcLogRecordExporter;
 import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter;
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
 import io.opentelemetry.sdk.logs.export.LogRecordExporter;
+import io.opentelemetry.sdk.metrics.InstrumentType;
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import org.junit.jupiter.api.Test;
@@ -114,6 +116,7 @@ final class TestOpenTelemetryExporterModule
             metricExporter = OpenTelemetryExporterModule.createMetricExporter(config);
             logRecordExporter = OpenTelemetryExporterModule.createLogRecordExporter(config);
 
+            assertThat(metricExporter.getAggregationTemporality(InstrumentType.COUNTER)).isEqualTo(AggregationTemporality.DELTA);
             if (config.getProtocol() == GRPC) {
                 assertThat(spanExporter).isInstanceOf(OtlpGrpcSpanExporter.class);
                 assertThat(metricExporter).isInstanceOf(OtlpGrpcMetricExporter.class);


### PR DESCRIPTION
## Why

- Cumulative OTLP counters require downstream exporters to retain initial values and conversion state. Short-lived series can lose their first update during cumulative-to-delta conversion.

## Approach

- Configure both OTLP metric exporters with the OpenTelemetry SDK delta-preferred selector and assert counter temporality for both protocols.