### PR TITLE
Fix NPE when HTTPS keystore password is unset

### DIFF
--- a/http-server/src/main/java/io/airlift/http/server/ReloadableSslContextFactoryProvider.java
+++ b/http-server/src/main/java/io/airlift/http/server/ReloadableSslContextFactoryProvider.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
+import java.util.Enumeration;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
@@ -140,11 +141,27 @@ final class ReloadableSslContextFactoryProvider
 
         try (InputStream in = new FileInputStream(file)) {
             KeyStore keyStore = KeyStore.getInstance(keystoreType);
-            keyStore.load(in, keystorePassword.toCharArray());
+            keyStore.load(in, keystorePassword == null ? null : keystorePassword.toCharArray());
+            validateKeystorePasswordProvided(keyStore, file, keystorePassword);
             return keyStore;
         }
         catch (IOException | GeneralSecurityException e) {
             throw new IllegalArgumentException("Error loading Java key store: " + file, e);
+        }
+    }
+
+    private static void validateKeystorePasswordProvided(KeyStore keyStore, File file, String keystorePassword)
+            throws GeneralSecurityException
+    {
+        if (keystorePassword != null) {
+            return;
+        }
+
+        Enumeration<String> aliases = keyStore.aliases();
+        while (aliases.hasMoreElements()) {
+            if (keyStore.isKeyEntry(aliases.nextElement())) {
+                throw new IllegalArgumentException("Keystore password is required to load key store: " + file);
+            }
         }
     }
 

--- a/http-server/src/test/java/io/airlift/http/server/TestHttpServerProvider.java
+++ b/http-server/src/test/java/io/airlift/http/server/TestHttpServerProvider.java
@@ -656,6 +656,18 @@ public class TestHttpServerProvider
     }
 
     @Test
+    public void testMissingKeystorePassword()
+    {
+        config.setHttpEnabled(false)
+                .setHttpsEnabled(true);
+        httpsConfig.setKeystorePath(getResource("test.keystore").getPath());
+
+        assertThatThrownBy(this::createAndStartServer)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageStartingWith("Keystore password is required to load key store:");
+    }
+
+    @Test
     public void testHttpsDaysUntilCertificateExpiration()
             throws Exception
     {


### PR DESCRIPTION
Fixes #976

## Summary
- Stop calling `String.toCharArray()` on a missing keystore password when loading a Java keystore (matches trust-store handling).
- After load, reject keystores that contain private key entries when no keystore password was configured, instead of failing later with an NPE or a misleading Jetty error (per feedback on #977).

## Test plan
- [x] `./mvnw -pl http-server test -Dtest=TestHttpServerProvider#testMissingKeystorePassword,TestHttpServerProvider#testInsufficientPasswordToAccessKeystore` (JDK 25, Temurin)
- [x] Existing `testInsufficientPasswordToAccessKeystore` still passes

# Airlift contribution check list

 - [x] Git commit messages follow https://cbea.ms/git-commit/.
 - [x] All automated tests are passing.
 - [ ] Pull request was categorized using one of the existing labels.