### PR TITLE
Keep HTTP client tests on their Jetty server

### DIFF
--- a/http-client/src/test/java/io/airlift/http/client/TestTestingHttpServerBinding.java
+++ b/http-client/src/test/java/io/airlift/http/client/TestTestingHttpServerBinding.java
@@ -1,0 +1,29 @@
+package io.airlift.http.client;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.BindException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestTestingHttpServerBinding
+{
+    @Test
+    public void testBindsAdvertisedAddressExclusively()
+            throws Exception
+    {
+        try (TestingHttpServer server = new TestingHttpServer(Optional.empty(), new EchoServlet());
+                ServerSocket competingSocket = new ServerSocket()) {
+            assertThat(server.baseURI().getHost()).isEqualTo("127.0.0.1");
+            assertThatThrownBy(() -> competingSocket.bind(new InetSocketAddress(
+                    InetAddress.getByName(server.baseURI().getHost()),
+                    server.baseURI().getPort())))
+                    .isInstanceOf(BindException.class);
+        }
+    }
+}

--- a/http-client/src/test/java/io/airlift/http/client/TestingHttpServer.java
+++ b/http-client/src/test/java/io/airlift/http/client/TestingHttpServer.java
@@ -45,6 +45,8 @@ import static java.util.Objects.requireNonNull;
 public class TestingHttpServer
         implements AutoCloseable
 {
+    private static final String LOOPBACK_ADDRESS = "127.0.0.1";
+
     static {
         Logging logging = Logging.initialize();
         logging.setLevel("org.eclipse.jetty", Level.ERROR);
@@ -75,6 +77,7 @@ public class TestingHttpServer
         configurationDecorator.accept(httpConfiguration);
 
         ServerConnector connector;
+        String advertisedAddress;
         if (keystore.isPresent()) {
             httpConfiguration.addCustomizer(new SecureRequestCustomizer(false));
 
@@ -82,13 +85,17 @@ public class TestingHttpServer
             sslContextFactory.setKeyStorePath(keystore.orElseThrow());
             sslContextFactory.setKeyStorePassword("changeit");
             connector = new ServerConnector(server, secureFactories(httpConfiguration, sslContextFactory));
+            connector.setName("https");
+            connector.setHost("0.0.0.0");
+            advertisedAddress = "localhost";
         }
         else {
             connector = new ServerConnector(server, insecureFactories(httpConfiguration));
+            connector.setName("http");
+            connector.setHost(LOOPBACK_ADDRESS);
+            advertisedAddress = LOOPBACK_ADDRESS;
         }
-
         connector.setIdleTimeout(30000);
-        connector.setName(keystore.isPresent() ? "https" : "http");
 
         server.addConnector(connector);
 
@@ -115,7 +122,7 @@ public class TestingHttpServer
 
         this.server = server;
         this.server.start();
-        this.hostAndPort = HostAndPort.fromParts("localhost", connector.getLocalPort());
+        this.hostAndPort = HostAndPort.fromParts(advertisedAddress, connector.getLocalPort());
     }
 
     private ConnectionFactory[] insecureFactories(HttpConfiguration httpConfiguration)


### PR DESCRIPTION
## Summary

`TestingHttpServer` opened non-TLS connectors on a wildcard address but gave clients a `localhost` URI. On hosts where another listener can bind the corresponding `127.0.0.1` endpoint, requests intended for Jetty could reach that listener instead.

A deliberate reproducer confirmed the failure mode: the request reached the competing listener rather than Jetty. This explains the wrong-server symptoms seen in the affected tests: foreign `OK\n` content, unexpected 404 responses, null response content, and requests completing when they should have timed out. The retained CI logs do not prove that every historical HTTP-client failure had this cause.

This change binds non-TLS `TestingHttpServer` connectors to `127.0.0.1` and advertises the same address. The regression test proves that a competing socket cannot claim the server's advertised address and port.

TLS fixtures remain unchanged. Their `localhost` certificate and dual-stack routing are separate concerns; binding only the IPv4 route would leave the IPv6 `localhost` route untreated.

## Testing

- Full `http-client` suite: 749 tests passed, 13 skipped
- Two subsequent full-suite pressure runs: 750 tests passed, 13 skipped in each run
- Focused HTTP/HTTPS compatibility run: 94 tests passed, 2 skipped
- HTTP proxy-authentication tests: 46 tests passed, 1 skipped
- Latest focused pre-PR run: 47 tests passed, 1 skipped

The skipped proxy test is `test100kGets`, which is disabled because it takes over a minute to run.
