### PR TITLE
[MCP] Ensure `resultType` is on all needed responses

### DIFF
--- a/mcp/src/main/java/io/airlift/mcp/model/CacheableResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/CacheableResult.java
@@ -32,12 +32,6 @@ public interface CacheableResult<T extends CacheableResult<T>>
     };
 
     @JsonProperty
-    default Optional<ResultType> resultType()
-    {
-        return Optional.empty();
-    }
-
-    @JsonProperty
     default OptionalInt ttlMs()
     {
         return OptionalInt.empty();

--- a/mcp/src/main/java/io/airlift/mcp/model/DiscoverResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/DiscoverResult.java
@@ -13,7 +13,6 @@ import static java.util.Objects.requireNonNull;
 import static java.util.Objects.requireNonNullElse;
 
 public record DiscoverResult(
-        Optional<ResultType> resultType,
         List<String> supportedVersions,
         ServerCapabilities capabilities,
         Optional<String> instructions,
@@ -24,7 +23,6 @@ public record DiscoverResult(
 {
     public DiscoverResult
     {
-        resultType = requireNonNullElse(resultType, Optional.empty());
         supportedVersions = ImmutableList.copyOf(supportedVersions);
         requireNonNull(capabilities, "capabilities is null");
         instructions = requireNonNullElse(instructions, Optional.empty());
@@ -36,12 +34,12 @@ public record DiscoverResult(
     @Override
     public DiscoverResult withMeta(Map<String, Object> meta)
     {
-        return new DiscoverResult(resultType, supportedVersions, capabilities, instructions, ttlMs, cacheScope, Optional.of(meta));
+        return new DiscoverResult(supportedVersions, capabilities, instructions, ttlMs, cacheScope, Optional.of(meta));
     }
 
     @Override
     public DiscoverResult withCacheableResult(int ttlMs, CacheScope cacheScope)
     {
-        return new DiscoverResult(Optional.of(ResultType.COMPLETE), supportedVersions, capabilities, instructions, OptionalInt.of(ttlMs), Optional.of(cacheScope), meta);
+        return new DiscoverResult(supportedVersions, capabilities, instructions, OptionalInt.of(ttlMs), Optional.of(cacheScope), meta);
     }
 }

--- a/mcp/src/main/java/io/airlift/mcp/model/ListPromptsResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ListPromptsResult.java
@@ -10,14 +10,13 @@ import java.util.OptionalInt;
 import static io.airlift.mcp.model.Meta.normalize;
 import static java.util.Objects.requireNonNullElse;
 
-public record ListPromptsResult(Optional<ResultType> resultType, List<Prompt> prompts, Optional<String> nextCursor, OptionalInt ttlMs, Optional<CacheScope> cacheScope, Optional<Map<String, Object>> meta)
+public record ListPromptsResult(List<Prompt> prompts, Optional<String> nextCursor, OptionalInt ttlMs, Optional<CacheScope> cacheScope, Optional<Map<String, Object>> meta)
         implements CacheableResult<ListPromptsResult>,
                    Meta<ListPromptsResult>,
                    PaginatedResult
 {
     public ListPromptsResult
     {
-        resultType = requireNonNullElse(resultType, Optional.empty());
         prompts = ImmutableList.copyOf(prompts);
         nextCursor = requireNonNullElse(nextCursor, Optional.empty());
         ttlMs = requireNonNullElse(ttlMs, OptionalInt.empty());
@@ -27,23 +26,23 @@ public record ListPromptsResult(Optional<ResultType> resultType, List<Prompt> pr
 
     public ListPromptsResult(List<Prompt> prompts)
     {
-        this(Optional.empty(), prompts, Optional.empty(), OptionalInt.empty(), Optional.empty(), Optional.empty());
+        this(prompts, Optional.empty(), OptionalInt.empty(), Optional.empty(), Optional.empty());
     }
 
     public ListPromptsResult(List<Prompt> prompts, Optional<String> nextCursor)
     {
-        this(Optional.empty(), prompts, nextCursor, OptionalInt.empty(), Optional.empty(), Optional.empty());
+        this(prompts, nextCursor, OptionalInt.empty(), Optional.empty(), Optional.empty());
     }
 
     @Override
     public ListPromptsResult withCacheableResult(int ttlMs, CacheScope cacheScope)
     {
-        return new ListPromptsResult(Optional.of(ResultType.COMPLETE), prompts, nextCursor, OptionalInt.of(ttlMs), Optional.of(cacheScope), meta);
+        return new ListPromptsResult(prompts, nextCursor, OptionalInt.of(ttlMs), Optional.of(cacheScope), meta);
     }
 
     @Override
     public ListPromptsResult withMeta(Map<String, Object> meta)
     {
-        return new ListPromptsResult(resultType, prompts, nextCursor, ttlMs, cacheScope, Optional.of(meta));
+        return new ListPromptsResult(prompts, nextCursor, ttlMs, cacheScope, Optional.of(meta));
     }
 }

--- a/mcp/src/main/java/io/airlift/mcp/model/ListResourceTemplatesResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ListResourceTemplatesResult.java
@@ -10,14 +10,13 @@ import java.util.OptionalInt;
 import static io.airlift.mcp.model.Meta.normalize;
 import static java.util.Objects.requireNonNullElse;
 
-public record ListResourceTemplatesResult(Optional<ResultType> resultType, List<ResourceTemplate> resourceTemplates, Optional<String> nextCursor, OptionalInt ttlMs, Optional<CacheScope> cacheScope, Optional<Map<String, Object>> meta)
+public record ListResourceTemplatesResult(List<ResourceTemplate> resourceTemplates, Optional<String> nextCursor, OptionalInt ttlMs, Optional<CacheScope> cacheScope, Optional<Map<String, Object>> meta)
         implements CacheableResult<ListResourceTemplatesResult>,
                    Meta<ListResourceTemplatesResult>,
                    PaginatedResult
 {
     public ListResourceTemplatesResult
     {
-        resultType = requireNonNullElse(resultType, Optional.empty());
         resourceTemplates = ImmutableList.copyOf(resourceTemplates);
         nextCursor = requireNonNullElse(nextCursor, Optional.empty());
         ttlMs = requireNonNullElse(ttlMs, OptionalInt.empty());
@@ -27,23 +26,23 @@ public record ListResourceTemplatesResult(Optional<ResultType> resultType, List<
 
     public ListResourceTemplatesResult(List<ResourceTemplate> resourceTemplates)
     {
-        this(Optional.empty(), resourceTemplates, Optional.empty(), OptionalInt.empty(), Optional.empty(), Optional.empty());
+        this(resourceTemplates, Optional.empty(), OptionalInt.empty(), Optional.empty(), Optional.empty());
     }
 
     public ListResourceTemplatesResult(List<ResourceTemplate> resourceTemplates, Optional<String> nextCursor)
     {
-        this(Optional.empty(), resourceTemplates, nextCursor, OptionalInt.empty(), Optional.empty(), Optional.empty());
+        this(resourceTemplates, nextCursor, OptionalInt.empty(), Optional.empty(), Optional.empty());
     }
 
     @Override
     public ListResourceTemplatesResult withCacheableResult(int ttlMs, CacheScope cacheScope)
     {
-        return new ListResourceTemplatesResult(Optional.of(ResultType.COMPLETE), resourceTemplates, nextCursor, OptionalInt.of(ttlMs), Optional.of(cacheScope), meta);
+        return new ListResourceTemplatesResult(resourceTemplates, nextCursor, OptionalInt.of(ttlMs), Optional.of(cacheScope), meta);
     }
 
     @Override
     public ListResourceTemplatesResult withMeta(Map<String, Object> meta)
     {
-        return new ListResourceTemplatesResult(resultType, resourceTemplates, nextCursor, ttlMs, cacheScope, Optional.of(meta));
+        return new ListResourceTemplatesResult(resourceTemplates, nextCursor, ttlMs, cacheScope, Optional.of(meta));
     }
 }

--- a/mcp/src/main/java/io/airlift/mcp/model/ListResourcesResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ListResourcesResult.java
@@ -10,14 +10,13 @@ import java.util.OptionalInt;
 import static io.airlift.mcp.model.Meta.normalize;
 import static java.util.Objects.requireNonNullElse;
 
-public record ListResourcesResult(Optional<ResultType> resultType, List<Resource> resources, Optional<String> nextCursor, OptionalInt ttlMs, Optional<CacheScope> cacheScope, Optional<Map<String, Object>> meta)
+public record ListResourcesResult(List<Resource> resources, Optional<String> nextCursor, OptionalInt ttlMs, Optional<CacheScope> cacheScope, Optional<Map<String, Object>> meta)
         implements CacheableResult<ListResourcesResult>,
                    Meta<ListResourcesResult>,
                    PaginatedResult
 {
     public ListResourcesResult
     {
-        resultType = requireNonNullElse(resultType, Optional.empty());
         resources = ImmutableList.copyOf(resources);
         nextCursor = requireNonNullElse(nextCursor, Optional.empty());
         ttlMs = requireNonNullElse(ttlMs, OptionalInt.empty());
@@ -27,23 +26,23 @@ public record ListResourcesResult(Optional<ResultType> resultType, List<Resource
 
     public ListResourcesResult(List<Resource> resources, Optional<String> nextCursor)
     {
-        this(Optional.empty(), resources, nextCursor, OptionalInt.empty(), Optional.empty(), Optional.empty());
+        this(resources, nextCursor, OptionalInt.empty(), Optional.empty(), Optional.empty());
     }
 
     public ListResourcesResult(List<Resource> resources)
     {
-        this(Optional.empty(), resources, Optional.empty(), OptionalInt.empty(), Optional.empty(), Optional.empty());
+        this(resources, Optional.empty(), OptionalInt.empty(), Optional.empty(), Optional.empty());
     }
 
     @Override
     public ListResourcesResult withCacheableResult(int ttlMs, CacheScope cacheScope)
     {
-        return new ListResourcesResult(Optional.of(ResultType.COMPLETE), resources, nextCursor, OptionalInt.of(ttlMs), Optional.of(cacheScope), meta);
+        return new ListResourcesResult(resources, nextCursor, OptionalInt.of(ttlMs), Optional.of(cacheScope), meta);
     }
 
     @Override
     public ListResourcesResult withMeta(Map<String, Object> meta)
     {
-        return new ListResourcesResult(resultType, resources, nextCursor, ttlMs, cacheScope, Optional.of(meta));
+        return new ListResourcesResult(resources, nextCursor, ttlMs, cacheScope, Optional.of(meta));
     }
 }

--- a/mcp/src/main/java/io/airlift/mcp/model/ListToolsResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ListToolsResult.java
@@ -10,14 +10,13 @@ import java.util.OptionalInt;
 import static io.airlift.mcp.model.Meta.normalize;
 import static java.util.Objects.requireNonNullElse;
 
-public record ListToolsResult(Optional<ResultType> resultType, List<Tool> tools, Optional<String> nextCursor, OptionalInt ttlMs, Optional<CacheScope> cacheScope, Optional<Map<String, Object>> meta)
+public record ListToolsResult(List<Tool> tools, Optional<String> nextCursor, OptionalInt ttlMs, Optional<CacheScope> cacheScope, Optional<Map<String, Object>> meta)
         implements CacheableResult<ListToolsResult>,
                    Meta<ListToolsResult>,
                    PaginatedResult
 {
     public ListToolsResult
     {
-        resultType = requireNonNullElse(resultType, Optional.empty());
         tools = ImmutableList.copyOf(tools);
         nextCursor = requireNonNullElse(nextCursor, Optional.empty());
         ttlMs = requireNonNullElse(ttlMs, OptionalInt.empty());
@@ -27,23 +26,23 @@ public record ListToolsResult(Optional<ResultType> resultType, List<Tool> tools,
 
     public ListToolsResult(List<Tool> tools)
     {
-        this(Optional.empty(), tools, Optional.empty(), OptionalInt.empty(), Optional.empty(), Optional.empty());
+        this(tools, Optional.empty(), OptionalInt.empty(), Optional.empty(), Optional.empty());
     }
 
     public ListToolsResult(List<Tool> tools, Optional<String> nextCursor)
     {
-        this(Optional.empty(), tools, nextCursor, OptionalInt.empty(), Optional.empty(), Optional.empty());
+        this(tools, nextCursor, OptionalInt.empty(), Optional.empty(), Optional.empty());
     }
 
     @Override
     public ListToolsResult withCacheableResult(int ttlMs, CacheScope cacheScope)
     {
-        return new ListToolsResult(Optional.of(ResultType.COMPLETE), tools, nextCursor, OptionalInt.of(ttlMs), Optional.of(cacheScope), meta);
+        return new ListToolsResult(tools, nextCursor, OptionalInt.of(ttlMs), Optional.of(cacheScope), meta);
     }
 
     @Override
     public ListToolsResult withMeta(Map<String, Object> meta)
     {
-        return new ListToolsResult(resultType, tools, nextCursor, ttlMs, cacheScope, Optional.of(meta));
+        return new ListToolsResult(tools, nextCursor, ttlMs, cacheScope, Optional.of(meta));
     }
 }

--- a/mcp/src/main/java/io/airlift/mcp/model/ReadResourceResult.java
+++ b/mcp/src/main/java/io/airlift/mcp/model/ReadResourceResult.java
@@ -10,12 +10,11 @@ import java.util.OptionalInt;
 import static io.airlift.mcp.model.Meta.normalize;
 import static java.util.Objects.requireNonNullElse;
 
-public record ReadResourceResult(Optional<ResultType> resultType, List<ResourceContents> contents, OptionalInt ttlMs, Optional<CacheScope> cacheScope, Optional<Map<String, Object>> meta)
+public record ReadResourceResult(List<ResourceContents> contents, OptionalInt ttlMs, Optional<CacheScope> cacheScope, Optional<Map<String, Object>> meta)
         implements CacheableResult<ReadResourceResult>, Meta<ReadResourceResult>
 {
     public ReadResourceResult
     {
-        resultType = requireNonNullElse(resultType, Optional.empty());
         contents = ImmutableList.copyOf(contents);
         ttlMs = requireNonNullElse(ttlMs, OptionalInt.empty());
         cacheScope = requireNonNullElse(cacheScope, Optional.empty());
@@ -24,18 +23,18 @@ public record ReadResourceResult(Optional<ResultType> resultType, List<ResourceC
 
     public ReadResourceResult(List<ResourceContents> contents)
     {
-        this(Optional.empty(), contents, OptionalInt.empty(), Optional.empty(), Optional.empty());
+        this(contents, OptionalInt.empty(), Optional.empty(), Optional.empty());
     }
 
     @Override
     public ReadResourceResult withCacheableResult(int ttlMs, CacheScope cacheScope)
     {
-        return new ReadResourceResult(Optional.of(ResultType.COMPLETE), contents, OptionalInt.of(ttlMs), Optional.of(cacheScope), meta);
+        return new ReadResourceResult(contents, OptionalInt.of(ttlMs), Optional.of(cacheScope), meta);
     }
 
     @Override
     public ReadResourceResult withMeta(Map<String, Object> meta)
     {
-        return new ReadResourceResult(resultType, contents, ttlMs, cacheScope, Optional.of(meta));
+        return new ReadResourceResult(contents, ttlMs, cacheScope, Optional.of(meta));
     }
 }

--- a/mcp/src/main/java/io/airlift/mcp/operations/OperationsImpl.java
+++ b/mcp/src/main/java/io/airlift/mcp/operations/OperationsImpl.java
@@ -43,6 +43,7 @@ import io.airlift.mcp.model.ReadResourceResult;
 import io.airlift.mcp.model.Resource;
 import io.airlift.mcp.model.ResourceContents;
 import io.airlift.mcp.model.ResourceTemplate;
+import io.airlift.mcp.model.ResultType;
 import io.airlift.mcp.model.SubscribeListChanged;
 import io.airlift.mcp.model.SubscriptionNotifications;
 import io.airlift.mcp.model.Tool;
@@ -77,7 +78,6 @@ import static io.airlift.mcp.model.Constants.METHOD_TOOLS_LIST;
 import static io.airlift.mcp.model.JsonRpcErrorCode.HEADER_MISMATCH;
 import static io.airlift.mcp.model.JsonRpcErrorCode.INVALID_PARAMS;
 import static io.airlift.mcp.model.JsonRpcErrorCode.METHOD_NOT_FOUND;
-import static io.airlift.mcp.model.ResultType.COMPLETE;
 import static io.airlift.mcp.operations.McpTracingAttributes.MCP_METHOD_NAME;
 import static io.airlift.mcp.operations.McpTracingAttributes.MCP_PROTOCOL_VERSION;
 import static io.airlift.mcp.operations.McpTracingAttributes.MCP_RESOURCE_URI;
@@ -161,6 +161,10 @@ public class OperationsImpl
 
         if (result instanceof Meta<?> resultMeta) {
             result = addServerInfo(serverImplementation, resultMeta);
+        }
+
+        if (!(result instanceof MetaOnly)) {
+            result = new ResultTypeWrapper(ResultType.COMPLETE, result);
         }
 
         writeResult(jsonMapper, messageWriter, response, requestId, result);
@@ -305,7 +309,7 @@ public class OperationsImpl
                 tools.isEmpty() ? Optional.empty() : Optional.of(new ListChanged(true)),
                 Optional.empty());
 
-        return withCacheableResult(metadata, DiscoverResult.class, new DiscoverResult(Optional.of(COMPLETE), SUPPORTED_VERSIONS, serverCapabilities, metadata.instructions(), OptionalInt.empty(), Optional.empty(), Optional.empty()));
+        return withCacheableResult(metadata, DiscoverResult.class, new DiscoverResult(SUPPORTED_VERSIONS, serverCapabilities, metadata.instructions(), OptionalInt.empty(), Optional.empty(), Optional.empty()));
     }
 
     private <T extends CacheableResult<?>> T withCacheableResult(McpMetadata metadata, Class<T> clazz, T result)

--- a/mcp/src/main/java/io/airlift/mcp/operations/ResultTypeWrapper.java
+++ b/mcp/src/main/java/io/airlift/mcp/operations/ResultTypeWrapper.java
@@ -1,0 +1,15 @@
+package io.airlift.mcp.operations;
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import io.airlift.mcp.model.ResultType;
+
+import static java.util.Objects.requireNonNull;
+
+public record ResultTypeWrapper(ResultType resultType, @JsonUnwrapped Object result)
+{
+    public ResultTypeWrapper
+    {
+        requireNonNull(resultType, "resultType is null");
+        requireNonNull(result, "result is null");
+    }
+}

--- a/mcp/src/test/java/io/airlift/mcp/TestConformance.java
+++ b/mcp/src/test/java/io/airlift/mcp/TestConformance.java
@@ -93,7 +93,7 @@ public class TestConformance
     public void testConformance(String scenario)
     {
         // see: https://github.com/modelcontextprotocol/conformance?tab=readme-ov-file#testing-servers
-        String result = nodeContainer.execute("npx", "--yes", "@modelcontextprotocol/conformance@0.2.0-alpha.10", "server", "--url", mcpUri, "--scenario", scenario, "--verbose");
+        String result = nodeContainer.execute("npx", "--yes", "@modelcontextprotocol/conformance@0.2.0-alpha.11", "server", "--url", mcpUri, "--scenario", scenario, "--verbose");
         assertThat(result).contains("0 failed, 0 warnings");
     }
 


### PR DESCRIPTION
Clients are more strict with the latest protocol. Nearly all responses are required to have `resultType` on the latest protocol. Instead of managing this at the `record` level, generically add `resultType` to responses when needed in the current protocol operation handler.

Note: for MRTR and Tasks we will be able to detect the need to set a different `resultType` easily.

Fixes #2126

# Airlift contribution check list

 - [X] Git commit messages follow https://cbea.ms/git-commit/.
 - [X] All automated tests are passing.
 - [X] Pull request was categorized using one of the existing labels.
