### PR TITLE
Fail HTTP/2 responses whose body was truncated

### DIFF
--- a/http-client/src/main/java/io/airlift/http/client/jetty/JettyResponseListener.java
+++ b/http-client/src/main/java/io/airlift/http/client/jetty/JettyResponseListener.java
@@ -5,7 +5,6 @@ import org.eclipse.jetty.client.AbstractResponseListener;
 import org.eclipse.jetty.client.Request;
 import org.eclipse.jetty.client.Response;
 import org.eclipse.jetty.client.Result;
-import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.io.RetainableByteBuffer;
 
@@ -39,34 +38,19 @@ class JettyResponseListener<T, E extends Exception>
     @Override
     public void onComplete(Result result)
     {
-        // Request-side-only failures surface differently on HTTP/1.1 vs stream-based protocols.
-        Response response = result.getResponse();
-        if (response != null && isStreamBased(response.getVersion())) {
-            completeStreamBased(result, response);
-        }
-        else {
-            completeHttp1(result, response);
-        }
-    }
-
-    private static boolean isStreamBased(HttpVersion version)
-    {
-        return switch (version) {
-            case null -> false;
-            case HTTP_2, HTTP_3 -> true;
-            case HTTP_0_9, HTTP_1_0, HTTP_1_1 -> false;
-        };
-    }
-
-    private void completeHttp1(Result result, Response response)
-    {
+        // A response failure is only recorded while the response is still pending, so a
+        // non-null failure means the body was not fully received (truncation, stream reset
+        // mid-body, GOAWAY, connection EOF) and Jetty has already discarded the accumulated
+        // content. A request-side failure with a complete response (an upload aborted after
+        // the server answered early, on any protocol) still delivers the response.
         Throwable responseFailure = result.getResponseFailure();
         if (responseFailure != null) {
             future.failed(responseFailure);
             return;
         }
+        Response response = result.getResponse();
+        Throwable requestFailure = result.getRequestFailure();
         if (response == null) {
-            Throwable requestFailure = result.getRequestFailure();
             if (requestFailure == null) {
                 // Settle the future so the caller is not left blocking on a violated invariant.
                 future.failed(new IllegalStateException("Result has neither response nor failure: " + result));
@@ -75,28 +59,10 @@ class JettyResponseListener<T, E extends Exception>
             future.failed(requestFailure);
             return;
         }
-        Throwable requestFailure = result.getRequestFailure();
         if (requestFailure != null) {
             log.debug(requestFailure, "Suppressing request failure for fully-received response from %s", request.getURI());
         }
         deliver(response);
-    }
-
-    private void completeStreamBased(Result result, Response response)
-    {
-        Throwable responseFailure = result.getResponseFailure();
-        if (responseFailure == null) {
-            deliver(response);
-            return;
-        }
-        // Transport-layer failure after headers were committed (e.g. a server stream reset
-        // following an early response). Locally-initiated aborts propagate as RuntimeException.
-        if (response.getStatus() > 0 && responseFailure instanceof IOException) {
-            log.debug(responseFailure, "Suppressing transport failure after headers were received from %s", request.getURI());
-            deliver(response);
-            return;
-        }
-        future.failed(responseFailure);
     }
 
     private void deliver(Response response)

--- a/http-client/src/test/java/io/airlift/http/client/AbstractHttpClientTest.java
+++ b/http-client/src/test/java/io/airlift/http/client/AbstractHttpClientTest.java
@@ -841,6 +841,25 @@ public abstract class AbstractHttpClientTest
 
     @Test
     @Timeout(30)
+    public void testTruncatedResponseBodyFails()
+            throws Exception
+    {
+        // The server commits headers promising 100 bytes, writes a few and then aborts the
+        // exchange (connection close on HTTP/1.1, stream reset on HTTP/2). The transport
+        // failure must reach the caller instead of a "successful" response with an empty
+        // or truncated body. The async client reports it through handleException; the
+        // sync client delivers the headers and fails while the body is being read.
+        try (CloseableTestHttpServer server = newServerWithServlet(new TruncatedResponseServlet())) {
+            Request request = prepareGet()
+                    .setUri(server.baseURI())
+                    .build();
+            assertThatThrownBy(() -> executeRequest(server, request, new ReadBodyResponseHandler()))
+                    .isInstanceOf(IOException.class);
+        }
+    }
+
+    @Test
+    @Timeout(30)
     public void testEarlyServerResponseIsDelivered()
             throws Exception
     {
@@ -1308,6 +1327,24 @@ public abstract class AbstractHttpClientTest
         }
     }
 
+    public static class ReadBodyResponseHandler
+            implements ResponseHandler<byte[], Exception>
+    {
+        @Override
+        public byte[] handleException(Request request, Exception exception)
+                throws Exception
+        {
+            throw exception;
+        }
+
+        @Override
+        public byte[] handle(Request request, Response response)
+                throws IOException
+        {
+            return response.getInputStream().readAllBytes();
+        }
+    }
+
     private static class PassThroughResponseHandler
             implements ResponseHandler<Response, RuntimeException>
     {
@@ -1645,6 +1682,23 @@ public abstract class AbstractHttpClientTest
                 bytesRead.addAndGet(n);
             }
             return n;
+        }
+    }
+
+    public static final class TruncatedResponseServlet
+            extends HttpServlet
+    {
+        @Override
+        protected void service(HttpServletRequest request, HttpServletResponse response)
+                throws IOException
+        {
+            response.setStatus(200);
+            response.setContentLength(100);
+            response.getOutputStream().print("short");
+            response.flushBuffer();
+            // Throwing after the response is committed makes the container abort the
+            // exchange rather than complete it, truncating the body on the wire.
+            throw new IllegalStateException("simulated failure after commit");
         }
     }
 


### PR DESCRIPTION
JettyResponseListener suppressed any IOException response failure on HTTP/2 and HTTP/3 once a status line had been parsed and delivered the response anyway. Jetty only records a response failure while the response is still pending, so a non-null response failure always means the body was not fully received (stream reset mid-body, GOAWAY, connection EOF). Jetty's onFailure also clears the accumulated content before onComplete runs, so the handler received the original status code with an empty body. StatusResponseHandler reported success and JsonResponseHandler failed with a parse error that hid the underlying IOException that callers key their retries on.

The early-response case that motivated the suppression (a server that answers before the upload finishes and then resets the stream) is already a request-only failure: HttpReceiverOverHTTP2.onReset calls Request.fail() rather than abort() when the last DATA frame has been received, so the response completes normally and is delivered.

Fail the future on any response failure and keep delivering responses whose only failure is request-side. The HTTP/1.1 and stream-based paths are identical after this, so collapse them into a single onComplete.

Add testTruncatedResponseBodyFails to AbstractHttpClientTest so every client configuration (sync and async, HTTP/1.1 and HTTP/2, plain and TLS, HTTP/HTTPS/SOCKS proxies, virtual threads) verifies that a body truncated after commit surfaces as an IOException. Without the fix the HTTP/2 async client returns a 200 with an empty body.

<!-- Thank you for submitting pull request to Airlift -->

# Airlift contribution check list

 - [ ] Git commit messages follow https://cbea.ms/git-commit/.
 - [ ] All automated tests are passing.
 - [ ] Pull request was categorized using one of the existing labels.
